### PR TITLE
Store entities with `collection` and `id`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1695,6 +1695,21 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.149",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
+      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
+      "dev": true
+    },
+    "@types/lodash-es": {
+      "version": "4.17.3",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.3.tgz",
+      "integrity": "sha512-iHI0i7ZAL1qepz1Y7f3EKg/zUMDwDfTzitx+AlHhJJvXwenP682ZyGbgPSc5Ej3eEAKVbNWKFuwOadCj5vBbYQ==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -3417,6 +3432,12 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
           "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+          "dev": true
+        },
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
           "dev": true
         }
       }
@@ -9226,6 +9247,11 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
+    "lodash-es": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
+      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
+    },
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
@@ -9379,12 +9405,6 @@
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
     },
-    "map-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-      "dev": true
-    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -9529,6 +9549,12 @@
             "pinkie-promise": "^2.0.0",
             "strip-bom": "^2.0.0"
           }
+        },
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "dev": true
         },
         "parse-json": {
           "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "axios": "^0.19.2",
     "classnames": "^2.2.6",
+    "lodash-es": "^4.17.15",
     "nanoid": "^2.1.11",
     "normalize.css": "^8.0.1",
     "numeral": "^2.0.6",
@@ -39,6 +40,7 @@
     "@testing-library/react": "^9.4.0",
     "@testing-library/user-event": "^7.2.1",
     "@types/jest": "^24.9.1",
+    "@types/lodash-es": "^4.17.3",
     "@types/nanoid": "^2.1.0",
     "@types/node": "^12.12.28",
     "@types/numeral": "0.0.26",
@@ -56,7 +58,10 @@
     "typescript": "^3.8.2"
   },
   "jest": {
-    "resetMocks": true
+    "resetMocks": true,
+    "transformIgnorePatterns": [
+      "/node_modules/(?!lodash-es/.*)"
+    ]
   },
   "browserslist": {
     "production": [

--- a/src/h5web/App.tsx
+++ b/src/h5web/App.tsx
@@ -3,7 +3,7 @@ import { ReflexContainer, ReflexSplitter, ReflexElement } from 'react-reflex';
 
 import Explorer from './explorer/Explorer';
 import DatasetVisualizer from './dataset-visualizer/DatasetVisualizer';
-import { HDF5Link, HDF5Collection, HDF5Entity } from './providers/models';
+import { HDF5Link, HDF5Dataset } from './providers/models';
 import MetadataViewer from './metadata-viewer/MetadataViewer';
 import styles from './App.module.css';
 import { isDataset } from './providers/utils';
@@ -11,9 +11,7 @@ import { useEntity } from './providers/hooks';
 
 function App(): JSX.Element {
   const [selectedLink, setSelectedLink] = useState<HDF5Link>();
-  const [selectedDataset, setSelectedDataset] = useState<
-    HDF5Entity<HDF5Collection.Datasets>
-  >();
+  const [selectedDataset, setSelectedDataset] = useState<HDF5Dataset>();
 
   const selectedEntity = useEntity(selectedLink);
 

--- a/src/h5web/dataset-visualizer/DatasetVisualizer.tsx
+++ b/src/h5web/dataset-visualizer/DatasetVisualizer.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import { HDF5Entity, HDF5Collection } from '../providers/models';
+import { HDF5Dataset } from '../providers/models';
 import styles from './DatasetVisualizer.module.css';
 import { useValue } from '../providers/hooks';
 import VisSelector from './VisSelector';
@@ -8,7 +8,7 @@ import { getSupportedVis } from './utils';
 import VisDisplay from './VisDisplay';
 
 interface Props {
-  dataset: HDF5Entity<HDF5Collection.Datasets>;
+  dataset: HDF5Dataset;
 }
 
 function DatasetVisualizer(props: Props): JSX.Element {

--- a/src/h5web/dataset-visualizer/VisDisplay.tsx
+++ b/src/h5web/dataset-visualizer/VisDisplay.tsx
@@ -1,17 +1,12 @@
 import React from 'react';
-import {
-  HDF5Value,
-  HDF5Entity,
-  HDF5Collection,
-  HDF5SimpleShape,
-} from '../providers/models';
+import { HDF5Value, HDF5SimpleShape, HDF5Dataset } from '../providers/models';
 import { Vis } from './models';
 import RawVis from './vis/RawVis';
 import MatrixVis from './vis/MatrixVis';
 
 interface Props {
   vis: Vis;
-  dataset: HDF5Entity<HDF5Collection.Datasets>;
+  dataset: HDF5Dataset;
   value: HDF5Value;
 }
 

--- a/src/h5web/dataset-visualizer/utils.ts
+++ b/src/h5web/dataset-visualizer/utils.ts
@@ -1,19 +1,15 @@
 import { supportsMatrixVis } from './vis/MatrixVis';
 import { Vis } from './models';
-import { HDF5Collection, HDF5Entity } from '../providers/models';
+import { HDF5Dataset } from '../providers/models';
 
-type SupportFunction = (
-  dataset: HDF5Entity<HDF5Collection.Datasets>
-) => boolean;
+type SupportFunction = (dataset: HDF5Dataset) => boolean;
 
 const SUPPORT_CHECKS: Record<Vis, SupportFunction> = {
   [Vis.Raw]: () => true,
   [Vis.Matrix]: supportsMatrixVis,
 };
 
-export function getSupportedVis(
-  dataset: HDF5Entity<HDF5Collection.Datasets>
-): Vis[] {
+export function getSupportedVis(dataset: HDF5Dataset): Vis[] {
   const supported = Object.entries(SUPPORT_CHECKS).reduce<Vis[]>(
     (arr, [vis, check]) => (check(dataset) ? [...arr, vis as Vis] : arr),
     []

--- a/src/h5web/dataset-visualizer/vis/MatrixVis.tsx
+++ b/src/h5web/dataset-visualizer/vis/MatrixVis.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { FixedSizeGrid as Grid } from 'react-window';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import numeral from 'numeral';
-import { HDF5Value, HDF5Entity, HDF5Collection } from '../../providers/models';
+import { HDF5Value, HDF5Dataset } from '../../providers/models';
 import styles from './MatrixVis.module.css';
 import {
   isBaseType,
@@ -51,9 +51,7 @@ function MatrixVis(props: Props): JSX.Element {
   );
 }
 
-export function supportsMatrixVis(
-  dataset: HDF5Entity<HDF5Collection.Datasets>
-): boolean {
+export function supportsMatrixVis(dataset: HDF5Dataset): boolean {
   const { type, shape } = dataset;
   return isBaseType(type) && isSimpleShape(shape) && hasSimpleDims(shape);
 }

--- a/src/h5web/metadata-viewer/EntityInfo.tsx
+++ b/src/h5web/metadata-viewer/EntityInfo.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { HDF5GenericEntity } from '../providers/models';
+import { HDF5Entity } from '../providers/models';
 import styles from './MetadataViewer.module.css';
 import { isBaseType, isSimpleShape } from '../providers/utils';
 import { renderShapeDims } from './utils';
 import RawInspector from './RawInspector';
 
 interface Props {
-  entity: HDF5GenericEntity;
+  entity: HDF5Entity;
 }
 
 function EntityInfo(props: Props): JSX.Element {

--- a/src/h5web/metadata-viewer/MetadataViewer.tsx
+++ b/src/h5web/metadata-viewer/MetadataViewer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { HDF5Link, HDF5GenericEntity } from '../providers/models';
+import { HDF5Link, HDF5Entity } from '../providers/models';
 import AttributesInfo from './AttributesInfo';
 import LinkInfo from './LinkInfo';
 import EntityInfo from './EntityInfo';
@@ -7,7 +7,7 @@ import EntityInfo from './EntityInfo';
 interface Props {
   key: string;
   link: HDF5Link;
-  entity?: HDF5GenericEntity;
+  entity?: HDF5Entity;
 }
 
 function MetadataViewer(props: Props): JSX.Element {

--- a/src/h5web/metadata-viewer/RawInspector.tsx
+++ b/src/h5web/metadata-viewer/RawInspector.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { HDF5Link, HDF5GenericEntity } from '../providers/models';
+import { HDF5Link, HDF5Entity } from '../providers/models';
 
 import styles from './RawInspector.module.css';
 
 interface Props {
-  data: HDF5Link | HDF5GenericEntity;
+  data: HDF5Link | HDF5Entity;
 }
 
 function RawInspector(props: Props): JSX.Element {

--- a/src/h5web/providers/hooks.ts
+++ b/src/h5web/providers/hooks.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useContext } from 'react';
-import { HDF5Link, HDF5GenericEntity, HDF5Id, HDF5Value } from './models';
+import { HDF5Link, HDF5Entity, HDF5Id, HDF5Value } from './models';
 import { TreeNode } from '../explorer/models';
 import { ProviderContext } from './context';
 import { buildTree, isReachable } from './utils';
@@ -22,9 +22,9 @@ export function useMetadataTree(): TreeNode<HDF5Link> | undefined {
   return tree;
 }
 
-export function useEntity(link?: HDF5Link): HDF5GenericEntity | undefined {
+export function useEntity(link?: HDF5Link): HDF5Entity | undefined {
   const { getMetadata } = useContext(ProviderContext);
-  const [entity, setEntity] = useState<HDF5GenericEntity | undefined>();
+  const [entity, setEntity] = useState<HDF5Entity | undefined>();
 
   useEffect(() => {
     if (!link || !isReachable(link)) {
@@ -35,7 +35,7 @@ export function useEntity(link?: HDF5Link): HDF5GenericEntity | undefined {
     getMetadata().then(metadata => {
       const { collection, id } = link;
       const dict = metadata[collection];
-      setEntity(dict && { id, collection, ...dict[id] });
+      setEntity(dict && dict[id]);
     });
   }, [link, getMetadata]);
 

--- a/src/h5web/providers/models.ts
+++ b/src/h5web/providers/models.ts
@@ -20,30 +20,26 @@ export interface HDF5Metadata {
 /* -------------------- */
 /* ----- ENTITIES ----- */
 
-export type HDF5GenericEntity = HDF5Entity<HDF5Collection>;
-export type HDF5Entity<C extends HDF5Collection> = HDF5EntityMapping[C] & {
-  id: HDF5Id;
-  collection: C;
-};
-
-interface HDF5EntityMapping {
-  [HDF5Collection.Groups]: HDF5Group;
-  [HDF5Collection.Datasets]: HDF5Dataset;
-  [HDF5Collection.Datatypes]: HDF5Datatype;
-}
+export type HDF5Entity = HDF5Group | HDF5Dataset | HDF5Datatype;
 
 export interface HDF5Group {
+  id: HDF5Id;
+  collection: HDF5Collection.Groups;
   attributes?: HDF5Attribute[];
   links?: HDF5Link[];
 }
 
 export interface HDF5Dataset {
+  id: HDF5Id;
+  collection: HDF5Collection.Datasets;
   attributes?: HDF5Attribute[];
   shape: HDF5Shape;
   type: HDF5Type;
 }
 
 export interface HDF5Datatype {
+  id: HDF5Id;
+  collection: HDF5Collection.Datatypes;
   type: HDF5Type;
 }
 

--- a/src/h5web/providers/silx/models.ts
+++ b/src/h5web/providers/silx/models.ts
@@ -1,4 +1,20 @@
-import { HDF5Metadata, HDF5Value } from '../models';
+import {
+  HDF5Value,
+  HDF5Id,
+  HDF5Collection,
+  HDF5Entity,
+  HDF5Group,
+  HDF5Dataset,
+  HDF5Datatype,
+} from '../models';
 
-export type SilxMetadataResponse = HDF5Metadata;
+type BareEntity<T extends HDF5Entity> = Omit<T, 'id' | 'collection'>;
+
+export interface SilxMetadataResponse {
+  root: HDF5Id;
+  [HDF5Collection.Groups]: Record<HDF5Id, BareEntity<HDF5Group>>;
+  [HDF5Collection.Datasets]?: Record<HDF5Id, BareEntity<HDF5Dataset>>;
+  [HDF5Collection.Datatypes]?: Record<HDF5Id, BareEntity<HDF5Datatype>>;
+}
+
 export type SilxValuesResponse = Record<string, HDF5Value>;

--- a/src/h5web/providers/utils.test.ts
+++ b/src/h5web/providers/utils.test.ts
@@ -3,6 +3,7 @@ import {
   HDF5LinkClass,
   HDF5RootLink,
   HDF5Metadata,
+  HDF5Group,
 } from './models';
 import { buildTree } from './utils';
 
@@ -18,7 +19,12 @@ describe('Provider utilities', () => {
     it('should process empty metadata', () => {
       const emptyMetadata = {
         root: '913d8791',
-        groups: { '913d8791': {} },
+        groups: {
+          '913d8791': {
+            id: '913d8791',
+            collection: HDF5Collection.Groups,
+          } as HDF5Group,
+        },
       };
 
       expect(buildTree(emptyMetadata)).toEqual({
@@ -41,7 +47,11 @@ describe('Provider utilities', () => {
       const simpleMetadata = {
         root: '913d8791',
         groups: {
-          '913d8791': { links: [link] },
+          '913d8791': {
+            id: '913d8791',
+            collection: HDF5Collection.Groups,
+            links: [link],
+          },
         },
       } as HDF5Metadata;
 
@@ -79,8 +89,16 @@ describe('Provider utilities', () => {
       const nestedMetadata = {
         root: '913d8791',
         groups: {
-          '913d8791': { links: [link1] },
-          '0a68caca': { links: [link2] },
+          '913d8791': {
+            id: '913d8791',
+            collection: HDF5Collection.Groups,
+            links: [link1],
+          },
+          '0a68caca': {
+            id: '0a68caca',
+            collection: HDF5Collection.Groups,
+            links: [link2],
+          },
         },
       } as HDF5Metadata;
 

--- a/src/h5web/providers/utils.ts
+++ b/src/h5web/providers/utils.ts
@@ -11,9 +11,9 @@ import {
   HDF5BaseType,
   HDF5Type,
   HDF5TypeClass,
-  HDF5GenericEntity,
   HDF5RootLink,
   HDF5Metadata,
+  HDF5Dataset,
 } from './models';
 import { TreeNode } from '../explorer/models';
 
@@ -28,9 +28,7 @@ export function isReachable(
   return link.class === HDF5LinkClass.Hard || link.class === HDF5LinkClass.Root;
 }
 
-export function isDataset(
-  entity: HDF5GenericEntity
-): entity is HDF5Entity<HDF5Collection.Datasets> {
+export function isDataset(entity: HDF5Entity): entity is HDF5Dataset {
   return entity.collection === HDF5Collection.Datasets;
 }
 


### PR DESCRIPTION
Review the models so that entities are persisted with `collection` and `id` properties directly (instead of adding these properties dynamically in the `useEntity` hook).