### PR TITLE
Stop using AutoSizer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13309,11 +13309,6 @@
         "debounce": "^1.2.0"
       }
     },
-    "react-virtualized-auto-sizer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.2.tgz",
-      "integrity": "sha512-MYXhTY1BZpdJFjUovvYHVBmkq79szK/k7V3MO+36gJkWGkrXKtyr4vCPtpphaTLRAdDNoYEYFZWE8LjN+PIHNg=="
-    },
     "react-window": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.5.tgz",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "react-select": "^3.1.0",
     "react-three-fiber": "^4.0.23",
     "react-use": "^13.26.3",
-    "react-virtualized-auto-sizer": "^1.0.2",
     "react-window": "^1.8.5",
     "recharts": "^1.8.5",
     "three": "^0.115.0"

--- a/src/h5web/visualizations/LineVis.module.css
+++ b/src/h5web/visualizations/LineVis.module.css
@@ -1,3 +1,8 @@
+.root {
+  flex: 1 1 0%;
+  min-width: 0;
+}
+
 .chart {
   display: block;
   overflow: hidden;

--- a/src/h5web/visualizations/LineVis.tsx
+++ b/src/h5web/visualizations/LineVis.tsx
@@ -7,8 +7,8 @@ import {
   Tooltip,
   CartesianGrid,
 } from 'recharts';
-import AutoSizer from 'react-virtualized-auto-sizer';
 
+import { useMeasure } from 'react-use';
 import styles from './LineVis.module.css';
 
 interface Props {
@@ -18,13 +18,16 @@ interface Props {
 function LineVis(props: Props): JSX.Element {
   const { data } = props;
 
+  const [divRef, { width, height }] = useMeasure();
+  const isVisible = width > 0 && height > 0;
+
   const chartData = useMemo(() => {
     return data.map((val, index) => ({ x: index + 1, y: val }));
   }, [data]);
 
   return (
-    <AutoSizer>
-      {({ width, height }) => (
+    <div ref={divRef} className={styles.root}>
+      {isVisible && (
         <LineChart
           className={styles.chart}
           data={chartData}
@@ -39,7 +42,7 @@ function LineVis(props: Props): JSX.Element {
           <Line dataKey="y" dot={false} isAnimationActive={false} />
         </LineChart>
       )}
-    </AutoSizer>
+    </div>
   );
 }
 

--- a/src/h5web/visualizations/heatmap/ColorBar.tsx
+++ b/src/h5web/visualizations/heatmap/ColorBar.tsx
@@ -25,17 +25,23 @@ function ColorBar(): JSX.Element {
           backgroundImage: generateCSSLinearGradient(interpolator, 'top'),
         }}
       />
-      <svg className={styles.colorBarAxis} height={gradientHeight} width="2em">
-        <AxisRight
-          scale={axisScale}
-          hideAxisLine
-          numTicks={adaptedNumTicks(gradientHeight)}
-          tickFormat={axisScale.tickFormat(
-            adaptedNumTicks(gradientHeight),
-            '.3'
-          )}
-        />
-      </svg>
+      {gradientHeight > 0 && (
+        <svg
+          className={styles.colorBarAxis}
+          height={gradientHeight}
+          width="2em"
+        >
+          <AxisRight
+            scale={axisScale}
+            hideAxisLine
+            numTicks={adaptedNumTicks(gradientHeight)}
+            tickFormat={axisScale.tickFormat(
+              adaptedNumTicks(gradientHeight),
+              '.3'
+            )}
+          />
+        </svg>
+      )}
     </div>
   );
 }

--- a/src/h5web/visualizations/heatmap/IndexAxis.tsx
+++ b/src/h5web/visualizations/heatmap/IndexAxis.tsx
@@ -17,11 +17,13 @@ interface Props {
 
 function IndexAxis(props: Props): JSX.Element {
   const { className, domain, orientation } = props;
-  const [divRef, { width, height }] = useMeasure();
 
   const [min, max] = domain;
   const isLeftAxis = orientation === 'left';
   const Axis = isLeftAxis ? AxisLeft : AxisBottom;
+
+  const [divRef, { width, height }] = useMeasure();
+  const isVisible = width > 0 && height > 0;
 
   const scale = scaleLinear()
     .domain([min - 0.5, max - 0.5])
@@ -34,19 +36,21 @@ function IndexAxis(props: Props): JSX.Element {
 
   return (
     <div ref={divRef} className={className}>
-      <svg className={styles.axis} data-orientation={orientation}>
-        <Axis
-          scale={scale}
-          left={isLeftAxis ? width : 0}
-          numTicks={numTicks}
-          hideAxisLine
-          tickFormat={format('0')}
-          tickClassName={styles.tick}
-          tickComponent={({ formattedValue, ...tickProps }) => (
-            <text {...tickProps}>{formattedValue}</text>
-          )}
-        />
-      </svg>
+      {isVisible && (
+        <svg className={styles.axis} data-orientation={orientation}>
+          <Axis
+            scale={scale}
+            left={isLeftAxis ? width : 0}
+            numTicks={numTicks}
+            hideAxisLine
+            tickFormat={format('0')}
+            tickClassName={styles.tick}
+            tickComponent={({ formattedValue, ...tickProps }) => (
+              <text {...tickProps}>{formattedValue}</text>
+            )}
+          />
+        </svg>
+      )}
     </div>
   );
 }

--- a/src/h5web/visualizations/matrix/MatrixVis.module.css
+++ b/src/h5web/visualizations/matrix/MatrixVis.module.css
@@ -1,3 +1,8 @@
+.wrapper {
+  flex: 1 1 0%;
+  min-width: 0;
+}
+
 .grid {
   font-family: var(--monospace);
   scrollbar-width: thin;

--- a/src/h5web/visualizations/matrix/MatrixVis.tsx
+++ b/src/h5web/visualizations/matrix/MatrixVis.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef } from 'react';
 import { FixedSizeGrid as IndexedGrid } from 'react-window';
-import AutoSizer from 'react-virtualized-auto-sizer';
+import { useMeasure } from 'react-use';
 import { HDF5Value } from '../../providers/models';
 import styles from './MatrixVis.module.css';
 import GridSettingsProvider from './GridSettingsContext';
@@ -17,6 +17,9 @@ interface Props {
 function MatrixVis(props: Props): JSX.Element {
   const { dims, data } = props;
 
+  const [divRef, { width, height }] = useMeasure();
+  const isVisible = width > 0 && height > 0;
+
   const rowCount = dims[0] + 1; // includes IndexRow
   const columnCount = (dims.length === 2 ? dims[1] : 1) + 1; // includes IndexColumn
 
@@ -29,8 +32,8 @@ function MatrixVis(props: Props): JSX.Element {
         dims.length === 1 ? row => data[row] : (row, col) => data[row][col]
       }
     >
-      <AutoSizer>
-        {({ width, height }) => (
+      <div ref={divRef} className={styles.wrapper}>
+        {isVisible && (
           <IndexedGrid
             className={styles.grid}
             innerElementType={forwardRef(StickyGrid)}
@@ -44,7 +47,7 @@ function MatrixVis(props: Props): JSX.Element {
             {Cell}
           </IndexedGrid>
         )}
-      </AutoSizer>
+      </div>
     </GridSettingsProvider>
   );
 }


### PR DESCRIPTION
Fix #88 

I use `useMeasure` everywhere instead. This leads to a significant gain in performance when resizing the matrix and line visualizations. It also fixes a bug where the internal state of the matrix vis, notably, would reset on resize (e.g. turn sticky off then resize => stickiness turns back on).

When `useMeasure` is first executed, it returns a width and height of 0. I check for this everywhere to save us from rendering invisible things.