### PR TITLE
Perform texture computation on web worker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4076,6 +4076,11 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "comlink": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.3.0.tgz",
+      "integrity": "sha512-mu4KKKNuW8TvkfpW/H88HBPeILubBS6T94BdD1VWBXNXfiyqVtwUCVNO1GeNOBTsIswzsMjWlycYr+77F5b84g=="
+    },
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -13297,6 +13302,11 @@
         "tslib": "^1.10.0"
       }
     },
+    "react-use-comlink": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/react-use-comlink/-/react-use-comlink-2.0.1.tgz",
+      "integrity": "sha512-YDN2wJN2UY7IJB3rDTF9e1Z7Ffo8BtDCeHzcB3vTBfTZ0R/cdi6PgOpPZ4G2Fg2xDdxJL4hwovFboXtdsfQH1Q=="
+    },
     "react-use-measure": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.0.0.tgz",
@@ -18327,6 +18337,28 @@
       "dev": true,
       "requires": {
         "errno": "~0.1.7"
+      }
+    },
+    "worker-loader": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-2.0.0.tgz",
+      "integrity": "sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.0.0",
+        "schema-utils": "^0.4.0"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "0.4.7",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
+          "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
       }
     },
     "worker-rpc": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@vx/tooltip": "0.0.195",
     "axios": "^0.19.2",
     "classnames": "^2.2.6",
+    "comlink": "^4.3.0",
     "d3-array": "^2.4.0",
     "d3-color": "^1.4.0",
     "d3-format": "^1.4.4",
@@ -41,6 +42,7 @@
     "react-slider": "^1.0.4",
     "react-three-fiber": "^4.0.23",
     "react-use": "^13.26.3",
+    "react-use-comlink": "^2.0.1",
     "react-window": "^1.8.5",
     "recharts": "^1.8.5",
     "three": "^0.115.0",
@@ -73,13 +75,17 @@
     "prettier": "^1.19.1",
     "react-reflex": "^3.0.22",
     "react-scripts": "3.4.0",
-    "typescript": "^3.8.2"
+    "typescript": "^3.8.2",
+    "worker-loader": "^2.0.0"
   },
   "jest": {
     "resetMocks": true,
     "transformIgnorePatterns": [
-      "/node_modules/(?!lodash-es/.*)"
-    ]
+      "/node_modules/(?!lodash-es|react-use-comlink)/.*"
+    ],
+    "moduleNameMapper": {
+      "worker-loader!.*": "<rootDir>/src/workerLoaderMock.js"
+    }
   },
   "browserslist": {
     "production": [

--- a/src/h5web/visualizations/heatmap/ColorBar.tsx
+++ b/src/h5web/visualizations/heatmap/ColorBar.tsx
@@ -1,21 +1,30 @@
 import React from 'react';
 import { AxisRight } from '@vx/axis';
 import { useMeasure } from 'react-use';
-import { adaptedNumTicks, generateCSSLinearGradient } from './utils';
+import shallow from 'zustand/shallow';
+import {
+  adaptedNumTicks,
+  generateCSSLinearGradient,
+  getDataScale,
+} from './utils';
 import styles from './HeatmapVis.module.css';
-import { useDataScale, useInterpolator } from './hooks';
+import { useInterpolator } from './hooks';
+import { useHeatmapConfig } from './config';
 
 function ColorBar(): JSX.Element {
-  const dataScale = useDataScale();
-  const interpolator = useInterpolator();
+  const [dataDomain, customDomain, hasLogScale] = useHeatmapConfig(
+    state => [state.dataDomain, state.customDomain, state.hasLogScale],
+    shallow
+  );
 
+  const interpolator = useInterpolator();
   const [gradientRef, { height: gradientHeight }] = useMeasure();
 
-  if (!dataScale) {
+  if (!dataDomain) {
     return <></>;
   }
 
-  const axisScale = dataScale.copy();
+  const axisScale = getDataScale(customDomain || dataDomain, hasLogScale);
   axisScale.range([gradientHeight, 0]);
 
   return (

--- a/src/h5web/visualizations/heatmap/utils.ts
+++ b/src/h5web/visualizations/heatmap/utils.ts
@@ -1,11 +1,17 @@
-import { scaleLinear } from 'd3-scale';
+import { scaleLinear, scaleSymlog } from 'd3-scale';
 import { range } from 'lodash-es';
-import { D3Interpolator } from './models';
+import { D3Interpolator, Domain, DataScale } from './models';
 
 export const adaptedNumTicks = scaleLinear()
   .domain([300, 900])
   .rangeRound([3, 10])
   .clamp(true);
+
+export function getDataScale(domain: Domain, isLog: boolean): DataScale {
+  const scale = (isLog ? scaleSymlog : scaleLinear)();
+  scale.domain(domain);
+  return scale;
+}
 
 export function generateCSSLinearGradient(
   interpolator: D3Interpolator,

--- a/src/h5web/visualizations/heatmap/worker.ts
+++ b/src/h5web/visualizations/heatmap/worker.ts
@@ -1,0 +1,30 @@
+import { expose } from 'comlink';
+import { rgb } from 'd3-color';
+import { scaleSequential } from 'd3-scale';
+import { getDataScale } from './utils';
+import { Domain, ColorMap } from './models';
+import { INTERPOLATORS } from './interpolators';
+
+function computeTextureData(
+  values: number[],
+  domain: Domain,
+  hasLogScale: boolean,
+  colorMap: ColorMap
+): Uint8Array | undefined {
+  const dataScale = getDataScale(domain, hasLogScale);
+  const colorScale = scaleSequential(INTERPOLATORS[colorMap]);
+
+  // Compute RGB color array for each datapoint `[[<r>, <g>, <b>], [<r>, <g>, <b>], ...]`
+  const colors = values.map(val => {
+    const { r, g, b } = rgb(colorScale(dataScale(val))); // `colorScale` returns CSS RGB strings
+    return [r, g, b];
+  });
+
+  return Uint8Array.from(colors.flat());
+}
+
+export interface TextureWorker {
+  computeTextureData: typeof computeTextureData;
+}
+
+expose({ computeTextureData });

--- a/src/workerLoaderMock.js
+++ b/src/workerLoaderMock.js
@@ -1,0 +1,1 @@
+module.exports = 'WORKER_LOADER_MOCK';


### PR DESCRIPTION
I used [`comlink`](https://github.com/GoogleChromeLabs/comlink), which simplifies writing and communicating with web workers, along with [`react-use-comlink`](https://github.com/pocesar/react-use-comlink).

I had to replace `useDataScale` with a utility function so I could recreate the data scale on the web worker (functions can't be sent to web workers).

The result is that the UI remains fluid while the texture is being recomputed.

![ezgif-2-ff38971ec5c4](https://user-images.githubusercontent.com/2936402/80692368-c0765580-8ad1-11ea-883b-3fa7fb792dc4.gif)

Next, I'll investigate whether there's a better way to send the values to the web worker. At the moment, the JS array is copied. I hear it's better to _transfer_ a `Uint8Array` by reference... I don't think I'll bother with moving finding the domain to a web worker, as it seems to be pretty fast at the moment, and it only occurs once when selecting a dataset (contrary to the texture, which is recomputed when the config changes).