### PR TITLE
Fluid resizing and optimised animation loop

### DIFF
--- a/src/h5web/visualizations/heatmap/HeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapVis.tsx
@@ -23,7 +23,7 @@ function HeatmapVis(props: Props): JSX.Element {
   return (
     <div className={styles.chart}>
       <div className={styles.mapArea}>
-        <Canvas className={styles.heatmap} orthographic>
+        <Canvas className={styles.heatmap} orthographic invalidateFrameloop>
           <ambientLight />
           {textureData && <Mesh dims={dims} textureData={textureData} />}
         </Canvas>

--- a/src/h5web/visualizations/heatmap/Mesh.tsx
+++ b/src/h5web/visualizations/heatmap/Mesh.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useThree } from 'react-three-fiber';
-import { RGBFormat } from 'three';
+import { RGBFormat, MeshBasicMaterial, DataTexture } from 'three';
 import { usePanZoom } from './utils';
 
 interface Props {
@@ -12,17 +12,19 @@ function Mesh(props: Props): JSX.Element {
   const { dims, textureData } = props;
 
   const { size } = useThree();
+  const { width, height } = size;
+
+  const material = useMemo(() => {
+    return new MeshBasicMaterial({
+      map: new DataTexture(textureData, dims[1], dims[0], RGBFormat),
+    });
+  }, [dims, textureData]);
+
   const pointerHandlers = usePanZoom();
 
-  const { width, height } = size;
-  const [rows, cols] = dims;
-
   return (
-    <mesh {...pointerHandlers}>
+    <mesh material={material} {...pointerHandlers}>
       <planeBufferGeometry attach="geometry" args={[width, height]} />
-      <meshBasicMaterial attach="material">
-        <dataTexture attach="map" args={[textureData, cols, rows, RGBFormat]} />
-      </meshBasicMaterial>
     </mesh>
   );
 }

--- a/src/h5web/visualizations/heatmap/utils.ts
+++ b/src/h5web/visualizations/heatmap/utils.ts
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useRef, useEffect } from 'react';
 import { extent } from 'd3-array';
 import { rgb } from 'd3-color';
 import { scaleLinear, scaleSequential } from 'd3-scale';
@@ -41,7 +41,7 @@ export const adaptedNumTicks = scaleLinear()
   .clamp(true);
 
 export function usePanZoom(): ReactThreeFiber.Events {
-  const { size, camera } = useThree();
+  const { size, camera, invalidate } = useThree();
   const { width, height } = size;
 
   const startOffsetPosition = useRef<Vector3>(); // `useRef` to avoid re-renders
@@ -59,8 +59,10 @@ export function usePanZoom(): ReactThreeFiber.Events {
         clamp(y, -yBound, yBound),
         position.z
       );
+
+      invalidate();
     },
-    [camera, height, width]
+    [camera, height, invalidate, width]
   );
 
   const onPointerDown = useCallback(
@@ -124,6 +126,11 @@ export function usePanZoom(): ReactThreeFiber.Events {
     },
     [camera, moveCameraTo]
   );
+
+  useEffect(() => {
+    // Move camera on resize to stay within mesh bounds
+    moveCameraTo(camera.position.x, camera.position.y);
+  }, [camera, moveCameraTo, size]); // `size` is key here
 
   return {
     onPointerDown,


### PR DESCRIPTION
**VICTORY** 😤 

I found these two techniques while digging through [this R3F issue](https://github.com/react-spring/react-three-fiber/issues/240).

### Fluid resizing

The material and the texture are initialised within `useMemo`, which means they're not recreated on resize. This is enough to provide fluid resizing.

### Optimised animation loop

By default, R3F starts a game loop - i.e. it re-renders continuously in a `requestAnimationFrame()` loop. This simplifies things, but it also uses more CPU/GPU/battery.

I switch off the game loop with `invalidateFrameloop`, and trigger re-renders manually with `invalidate()` when needed. Re-renders are required when zooming/panning, so I call `invalidate` inside `moveCameraTo`.

Interestingly, disabling the game loop resulted in a side effect on resize: the camera's viewport would leave the bounds of the mesh. To work around this, I call `moveCameraTo` on every resize to make sure it gets clamped like it does when panning.