### PR TITLE
Add button to show/hide explorer sidebar

### DIFF
--- a/src/h5web/App.module.css
+++ b/src/h5web/App.module.css
@@ -18,7 +18,7 @@
   justify-content: flex-end;
   font-size: 0.9rem;
   background-color: var(--secondary-bg);
-  padding: 0.4rem;
+  padding: calc(0.5rem - 1px) 1rem 0.5rem;
 }
 
 .roleToggler {
@@ -31,8 +31,7 @@
   composes: btn-clean from global;
   display: flex;
   align-items: center;
-  padding: 0.2rem 0.8rem;
-  padding-bottom: 0.3rem;
+  padding: 0.2rem 0.8rem 0.3rem;
   background-color: var(--secondary-light-bg);
   transition: background-color 0s ease-out;
 }
@@ -46,7 +45,14 @@
   background-color: var(--secondary-light);
 }
 
-.btn[aria-selected='true'] {
+.btn[aria-selected='true'],
+.btn[aria-pressed='true'] {
   background-color: var(--secondary);
   font-weight: bold;
+}
+
+.sidebarBtn {
+  composes: btn;
+  margin-right: 1rem;
+  border-radius: 0.5rem;
 }

--- a/src/h5web/App.tsx
+++ b/src/h5web/App.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { ReflexContainer, ReflexSplitter, ReflexElement } from 'react-reflex';
 
+import { FiSidebar } from 'react-icons/fi';
 import Explorer from './explorer/Explorer';
 import DatasetVisualizer from './dataset-visualizer/DatasetVisualizer';
 import { HDF5Link, HDF5Dataset } from './providers/models';
@@ -17,6 +18,8 @@ enum Role {
 function App(): JSX.Element {
   const [selectedLink, setSelectedLink] = useState<HDF5Link>();
   const [selectedDataset, setSelectedDataset] = useState<HDF5Dataset>();
+
+  const [isExplorerOpen, setExplorerOpen] = useState(true);
   const [role, setRole] = useState<Role>(Role.Display);
 
   const selectedEntity = useEntity(selectedLink);
@@ -32,15 +35,34 @@ function App(): JSX.Element {
   return (
     <div className={styles.app}>
       <ReflexContainer orientation="vertical" windowResizeAware>
-        <ReflexElement className={styles.explorer} flex={0.25} minSize={250}>
+        <ReflexElement
+          className={styles.explorer}
+          style={{ display: isExplorerOpen ? undefined : 'none' }}
+          flex={0.25}
+          minSize={250}
+        >
           <Explorer onSelect={setSelectedLink} />
         </ReflexElement>
 
         <ReflexSplitter />
 
-        <ReflexElement className={styles.mainArea} minSize={500}>
+        <ReflexElement
+          className={styles.mainArea}
+          flex={isExplorerOpen ? 0.75 : 1}
+          minSize={500}
+        >
           <div className={styles.toolbar}>
-            {' '}
+            <button
+              className={styles.sidebarBtn}
+              type="button"
+              aria-label="Toggle explorer sidebar"
+              aria-pressed={isExplorerOpen}
+              onClick={() => {
+                setExplorerOpen(!isExplorerOpen);
+              }}
+            >
+              <FiSidebar />
+            </button>{' '}
             <div className={styles.roleToggler}>
               <button
                 type="button"


### PR DESCRIPTION
Fixes #85 

I didn't extract the sidebar into a separate component as I believe you've started on the breadcrumbs and didn't want to risk conflicts. I hide the explorer with `display: none` for now so it doesn't lose its internal state.