### PR TITLE
Add data provider SilxProvider, available through context

### DIFF
--- a/src/demo-app/DemoApp.tsx
+++ b/src/demo-app/DemoApp.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import App from '../h5web/App';
+import SilxProvider from '../h5web/providers/SilxProvider';
 
 function DemoApp(): JSX.Element {
-  return <App />;
+  return (
+    <SilxProvider domain="bsa_002_000-integrate-sub">
+      <App />
+    </SilxProvider>
+  );
 }
 
 export default DemoApp;

--- a/src/h5web/App.tsx
+++ b/src/h5web/App.tsx
@@ -37,7 +37,10 @@ function App(): JSX.Element {
           <ReflexContainer orientation="horizontal">
             <ReflexElement minSize={250}>
               {selectedDataset ? (
-                <DatasetVisualizer link={selectedDataset} />
+                <DatasetVisualizer
+                  key={JSON.stringify(selectedDataset)}
+                  link={selectedDataset}
+                />
               ) : (
                 <div className={styles.empty}>
                   <p>No dataset selected.</p>
@@ -49,7 +52,10 @@ function App(): JSX.Element {
 
             <ReflexElement flex={0.7} minSize={250}>
               {selectedLink ? (
-                <MetadataViewer link={selectedLink} />
+                <MetadataViewer
+                  key={JSON.stringify(selectedLink)}
+                  link={selectedLink}
+                />
               ) : (
                 <div className={styles.empty}>
                   <p>No entity selected.</p>

--- a/src/h5web/dataset-visualizer/DatasetVisualizer.tsx
+++ b/src/h5web/dataset-visualizer/DatasetVisualizer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { HDF5HardLink } from '../providers/models';
 import styles from './DatasetVisualizer.module.css';
-import { useValues } from '../providers/hooks';
+import { useValue } from '../providers/hooks';
 
 interface Props {
   link: HDF5HardLink;
@@ -11,20 +11,22 @@ function DatasetVisualizer(props: Props): JSX.Element {
   const { link } = props;
   const { title } = link;
 
-  const values = useValues(link);
+  const value = useValue(link);
 
   return (
     <div className={styles.visualizer}>
       <h2 className={styles.heading}>
         Dataset <code>{title}</code>
       </h2>
-      <pre>
-        {JSON.stringify(values, null)
-          .replace(/\[{2}/g, '[\n  [')
-          .replace(/\]{2}/g, ']\n]')
-          .replace(/\],\[/g, '],\n  [')
-          .replace(/([0-9],)/g, '$1 ')}
-      </pre>
+      {value !== undefined && (
+        <pre>
+          {JSON.stringify(value, null)
+            .replace(/\[{2}/g, '[\n  [')
+            .replace(/\]{2}/g, ']\n]')
+            .replace(/\],\[/g, '],\n  [')
+            .replace(/([0-9],)/g, '$1 ')}
+        </pre>
+      )}
     </div>
   );
 }

--- a/src/h5web/metadata-viewer/MetadataViewer.tsx
+++ b/src/h5web/metadata-viewer/MetadataViewer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { HDF5Link, HDF5Collection } from '../providers/models';
 import styles from './MetadataViewer.module.css';
-import { useEntityMetadata } from '../providers/hooks';
+import { useEntity } from '../providers/hooks';
 import { isBaseType, isDataset, isHardLink } from '../providers/type-guards';
 import ShapeRenderer from './ShapeRenderer';
 
@@ -12,13 +12,14 @@ const ENTITY_TYPE: Record<HDF5Collection, string> = {
 };
 
 interface Props {
+  key: string;
   link: HDF5Link;
 }
 
 function MetadataViewer(props: Props): JSX.Element {
   const { link } = props;
 
-  const metadata = useEntityMetadata(link);
+  const metadata = useEntity(link);
 
   return (
     <div className={styles.viewer}>
@@ -26,7 +27,7 @@ function MetadataViewer(props: Props): JSX.Element {
         Metadata for {isHardLink(link) ? ENTITY_TYPE[link.collection] : 'link'}{' '}
         <code>{link.title}</code>
       </h2>
-      {!!metadata && isHardLink(link) && isDataset(metadata, link) && (
+      {metadata && isHardLink(link) && isDataset(metadata, link) && (
         <table>
           <thead>
             <tr>
@@ -49,13 +50,15 @@ function MetadataViewer(props: Props): JSX.Element {
           </tbody>
         </table>
       )}
-      <pre>
-        {JSON.stringify(
-          metadata,
-          (key, value) => (key === 'links' ? undefined : value),
-          2
-        )}
-      </pre>
+      {metadata && (
+        <pre>
+          {JSON.stringify(
+            metadata,
+            (key, value) => (key === 'links' ? undefined : value),
+            2
+          )}
+        </pre>
+      )}
     </div>
   );
 }

--- a/src/h5web/providers/SilxProvider.tsx
+++ b/src/h5web/providers/SilxProvider.tsx
@@ -1,0 +1,52 @@
+import React, { ReactNode } from 'react';
+import { DataProviderContext } from './context';
+import { buildTree } from '../explorer/utils';
+import { Tree } from '../explorer/models';
+import { HDF5Link, HDF5Entity, HDF5HardLink } from './models';
+import mockMetadata from '../../demo-app/mock-data/metadata.json';
+import mockValues from '../../demo-app/mock-data/values.json';
+import {
+  MockHDF5Metadata,
+  MockHDF5Values,
+} from '../../demo-app/mock-data/models';
+import { isHardLink } from './type-guards';
+
+// const ROOT_URL = 'http://www.silx.org/pub/h5web/';
+
+interface Props {
+  domain: string;
+  children: ReactNode;
+}
+
+function SilxProvider(props: Props): JSX.Element {
+  const { children } = props;
+
+  async function getMetadataTree(): Promise<Tree<HDF5Link>> {
+    return buildTree(mockMetadata as MockHDF5Metadata);
+  }
+
+  async function getEntity(link: HDF5Link): Promise<HDF5Entity | undefined> {
+    if (!isHardLink(link)) {
+      return undefined;
+    }
+
+    const { collection, id } = link;
+    return (mockMetadata as MockHDF5Metadata)[collection]![id]; // eslint-disable-line @typescript-eslint/no-non-null-assertion
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async function getValue(hardLink: HDF5HardLink): Promise<any> {
+    const { id } = hardLink;
+    return (mockValues as MockHDF5Values)[id];
+  }
+
+  return (
+    <DataProviderContext.Provider
+      value={{ getMetadataTree, getEntity, getValue }}
+    >
+      {children}
+    </DataProviderContext.Provider>
+  );
+}
+
+export default SilxProvider;

--- a/src/h5web/providers/context.ts
+++ b/src/h5web/providers/context.ts
@@ -1,0 +1,21 @@
+import { createContext } from 'react';
+import { HDF5Link, HDF5Entity, HDF5HardLink } from './models';
+import { Tree } from '../explorer/models';
+
+interface DataProvider {
+  getMetadataTree: () => Promise<Tree<HDF5Link>>;
+  getEntity: (link: HDF5Link) => Promise<HDF5Entity | undefined>;
+  getValue: (link: HDF5HardLink) => Promise<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+}
+
+function missing(): never {
+  throw new Error(
+    'Missing data provider context; please wrap `<H5Web />` with one of the available providers.'
+  );
+}
+
+export const DataProviderContext = createContext<DataProvider>({
+  getMetadataTree: missing as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  getEntity: missing as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  getValue: missing as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+});

--- a/src/h5web/providers/hooks.ts
+++ b/src/h5web/providers/hooks.ts
@@ -1,35 +1,38 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useContext } from 'react';
 import { HDF5Link, HDF5HardLink, HDF5Entity } from './models';
-import mockMetadata from '../../demo-app/mock-data/metadata.json';
-import mockValues from '../../demo-app/mock-data/values.json';
-import {
-  MockHDF5Metadata,
-  MockHDF5Values,
-} from '../../demo-app/mock-data/models';
-import { isHardLink } from './type-guards';
-import { buildTree } from '../explorer/utils';
 import { Tree } from '../explorer/models';
+import { DataProviderContext } from './context';
 
 export function useMetadataTree(): Tree<HDF5Link> {
+  const { getMetadataTree } = useContext(DataProviderContext);
   const [tree, setTree] = useState<Tree<HDF5Link>>([]);
 
   useEffect(() => {
-    setTree(buildTree(mockMetadata as MockHDF5Metadata));
-  }, []);
+    getMetadataTree().then(setTree);
+  }, [getMetadataTree]);
 
   return tree;
 }
 
-export function useEntityMetadata(link: HDF5Link): HDF5Entity | undefined {
-  if (!isHardLink(link)) {
-    return undefined;
-  }
+export function useEntity(link: HDF5Link): HDF5Entity | undefined {
+  const { getEntity } = useContext(DataProviderContext);
+  const [entity, setEntity] = useState<HDF5Entity | undefined>();
 
-  const { collection, id } = link;
-  return (mockMetadata as MockHDF5Metadata)[collection]![id]; // eslint-disable-line @typescript-eslint/no-non-null-assertion
+  useEffect(() => {
+    getEntity(link).then(setEntity);
+  }, [link, getEntity]);
+
+  return entity;
 }
 
-export function useValues(link: HDF5HardLink): MockHDF5Values {
-  const { id } = link;
-  return (mockValues as MockHDF5Values)[id];
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function useValue(hardLink: HDF5HardLink): any {
+  const { getValue } = useContext(DataProviderContext);
+  const [value, setValue] = useState<any>(); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+  useEffect(() => {
+    getValue(hardLink).then(setValue);
+  }, [hardLink, getValue]);
+
+  return value;
 }


### PR DESCRIPTION
This PR adds a [React Context](https://reactjs.org/docs/context.html) called `DataProviderContext`. This context can hold an object of type `DataProvider` composed of three methods to encapsulate three data retrieval operations: `getMetadataTree`, `getEntity` and `getValues`.

In order to provide data, one must provide implementations of these methods and wrap the app with the context's provider:

```tsx
<DataProviderContext.Provider value={impl}>
  <App />
</DataProviderContext.Provider>
```

`SilxProvider` is one such implementations that will be used to retrieve data from silx.org/pub/h5web