### PR TITLE
Move domain, interpolator and scales to Heatmap state

### DIFF
--- a/src/h5web/visualizations/heatmap/ColorBar.tsx
+++ b/src/h5web/visualizations/heatmap/ColorBar.tsx
@@ -7,15 +7,15 @@ import {
   ColorScale,
 } from './utils';
 import styles from './HeatmapVis.module.css';
-import { D3Interpolator } from './interpolators';
+import { useHeatmapState } from './store';
 
 interface Props {
-  interpolator: D3Interpolator;
   colorScale: ColorScale;
 }
 
 function ColorBar(props: Props): JSX.Element {
-  const { interpolator, colorScale } = props;
+  const { colorScale } = props;
+  const { interpolator } = useHeatmapState();
 
   const [gradientRef, { height: gradientHeight }] = useMeasure();
   const scale = colorScale

--- a/src/h5web/visualizations/heatmap/ColorBar.tsx
+++ b/src/h5web/visualizations/heatmap/ColorBar.tsx
@@ -3,17 +3,15 @@ import { AxisRight } from '@vx/axis';
 import { useMeasure } from 'react-use';
 import { adaptedNumTicks, generateCSSLinearGradient } from './utils';
 import styles from './HeatmapVis.module.css';
-import { useHeatmapState, DataScale } from './store';
+import { useHeatmapState } from './store';
 
-interface Props {
-  dataScale: DataScale;
-}
-
-function ColorBar(props: Props): JSX.Element {
-  const { dataScale } = props;
-  const { interpolator } = useHeatmapState();
-
+function ColorBar(): JSX.Element {
+  const { dataScale, interpolator } = useHeatmapState();
   const [gradientRef, { height: gradientHeight }] = useMeasure();
+
+  if (!dataScale) {
+    return <></>;
+  }
 
   const axisScale = dataScale.copy();
   axisScale.range([gradientHeight, 0]);

--- a/src/h5web/visualizations/heatmap/ColorBar.tsx
+++ b/src/h5web/visualizations/heatmap/ColorBar.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { AxisRight } from '@vx/axis';
 import { useMeasure } from 'react-use';
-import { adaptedNumTicks, generateCSSLinearGradient, DataScale } from './utils';
+import { adaptedNumTicks, generateCSSLinearGradient } from './utils';
 import styles from './HeatmapVis.module.css';
-import { useHeatmapState } from './store';
+import { useHeatmapState, DataScale } from './store';
 
 interface Props {
   dataScale: DataScale;

--- a/src/h5web/visualizations/heatmap/ColorBar.tsx
+++ b/src/h5web/visualizations/heatmap/ColorBar.tsx
@@ -1,26 +1,22 @@
 import React from 'react';
 import { AxisRight } from '@vx/axis';
 import { useMeasure } from 'react-use';
-import {
-  adaptedNumTicks,
-  generateCSSLinearGradient,
-  ColorScale,
-} from './utils';
+import { adaptedNumTicks, generateCSSLinearGradient, DataScale } from './utils';
 import styles from './HeatmapVis.module.css';
 import { useHeatmapState } from './store';
 
 interface Props {
-  colorScale: ColorScale;
+  dataScale: DataScale;
 }
 
 function ColorBar(props: Props): JSX.Element {
-  const { colorScale } = props;
+  const { dataScale } = props;
   const { interpolator } = useHeatmapState();
 
   const [gradientRef, { height: gradientHeight }] = useMeasure();
-  const scale = colorScale
-    .copy()
-    .range([gradientHeight, 0]) as typeof colorScale;
+
+  const axisScale = dataScale.copy();
+  axisScale.range([gradientHeight, 0]);
 
   return (
     <div className={styles.colorBar}>
@@ -33,10 +29,13 @@ function ColorBar(props: Props): JSX.Element {
       />
       <svg className={styles.colorBarAxis} height={gradientHeight} width="2em">
         <AxisRight
-          scale={scale}
+          scale={axisScale}
           hideAxisLine
           numTicks={adaptedNumTicks(gradientHeight)}
-          tickFormat={scale.tickFormat(adaptedNumTicks(gradientHeight), '.3')}
+          tickFormat={axisScale.tickFormat(
+            adaptedNumTicks(gradientHeight),
+            '.3'
+          )}
         />
       </svg>
     </div>

--- a/src/h5web/visualizations/heatmap/ColorMapSelector.tsx
+++ b/src/h5web/visualizations/heatmap/ColorMapSelector.tsx
@@ -2,8 +2,8 @@ import React, { CSSProperties } from 'react';
 import Select, { components } from 'react-select';
 import { FiChevronUp } from 'react-icons/fi';
 import { generateCSSLinearGradient } from './utils';
-import { ColorMap, INTERPOLATORS } from './interpolators';
-import { useHeatmapState, useHeatmapActions } from './store';
+import { INTERPOLATORS } from './interpolators';
+import { useHeatmapState, useHeatmapActions, ColorMap } from './store';
 
 interface Props {
   className: string;

--- a/src/h5web/visualizations/heatmap/ColorMapSelector.tsx
+++ b/src/h5web/visualizations/heatmap/ColorMapSelector.tsx
@@ -31,13 +31,10 @@ function ColorMapSelector(props: Props): JSX.Element {
   const gradientStyles = {
     option: (
       styles: CSSProperties,
-      { data }: { data: { label: ColorMap } }
+      { data: { label } }: { data: { label: ColorMap } }
     ) => ({
       ...styles,
-      backgroundImage: generateCSSLinearGradient(
-        INTERPOLATORS[data.label],
-        'right'
-      ),
+      backgroundImage: generateCSSLinearGradient(INTERPOLATORS[label], 'right'),
       marginTop: '1px',
       marginBottom: '1px',
     }),

--- a/src/h5web/visualizations/heatmap/HeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapVis.tsx
@@ -41,12 +41,12 @@ function HeatmapVis(props: Props): JSX.Element {
       <IndexAxis
         className={styles.leftArea}
         orientation="left"
-        numberPixels={dims[0]}
+        indicesCount={dims[0]}
       />
       <IndexAxis
         className={styles.bottomArea}
         orientation="bottom"
-        numberPixels={dims[1]}
+        indicesCount={dims[1]}
       />
       <div className={styles.rightArea}>
         <LogScaleToggler />

--- a/src/h5web/visualizations/heatmap/HeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapVis.tsx
@@ -21,12 +21,10 @@ function HeatmapVis(props: Props): JSX.Element {
   const values = data.flat();
   const domain = findDomain(values);
 
-  const { colorMap } = useHeatmapState();
+  const { colorMap, hasLogScale } = useHeatmapState();
   const interpolator = INTERPOLATORS[colorMap];
 
-  const [logScale, setLogScale] = useState<boolean>(false);
-
-  const colorScale = getColorScale(domain, logScale);
+  const colorScale = getColorScale(domain, hasLogScale);
   const textureData = computeTextureData(values, interpolator, colorScale);
 
   return (
@@ -49,7 +47,7 @@ function HeatmapVis(props: Props): JSX.Element {
       />
       {colorScale && (
         <div className={styles.rightArea}>
-          <LogScaleToggler value={logScale} onChange={setLogScale} />
+          <LogScaleToggler />
           <ColorBar
             interpolator={INTERPOLATORS[colorMap]}
             colorScale={colorScale}

--- a/src/h5web/visualizations/heatmap/HeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapVis.tsx
@@ -17,19 +17,18 @@ interface Props {
 function HeatmapVis(props: Props): JSX.Element {
   const { dims, data } = props;
 
-  const { interpolator, dataScale } = useHeatmapState();
+  const { colorScale, dataScale } = useHeatmapState();
   const { findDomain } = useHeatmapActions();
 
   const values = useMemo(() => data.flat(), [data]);
+  const textureData = useMemo(
+    () => computeTextureData(values, colorScale, dataScale),
+    [dataScale, colorScale, values]
+  );
 
   useEffect(() => {
     findDomain(values);
   }, [findDomain, values]);
-
-  const textureData = useMemo(
-    () => computeTextureData(values, interpolator, dataScale),
-    [dataScale, interpolator, values]
-  );
 
   return (
     <div className={styles.chart}>
@@ -49,12 +48,10 @@ function HeatmapVis(props: Props): JSX.Element {
         orientation="bottom"
         numberPixels={dims[1]}
       />
-      {dataScale && (
-        <div className={styles.rightArea}>
-          <LogScaleToggler />
-          <ColorBar dataScale={dataScale} />
-        </div>
-      )}
+      <div className={styles.rightArea}>
+        <LogScaleToggler />
+        <ColorBar />
+      </div>
       <ColorMapSelector className={styles.bottomRightArea} />
     </div>
   );

--- a/src/h5web/visualizations/heatmap/HeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapVis.tsx
@@ -1,12 +1,11 @@
 import { Canvas } from 'react-three-fiber';
-import React, { useState } from 'react';
+import React from 'react';
 import Mesh from './Mesh';
 import { computeTextureData, findDomain, getColorScale } from './utils';
 import styles from './HeatmapVis.module.css';
 import IndexAxis from './IndexAxis';
 import ColorBar from './ColorBar';
 import ColorMapSelector from './ColorMapSelector';
-import { INTERPOLATORS } from './interpolators';
 import LogScaleToggler from './LogScaleToggler';
 import { useHeatmapState } from './store';
 
@@ -21,8 +20,7 @@ function HeatmapVis(props: Props): JSX.Element {
   const values = data.flat();
   const domain = findDomain(values);
 
-  const { colorMap, hasLogScale } = useHeatmapState();
-  const interpolator = INTERPOLATORS[colorMap];
+  const { interpolator, hasLogScale } = useHeatmapState();
 
   const colorScale = getColorScale(domain, hasLogScale);
   const textureData = computeTextureData(values, interpolator, colorScale);
@@ -48,10 +46,7 @@ function HeatmapVis(props: Props): JSX.Element {
       {colorScale && (
         <div className={styles.rightArea}>
           <LogScaleToggler />
-          <ColorBar
-            interpolator={INTERPOLATORS[colorMap]}
-            colorScale={colorScale}
-          />
+          <ColorBar colorScale={colorScale} />
         </div>
       )}
       <ColorMapSelector className={styles.bottomRightArea} />

--- a/src/h5web/visualizations/heatmap/HeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapVis.tsx
@@ -1,7 +1,7 @@
 import { Canvas } from 'react-three-fiber';
 import React, { useEffect, useMemo } from 'react';
 import Mesh from './Mesh';
-import { computeTextureData, getDataScale } from './utils';
+import { computeTextureData } from './utils';
 import styles from './HeatmapVis.module.css';
 import IndexAxis from './IndexAxis';
 import ColorBar from './ColorBar';
@@ -17,7 +17,7 @@ interface Props {
 function HeatmapVis(props: Props): JSX.Element {
   const { dims, data } = props;
 
-  const { domain, interpolator, hasLogScale } = useHeatmapState();
+  const { interpolator, dataScale } = useHeatmapState();
   const { findDomain } = useHeatmapActions();
 
   const values = useMemo(() => data.flat(), [data]);
@@ -26,7 +26,6 @@ function HeatmapVis(props: Props): JSX.Element {
     findDomain(values);
   }, [findDomain, values]);
 
-  const dataScale = getDataScale(domain, hasLogScale);
   const textureData = useMemo(
     () => computeTextureData(values, interpolator, dataScale),
     [dataScale, interpolator, values]

--- a/src/h5web/visualizations/heatmap/HeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapVis.tsx
@@ -1,7 +1,7 @@
 import { Canvas } from 'react-three-fiber';
 import React, { useEffect, useMemo } from 'react';
 import Mesh from './Mesh';
-import { computeTextureData, getColorScale } from './utils';
+import { computeTextureData, getDataScale } from './utils';
 import styles from './HeatmapVis.module.css';
 import IndexAxis from './IndexAxis';
 import ColorBar from './ColorBar';
@@ -26,10 +26,10 @@ function HeatmapVis(props: Props): JSX.Element {
     findDomain(values);
   }, [findDomain, values]);
 
-  const colorScale = getColorScale(domain, hasLogScale);
+  const dataScale = getDataScale(domain, hasLogScale);
   const textureData = useMemo(
-    () => computeTextureData(values, interpolator, colorScale),
-    [colorScale, interpolator, values]
+    () => computeTextureData(values, interpolator, dataScale),
+    [dataScale, interpolator, values]
   );
 
   return (
@@ -50,10 +50,10 @@ function HeatmapVis(props: Props): JSX.Element {
         orientation="bottom"
         numberPixels={dims[1]}
       />
-      {colorScale && (
+      {dataScale && (
         <div className={styles.rightArea}>
           <LogScaleToggler />
-          <ColorBar colorScale={colorScale} />
+          <ColorBar dataScale={dataScale} />
         </div>
       )}
       <ColorMapSelector className={styles.bottomRightArea} />

--- a/src/h5web/visualizations/heatmap/HeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapVis.tsx
@@ -1,13 +1,13 @@
 import { Canvas } from 'react-three-fiber';
-import React from 'react';
+import React, { useEffect, useMemo } from 'react';
 import Mesh from './Mesh';
-import { computeTextureData, findDomain, getColorScale } from './utils';
+import { computeTextureData, getColorScale } from './utils';
 import styles from './HeatmapVis.module.css';
 import IndexAxis from './IndexAxis';
 import ColorBar from './ColorBar';
 import ColorMapSelector from './ColorMapSelector';
 import LogScaleToggler from './LogScaleToggler';
-import { useHeatmapState } from './store';
+import { useHeatmapState, useHeatmapActions } from './store';
 
 interface Props {
   dims: [number, number];
@@ -17,13 +17,20 @@ interface Props {
 function HeatmapVis(props: Props): JSX.Element {
   const { dims, data } = props;
 
-  const values = data.flat();
-  const domain = findDomain(values);
+  const { domain, interpolator, hasLogScale } = useHeatmapState();
+  const { findDomain } = useHeatmapActions();
 
-  const { interpolator, hasLogScale } = useHeatmapState();
+  const values = useMemo(() => data.flat(), [data]);
+
+  useEffect(() => {
+    findDomain(values);
+  }, [findDomain, values]);
 
   const colorScale = getColorScale(domain, hasLogScale);
-  const textureData = computeTextureData(values, interpolator, colorScale);
+  const textureData = useMemo(
+    () => computeTextureData(values, interpolator, colorScale),
+    [colorScale, interpolator, values]
+  );
 
   return (
     <div className={styles.chart}>

--- a/src/h5web/visualizations/heatmap/IndexAxis.tsx
+++ b/src/h5web/visualizations/heatmap/IndexAxis.tsx
@@ -11,22 +11,22 @@ type Orientation = 'bottom' | 'left';
 interface Props {
   orientation: Orientation;
   className: string;
-  numberPixels: number;
+  indicesCount: number;
 }
 
 function IndexAxis(props: Props): JSX.Element {
-  const { orientation, numberPixels, className } = props;
+  const { orientation, indicesCount, className } = props;
 
   const [divRef, { width, height }] = useMeasure();
   const isLeftAxis = orientation === 'left';
   const Axis = isLeftAxis ? AxisLeft : AxisBottom;
 
   const scale = scaleLinear()
-    .domain([-0.5, numberPixels - 0.5])
+    .domain([-0.5, indicesCount - 0.5])
     .range(isLeftAxis ? [height, 0] : [0, width]);
 
   const numTicks = Math.min(
-    numberPixels,
+    indicesCount,
     adaptedNumTicks(isLeftAxis ? height : width)
   );
 

--- a/src/h5web/visualizations/heatmap/LogScaleToggler.tsx
+++ b/src/h5web/visualizations/heatmap/LogScaleToggler.tsx
@@ -1,26 +1,23 @@
 import React from 'react';
 import { FiEyeOff, FiEye } from 'react-icons/fi';
 import styles from './HeatmapVis.module.css';
+import { useHeatmapState, useHeatmapActions } from './store';
 
-interface Props {
-  value: boolean;
-  onChange: (val: boolean) => void;
-}
-
-function LogScaleToggler(props: Props): JSX.Element {
-  const { value, onChange } = props;
+function LogScaleToggler(): JSX.Element {
+  const { hasLogScale } = useHeatmapState();
+  const { toggleLogScale } = useHeatmapActions();
 
   return (
     <button
-      onClick={() => {
-        onChange(!value);
-      }}
+      className={styles.scaleTypeSelector}
       type="button"
       role="switch"
-      aria-checked={value}
-      className={styles.scaleTypeSelector}
+      aria-checked={hasLogScale}
+      onClick={() => {
+        toggleLogScale();
+      }}
     >
-      {value ? <FiEye /> : <FiEyeOff />}
+      {hasLogScale ? <FiEye /> : <FiEyeOff />}
       SymLog scale
     </button>
   );

--- a/src/h5web/visualizations/heatmap/interpolators.ts
+++ b/src/h5web/visualizations/heatmap/interpolators.ts
@@ -38,8 +38,6 @@ import {
   interpolateTurbo,
 } from 'd3-scale-chromatic';
 
-export type D3Interpolator = (t: number) => string;
-
 export const INTERPOLATORS = {
   // Diverging
   BrBG: interpolateBrBG,

--- a/src/h5web/visualizations/heatmap/interpolators.ts
+++ b/src/h5web/visualizations/heatmap/interpolators.ts
@@ -81,5 +81,3 @@ export const INTERPOLATORS = {
   Rainbow: interpolateRainbow,
   Sinebow: interpolateSinebow,
 };
-
-export type ColorMap = keyof typeof INTERPOLATORS;

--- a/src/h5web/visualizations/heatmap/store.ts
+++ b/src/h5web/visualizations/heatmap/store.ts
@@ -8,11 +8,15 @@ import {
   Computed,
   computed,
 } from 'easy-peasy';
+import { extent } from 'd3-array';
 import { ColorMap, INTERPOLATORS } from './interpolators';
 
 export type D3Interpolator = (t: number) => string;
 
 interface HeatmapState {
+  domain?: [number, number];
+  findDomain: Action<HeatmapState, number[]>;
+
   colorMap: ColorMap;
   setColorMap: Action<HeatmapState, ColorMap>;
 
@@ -23,6 +27,13 @@ interface HeatmapState {
 }
 
 export const HeatmapStore = createContextStore<HeatmapState>({
+  domain: undefined,
+  findDomain: action((state, values) => {
+    const [min, max] = extent(values);
+    state.domain =
+      min === undefined || max === undefined ? undefined : [min, max];
+  }),
+
   colorMap: 'Magma',
   setColorMap: action((state, colorMap) => {
     state.colorMap = colorMap;

--- a/src/h5web/visualizations/heatmap/store.ts
+++ b/src/h5web/visualizations/heatmap/store.ts
@@ -5,12 +5,20 @@ import { ColorMap } from './interpolators';
 interface HeatmapState {
   colorMap: ColorMap;
   setColorMap: Action<HeatmapState, ColorMap>;
+
+  hasLogScale: boolean;
+  toggleLogScale: Action<HeatmapState>;
 }
 
 export const HeatmapStore = createContextStore<HeatmapState>({
   colorMap: 'Magma',
   setColorMap: action((state, colorMap) => {
     state.colorMap = colorMap;
+  }),
+
+  hasLogScale: false,
+  toggleLogScale: action(state => {
+    state.hasLogScale = !state.hasLogScale;
   }),
 });
 
@@ -19,5 +27,5 @@ export function useHeatmapState(): State<HeatmapState> {
 }
 
 export function useHeatmapActions(): Actions<HeatmapState> {
-  return HeatmapStore.useStoreActions(state => state);
+  return HeatmapStore.useStoreActions(actions => actions);
 }

--- a/src/h5web/visualizations/heatmap/store.ts
+++ b/src/h5web/visualizations/heatmap/store.ts
@@ -9,10 +9,19 @@ import {
   computed,
 } from 'easy-peasy';
 import { extent } from 'd3-array';
-import { ScaleLinear, ScaleSymLog, scaleSymlog, scaleLinear } from 'd3-scale';
-import { ColorMap, INTERPOLATORS } from './interpolators';
+import {
+  ScaleLinear,
+  ScaleSymLog,
+  scaleSymlog,
+  scaleLinear,
+  ScaleSequential,
+  scaleSequential,
+} from 'd3-scale';
+import { INTERPOLATORS } from './interpolators';
 
+export type ColorMap = keyof typeof INTERPOLATORS;
 export type D3Interpolator = (t: number) => string;
+export type ColorScale = ScaleSequential<string>;
 export type DataScale =
   | ScaleLinear<number, number>
   | ScaleSymLog<number, number>;
@@ -28,6 +37,7 @@ interface HeatmapState {
   toggleLogScale: Action<HeatmapState>;
 
   interpolator: Computed<HeatmapState, D3Interpolator>;
+  colorScale: Computed<HeatmapState, ColorScale>;
   dataScale: Computed<HeatmapState, DataScale | undefined>;
 }
 
@@ -50,6 +60,7 @@ export const HeatmapStore = createContextStore<HeatmapState>({
   }),
 
   interpolator: computed(state => INTERPOLATORS[state.colorMap]),
+  colorScale: computed(state => scaleSequential(state.interpolator)),
   dataScale: computed(state => {
     if (state.domain === undefined) {
       return undefined;

--- a/src/h5web/visualizations/heatmap/store.ts
+++ b/src/h5web/visualizations/heatmap/store.ts
@@ -1,6 +1,16 @@
 /* eslint-disable no-param-reassign */
-import { createContextStore, Action, State, action, Actions } from 'easy-peasy';
-import { ColorMap } from './interpolators';
+import {
+  createContextStore,
+  Action,
+  State,
+  action,
+  Actions,
+  Computed,
+  computed,
+} from 'easy-peasy';
+import { ColorMap, INTERPOLATORS } from './interpolators';
+
+export type D3Interpolator = (t: number) => string;
 
 interface HeatmapState {
   colorMap: ColorMap;
@@ -8,6 +18,8 @@ interface HeatmapState {
 
   hasLogScale: boolean;
   toggleLogScale: Action<HeatmapState>;
+
+  interpolator: Computed<HeatmapState, D3Interpolator>;
 }
 
 export const HeatmapStore = createContextStore<HeatmapState>({
@@ -20,6 +32,8 @@ export const HeatmapStore = createContextStore<HeatmapState>({
   toggleLogScale: action(state => {
     state.hasLogScale = !state.hasLogScale;
   }),
+
+  interpolator: computed(state => INTERPOLATORS[state.colorMap]),
 });
 
 export function useHeatmapState(): State<HeatmapState> {

--- a/src/h5web/visualizations/heatmap/store.ts
+++ b/src/h5web/visualizations/heatmap/store.ts
@@ -9,9 +9,13 @@ import {
   computed,
 } from 'easy-peasy';
 import { extent } from 'd3-array';
+import { ScaleLinear, ScaleSymLog, scaleSymlog, scaleLinear } from 'd3-scale';
 import { ColorMap, INTERPOLATORS } from './interpolators';
 
 export type D3Interpolator = (t: number) => string;
+export type DataScale =
+  | ScaleLinear<number, number>
+  | ScaleSymLog<number, number>;
 
 interface HeatmapState {
   domain?: [number, number];
@@ -24,6 +28,7 @@ interface HeatmapState {
   toggleLogScale: Action<HeatmapState>;
 
   interpolator: Computed<HeatmapState, D3Interpolator>;
+  dataScale: Computed<HeatmapState, DataScale | undefined>;
 }
 
 export const HeatmapStore = createContextStore<HeatmapState>({
@@ -45,6 +50,16 @@ export const HeatmapStore = createContextStore<HeatmapState>({
   }),
 
   interpolator: computed(state => INTERPOLATORS[state.colorMap]),
+  dataScale: computed(state => {
+    if (state.domain === undefined) {
+      return undefined;
+    }
+
+    const scale = (state.hasLogScale ? scaleSymlog : scaleLinear)();
+    scale.domain(state.domain);
+
+    return scale;
+  }),
 });
 
 export function useHeatmapState(): State<HeatmapState> {

--- a/src/h5web/visualizations/heatmap/utils.ts
+++ b/src/h5web/visualizations/heatmap/utils.ts
@@ -1,4 +1,3 @@
-import { extent } from 'd3-array';
 import { rgb } from 'd3-color';
 import {
   scaleSequential,
@@ -34,15 +33,6 @@ export function computeTextureData(
   });
 
   return Uint8Array.from(colors.flat());
-}
-
-export function findDomain(values: number[]): [number, number] | undefined {
-  const [min, max] = extent(values);
-
-  if (min === undefined || max === undefined) {
-    return undefined;
-  }
-  return [min, max];
 }
 
 export const adaptedNumTicks = scaleLinear()

--- a/src/h5web/visualizations/heatmap/utils.ts
+++ b/src/h5web/visualizations/heatmap/utils.ts
@@ -8,7 +8,7 @@ import {
   scaleSymlog,
 } from 'd3-scale';
 import { range } from 'lodash-es';
-import { D3Interpolator } from './interpolators';
+import { D3Interpolator } from './store';
 
 export type ColorScale =
   | ScaleLinear<number, number>

--- a/src/h5web/visualizations/heatmap/utils.ts
+++ b/src/h5web/visualizations/heatmap/utils.ts
@@ -63,12 +63,12 @@ export function generateCSSLinearGradient(
 
 export function getColorScale(
   domain: [number, number] | undefined,
-  logScale: boolean
+  hasLogScale: boolean
 ): ColorScale | undefined {
   if (domain === undefined) {
     return undefined;
   }
 
-  const scaleFunction = logScale ? scaleSymlog : scaleLinear;
+  const scaleFunction = hasLogScale ? scaleSymlog : scaleLinear;
   return scaleFunction().domain(domain) as ColorScale;
 }

--- a/src/h5web/visualizations/heatmap/utils.ts
+++ b/src/h5web/visualizations/heatmap/utils.ts
@@ -1,21 +1,17 @@
 import { rgb } from 'd3-color';
-import { scaleSequential, scaleLinear } from 'd3-scale';
+import { scaleLinear } from 'd3-scale';
 import { range } from 'lodash-es';
-import { D3Interpolator, DataScale } from './store';
+import { D3Interpolator, DataScale, ColorScale } from './store';
 
 export function computeTextureData(
   values: number[],
-  interpolator: D3Interpolator,
+  colorScale: ColorScale,
   dataScale?: DataScale
 ): Uint8Array | undefined {
   if (dataScale === undefined) {
     return undefined;
   }
 
-  // Map colors to the output of colorScale
-  const colorScale = scaleSequential(interpolator).domain(
-    dataScale.range() as [number, number]
-  );
   // Compute RGB color array for each datapoint `[[<r>, <g>, <b>], [<r>, <g>, <b>], ...]`
   const colors = values.map(val => {
     const { r, g, b } = rgb(colorScale(dataScale(val))); // `scale` returns CSS RGB strings

--- a/src/h5web/visualizations/heatmap/utils.ts
+++ b/src/h5web/visualizations/heatmap/utils.ts
@@ -1,17 +1,7 @@
 import { rgb } from 'd3-color';
-import {
-  scaleSequential,
-  ScaleLinear,
-  ScaleSymLog,
-  scaleLinear,
-  scaleSymlog,
-} from 'd3-scale';
+import { scaleSequential, scaleLinear } from 'd3-scale';
 import { range } from 'lodash-es';
-import { D3Interpolator } from './store';
-
-export type DataScale =
-  | ScaleLinear<number, number>
-  | ScaleSymLog<number, number>;
+import { D3Interpolator, DataScale } from './store';
 
 export function computeTextureData(
   values: number[],
@@ -49,16 +39,4 @@ export function generateCSSLinearGradient(
     .reduce((acc, val) => `${acc},${val}`);
 
   return `linear-gradient(to ${direction}, ${gradientColors})`;
-}
-
-export function getDataScale(
-  domain: [number, number] | undefined,
-  hasLogScale: boolean
-): DataScale | undefined {
-  if (domain === undefined) {
-    return undefined;
-  }
-
-  const scaleFunction = hasLogScale ? scaleSymlog : scaleLinear;
-  return scaleFunction().domain(domain) as DataScale;
 }

--- a/src/h5web/visualizations/heatmap/utils.ts
+++ b/src/h5web/visualizations/heatmap/utils.ts
@@ -9,26 +9,26 @@ import {
 import { range } from 'lodash-es';
 import { D3Interpolator } from './store';
 
-export type ColorScale =
+export type DataScale =
   | ScaleLinear<number, number>
   | ScaleSymLog<number, number>;
 
 export function computeTextureData(
   values: number[],
   interpolator: D3Interpolator,
-  colorScale?: ColorScale
+  dataScale?: DataScale
 ): Uint8Array | undefined {
-  if (colorScale === undefined) {
+  if (dataScale === undefined) {
     return undefined;
   }
 
   // Map colors to the output of colorScale
-  const scale = scaleSequential(interpolator).domain(
-    colorScale.range() as [number, number]
+  const colorScale = scaleSequential(interpolator).domain(
+    dataScale.range() as [number, number]
   );
   // Compute RGB color array for each datapoint `[[<r>, <g>, <b>], [<r>, <g>, <b>], ...]`
   const colors = values.map(val => {
-    const { r, g, b } = rgb(scale(colorScale(val))); // `scale` returns CSS RGB strings
+    const { r, g, b } = rgb(colorScale(dataScale(val))); // `scale` returns CSS RGB strings
     return [r, g, b];
   });
 
@@ -51,14 +51,14 @@ export function generateCSSLinearGradient(
   return `linear-gradient(to ${direction}, ${gradientColors})`;
 }
 
-export function getColorScale(
+export function getDataScale(
   domain: [number, number] | undefined,
   hasLogScale: boolean
-): ColorScale | undefined {
+): DataScale | undefined {
   if (domain === undefined) {
     return undefined;
   }
 
   const scaleFunction = hasLogScale ? scaleSymlog : scaleLinear;
-  return scaleFunction().domain(domain) as ColorScale;
+  return scaleFunction().domain(domain) as DataScale;
 }


### PR DESCRIPTION
The commits give a good overview of the refactor, but basically the whole domain/interpolator/scale logic now resides in a single place: the store.