### PR TITLE
Implement orthonormal option for heatmap

### DIFF
--- a/src/h5web/visualizations/heatmap/HeatmapVis.module.css
+++ b/src/h5web/visualizations/heatmap/HeatmapVis.module.css
@@ -1,17 +1,23 @@
 .root {
   flex: 1 1 0%;
   display: flex;
-  background-color: var(--primary-light-bg);
   min-width: 0;
 }
 
 .mapArea {
   flex: 1 1 0%;
   min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.heatmap {
+  flex: none;
 }
 
 /* R3F's <Dom /> element*/
-.mapArea > div > div {
+.heatmap > div > div {
   transform: none !important;
   pointer-events: none;
 }

--- a/src/h5web/visualizations/heatmap/HeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapVis.tsx
@@ -8,6 +8,7 @@ import ColorMapSelector from './ColorMapSelector';
 import LogScaleToggler from './LogScaleToggler';
 import { useHeatmapState, useHeatmapActions } from './store';
 import AxisGrid from './AxisGrid';
+import { useHeatmapSize } from './hooks';
 
 const AXIS_OFFSETS: [number, number] = [72, 36];
 
@@ -22,6 +23,8 @@ function HeatmapVis(props: Props): JSX.Element {
   const { colorScale, dataScale } = useHeatmapState();
   const { findDomain } = useHeatmapActions();
 
+  const [mapAreaRef, heatmapSize] = useHeatmapSize(dims, AXIS_OFFSETS);
+
   const values = useMemo(() => data.flat(), [data]);
   const textureData = useMemo(
     () => computeTextureData(values, colorScale, dataScale),
@@ -34,18 +37,22 @@ function HeatmapVis(props: Props): JSX.Element {
 
   return (
     <div className={styles.root}>
-      <div className={styles.mapArea}>
-        <Canvas className={styles.heatmap} orthographic invalidateFrameloop>
-          <ambientLight />
-          {textureData && (
-            <Mesh
-              dims={dims}
-              textureData={textureData}
-              axisOffsets={AXIS_OFFSETS}
-            />
-          )}
-          <AxisGrid dims={dims} axisOffsets={AXIS_OFFSETS} />
-        </Canvas>
+      <div ref={mapAreaRef} className={styles.mapArea}>
+        {heatmapSize && (
+          <div className={styles.heatmap} style={heatmapSize}>
+            <Canvas orthographic invalidateFrameloop>
+              <ambientLight />
+              {textureData && (
+                <Mesh
+                  dims={dims}
+                  textureData={textureData}
+                  axisOffsets={AXIS_OFFSETS}
+                />
+              )}
+              <AxisGrid dims={dims} axisOffsets={AXIS_OFFSETS} />
+            </Canvas>
+          </div>
+        )}
       </div>
       <div className={styles.colorBarArea}>
         <LogScaleToggler />

--- a/src/h5web/visualizations/heatmap/hooks.ts
+++ b/src/h5web/visualizations/heatmap/hooks.ts
@@ -2,8 +2,51 @@ import React, { useCallback, useRef, useEffect } from 'react';
 import { Vector3 } from 'three';
 import { ReactThreeFiber, PointerEvent, useThree } from 'react-three-fiber';
 import { clamp } from 'lodash-es';
+import { useMeasure } from 'react-use';
+import { useHeatmapState } from './store';
 
 const ZOOM_FACTOR = 0.95;
+
+export function useHeatmapSize<T>(
+  dims: [number, number],
+  axisOffset: [number, number]
+): [(elem: T) => void, { width: number; height: number } | undefined] {
+  const { keepAspectRatio } = useHeatmapState();
+  const [wrapperRef, { width, height }] = useMeasure();
+
+  if (width === 0 && height === 0) {
+    return [wrapperRef, undefined];
+  }
+
+  if (!keepAspectRatio) {
+    return [wrapperRef, { width, height }];
+  }
+
+  const [rows, cols] = dims;
+  const aspectRatio = rows / cols;
+
+  const [leftAxisWidth, bottomAxisHeight] = axisOffset;
+  const availableWidth = width - leftAxisWidth;
+  const availableHeight = height - bottomAxisHeight;
+
+  // Determine how to compute mesh size to fit available space while maintaining aspect ratio
+  const shouldAdjustWidth = availableWidth >= availableHeight * aspectRatio;
+
+  const meshWidth = shouldAdjustWidth
+    ? availableHeight * aspectRatio
+    : availableWidth;
+  const meshHeight = shouldAdjustWidth
+    ? availableHeight
+    : availableWidth / aspectRatio;
+
+  return [
+    wrapperRef,
+    {
+      width: meshWidth + leftAxisWidth,
+      height: meshHeight + bottomAxisHeight,
+    },
+  ];
+}
 
 export function usePanZoom(
   leftAxisWidth: number,

--- a/src/h5web/visualizations/heatmap/store.ts
+++ b/src/h5web/visualizations/heatmap/store.ts
@@ -37,6 +37,8 @@ interface HeatmapState {
   hasLogScale: boolean;
   toggleLogScale: Action<HeatmapState>;
 
+  keepAspectRatio: boolean;
+
   interpolator: Computed<HeatmapState, D3Interpolator>;
   colorScale: Computed<HeatmapState, ColorScale>;
   dataScale: Computed<HeatmapState, DataScale | undefined>;
@@ -59,6 +61,8 @@ export const HeatmapStore = createContextStore<HeatmapState>({
   toggleLogScale: action(state => {
     state.hasLogScale = !state.hasLogScale;
   }),
+
+  keepAspectRatio: true,
 
   interpolator: computed(state => INTERPOLATORS[state.colorMap]),
   colorScale: computed(state => scaleSequential(state.interpolator)),


### PR DESCRIPTION
Fixes #70 

I added a boolean to the state (`true` by default), but I didn't add a button to change it as this will go in the soon-to-be toolbar.

The Heatmap takes all available width or height depending on the size ratio of the dataset.

![image](https://user-images.githubusercontent.com/2936402/79881944-2851df80-83f2-11ea-890e-b806db3e7dcc.png)

![image](https://user-images.githubusercontent.com/2936402/79881977-3273de00-83f2-11ea-8e7a-50a98290f133.png)
