### PR TITLE
Review metadata models

### DIFF
--- a/src/demo-app/mock-data/metadata.json
+++ b/src/demo-app/mock-data/metadata.json
@@ -1,5 +1,4 @@
 {
-  "apiVersion": "0.0.0",
   "id": "e203fee7-89b4-4216-894d-7aef0e3a199d",
   "root": "903d1d75-e617-4767-a3bf-0cb3ee509027",
   "groups": {

--- a/src/demo-app/mock-data/models.ts
+++ b/src/demo-app/mock-data/models.ts
@@ -1,0 +1,18 @@
+import {
+  HDF5Id,
+  HDF5Collection,
+  HDF5Group,
+  HDF5Dataset,
+  HDF5Datatype,
+} from '../../h5web/providers/models';
+
+export interface MockHDF5Metadata {
+  id?: HDF5Id;
+  root: HDF5Id;
+  [HDF5Collection.Groups]: Record<HDF5Id, HDF5Group>;
+  [HDF5Collection.Datasets]?: Record<HDF5Id, HDF5Dataset>;
+  [HDF5Collection.Datatypes]?: Record<HDF5Id, HDF5Datatype>;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type MockHDF5Values = Record<HDF5Id, any>;

--- a/src/h5web/App.tsx
+++ b/src/h5web/App.tsx
@@ -4,13 +4,15 @@ import { ReflexContainer, ReflexSplitter, ReflexElement } from 'react-reflex';
 import mockMetadata from '../demo-app/mock-data/metadata.json';
 import Explorer from './explorer/Explorer';
 import DatasetVisualizer from './dataset-visualizer/DatasetVisualizer';
-import { HDF5Metadata, HDF5Link, HDF5Collection } from './providers/models';
+import { HDF5Link, HDF5Collection, HDF5HardLink } from './providers/models';
 import MetadataViewer from './metadata-viewer/MetadataViewer';
 import styles from './App.module.css';
+import { MockHDF5Metadata } from '../demo-app/mock-data/models';
+import { isHardLink } from './providers/type-guards';
 
 function App(): JSX.Element {
   const [selectedLink, setSelectedLink] = useState<HDF5Link>();
-  const [lastSelectedDataset, setLastSelectedDataset] = useState<HDF5Link>();
+  const [selectedDataset, setSelectedDataset] = useState<HDF5HardLink>();
 
   return (
     <div className={styles.app}>
@@ -18,12 +20,15 @@ function App(): JSX.Element {
         <ReflexElement className={styles.explorer} flex={0.3} minSize={250}>
           <Explorer
             filename="water_224.h5"
-            metadata={mockMetadata as HDF5Metadata}
+            metadata={mockMetadata as MockHDF5Metadata}
             onSelect={link => {
               setSelectedLink(link);
 
-              if (link.collection === HDF5Collection.Datasets) {
-                setLastSelectedDataset(link);
+              if (
+                isHardLink(link) &&
+                link.collection === HDF5Collection.Datasets
+              ) {
+                setSelectedDataset(link);
               }
             }}
           />
@@ -34,8 +39,8 @@ function App(): JSX.Element {
         <ReflexElement minSize={500}>
           <ReflexContainer orientation="horizontal">
             <ReflexElement minSize={250}>
-              {lastSelectedDataset ? (
-                <DatasetVisualizer link={lastSelectedDataset} />
+              {selectedDataset ? (
+                <DatasetVisualizer link={selectedDataset} />
               ) : (
                 <div className={styles.empty}>
                   <p>No dataset selected.</p>

--- a/src/h5web/dataset-visualizer/DatasetVisualizer.tsx
+++ b/src/h5web/dataset-visualizer/DatasetVisualizer.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { HDF5Link } from '../providers/models';
+import { HDF5HardLink } from '../providers/models';
 import styles from './DatasetVisualizer.module.css';
 import { useValues } from '../providers/hooks';
 
 interface Props {
-  link: HDF5Link;
+  link: HDF5HardLink;
 }
 
 function DatasetVisualizer(props: Props): JSX.Element {

--- a/src/h5web/explorer/Explorer.tsx
+++ b/src/h5web/explorer/Explorer.tsx
@@ -1,15 +1,15 @@
 import React, { useEffect, useState } from 'react';
-import { HDF5Metadata, HDF5Link } from '../providers/models';
+import { HDF5Link } from '../providers/models';
 import { buildTree } from './utils';
 import { Tree, TreeNode } from './models';
 import TreeView from './TreeView';
-
 import styles from './Explorer.module.css';
 import Icon from './Icon';
+import { MockHDF5Metadata } from '../../demo-app/mock-data/models';
 
 interface Props {
   filename: string;
-  metadata: HDF5Metadata;
+  metadata: MockHDF5Metadata;
   onSelect: (link: HDF5Link) => void;
 }
 

--- a/src/h5web/explorer/Icon.tsx
+++ b/src/h5web/explorer/Icon.tsx
@@ -5,12 +5,14 @@ import {
   FiChevronDown,
   FiChevronRight,
   FiLayers,
+  FiLink,
 } from 'react-icons/fi';
 import { IconType } from 'react-icons';
 
 import { HDF5Link, HDF5Collection } from '../providers/models';
 
 import styles from './Icon.module.css';
+import { isHardLink } from '../providers/type-guards';
 
 const LEAF_ICONS: Record<HDF5Collection, IconType> = {
   [HDF5Collection.Groups]: FiFolder,
@@ -35,8 +37,12 @@ function Icon(props: Props): JSX.Element {
     );
   }
 
-  const LeafIcon = LEAF_ICONS[data.collection];
-  return <LeafIcon className={styles.icon} />;
+  if (isHardLink(data)) {
+    const LeafIcon = LEAF_ICONS[data.collection];
+    return <LeafIcon className={styles.icon} />;
+  }
+
+  return <FiLink className={styles.icon} />;
 }
 
 export default Icon;

--- a/src/h5web/explorer/utils.test.ts
+++ b/src/h5web/explorer/utils.test.ts
@@ -1,5 +1,5 @@
 import { buildTree } from './utils';
-import { HDF5Metadata } from '../providers/models';
+import { MockHDF5Metadata } from '../../demo-app/mock-data/models';
 
 describe('Explorer Utils', () => {
   describe('buildTree', () => {
@@ -27,7 +27,7 @@ describe('Explorer Utils', () => {
         groups: {
           '913d8791': { links: [link] },
         },
-      } as HDF5Metadata;
+      } as MockHDF5Metadata;
 
       expect(buildTree(simpleMetadata)).toEqual([
         {

--- a/src/h5web/explorer/utils.ts
+++ b/src/h5web/explorer/utils.ts
@@ -1,25 +1,24 @@
 import nanoid from 'nanoid';
-import { HDF5Metadata, HDF5Collection, HDF5Link } from '../providers/models';
+import { HDF5Collection, HDF5Link } from '../providers/models';
 import { Tree } from './models';
+import { MockHDF5Metadata } from '../../demo-app/mock-data/models';
+import { isHardLink } from '../providers/type-guards';
 
 export function buildTree(
-  metadata: HDF5Metadata,
+  metadata: MockHDF5Metadata,
   groupId = metadata.root,
   level = 1
 ): Tree<HDF5Link> {
   const group = metadata.groups[groupId];
   const { links } = group;
 
-  return (links || []).map(link => {
-    const { title, collection, id } = link;
-    return {
-      uid: nanoid(),
-      label: title,
-      level,
-      data: link,
-      ...(collection === HDF5Collection.Groups
-        ? { children: buildTree(metadata, id, level + 1) }
-        : {}),
-    };
-  });
+  return (links || []).map(link => ({
+    uid: nanoid(),
+    label: link.title,
+    level,
+    data: link,
+    ...(isHardLink(link) && link.collection === HDF5Collection.Groups
+      ? { children: buildTree(metadata, link.id, level + 1) }
+      : {}),
+  }));
 }

--- a/src/h5web/metadata-viewer/MetadataViewer.tsx
+++ b/src/h5web/metadata-viewer/MetadataViewer.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { HDF5Link, HDF5Collection } from '../providers/models';
 import styles from './MetadataViewer.module.css';
 import { useMetadata } from '../providers/hooks';
+import { isHardLink } from '../providers/type-guards';
 
 const ENTITY_TYPE: Record<HDF5Collection, string> = {
   [HDF5Collection.Datasets]: 'dataset',
@@ -15,14 +16,14 @@ interface Props {
 
 function MetadataViewer(props: Props): JSX.Element {
   const { link } = props;
-  const { collection, title } = link;
 
   const metadata = useMetadata(link);
 
   return (
     <div className={styles.viewer}>
       <h2 className={styles.heading}>
-        Metadata for {ENTITY_TYPE[collection]} <code>{title}</code>
+        Metadata for {isHardLink(link) ? ENTITY_TYPE[link.collection] : 'link'}{' '}
+        <code>{link.title}</code>
       </h2>
       <pre>
         {JSON.stringify(

--- a/src/h5web/providers/hooks.ts
+++ b/src/h5web/providers/hooks.ts
@@ -1,23 +1,30 @@
 import {
   HDF5Link,
-  HDF5Values,
-  HDF5Metadata,
   HDF5Dataset,
   HDF5Datatype,
   HDF5Group,
+  HDF5HardLink,
 } from './models';
 import mockMetadata from '../../demo-app/mock-data/metadata.json';
 import mockValues from '../../demo-app/mock-data/values.json';
+import {
+  MockHDF5Metadata,
+  MockHDF5Values,
+} from '../../demo-app/mock-data/models';
+import { isHardLink } from './type-guards';
 
 export function useMetadata(
   link: HDF5Link
-): HDF5Group | HDF5Dataset | HDF5Datatype {
+): HDF5Group | HDF5Dataset | HDF5Datatype | undefined {
+  if (!isHardLink(link)) {
+    return undefined;
+  }
+
   const { collection, id } = link;
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  return (mockMetadata as HDF5Metadata)[collection]![id];
+  return (mockMetadata as MockHDF5Metadata)[collection]![id]; // eslint-disable-line @typescript-eslint/no-non-null-assertion
 }
 
-export function useValues(link: HDF5Link): HDF5Values {
+export function useValues(link: HDF5HardLink): MockHDF5Values {
   const { id } = link;
-  return (mockValues as HDF5Values)[id];
+  return (mockValues as MockHDF5Values)[id];
 }

--- a/src/h5web/providers/models.ts
+++ b/src/h5web/providers/models.ts
@@ -1,39 +1,181 @@
+/* -------------------- */
+/* ----- ENTITIES ----- */
+
+export type HDF5Entity = HDF5Group | HDF5Dataset | HDF5Datatype;
 export type HDF5Id = string;
 
-export interface HDF5Metadata {
-  apiVersion: string;
-  id?: HDF5Id;
-  root: HDF5Id;
-  groups: Record<HDF5Id, HDF5Group>;
-  datasets?: Record<HDF5Id, HDF5Dataset>;
-  datatypes?: Record<HDF5Id, HDF5Datatype>;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type HDF5Values = Record<HDF5Id, any>;
-
 export interface HDF5Group {
+  attributes?: HDF5Attribute[];
   links?: HDF5Link[];
 }
 
 export interface HDF5Dataset {
-  type: HDF5Id | object;
-  shape: object;
+  attributes?: HDF5Attribute[];
+  shape: HDF5Shape;
+  type: HDF5Type;
 }
 
 export interface HDF5Datatype {
-  type: object;
+  type: HDF5Type;
 }
 
-export interface HDF5Link {
-  class: 'H5L_TYPE_HARD';
-  title: string;
-  collection: HDF5Collection;
-  id: HDF5Id;
+/* ---------------------- */
+/* ----- ATTRIBUTES ----- */
+
+interface HDF5Attribute {
+  name: string;
+  shape: HDF5Shape;
+  type: HDF5Type;
+  value: unknown;
+}
+
+/* ----------------- */
+/* ----- LINKS ----- */
+
+export type HDF5Link = HDF5HardLink | HDF5SoftLink | HDF5ExternalLink;
+
+export enum HDF5LinkClass {
+  Hard = 'H5L_TYPE_HARD',
+  Soft = 'H5L_TYPE_SOFT',
+  External = 'H5L_TYPE_EXTERNAL',
 }
 
 export enum HDF5Collection {
   Groups = 'groups',
   Datasets = 'datasets',
   Datatypes = 'datatypes',
+}
+
+export interface HDF5HardLink {
+  class: HDF5LinkClass.Hard;
+  title: string;
+  collection: HDF5Collection;
+  id: HDF5Id;
+}
+
+interface HDF5SoftLink {
+  class: HDF5LinkClass.Soft;
+  title: string;
+  h5path: string;
+}
+
+interface HDF5ExternalLink {
+  class: HDF5LinkClass.External;
+  title: string;
+  file: string;
+  h5path: string;
+}
+
+/* ----------------- */
+/* ----- SHAPE ----- */
+
+type HDF5Shape = HDF5SimpleShape | HDF5ScalarShape | HDF5NullShape;
+
+enum HDF5ShapeClass {
+  Simple = 'H5S_SIMPLE',
+  Scalar = 'H5S_SCALAR',
+  Null = 'H5S_NUL',
+}
+
+interface HDF5SimpleShape {
+  class: HDF5ShapeClass.Simple;
+  dims: number[];
+  maxdims?: number[];
+}
+
+interface HDF5ScalarShape {
+  class: HDF5ShapeClass.Scalar;
+}
+
+interface HDF5NullShape {
+  class: HDF5ShapeClass.Null;
+}
+
+/* ---------------- */
+/* ----- TYPE ----- */
+
+type HDF5Type = HDF5BaseType | HDF5AdvancedType;
+
+// https://support.hdfgroup.org/HDF5/doc/RM/PredefDTypes.html
+type HDF5BaseType = HDF5IntegerType | HDF5FloatType | HDF5StringType;
+
+type HDF5AdvancedType =
+  | HDF5Id
+  | HDF5ArrayType
+  | HDF5VLenType
+  | HDF5CompoundType;
+
+enum HDF5TypeClass {
+  Integer = 'H5T_INTEGER',
+  Float = 'H5T_FLOAT',
+  String = 'H5T_STRING',
+  Array = 'H5T_ARRAY',
+  VLen = 'H5T_VLEN',
+  Compound = 'H5T_COMPOUND',
+}
+
+interface HDF5IntegerType {
+  class: HDF5TypeClass.Integer;
+  base:
+    | 'H5T_STD_I8BE'
+    | 'H5T_STD_I8LE'
+    | 'H5T_STD_I16BE'
+    | 'H5T_STD_I16LE'
+    | 'H5T_STD_I32BE'
+    | 'H5T_STD_I32LE'
+    | 'H5T_STD_I64BE'
+    | 'H5T_STD_I64LE'
+    | 'H5T_STD_U8BE'
+    | 'H5T_STD_U8LE'
+    | 'H5T_STD_U16BE'
+    | 'H5T_STD_U16LE'
+    | 'H5T_STD_U32BE'
+    | 'H5T_STD_U32LE'
+    | 'H5T_STD_U64BE'
+    | 'H5T_STD_U64LE'
+    | 'H5T_STD_B8BE'
+    | 'H5T_STD_B8LE'
+    | 'H5T_STD_B16BE'
+    | 'H5T_STD_B16LE'
+    | 'H5T_STD_B32BE'
+    | 'H5T_STD_B32LE'
+    | 'H5T_STD_B64BE'
+    | 'H5T_STD_B64LE';
+}
+
+interface HDF5FloatType {
+  class: HDF5TypeClass.Float;
+  base:
+    | 'H5T_IEEE_F32BE'
+    | 'H5T_IEEE_F32LE'
+    | 'H5T_IEEE_F64BE'
+    | 'H5T_IEEE_F64LE';
+}
+
+interface HDF5StringType {
+  class: HDF5TypeClass.String;
+  charSet: 'H5T_CSET_ASCII' | 'H5T_CSET_UTF8';
+  strPad: 'H5T_STR_SPACEPAD' | 'H5T_STR_NULLTERM' | 'H5T_STR_NULLPAD';
+  length: number | 'H5T_VARIABLE';
+}
+
+interface HDF5ArrayType {
+  class: HDF5TypeClass.Array;
+  base: HDF5BaseType;
+  dims: number[];
+}
+
+interface HDF5VLenType {
+  class: HDF5TypeClass.VLen;
+  base: HDF5BaseType;
+}
+
+interface HDF5CompoundType {
+  class: HDF5TypeClass.Compound;
+  fields: HDF5CompoundTypeField[];
+}
+
+interface HDF5CompoundTypeField {
+  name: string;
+  type: HDF5Type;
 }

--- a/src/h5web/providers/type-guards.ts
+++ b/src/h5web/providers/type-guards.ts
@@ -1,0 +1,5 @@
+import { HDF5Link, HDF5LinkClass, HDF5HardLink } from './models';
+
+export function isHardLink(link: HDF5Link): link is HDF5HardLink {
+  return link.class === HDF5LinkClass.Hard;
+}


### PR DESCRIPTION
- Add interfaces for HDF5 shape, type, attributes, etc.
- Rename interface used to type a mocked JSON metadata file from `HDF5Metadata` to `MockHDF5Metadata`, since this interface won't be used to type the data returned from HSDS.