### PR TITLE
Optimise rendering of DatasetVisualizer

### DIFF
--- a/src/h5web/App.tsx
+++ b/src/h5web/App.tsx
@@ -35,10 +35,7 @@ function App(): JSX.Element {
         <ReflexElement minSize={500}>
           <ReflexContainer orientation="horizontal">
             <ReflexElement className={styles.dataVisualizer} minSize={250}>
-              <DatasetVisualizer
-                key={JSON.stringify(selectedDataset)}
-                dataset={selectedDataset}
-              />
+              <DatasetVisualizer dataset={selectedDataset} />
             </ReflexElement>
 
             <ReflexSplitter />

--- a/src/h5web/dataset-visualizer/DatasetVisualizer.tsx
+++ b/src/h5web/dataset-visualizer/DatasetVisualizer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { HDF5Dataset } from '../providers/models';
 import styles from './DatasetVisualizer.module.css';
 import VisSelector from './VisSelector';
@@ -14,9 +14,11 @@ function DatasetVisualizer(props: Props): JSX.Element {
   const { dataset } = props;
 
   const supportedVis = useMemo(() => getSupportedVis(dataset), [dataset]);
-  const [activeVis, setActiveVis] = useState<Vis | undefined>(
-    dataset && supportedVis[supportedVis.length - 1]
-  );
+  const [activeVis, setActiveVis] = useState<Vis>();
+
+  useEffect(() => {
+    setActiveVis(dataset && supportedVis[supportedVis.length - 1]);
+  }, [dataset, supportedVis]);
 
   return (
     <div className={styles.visualizer}>

--- a/src/h5web/dataset-visualizer/DatasetVisualizer.tsx
+++ b/src/h5web/dataset-visualizer/DatasetVisualizer.tsx
@@ -17,8 +17,8 @@ function DatasetVisualizer(props: Props): JSX.Element {
   const [activeVis, setActiveVis] = useState<Vis>();
 
   useEffect(() => {
-    setActiveVis(dataset && supportedVis[supportedVis.length - 1]);
-  }, [dataset, supportedVis]);
+    setActiveVis(supportedVis[supportedVis.length - 1]);
+  }, [supportedVis]);
 
   return (
     <div className={styles.visualizer}>

--- a/src/h5web/dataset-visualizer/DatasetVisualizer.tsx
+++ b/src/h5web/dataset-visualizer/DatasetVisualizer.tsx
@@ -36,4 +36,5 @@ function DatasetVisualizer(props: Props): JSX.Element {
   );
 }
 
-export default DatasetVisualizer;
+// Optimise consecutive renders when selecting a link in the explorer
+export default React.memo(DatasetVisualizer);

--- a/src/h5web/metadata-viewer/MetadataViewer.tsx
+++ b/src/h5web/metadata-viewer/MetadataViewer.tsx
@@ -24,4 +24,5 @@ function MetadataViewer(props: Props): JSX.Element {
   );
 }
 
-export default MetadataViewer;
+// Optimise consecutive renders when selecting a link in the explorer
+export default React.memo(MetadataViewer);

--- a/src/h5web/providers/hooks.ts
+++ b/src/h5web/providers/hooks.ts
@@ -24,7 +24,7 @@ export function useMetadataTree(): TreeNode<HDF5Link> | undefined {
 
 export function useEntity(link?: HDF5Link): HDF5Entity | undefined {
   const { getMetadata } = useContext(ProviderContext);
-  const [entity, setEntity] = useState<HDF5Entity | undefined>();
+  const [entity, setEntity] = useState<HDF5Entity>();
 
   useEffect(() => {
     if (!link || !isReachable(link)) {

--- a/src/h5web/visualizations/heatmap/HeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapVis.tsx
@@ -36,4 +36,4 @@ function HeatmapVis(props: Props): JSX.Element {
   );
 }
 
-export default React.memo(HeatmapVis);
+export default HeatmapVis;


### PR DESCRIPTION
### Optimise consecutive renders when navigating in the explorer

The re-renders when navigating in the explorer are caused by `App`, so the memoization we had on `HeatmapVis` can be moved higher up, to the direct descendants of `App`: `DatasetVisualizer` and `MetadataViewer`.

Now we'll notice if we ever trigger re-renders in `HeatmapVis` by mistake.

### Let React reconcile children of `DatasetVisualizer`

`key` prop was telling React to delete the entire DOM sub-tree and to recreate it when switching between two datasets, leading to the ThreeJS canvas and rendering context having to be recreated each time.