### PR TITLE
Pass dataset instead of link to DatasetVisualizer

### DIFF
--- a/src/h5web/App.tsx
+++ b/src/h5web/App.tsx
@@ -1,33 +1,33 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { ReflexContainer, ReflexSplitter, ReflexElement } from 'react-reflex';
 
 import Explorer from './explorer/Explorer';
 import DatasetVisualizer from './dataset-visualizer/DatasetVisualizer';
-import { HDF5Link, HDF5Collection, HDF5HardLink } from './providers/models';
+import { HDF5Link, HDF5Collection, HDF5Entity } from './providers/models';
 import MetadataViewer from './metadata-viewer/MetadataViewer';
 import styles from './App.module.css';
-import { isHardLink } from './providers/type-guards';
+import { isDataset } from './providers/type-guards';
+import { useEntity } from './providers/hooks';
 
 function App(): JSX.Element {
   const [selectedLink, setSelectedLink] = useState<HDF5Link>();
-  const [selectedDataset, setSelectedDataset] = useState<HDF5HardLink>();
+  const [selectedDataset, setSelectedDataset] = useState<
+    HDF5Entity<HDF5Collection.Datasets>
+  >();
+
+  const selectedEntity = useEntity(selectedLink);
+
+  useEffect(() => {
+    if (selectedEntity && isDataset(selectedEntity)) {
+      setSelectedDataset(selectedEntity);
+    }
+  }, [selectedEntity]);
 
   return (
     <div className={styles.app}>
       <ReflexContainer orientation="vertical" windowResizeAware>
         <ReflexElement className={styles.explorer} flex={0.3} minSize={250}>
-          <Explorer
-            onSelect={link => {
-              setSelectedLink(link);
-
-              if (
-                isHardLink(link) &&
-                link.collection === HDF5Collection.Datasets
-              ) {
-                setSelectedDataset(link);
-              }
-            }}
-          />
+          <Explorer onSelect={setSelectedLink} />
         </ReflexElement>
 
         <ReflexSplitter />
@@ -38,7 +38,7 @@ function App(): JSX.Element {
               {selectedDataset ? (
                 <DatasetVisualizer
                   key={JSON.stringify(selectedDataset)}
-                  link={selectedDataset}
+                  dataset={selectedDataset}
                 />
               ) : (
                 <div className={styles.empty}>
@@ -58,6 +58,7 @@ function App(): JSX.Element {
                 <MetadataViewer
                   key={JSON.stringify(selectedLink)}
                   link={selectedLink}
+                  entity={selectedEntity}
                 />
               ) : (
                 <div className={styles.empty}>

--- a/src/h5web/dataset-visualizer/DatasetVisualizer.module.css
+++ b/src/h5web/dataset-visualizer/DatasetVisualizer.module.css
@@ -2,7 +2,6 @@
   padding: 1rem;
 }
 
-.heading {
-  font-weight: 500;
-  font-size: 1.375rem;
+.raw {
+  margin: 0;
 }

--- a/src/h5web/dataset-visualizer/DatasetVisualizer.tsx
+++ b/src/h5web/dataset-visualizer/DatasetVisualizer.tsx
@@ -1,25 +1,22 @@
 import React from 'react';
-import { HDF5HardLink } from '../providers/models';
+import { HDF5Entity, HDF5Collection } from '../providers/models';
 import styles from './DatasetVisualizer.module.css';
 import { useValue } from '../providers/hooks';
 
 interface Props {
-  link: HDF5HardLink;
+  dataset: HDF5Entity<HDF5Collection.Datasets>;
 }
 
 function DatasetVisualizer(props: Props): JSX.Element {
-  const { link } = props;
-  const { title } = link;
+  const { dataset } = props;
+  const { id } = dataset;
 
-  const value = useValue(link);
+  const value = useValue(id);
 
   return (
     <div className={styles.visualizer}>
-      <h2 className={styles.heading}>
-        Dataset <code>{title}</code>
-      </h2>
       {value !== undefined && (
-        <pre>
+        <pre className={styles.raw}>
           {JSON.stringify(value, null)
             .replace(/\[{2}/g, '[\n  [')
             .replace(/\]{2}/g, ']\n]')

--- a/src/h5web/metadata-viewer/MetadataViewer.tsx
+++ b/src/h5web/metadata-viewer/MetadataViewer.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { HDF5Link } from '../providers/models';
-import { useEntity } from '../providers/hooks';
+import { HDF5Link, HDF5GenericEntity } from '../providers/models';
 import AttributesInfo from './AttributesInfo';
 import LinkInfo from './LinkInfo';
 import EntityInfo from './EntityInfo';
@@ -8,12 +7,11 @@ import EntityInfo from './EntityInfo';
 interface Props {
   key: string;
   link: HDF5Link;
+  entity?: HDF5GenericEntity;
 }
 
 function MetadataViewer(props: Props): JSX.Element {
-  const { link } = props;
-
-  const entity = useEntity(link);
+  const { link, entity } = props;
 
   return (
     <>

--- a/src/h5web/providers/context.ts
+++ b/src/h5web/providers/context.ts
@@ -1,12 +1,12 @@
 import { createContext } from 'react';
-import { HDF5Link, HDF5GenericEntity, HDF5HardLink } from './models';
+import { HDF5Link, HDF5GenericEntity, HDF5Id } from './models';
 import { TreeNode } from '../explorer/models';
 
 interface DataProvider {
   getDomain: () => string;
   getMetadataTree: () => Promise<TreeNode<HDF5Link>>;
-  getEntity: (link: HDF5Link) => Promise<HDF5GenericEntity | undefined>;
-  getValue: (link: HDF5HardLink) => Promise<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+  getEntity: (link?: HDF5Link) => Promise<HDF5GenericEntity | undefined>;
+  getValue: (id: HDF5Id) => Promise<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 function missing(): never {

--- a/src/h5web/providers/hooks.ts
+++ b/src/h5web/providers/hooks.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useContext } from 'react';
-import { HDF5Link, HDF5HardLink, HDF5GenericEntity } from './models';
+import { HDF5Link, HDF5GenericEntity, HDF5Id } from './models';
 import { TreeNode } from '../explorer/models';
 import { DataProviderContext } from './context';
 
@@ -19,7 +19,7 @@ export function useMetadataTree(): TreeNode<HDF5Link> | undefined {
   return tree;
 }
 
-export function useEntity(link: HDF5Link): HDF5GenericEntity | undefined {
+export function useEntity(link?: HDF5Link): HDF5GenericEntity | undefined {
   const { getEntity } = useContext(DataProviderContext);
   const [entity, setEntity] = useState<HDF5GenericEntity | undefined>();
 
@@ -31,13 +31,13 @@ export function useEntity(link: HDF5Link): HDF5GenericEntity | undefined {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function useValue(hardLink: HDF5HardLink): any {
+export function useValue(id: HDF5Id): any {
   const { getValue } = useContext(DataProviderContext);
   const [value, setValue] = useState<any>(); // eslint-disable-line @typescript-eslint/no-explicit-any
 
   useEffect(() => {
-    getValue(hardLink).then(setValue);
-  }, [hardLink, getValue]);
+    getValue(id).then(setValue);
+  }, [getValue, id]);
 
   return value;
 }

--- a/src/h5web/providers/silx/SilxProvider.tsx
+++ b/src/h5web/providers/silx/SilxProvider.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from 'react';
 import { DataProviderContext } from '../context';
 import { buildTree } from './utils';
 import { TreeNode } from '../../explorer/models';
-import { HDF5Link, HDF5HardLink, HDF5GenericEntity } from '../models';
+import { HDF5Link, HDF5GenericEntity, HDF5Id } from '../models';
 import { isHardLink } from '../type-guards';
 import { SilxApi } from './api';
 
@@ -24,9 +24,9 @@ function SilxProvider(props: Props): JSX.Element {
   }
 
   async function getEntity(
-    link: HDF5Link
+    link?: HDF5Link
   ): Promise<HDF5GenericEntity | undefined> {
-    if (!isHardLink(link)) {
+    if (!link || !isHardLink(link)) {
       return undefined;
     }
 
@@ -46,9 +46,9 @@ function SilxProvider(props: Props): JSX.Element {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async function getValue(hardLink: HDF5HardLink): Promise<any> {
+  async function getValue(id: HDF5Id): Promise<any> {
     const values = await api.getValues();
-    return values[hardLink.id];
+    return values[id];
   }
 
   return (


### PR DESCRIPTION
I think it makes more sense to pass a valid dataset to the visualizer rather than a link. In `App.tsx`, `selectedDataset` is now of type `HDF5Entity<HDF5Collection.Datasets>`, which is more logicial and means we don't have to re-check that the corresponding entity is indeed a dataset inside `DatasetVisualizer`.