### PR TITLE
Implement centred zoom

### DIFF
--- a/src/h5web/visualizations/heatmap/HeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapVis.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo } from 'react';
 import { Canvas } from 'react-three-fiber';
+import React, { useMemo } from 'react';
 import Mesh from './Mesh';
 import { computeTextureData } from './utils';
 

--- a/src/h5web/visualizations/heatmap/Mesh.tsx
+++ b/src/h5web/visualizations/heatmap/Mesh.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import { useThree } from 'react-three-fiber';
-import { RGBFormat } from 'three';
+import { useThree, PointerEvent } from 'react-three-fiber';
+import { RGBFormat, OrthographicCamera } from 'three';
+
+const ZOOM_FACTOR = 0.95;
 
 interface Props {
   dims: [number, number];
@@ -14,8 +16,20 @@ function Mesh(props: Props): JSX.Element {
   const { size } = useThree();
   const { width, height } = size;
 
+  function handleWheel(evt: PointerEvent): void {
+    evt.stopPropagation();
+
+    // Fix react-three-fiber typings
+    const camera = evt.camera as OrthographicCamera;
+    const wheelEvt = evt as React.WheelEvent<HTMLDivElement>;
+
+    const factor = wheelEvt.deltaY > 0 ? ZOOM_FACTOR : 1 / ZOOM_FACTOR;
+    camera.zoom = Math.max(1, camera.zoom * factor);
+    camera.updateProjectionMatrix();
+  }
+
   return (
-    <mesh>
+    <mesh onWheel={handleWheel}>
       <planeBufferGeometry attach="geometry" args={[width, height]} />
       <meshBasicMaterial attach="material">
         <dataTexture attach="map" args={[textureData, cols, rows, RGBFormat]} />


### PR DESCRIPTION
I tried using Three's [OrbitControls](https://threejs.org/examples/?q=orbit#misc_controls_orbit) ([doc](https://threejs.org/docs/#examples/en/controls/OrbitControls)) but it's not quite our use case - we don't want to orbit the camera around an object. I got zoom and pan (screen pan, not target pan) working but I couldn't restrict the screen pan to the bounds of the mesh... So I went for a simple, custom solution.

For now, I just zoom on the centre of the mesh.