### PR TITLE
Load real data from silx.org

### DIFF
--- a/src/h5web/App.tsx
+++ b/src/h5web/App.tsx
@@ -17,7 +17,6 @@ function App(): JSX.Element {
       <ReflexContainer orientation="vertical" windowResizeAware>
         <ReflexElement className={styles.explorer} flex={0.3} minSize={250}>
           <Explorer
-            filename="water_224.h5"
             onSelect={link => {
               setSelectedLink(link);
 

--- a/src/h5web/explorer/Explorer.module.css
+++ b/src/h5web/explorer/Explorer.module.css
@@ -3,7 +3,7 @@
   background-color: #f5fbef;
 }
 
-.filename {
+.domain {
   margin: 0;
   padding: 1rem;
   font-weight: 600;

--- a/src/h5web/explorer/Explorer.tsx
+++ b/src/h5web/explorer/Explorer.tsx
@@ -4,15 +4,16 @@ import { TreeNode } from './models';
 import TreeView from './TreeView';
 import styles from './Explorer.module.css';
 import Icon from './Icon';
-import { useMetadataTree } from '../providers/hooks';
+import { useMetadataTree, useDomain } from '../providers/hooks';
 
 interface Props {
-  filename: string;
   onSelect: (link: HDF5Link) => void;
 }
 
 function Explorer(props: Props): JSX.Element {
-  const { filename, onSelect } = props;
+  const { onSelect } = props;
+
+  const domain = useDomain();
   const tree = useMetadataTree();
 
   const [selectedNode, setSelectedNode] = useState<TreeNode<HDF5Link>>();
@@ -25,7 +26,7 @@ function Explorer(props: Props): JSX.Element {
 
   return (
     <div className={styles.explorer}>
-      <p className={styles.filename}>{filename}</p>
+      <p className={styles.domain}>{domain}</p>
 
       <TreeView
         nodes={tree}

--- a/src/h5web/providers/context.ts
+++ b/src/h5web/providers/context.ts
@@ -3,6 +3,7 @@ import { HDF5Link, HDF5Entity, HDF5HardLink } from './models';
 import { Tree } from '../explorer/models';
 
 interface DataProvider {
+  getDomain: () => string;
   getMetadataTree: () => Promise<Tree<HDF5Link>>;
   getEntity: (link: HDF5Link) => Promise<HDF5Entity | undefined>;
   getValue: (link: HDF5HardLink) => Promise<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -15,6 +16,7 @@ function missing(): never {
 }
 
 export const DataProviderContext = createContext<DataProvider>({
+  getDomain: missing as any, // eslint-disable-line @typescript-eslint/no-explicit-any
   getMetadataTree: missing as any, // eslint-disable-line @typescript-eslint/no-explicit-any
   getEntity: missing as any, // eslint-disable-line @typescript-eslint/no-explicit-any
   getValue: missing as any, // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/src/h5web/providers/hooks.ts
+++ b/src/h5web/providers/hooks.ts
@@ -3,6 +3,11 @@ import { HDF5Link, HDF5HardLink, HDF5Entity } from './models';
 import { Tree } from '../explorer/models';
 import { DataProviderContext } from './context';
 
+export function useDomain(): string {
+  const { getDomain } = useContext(DataProviderContext);
+  return getDomain();
+}
+
 export function useMetadataTree(): Tree<HDF5Link> {
   const { getMetadataTree } = useContext(DataProviderContext);
   const [tree, setTree] = useState<Tree<HDF5Link>>([]);

--- a/src/h5web/providers/silx/SilxProvider.tsx
+++ b/src/h5web/providers/silx/SilxProvider.tsx
@@ -14,6 +14,10 @@ interface Props {
 function SilxProvider(props: Props): JSX.Element {
   const { api, children } = props;
 
+  function getDomain(): string {
+    return api.getDomain();
+  }
+
   async function getMetadataTree(): Promise<Tree<HDF5Link>> {
     const metadata = await api.getMetadata();
     return buildTree(metadata);
@@ -37,7 +41,7 @@ function SilxProvider(props: Props): JSX.Element {
 
   return (
     <DataProviderContext.Provider
-      value={{ getMetadataTree, getEntity, getValue }}
+      value={{ getDomain, getMetadataTree, getEntity, getValue }}
     >
       {children}
     </DataProviderContext.Provider>

--- a/src/h5web/providers/silx/api.ts
+++ b/src/h5web/providers/silx/api.ts
@@ -8,10 +8,14 @@ export class SilxApi {
 
   private values?: SilxValues;
 
-  constructor(domain: string) {
+  constructor(private readonly domain: string) {
     this.client = axios.create({
-      baseURL: `https://www.silx.org/pub/h5web/${domain}`,
+      baseURL: `https://www.silx.org/pub/h5web/${this.domain}`,
     });
+  }
+
+  public getDomain(): string {
+    return this.domain;
   }
 
   public async getMetadata(): Promise<SilxMetadata> {

--- a/src/h5web/providers/silx/api.ts
+++ b/src/h5web/providers/silx/api.ts
@@ -4,13 +4,13 @@ import { SilxMetadata, SilxValues } from './models';
 export class SilxApi {
   private readonly client: AxiosInstance;
 
-  private readonly metadata?: SilxMetadata;
+  private metadata?: SilxMetadata;
 
-  private readonly values?: SilxValues;
+  private values?: SilxValues;
 
   constructor(domain: string) {
     this.client = axios.create({
-      baseURL: `http://www.silx.org/pub/h5web/${domain}`,
+      baseURL: `https://www.silx.org/pub/h5web/${domain}`,
     });
   }
 
@@ -19,11 +19,10 @@ export class SilxApi {
       return this.metadata;
     }
 
-    // const { data } = await this.client.get<SilxMetadata>('/metadata.json');
-    // return data;
+    const { data } = await this.client.get<SilxMetadata>('/metadata.json');
 
-    return (await import('../../../demo-app/mock-data/metadata.json'))
-      .default as SilxMetadata;
+    this.metadata = data;
+    return this.metadata;
   }
 
   public async getValues(): Promise<SilxValues> {
@@ -31,10 +30,9 @@ export class SilxApi {
       return this.values;
     }
 
-    // const { data } = await this.client.get<SilxValues>('/values.json');
-    // return data;
+    const { data } = await this.client.get<SilxValues>('/values.json');
 
-    return (await import('../../../demo-app/mock-data/values.json'))
-      .default as SilxValues;
+    this.values = data;
+    return this.values;
   }
 }


### PR DESCRIPTION
Also, display domain passed to `<Silx>` data provider instead of mocked filename.