### PR TITLE
Implement heatmap tooltip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1898,7 +1898,6 @@
       "version": "16.9.5",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.5.tgz",
       "integrity": "sha512-BX6RQ8s9D+2/gDhxrj8OW+YD4R+8hj7FEM/OJHGNR0KipE1h1mSsf39YeyC81qafkq+N3rU3h3RFbLSwE5VqUg==",
-      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -2064,6 +2063,16 @@
         "prop-types": "^15.6.0"
       }
     },
+    "@vx/bounds": {
+      "version": "0.0.195",
+      "resolved": "https://registry.npmjs.org/@vx/bounds/-/bounds-0.0.195.tgz",
+      "integrity": "sha512-G99BCC335UgOsKSecye2HRGrnDazOXEcfuu7F2SvzgfPu3jNanrLpu7Y8Te13Ibo13wNUMY3RUTJszTaBHSI4w==",
+      "requires": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "prop-types": "^15.5.10"
+      }
+    },
     "@vx/curve": {
       "version": "0.0.195",
       "resolved": "https://registry.npmjs.org/@vx/curve/-/curve-0.0.195.tgz",
@@ -2118,6 +2127,18 @@
         "lodash": "^4.17.15",
         "prop-types": "^15.7.2",
         "reduce-css-calc": "^1.3.0"
+      }
+    },
+    "@vx/tooltip": {
+      "version": "0.0.195",
+      "resolved": "https://registry.npmjs.org/@vx/tooltip/-/tooltip-0.0.195.tgz",
+      "integrity": "sha512-xgUuXhe6eeIBD7HohQ31lWxVXTuui11qF2S4nsd+tnQemd2qv0Bg+HmvqJnXDCp7uBwLLupb40T2j1y9y0rGCQ==",
+      "requires": {
+        "@types/classnames": "^2.2.9",
+        "@types/react": "*",
+        "@vx/bounds": "0.0.195",
+        "classnames": "^2.2.5",
+        "prop-types": "^15.5.10"
       }
     },
     "@webassemblyjs/ast": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@vx/axis": "0.0.195",
+    "@vx/tooltip": "0.0.195",
     "axios": "^0.19.2",
     "classnames": "^2.2.6",
     "d3-array": "^2.4.0",

--- a/src/h5web/visualizations/heatmap/HeatmapToolbar.module.css
+++ b/src/h5web/visualizations/heatmap/HeatmapToolbar.module.css
@@ -5,7 +5,7 @@
 }
 
 .toggler {
-  padding: 0 0.5rem;
+  padding: 0 0.75rem;
   composes: btn-clean from global;
   display: flex;
   align-items: center;
@@ -15,6 +15,10 @@
 .toggler:hover,
 .toggler[aria-checked='true'] {
   background-color: var(--primary-dark-bg);
+}
+
+.togglerLabel {
+  margin-left: 0.5rem;
 }
 
 .colorMapSelector {

--- a/src/h5web/visualizations/heatmap/HeatmapVis.module.css
+++ b/src/h5web/visualizations/heatmap/HeatmapVis.module.css
@@ -31,7 +31,7 @@
 }
 
 .axisGrid {
-  position: absolute;
+  position: relative;
   top: 0;
   display: grid;
   grid-template-areas:
@@ -89,4 +89,16 @@
   font-size: inherit;
   text-anchor: inherit;
   dominant-baseline: inherit;
+}
+
+.tooltip {
+  color: inherit !important;
+  background-color: rgba(245, 251, 239, 0.7) !important;
+}
+
+.tooltipValue {
+  display: block;
+  font-weight: 600;
+  margin-top: 0.25rem;
+  font-size: 1.125em;
 }

--- a/src/h5web/visualizations/heatmap/HeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapVis.tsx
@@ -7,6 +7,7 @@ import { useHeatmapStore, selectDataScale, selectColorScale } from './store';
 import { useHeatmapStyles } from './hooks';
 import AxisGrid from './AxisGrid';
 import Mesh from './Mesh';
+import Tooltip from './Tooltip';
 
 const AXIS_OFFSETS: [number, number] = [72, 36];
 
@@ -46,6 +47,7 @@ function HeatmapVis(props: Props): JSX.Element {
             >
               <ambientLight />
               <AxisGrid dims={dims} axisOffsets={AXIS_OFFSETS} />
+              <Tooltip dims={dims} data={data} />
               {textureData && <Mesh dims={dims} textureData={textureData} />}
             </Canvas>
           </div>

--- a/src/h5web/visualizations/heatmap/Toggler.tsx
+++ b/src/h5web/visualizations/heatmap/Toggler.tsx
@@ -21,7 +21,7 @@ function Toggler(props: Props): JSX.Element {
       }}
     >
       {value ? <FiToggleRight /> : <FiToggleLeft />}
-      {label}
+      <span className={styles.togglerLabel}>{label}</span>
     </button>
   );
 }

