### PR TITLE
Display link metadata

### DIFF
--- a/src/h5web/metadata-viewer/LinkInfo.tsx
+++ b/src/h5web/metadata-viewer/LinkInfo.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { HDF5Link, HDF5LinkClass } from '../providers/models';
+
+import styles from './MetadataViewer.module.css';
+
+interface Props {
+  link: HDF5Link;
+}
+
+function LinkInfo(props: Props): JSX.Element {
+  const { link } = props;
+
+  return (
+    <>
+      <tr>
+        <th className={styles.table_head} colSpan={2}>
+          Link info
+        </th>
+      </tr>
+      {link.class !== HDF5LinkClass.Root && (
+        <>
+          <tr>
+            <th scope="row">Title</th>
+            <td>{link.title}</td>
+          </tr>
+          <tr>
+            <th scope="row">Class</th>
+            <td>{link.class}</td>
+          </tr>
+        </>
+      )}
+      {'collection' in link && (
+        <tr>
+          <th scope="row">Entity collection</th>
+          <td>{link.collection}</td>
+        </tr>
+      )}
+      {'id' in link && (
+        <tr>
+          <th scope="row">Entity ID</th>
+          <td>{link.id}</td>
+        </tr>
+      )}
+      {'file' in link && (
+        <tr>
+          <th scope="row">File</th>
+          <td>{link.file}</td>
+        </tr>
+      )}
+      {'h5path' in link && (
+        <tr>
+          <th scope="row">Path</th>
+          <td>{link.h5path}</td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+export default LinkInfo;

--- a/src/h5web/metadata-viewer/MetadataViewer.tsx
+++ b/src/h5web/metadata-viewer/MetadataViewer.tsx
@@ -5,6 +5,7 @@ import { useEntity } from '../providers/hooks';
 import { isBaseType, isDataset, isHardLink } from '../providers/type-guards';
 import ShapeRenderer from './ShapeRenderer';
 import AttributesRenderer from './AttributesRenderer';
+import LinkInfo from './LinkInfo';
 
 const ENTITY_TYPE: Record<HDF5Collection, string> = {
   [HDF5Collection.Datasets]: 'dataset',
@@ -28,36 +29,39 @@ function MetadataViewer(props: Props): JSX.Element {
         Metadata for {isHardLink(link) ? ENTITY_TYPE[link.collection] : 'link'}{' '}
         <code>{link.title}</code>
       </h2>
-      {entity && (
-        <table>
-          <tbody>
-            {isHardLink(link) && isDataset(entity, link) && (
-              <>
-                <tr>
-                  <th className={styles.table_head} colSpan={2}>
-                    Dataset info
-                  </th>
-                </tr>
-                <tr>
-                  <th>HDF5 type</th>
-                  <td>
-                    {isBaseType(entity.type) ? entity.type.class : 'Complex'}
-                  </td>
-                </tr>
-                <tr>
-                  <th>Shape</th>
-                  <td>
-                    <ShapeRenderer shape={entity.shape} />
-                  </td>
-                </tr>
-              </>
-            )}
-            {'attributes' in entity && (
-              <AttributesRenderer attributes={entity.attributes} />
-            )}
-          </tbody>
-        </table>
-      )}
+      <table>
+        <tbody>
+          <LinkInfo link={link} />
+          {entity && (
+            <>
+              {isHardLink(link) && isDataset(entity, link) && (
+                <>
+                  <tr>
+                    <th className={styles.table_head} colSpan={2}>
+                      Dataset info
+                    </th>
+                  </tr>
+                  <tr>
+                    <th>HDF5 type</th>
+                    <td>
+                      {isBaseType(entity.type) ? entity.type.class : 'Complex'}
+                    </td>
+                  </tr>
+                  <tr>
+                    <th>Shape</th>
+                    <td>
+                      <ShapeRenderer shape={entity.shape} />
+                    </td>
+                  </tr>
+                </>
+              )}
+              {'attributes' in entity && (
+                <AttributesRenderer attributes={entity.attributes} />
+              )}
+            </>
+          )}
+        </tbody>
+      </table>
       {entity && (
         <pre>
           {JSON.stringify(

--- a/src/h5web/providers/models.ts
+++ b/src/h5web/providers/models.ts
@@ -33,9 +33,14 @@ export interface HDF5Attribute {
 /* ----------------- */
 /* ----- LINKS ----- */
 
-export type HDF5Link = HDF5HardLink | HDF5SoftLink | HDF5ExternalLink;
+export type HDF5Link =
+  | HDF5HardLink
+  | HDF5RootLink
+  | HDF5SoftLink
+  | HDF5ExternalLink;
 
 export enum HDF5LinkClass {
+  Root = 'ROOT',
   Hard = 'H5L_TYPE_HARD',
   Soft = 'H5L_TYPE_SOFT',
   External = 'H5L_TYPE_EXTERNAL',
@@ -45,6 +50,13 @@ export enum HDF5Collection {
   Groups = 'groups',
   Datasets = 'datasets',
   Datatypes = 'datatypes',
+}
+
+export interface HDF5RootLink {
+  class: HDF5LinkClass.Root;
+  title: '';
+  collection: HDF5Collection.Groups;
+  id: HDF5Id;
 }
 
 export interface HDF5HardLink {

--- a/src/h5web/providers/silx/SilxProvider.tsx
+++ b/src/h5web/providers/silx/SilxProvider.tsx
@@ -20,7 +20,7 @@ function SilxProvider(props: Props): JSX.Element {
 
   async function getMetadataTree(): Promise<TreeNode<HDF5Link>> {
     const metadata = await api.getMetadata();
-    return buildTree(metadata, api.getDomain());
+    return buildTree(metadata);
   }
 
   async function getEntity(link: HDF5Link): Promise<HDF5Entity | undefined> {

--- a/src/h5web/providers/silx/utils.test.ts
+++ b/src/h5web/providers/silx/utils.test.ts
@@ -1,11 +1,11 @@
 import { buildTree } from './utils';
 import { SilxMetadata } from './models';
-import { HDF5Collection, HDF5HardLink, HDF5LinkClass } from '../models';
+import { HDF5Collection, HDF5LinkClass, HDF5RootLink } from '../models';
 
-const rootLink: HDF5HardLink = {
-  class: HDF5LinkClass.Hard,
+const rootLink: HDF5RootLink = {
+  class: HDF5LinkClass.Root,
   collection: HDF5Collection.Groups,
-  title: 'domain',
+  title: '',
   id: '913d8791',
 };
 
@@ -18,9 +18,9 @@ describe('Silx Provider utilities', () => {
         groups: { '913d8791': {} },
       };
 
-      expect(buildTree(emptyMetadata, 'domain')).toEqual({
+      expect(buildTree(emptyMetadata)).toEqual({
         uid: expect.any(String),
-        label: 'domain',
+        label: '',
         level: 0,
         data: rootLink,
         children: [],
@@ -43,9 +43,9 @@ describe('Silx Provider utilities', () => {
         },
       } as SilxMetadata;
 
-      expect(buildTree(simpleMetadata, 'domain')).toEqual({
+      expect(buildTree(simpleMetadata)).toEqual({
         uid: expect.any(String),
-        label: 'domain',
+        label: '',
         level: 0,
         data: rootLink,
         children: [
@@ -83,9 +83,9 @@ describe('Silx Provider utilities', () => {
         },
       } as SilxMetadata;
 
-      expect(buildTree(nestedMetadata, 'domain')).toEqual({
+      expect(buildTree(nestedMetadata)).toEqual({
         uid: expect.any(String),
-        label: 'domain',
+        label: '',
         level: 0,
         data: rootLink,
         children: [

--- a/src/h5web/providers/silx/utils.ts
+++ b/src/h5web/providers/silx/utils.ts
@@ -2,12 +2,11 @@ import nanoid from 'nanoid';
 import {
   HDF5Collection,
   HDF5Link,
-  HDF5HardLink,
+  HDF5RootLink,
   HDF5LinkClass,
 } from '../models';
 import { TreeNode } from '../../explorer/models';
 import { SilxMetadata } from './models';
-import { isHardLink } from '../type-guards';
 
 function buildTreeNode(
   metadata: SilxMetadata,
@@ -15,7 +14,8 @@ function buildTreeNode(
   level = 0
 ): TreeNode<HDF5Link> {
   const group =
-    isHardLink(link) && link.collection === HDF5Collection.Groups
+    (link.class === HDF5LinkClass.Hard || link.class === HDF5LinkClass.Root) &&
+    link.collection === HDF5Collection.Groups
       ? metadata.groups[link.id]
       : undefined;
 
@@ -34,14 +34,11 @@ function buildTreeNode(
   };
 }
 
-export function buildTree(
-  metadata: SilxMetadata,
-  domain: string
-): TreeNode<HDF5Link> {
-  const rootLink: HDF5HardLink = {
-    class: HDF5LinkClass.Hard,
+export function buildTree(metadata: SilxMetadata): TreeNode<HDF5Link> {
+  const rootLink: HDF5RootLink = {
+    class: HDF5LinkClass.Root,
     collection: HDF5Collection.Groups,
-    title: domain,
+    title: '',
     id: metadata.root,
   };
 


### PR DESCRIPTION
- Add component `LinkInfo` to display metadata for a `link`
- Add a new type to represent the root link, `HDF5RootLink`, with a custom class, `H5WEB_ROOT`, to make it clear that this is not a class of link defined by the HDF5 spec.
- Don't show the title and class info for the root link, as this doesn't make sense.