### PR TITLE
Fix stale `activeVis` state

### DIFF
--- a/src/h5web/dataset-visualizer/DatasetVisualizer.tsx
+++ b/src/h5web/dataset-visualizer/DatasetVisualizer.tsx
@@ -1,9 +1,8 @@
-import React, { useState, useMemo, useEffect } from 'react';
+import React, { useMemo } from 'react';
 import { HDF5Dataset } from '../providers/models';
 import styles from './DatasetVisualizer.module.css';
 import VisSelector from './VisSelector';
-import { Vis } from './models';
-import { getSupportedVis } from './utils';
+import { getSupportedVis, useActiveVis } from './utils';
 import VisDisplay from './VisDisplay';
 
 interface Props {
@@ -14,11 +13,7 @@ function DatasetVisualizer(props: Props): JSX.Element {
   const { dataset } = props;
 
   const supportedVis = useMemo(() => getSupportedVis(dataset), [dataset]);
-  const [activeVis, setActiveVis] = useState<Vis>();
-
-  useEffect(() => {
-    setActiveVis(supportedVis[supportedVis.length - 1]);
-  }, [supportedVis]);
+  const [activeVis, setActiveVis] = useActiveVis(supportedVis);
 
   return (
     <div className={styles.visualizer}>
@@ -28,8 +23,8 @@ function DatasetVisualizer(props: Props): JSX.Element {
         onChange={setActiveVis}
       />
       <div className={styles.displayArea}>
-        {dataset && activeVis ? (
-          <VisDisplay vis={activeVis} dataset={dataset} />
+        {dataset ? (
+          activeVis && <VisDisplay vis={activeVis} dataset={dataset} />
         ) : (
           <p className={styles.noVis}>Nothing to visualize</p>
         )}

--- a/src/h5web/dataset-visualizer/DatasetVisualizer.tsx
+++ b/src/h5web/dataset-visualizer/DatasetVisualizer.tsx
@@ -24,7 +24,9 @@ function DatasetVisualizer(props: Props): JSX.Element {
       />
       <div className={styles.displayArea}>
         {dataset ? (
-          activeVis && <VisDisplay vis={activeVis} dataset={dataset} />
+          activeVis && (
+            <VisDisplay key={dataset.id} vis={activeVis} dataset={dataset} />
+          )
         ) : (
           <p className={styles.noVis}>Nothing to visualize</p>
         )}

--- a/src/h5web/dataset-visualizer/VisDisplay.tsx
+++ b/src/h5web/dataset-visualizer/VisDisplay.tsx
@@ -11,6 +11,7 @@ import {
 import { useValue } from '../providers/hooks';
 
 interface Props {
+  key: string; // reset states when switching between datasets
   vis: Vis;
   dataset: HDF5Dataset;
 }

--- a/src/h5web/dataset-visualizer/utils.ts
+++ b/src/h5web/dataset-visualizer/utils.ts
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { Vis } from './models';
 import { HDF5Dataset } from '../providers/models';
 import {
@@ -45,4 +46,21 @@ export function getSupportedVis(dataset?: HDF5Dataset): Vis[] {
 
   // Remove Raw vis if any other vis is supported
   return supported.length > 1 ? supported.slice(1) : supported;
+}
+
+export function useActiveVis(
+  supportedVis: Vis[]
+): [Vis | undefined, (vis: Vis) => void] {
+  const [activeVis, setActiveVis] = useState<Vis>();
+
+  // When switching between two datasets, `activeVis` may become stale for one render
+  const isValid = activeVis && supportedVis.includes(activeVis);
+
+  useEffect(() => {
+    if (!isValid) {
+      setActiveVis(supportedVis[supportedVis.length - 1]);
+    }
+  }, [isValid, supportedVis]);
+
+  return [isValid ? activeVis : undefined, setActiveVis];
 }


### PR DESCRIPTION
By removing the `key` prop from `DatasetVisualizer`, I introduced a regression where `activeVis` could become stale when switching between two datasets with different sets of supported visualizations. `activeVis` is updated asynchronously with `useEffect`, so it may become stale for one render.

I now check whether `activeVis` is stale before rendering `VisDisplay`.