### PR TITLE
Move data retrieval for Explorer in custom hook

### DIFF
--- a/src/h5web/App.tsx
+++ b/src/h5web/App.tsx
@@ -1,13 +1,11 @@
 import React, { useState } from 'react';
 import { ReflexContainer, ReflexSplitter, ReflexElement } from 'react-reflex';
 
-import mockMetadata from '../demo-app/mock-data/metadata.json';
 import Explorer from './explorer/Explorer';
 import DatasetVisualizer from './dataset-visualizer/DatasetVisualizer';
 import { HDF5Link, HDF5Collection, HDF5HardLink } from './providers/models';
 import MetadataViewer from './metadata-viewer/MetadataViewer';
 import styles from './App.module.css';
-import { MockHDF5Metadata } from '../demo-app/mock-data/models';
 import { isHardLink } from './providers/type-guards';
 
 function App(): JSX.Element {
@@ -20,7 +18,6 @@ function App(): JSX.Element {
         <ReflexElement className={styles.explorer} flex={0.3} minSize={250}>
           <Explorer
             filename="water_224.h5"
-            metadata={mockMetadata as MockHDF5Metadata}
             onSelect={link => {
               setSelectedLink(link);
 

--- a/src/h5web/explorer/Explorer.tsx
+++ b/src/h5web/explorer/Explorer.tsx
@@ -1,26 +1,21 @@
 import React, { useEffect, useState } from 'react';
 import { HDF5Link } from '../providers/models';
-import { buildTree } from './utils';
-import { Tree, TreeNode } from './models';
+import { TreeNode } from './models';
 import TreeView from './TreeView';
 import styles from './Explorer.module.css';
 import Icon from './Icon';
-import { MockHDF5Metadata } from '../../demo-app/mock-data/models';
+import { useMetadataTree } from '../providers/hooks';
 
 interface Props {
   filename: string;
-  metadata: MockHDF5Metadata;
   onSelect: (link: HDF5Link) => void;
 }
 
 function Explorer(props: Props): JSX.Element {
-  const { filename, metadata, onSelect } = props;
-  const [tree, setTree] = useState<Tree<HDF5Link>>([]);
-  const [selectedNode, setSelectedNode] = useState<TreeNode<HDF5Link>>();
+  const { filename, onSelect } = props;
+  const tree = useMetadataTree();
 
-  useEffect(() => {
-    setTree(buildTree(metadata));
-  }, [metadata]);
+  const [selectedNode, setSelectedNode] = useState<TreeNode<HDF5Link>>();
 
   useEffect(() => {
     if (selectedNode) {

--- a/src/h5web/metadata-viewer/MetadataViewer.tsx
+++ b/src/h5web/metadata-viewer/MetadataViewer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { HDF5Link, HDF5Collection } from '../providers/models';
 import styles from './MetadataViewer.module.css';
-import { useMetadata } from '../providers/hooks';
+import { useEntityMetadata } from '../providers/hooks';
 import { isBaseType, isDataset, isHardLink } from '../providers/type-guards';
 import ShapeRenderer from './ShapeRenderer';
 
@@ -18,7 +18,7 @@ interface Props {
 function MetadataViewer(props: Props): JSX.Element {
   const { link } = props;
 
-  const metadata = useMetadata(link);
+  const metadata = useEntityMetadata(link);
 
   return (
     <div className={styles.viewer}>

--- a/src/h5web/providers/hooks.ts
+++ b/src/h5web/providers/hooks.ts
@@ -1,10 +1,5 @@
-import {
-  HDF5Link,
-  HDF5Dataset,
-  HDF5Datatype,
-  HDF5Group,
-  HDF5HardLink,
-} from './models';
+import { useState, useEffect } from 'react';
+import { HDF5Link, HDF5HardLink, HDF5Entity } from './models';
 import mockMetadata from '../../demo-app/mock-data/metadata.json';
 import mockValues from '../../demo-app/mock-data/values.json';
 import {
@@ -12,10 +7,20 @@ import {
   MockHDF5Values,
 } from '../../demo-app/mock-data/models';
 import { isHardLink } from './type-guards';
+import { buildTree } from '../explorer/utils';
+import { Tree } from '../explorer/models';
 
-export function useMetadata(
-  link: HDF5Link
-): HDF5Group | HDF5Dataset | HDF5Datatype | undefined {
+export function useMetadataTree(): Tree<HDF5Link> {
+  const [tree, setTree] = useState<Tree<HDF5Link>>([]);
+
+  useEffect(() => {
+    setTree(buildTree(mockMetadata as MockHDF5Metadata));
+  }, []);
+
+  return tree;
+}
+
+export function useEntityMetadata(link: HDF5Link): HDF5Entity | undefined {
   if (!isHardLink(link)) {
     return undefined;
   }


### PR DESCRIPTION
Mock data retrieval is now abstracted out in custom hooks, which will make  adding the network layer easier.

> Note that the filename is still hardcoded for now.