### PR TITLE
Implement table visualization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1753,6 +1753,24 @@
         "@types/react": "*"
       }
     },
+    "@types/react-virtualized-auto-sizer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.0.tgz",
+      "integrity": "sha512-NMErdIdSnm2j/7IqMteRiRvRulpjoELnXWUwdbucYCz84xG9PHcoOrr7QfXwB/ku7wd6egiKFrzt/+QK4Imeeg==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-window": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.1.tgz",
+      "integrity": "sha512-V3k1O5cbfZIRa0VVbQ81Ekq/7w42CK1SuiB9U1oPMTxv270D9qUn7rHb3sZoqMkIJFfB1NZxaH7NRDlk+ToDsg==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -9403,6 +9421,11 @@
         "p-is-promise": "^2.0.0"
       }
     },
+    "memoize-one": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
+    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -12673,6 +12696,20 @@
         "throttle-debounce": "^2.1.0",
         "ts-easing": "^0.2.0",
         "tslib": "^1.10.0"
+      }
+    },
+    "react-virtualized-auto-sizer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.2.tgz",
+      "integrity": "sha512-MYXhTY1BZpdJFjUovvYHVBmkq79szK/k7V3MO+36gJkWGkrXKtyr4vCPtpphaTLRAdDNoYEYFZWE8LjN+PIHNg=="
+    },
+    "react-window": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.5.tgz",
+      "integrity": "sha512-HeTwlNa37AFa8MDZFZOKcNEkuF2YflA0hpGPiTT9vR7OawEt+GZbfM6wqkBahD3D3pUjIabQYzsnY/BSJbgq6Q==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
       }
     },
     "read-pkg": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-icons": "^3.9.0",
-    "react-use": "^13.26.3"
+    "react-use": "^13.26.3",
+    "react-virtualized-auto-sizer": "^1.0.2",
+    "react-window": "^1.8.5"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^4.2.4",
@@ -40,6 +42,8 @@
     "@types/node": "^12.12.28",
     "@types/react": "^16.9.21",
     "@types/react-dom": "^16.9.5",
+    "@types/react-virtualized-auto-sizer": "^1.0.0",
+    "@types/react-window": "^1.8.1",
     "@wsmd/eslint-config": "^1.2.0",
     "eslint": "^6.8.0",
     "node-sass": "^4.13.1",

--- a/src/h5web/App.module.css
+++ b/src/h5web/App.module.css
@@ -7,6 +7,10 @@
   scrollbar-width: thin;
 }
 
+.dataVisualizer {
+  display: flex;
+}
+
 .metadataViewer {
   overflow: scroll !important;
   scrollbar-width: thin;

--- a/src/h5web/App.tsx
+++ b/src/h5web/App.tsx
@@ -34,7 +34,7 @@ function App(): JSX.Element {
 
         <ReflexElement minSize={500}>
           <ReflexContainer orientation="horizontal">
-            <ReflexElement minSize={250}>
+            <ReflexElement className={styles.dataVisualizer} minSize={250}>
               {selectedDataset ? (
                 <DatasetVisualizer
                   key={JSON.stringify(selectedDataset)}

--- a/src/h5web/dataset-visualizer/DatasetVisualizer.module.css
+++ b/src/h5web/dataset-visualizer/DatasetVisualizer.module.css
@@ -1,5 +1,5 @@
 .visualizer {
-  padding: 1rem;
+  flex: 1 1 0%;
 }
 
 .raw {

--- a/src/h5web/dataset-visualizer/DatasetVisualizer.tsx
+++ b/src/h5web/dataset-visualizer/DatasetVisualizer.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { HDF5Entity, HDF5Collection } from '../providers/models';
 import styles from './DatasetVisualizer.module.css';
 import { useValue } from '../providers/hooks';
+import { isBaseType, isSimpleShape } from '../providers/type-guards';
+import TableVis from './TableVis';
 
 interface Props {
   dataset: HDF5Entity<HDF5Collection.Datasets>;
@@ -9,20 +11,19 @@ interface Props {
 
 function DatasetVisualizer(props: Props): JSX.Element {
   const { dataset } = props;
-  const { id } = dataset;
+  const { id, type, shape } = dataset;
 
   const value = useValue(id);
 
   return (
     <div className={styles.visualizer}>
-      {value !== undefined && (
-        <pre className={styles.raw}>
-          {JSON.stringify(value, null)
-            .replace(/\[{2}/g, '[\n  [')
-            .replace(/\]{2}/g, ']\n]')
-            .replace(/\],\[/g, '],\n  [')
-            .replace(/([0-9],)/g, '$1 ')}
-        </pre>
+      {value &&
+      isBaseType(type) &&
+      isSimpleShape(shape) &&
+      [1, 2].includes(shape.dims.length) ? (
+        <TableVis dims={shape.dims} data={value} />
+      ) : (
+        <pre className={styles.raw}>{JSON.stringify(value)}</pre>
       )}
     </div>
   );

--- a/src/h5web/dataset-visualizer/TableVis.tsx
+++ b/src/h5web/dataset-visualizer/TableVis.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { FixedSizeGrid as Grid } from 'react-window';
+import AutoSizer from 'react-virtualized-auto-sizer';
+import { HDF5Value } from '../providers/models';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AccessorFunc = (row: number, col: number) => any;
+
+interface Props {
+  dims: number[];
+  data: HDF5Value;
+}
+
+function TableVis(props: Props): JSX.Element {
+  const { dims, data } = props;
+
+  const accessor: AccessorFunc =
+    dims.length === 1 ? row => data[row] : (row, col) => data[row][col];
+
+  return (
+    <AutoSizer>
+      {({ width, height }) => (
+        <Grid
+          rowCount={dims[0]}
+          rowHeight={35}
+          columnCount={dims.length === 2 ? dims[1] : 1}
+          columnWidth={200}
+          width={width}
+          height={height}
+        >
+          {({ columnIndex, rowIndex, style }) => (
+            <div style={style}>{accessor(rowIndex, columnIndex)}</div>
+          )}
+        </Grid>
+      )}
+    </AutoSizer>
+  );
+}
+
+export default TableVis;


### PR DESCRIPTION
Uses `react-window` for virtualization and works smoothly with one-million-point datasets!

> First implementation disclaimer: there's no styling, the columns have a fixed width, and the visualization appears only for datasets with a basic type and a simple shape with 1 or 2 dimensions.