--- a/src/h5web/visualizations/heatmap/Tooltip.tsx
+++ b/src/h5web/visualizations/heatmap/Tooltip.tsx
@@ -1,0 +1,89 @@
+import React, { ReactElement, useCallback } from 'react';
+import { Dom, PointerEvent, useThree } from 'react-three-fiber';
+import { TooltipWithBounds, useTooltip } from '@vx/tooltip';
+import { scaleLinear } from 'd3-scale';
+import { format } from 'd3-format';
+import styles from './HeatmapVis.module.css';
+
+interface Props {
+  data: number[][];
+  dims: [number, number];
+}
+
+function Tooltip(props: Props): ReactElement {
+  const { data, dims } = props;
+  const [rows, cols] = dims;
+
+  const { camera, size, intersect } = useThree();
+  const { width, height } = size;
+
+  const {
+    tooltipOpen,
+    tooltipTop,
+    tooltipLeft,
+    tooltipData,
+    showTooltip,
+    hideTooltip,
+  } = useTooltip<[number, number]>();
+
+  // Scales to compute data coordinates from unprojected mesh coordinates
+  const xCoordScale = scaleLinear()
+    .domain([-height / 2, height / 2])
+    .range([0, rows]);
+  const yCoordScale = scaleLinear()
+    .domain([-width / 2, width / 2])
+    .range([0, cols]);
+
+  // Update tooltip when pointer moves
+  // When panning, events are handled and stopped by texture mesh and do not reach this mesh (which is behind)
+  const onPointerMove = useCallback(
+    (evt: PointerEvent) => {
+      const { zoom } = camera;
+      const projectedPoint = camera.worldToLocal(evt.unprojectedPoint.clone());
+
+      const xCoord = Math.floor(xCoordScale(evt.unprojectedPoint.y));
+      const yCoord = Math.floor(yCoordScale(evt.unprojectedPoint.x));
+
+      showTooltip({
+        tooltipLeft: projectedPoint.x * zoom + width / 2,
+        tooltipTop: -projectedPoint.y * zoom + height / 2,
+        tooltipData: [xCoord, yCoord],
+      });
+    },
+    [yCoordScale, camera, height, xCoordScale, showTooltip, width]
+  );
+
+  // Hide tooltip when pointer leaves mesh or user starts to pan
+  const onPointerOut = useCallback(hideTooltip, [hideTooltip]);
+  const onPointerDown = useCallback(hideTooltip, [hideTooltip]);
+
+  // Trigger `pointermove` when user stops panning to show tooltip if pointer still intersects with mesh
+  const onPointerUp = useCallback(intersect, [intersect]);
+
+  return (
+    <>
+      <mesh {...{ onPointerMove, onPointerOut, onPointerDown, onPointerUp }}>
+        <planeBufferGeometry attach="geometry" args={[width, height]} />
+      </mesh>
+      <Dom style={{ width, height }}>
+        {tooltipOpen && tooltipData ? (
+          <TooltipWithBounds
+            key={Math.random()}
+            className={styles.tooltip}
+            top={tooltipTop}
+            left={tooltipLeft}
+          >
+            {`x=${tooltipData[0]}, y=${tooltipData[1]}`}
+            <span className={styles.tooltipValue}>
+              {format('.3e')(data[tooltipData[0]][tooltipData[1]])}
+            </span>
+          </TooltipWithBounds>
+        ) : (
+          <></>
+        )}
+      </Dom>
+    </>
+  );
+}
+
+export default Tooltip;

--- a/src/h5web/visualizations/heatmap/Tooltip.tsx
+++ b/src/h5web/visualizations/heatmap/Tooltip.tsx
@@ -53,7 +53,7 @@ function Tooltip(props: Props): ReactElement {
     [yCoordScale, camera, height, xCoordScale, showTooltip, width]
   );
 
-  // Hide tooltip when pointer leaves mesh or user starts to pan
+  // Hide tooltip when pointer leaves mesh or user starts panning
   const onPointerOut = useCallback(hideTooltip, [hideTooltip]);
   const onPointerDown = useCallback(hideTooltip, [hideTooltip]);
 

--- a/src/h5web/visualizations/heatmap/hooks.ts
+++ b/src/h5web/visualizations/heatmap/hooks.ts
@@ -87,8 +87,6 @@ export function usePanZoom(): ReactThreeFiber.Events {
 
   const onPointerDown = useCallback(
     (evt: PointerEvent) => {
-      evt.stopPropagation();
-
       const { currentTarget, pointerId } = evt as React.PointerEvent;
       currentTarget.setPointerCapture(pointerId);
 
@@ -99,8 +97,6 @@ export function usePanZoom(): ReactThreeFiber.Events {
   );
 
   const onPointerUp = useCallback((evt: PointerEvent) => {
-    evt.stopPropagation();
-
     const { currentTarget, pointerId } = evt as React.PointerEvent;
     currentTarget.releasePointerCapture(pointerId);
 
@@ -113,6 +109,7 @@ export function usePanZoom(): ReactThreeFiber.Events {
         return;
       }
 
+      // Prevent events from reaching tooltip mesh when panning
       evt.stopPropagation();
 
       const projectedPoint = camera.worldToLocal(evt.unprojectedPoint.clone());
@@ -126,8 +123,6 @@ export function usePanZoom(): ReactThreeFiber.Events {
 
   const onWheel = useCallback(
     (evt: PointerEvent) => {
-      evt.stopPropagation();
-
       const { deltaY } = evt as React.WheelEvent;
       const factor = deltaY > 0 ? ZOOM_FACTOR : 1 / ZOOM_FACTOR;
 


### PR DESCRIPTION
Fix #48 -- The tooltip:

- shows the data coordinates and value;
- moves to the other side of the cursor when reaching the bounds of the canvas (thanks to VX's `TooltipWithBounds`);
- disappears while panning.

![image](https://user-images.githubusercontent.com/2936402/80458510-31323c00-8931-11ea-909f-1ffb322ca19c.png)
![image](https://user-images.githubusercontent.com/2936402/80458582-4c04b080-8931-11ea-8ef6-5998c5236917.png)

In order to not couple the event handling logic for the tooltip with the zoom/pan logic, I render a second mesh behind the textured mesh to which I pass tooltip-specific pointer event listeners. I may refactor the zoom/pan code in a similar fashion so it can be re-used more easily in other visualizations.