### PR TITLE
Fix typing error in tests and improve linting script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ npm start
 ## Code quality 🔎
 
 - `npm run lint` - run all linting and code formatting commands
-- `npm run lint:ts` - lint all TS and JS files with ESLint
-- `npm run lint:pretty` - check that all files have been formatted with Prettier
+- `npm run lint:eslint` - lint all TS and JS files with ESLint
+- `npm run lint:tsc` - type-check the whole project, test files included
+- `npm run lint:prettier` - check that all files have been formatted with Prettier
 
 ### Automatic fixing and formatting
 
-- `npm run lint:ts --fix` - auto-fix linting issues
-- `npm run lint:pretty --write` - format all files with Prettier
+- `npm run lint:eslint --fix` - auto-fix linting issues
+- `npm run lint:prettier --write` - format all files with Prettier
 
 ### Editor integration
 

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "lint": "run-p lint:*",
-    "lint:ts": "eslint \"**/*.{ts,tsx,js,jsx}\"",
-    "lint:pretty": "prettier --check \"**/*.{ts,tsx,js,jsx,css,json,md,yml}\""
+    "lint:eslint": "eslint \"**/*.{ts,tsx,js,jsx}\"",
+    "lint:tsc": "tsc --noEmit",
+    "lint:prettier": "prettier --check \"**/*.{ts,tsx,js,jsx,css,json,md,yml}\""
   },
   "dependencies": {
     "classnames": "^2.2.6",

--- a/src/h5web/explorer/utils.test.ts
+++ b/src/h5web/explorer/utils.test.ts
@@ -61,7 +61,7 @@ describe('Explorer Utils', () => {
           '913d8791': { links: [link1] },
           '0a68caca': { links: [link2] },
         },
-      } as HDF5Metadata;
+      } as MockHDF5Metadata;
 
       expect(buildTree(nestedMetadata)).toEqual([
         {


### PR DESCRIPTION
Turns out ESLint and Jest don't type-check, so tests were not being type-checked. I've added a script to type-check the whole project. It's faster than running `npm run build`, so it will be useful for continuous integration.