### PR TITLE
MetadataViewer and DatasetVisualizer are now a single switchable panel

### DIFF
--- a/src/h5web/App.module.css
+++ b/src/h5web/App.module.css
@@ -8,16 +8,45 @@
   background-color: var(--primary-bg);
 }
 
-.dataVisualizer {
+.mainArea {
   display: flex;
-  scrollbar-width: thin;
+  flex-direction: column;
 }
 
-.metadataViewer {
-  overflow: scroll !important;
-  scrollbar-width: thin;
+.toolbar {
+  display: flex;
+  justify-content: center;
+  font-size: 1.2rem;
+  background-color: var(--secondary-bg);
+  padding: 0.5rem;
 }
 
-.empty {
-  padding: 1rem;
+.roleToggler {
+  display: flex;
+  font-size: 1.2rem;
+  border-radius: 10px;
+  z-index: 1;
+  overflow: hidden;
+}
+
+.btn {
+  composes: btn-clean from global;
+  display: flex;
+  align-items: center;
+  padding: 0.375rem 1rem;
+  background-color: var(--secondary-light-bg);
+}
+
+.btn:hover,
+.btn[aria-selected='true'] {
+  transition-duration: 0.2s, 0.2s;
+}
+
+.btn:hover {
+  background-color: var(--secondary-light);
+}
+
+.btn[aria-selected='true'] {
+  background-color: var(--secondary);
+  font-weight: bold;
 }

--- a/src/h5web/App.tsx
+++ b/src/h5web/App.tsx
@@ -9,9 +9,15 @@ import styles from './App.module.css';
 import { isDataset } from './providers/utils';
 import { useEntity } from './providers/hooks';
 
+enum Role {
+  Inspect,
+  Display,
+}
+
 function App(): JSX.Element {
   const [selectedLink, setSelectedLink] = useState<HDF5Link>();
   const [selectedDataset, setSelectedDataset] = useState<HDF5Dataset>();
+  const [role, setRole] = useState<Role>(Role.Inspect);
 
   const selectedEntity = useEntity(selectedLink);
 
@@ -32,32 +38,43 @@ function App(): JSX.Element {
 
         <ReflexSplitter />
 
-        <ReflexElement minSize={500}>
-          <ReflexContainer orientation="horizontal">
-            <ReflexElement className={styles.dataVisualizer} minSize={250}>
-              <DatasetVisualizer dataset={selectedDataset} />
-            </ReflexElement>
-
-            <ReflexSplitter />
-
-            <ReflexElement
-              className={styles.metadataViewer}
-              flex={0.25}
-              minSize={100}
-            >
-              {selectedLink ? (
-                <MetadataViewer
-                  key={JSON.stringify(selectedLink)}
-                  link={selectedLink}
-                  entity={selectedEntity}
-                />
-              ) : (
-                <div className={styles.empty}>
-                  <p>No entity selected.</p>
-                </div>
-              )}
-            </ReflexElement>
-          </ReflexContainer>
+        <ReflexElement className={styles.mainArea} minSize={500}>
+          <div className={styles.toolbar}>
+            {' '}
+            <div className={styles.roleToggler}>
+              <button
+                type="button"
+                role="tab"
+                className={styles.btn}
+                aria-selected={role === Role.Inspect}
+                onClick={() => {
+                  setRole(Role.Inspect);
+                }}
+              >
+                Inspect
+              </button>
+              <button
+                type="button"
+                role="tab"
+                className={styles.btn}
+                aria-selected={role === Role.Display}
+                onClick={() => {
+                  setRole(Role.Display);
+                }}
+              >
+                Display
+              </button>
+            </div>
+          </div>
+          {role === Role.Display ? (
+            <DatasetVisualizer dataset={selectedDataset} />
+          ) : (
+            <MetadataViewer
+              key={JSON.stringify(selectedLink)}
+              link={selectedLink}
+              entity={selectedEntity}
+            />
+          )}
         </ReflexElement>
       </ReflexContainer>
     </div>

--- a/src/h5web/dataset-visualizer/DatasetVisualizer.module.css
+++ b/src/h5web/dataset-visualizer/DatasetVisualizer.module.css
@@ -3,6 +3,7 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
+  scrollbar-width: thin;
 }
 
 .displayArea {

--- a/src/h5web/metadata-viewer/MetadataViewer.module.css
+++ b/src/h5web/metadata-viewer/MetadataViewer.module.css
@@ -41,3 +41,12 @@
 .table tbody tr:first-child > td.raw {
   padding-top: 0.5rem;
 }
+
+.metadataViewer {
+  overflow: scroll !important;
+  scrollbar-width: thin;
+}
+
+.empty {
+  padding: 1rem;
+}

--- a/src/h5web/metadata-viewer/MetadataViewer.tsx
+++ b/src/h5web/metadata-viewer/MetadataViewer.tsx
@@ -3,24 +3,29 @@ import { HDF5Link, HDF5Entity } from '../providers/models';
 import AttributesInfo from './AttributesInfo';
 import LinkInfo from './LinkInfo';
 import EntityInfo from './EntityInfo';
+import styles from './MetadataViewer.module.css';
 
 interface Props {
   key: string;
-  link: HDF5Link;
+  link?: HDF5Link;
   entity?: HDF5Entity;
 }
 
 function MetadataViewer(props: Props): JSX.Element {
   const { link, entity } = props;
 
-  return (
-    <>
+  return link ? (
+    <div className={styles.metadataViewer}>
       <LinkInfo link={link} />
       {entity && <EntityInfo entity={entity} />}
       {entity && 'attributes' in entity && (
         <AttributesInfo attributes={entity.attributes} />
       )}
-    </>
+    </div>
+  ) : (
+    <div className={styles.empty}>
+      <p>No entity selected.</p>
+    </div>
   );
 }
 

--- a/src/styles/vars.css
+++ b/src/styles/vars.css
@@ -1,6 +1,7 @@
 :root {
   --black: #020402;
   --primary: #c0da74;
+  --primary-dark: #9aae5d;
   --primary-light: #d4e09b;
   --primary-bg: #f5fbef;
   --primary-light-bg: #fafdf7;


### PR DESCRIPTION
Here is the first version:
![image](https://user-images.githubusercontent.com/42204205/79539833-5d270500-8087-11ea-8c47-1cbd86d54b1a.png)

I think some improvements are to be made on the styling so I open the PR early for discussion.

The reasons for the aspect of this first version are the following: I wanted the `roleToggler` to integrate with the rest of the viewer with the same background color. While this poses no problem in `Visualize` mode, in `Inspect` mode, the roleToggle merges visually with the first header `Link Info`. I added a border then but this is not extremely elegant...