### PR TITLE
Implement Scalar visualization

### DIFF
--- a/src/h5web/App.module.css
+++ b/src/h5web/App.module.css
@@ -10,6 +10,7 @@
 
 .dataVisualizer {
   display: flex;
+  scrollbar-width: thin;
 }
 
 .metadataViewer {

--- a/src/h5web/dataset-visualizer/VisDisplay.tsx
+++ b/src/h5web/dataset-visualizer/VisDisplay.tsx
@@ -3,6 +3,7 @@ import { HDF5Value, HDF5SimpleShape, HDF5Dataset } from '../providers/models';
 import { Vis } from './models';
 import RawVis from './vis/RawVis';
 import MatrixVis from './vis/MatrixVis';
+import ScalarVis from './vis/ScalarVis';
 
 interface Props {
   vis: Vis;
@@ -15,6 +16,10 @@ function VisDisplay(props: Props): JSX.Element {
 
   if (vis === Vis.Raw) {
     return <RawVis data={value} />;
+  }
+
+  if (vis === Vis.Scalar) {
+    return <ScalarVis data={value} />;
   }
 
   if (vis === Vis.Matrix) {

--- a/src/h5web/dataset-visualizer/VisSelector.tsx
+++ b/src/h5web/dataset-visualizer/VisSelector.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { FiCpu, FiGrid } from 'react-icons/fi';
+import { FiCpu, FiGrid, FiCode } from 'react-icons/fi';
 import { IconType } from 'react-icons';
 import { Vis } from './models';
 import styles from './VisSelector.module.css';
 
 const VIS_ICONS: Record<Vis, IconType> = {
   [Vis.Raw]: FiCpu,
+  [Vis.Scalar]: FiCode,
   [Vis.Matrix]: FiGrid,
 };
 

--- a/src/h5web/dataset-visualizer/models.ts
+++ b/src/h5web/dataset-visualizer/models.ts
@@ -1,4 +1,5 @@
 export enum Vis {
   Raw = 'Raw',
+  Scalar = 'Scalar',
   Matrix = 'Matrix',
 }

--- a/src/h5web/dataset-visualizer/utils.test.ts
+++ b/src/h5web/dataset-visualizer/utils.test.ts
@@ -11,6 +11,44 @@ const base = { id: 'dataset', collection: HDF5Collection.Datasets as const };
 
 describe('Dataset Visualizer utilities', () => {
   describe('getSupportedVis', () => {
+    it('should include Scalar Vis when passed a supported dataset', () => {
+      const supportedDatasets: HDF5Dataset[] = [
+        {
+          ...base,
+          type: { class: HDF5TypeClass.Integer, base: 'H5T_STD_I32LE' },
+          shape: { class: HDF5ShapeClass.Scalar },
+        },
+        {
+          ...base,
+          type: { class: HDF5TypeClass.Float, base: 'H5T_IEEE_F64LE' },
+          shape: { class: HDF5ShapeClass.Scalar },
+        },
+      ];
+
+      supportedDatasets.forEach(dataset => {
+        expect(getSupportedVis(dataset)).toContain(Vis.Scalar);
+      });
+    });
+
+    it('should not include Scalar Vis when passed an unsupported dataset', () => {
+      const unsupportedDatasets: HDF5Dataset[] = [
+        {
+          ...base,
+          type: { class: HDF5TypeClass.Integer, base: 'H5T_STD_I32LE' },
+          shape: { class: HDF5ShapeClass.Null }, // shape class not supported
+        },
+        {
+          ...base,
+          type: { class: HDF5TypeClass.Compound, fields: [] }, // type class not supported
+          shape: { class: HDF5ShapeClass.Scalar },
+        },
+      ];
+
+      unsupportedDatasets.forEach(dataset => {
+        expect(getSupportedVis(dataset)).not.toContain(Vis.Scalar);
+      });
+    });
+
     it('should include Matrix Vis when passed a supported dataset', () => {
       const supportedDatasets: HDF5Dataset[] = [
         {
@@ -20,18 +58,13 @@ describe('Dataset Visualizer utilities', () => {
         },
         {
           ...base,
-          type: { class: HDF5TypeClass.Float, base: 'H5T_IEEE_F64LE' },
-          shape: { class: HDF5ShapeClass.Simple, dims: [4, 2] },
-        },
-        {
-          ...base,
           type: {
             class: HDF5TypeClass.String,
             charSet: 'H5T_CSET_ASCII',
             strPad: 'H5T_STR_NULLPAD',
             length: 1,
           },
-          shape: { class: HDF5ShapeClass.Simple, dims: [10] },
+          shape: { class: HDF5ShapeClass.Simple, dims: [10, 12345] },
         },
       ];
 

--- a/src/h5web/dataset-visualizer/utils.ts
+++ b/src/h5web/dataset-visualizer/utils.ts
@@ -1,11 +1,20 @@
 import { Vis } from './models';
 import { HDF5Dataset } from '../providers/models';
-import { isBaseType, isSimpleShape, hasSimpleDims } from '../providers/utils';
+import {
+  isBaseType,
+  isSimpleShape,
+  hasSimpleDims,
+  isScalarShape,
+} from '../providers/utils';
 
 type SupportFunction = (dataset: HDF5Dataset) => boolean;
 
 const SUPPORT_CHECKS: Record<Vis, SupportFunction> = {
   [Vis.Raw]: () => true,
+  [Vis.Scalar]: dataset => {
+    const { type, shape } = dataset;
+    return isBaseType(type) && isScalarShape(shape);
+  },
   [Vis.Matrix]: dataset => {
     const { type, shape } = dataset;
     return isBaseType(type) && isSimpleShape(shape) && hasSimpleDims(shape);

--- a/src/h5web/dataset-visualizer/vis/MatrixVis.module.css
+++ b/src/h5web/dataset-visualizer/vis/MatrixVis.module.css
@@ -1,6 +1,5 @@
 .grid {
-  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier,
-    monospace;
+  font-family: var(--monospace);
   scrollbar-width: thin;
 }
 

--- a/src/h5web/dataset-visualizer/vis/ScalarVis.module.css
+++ b/src/h5web/dataset-visualizer/vis/ScalarVis.module.css
@@ -1,0 +1,4 @@
+.scalar {
+  padding: 1rem 1.5rem;
+  font-family: var(--monospace);
+}

--- a/src/h5web/dataset-visualizer/vis/ScalarVis.tsx
+++ b/src/h5web/dataset-visualizer/vis/ScalarVis.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import styles from './ScalarVis.module.css';
+import { HDF5Value } from '../../providers/models';
+
+interface Props {
+  data: HDF5Value;
+}
+
+function ScalarVis(props: Props): JSX.Element {
+  const { data } = props;
+  return <div className={styles.scalar}>{data.toString()}</div>;
+}
+
+export default ScalarVis;

--- a/src/h5web/providers/utils.ts
+++ b/src/h5web/providers/utils.ts
@@ -14,6 +14,7 @@ import {
   HDF5RootLink,
   HDF5Metadata,
   HDF5Dataset,
+  HDF5ScalarShape,
 } from './models';
 import { TreeNode } from '../explorer/models';
 
@@ -34,6 +35,10 @@ export function isDataset(entity: HDF5Entity): entity is HDF5Dataset {
 
 export function isSimpleShape(shape: HDF5Shape): shape is HDF5SimpleShape {
   return shape.class === HDF5ShapeClass.Simple;
+}
+
+export function isScalarShape(shape: HDF5Shape): shape is HDF5ScalarShape {
+  return shape.class === HDF5ShapeClass.Scalar;
 }
 
 export function hasSimpleDims(shape: HDF5SimpleShape): boolean {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import 'react-reflex/styles.css';
+import 'normalize.css';
 import './styles/index.css';
 
 import DemoApp from './demo-app/DemoApp';

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -37,6 +37,10 @@ dl {
   margin-bottom: 1rem;
 }
 
+pre {
+  font-family: var(--monospace);
+}
+
 [hidden] {
   display: none !important;
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,4 +1,3 @@
-@import 'normalize.css';
 @import 'vars.css';
 @import 'base.css';
 @import 'utils.css';

--- a/src/styles/vars.css
+++ b/src/styles/vars.css
@@ -8,4 +8,6 @@
   --secondary-bg: #d9f4ec;
   --secondary-light-bg: #ecfaf6;
   --secondary-dark: #1b998b;
+  --monospace: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier,
+    monospace;
 }


### PR DESCRIPTION
The Raw visualization was showing double quotes around scalar values, and backslashes in stringified JSON values. This is much more readable:

![image](https://user-images.githubusercontent.com/2936402/77158940-9e39f280-6aa4-11ea-82dc-3285861e9ac5.png)

![image](https://user-images.githubusercontent.com/2936402/77159019-cf1a2780-6aa4-11ea-9aa2-b3c5af01c680.png)

### Before with Raw Vis

![image](https://user-images.githubusercontent.com/2936402/77159450-aa727f80-6aa5-11ea-888f-ccc9518c4472.png)
