### PR TITLE
Implement screenshot button

### DIFF
--- a/src/h5web/visualizations/heatmap/HeatmapToolbar.module.css
+++ b/src/h5web/visualizations/heatmap/HeatmapToolbar.module.css
@@ -1,6 +1,5 @@
 .toolbar {
   display: flex;
-  padding: 0 0.5rem;
   font-size: 0.875rem;
 }
 

--- a/src/h5web/visualizations/heatmap/HeatmapToolbar.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapToolbar.tsx
@@ -5,6 +5,7 @@ import ColorMapSelector from './ColorMapSelector';
 import Toggler from '../shared/Toggler';
 import { useHeatmapConfig } from './config';
 import DomainSlider from './DomainSlider';
+import ScreenshotButton from '../shared/ScreenshotButton';
 
 function HeatmapToolbar(): JSX.Element {
   const [
@@ -34,6 +35,7 @@ function HeatmapToolbar(): JSX.Element {
         value={keepAspectRatio}
         onChange={toggleAspectRatio}
       />
+      <ScreenshotButton />
     </div>
   );
 }

--- a/src/h5web/visualizations/shared/ScreenshotButton.module.css
+++ b/src/h5web/visualizations/shared/ScreenshotButton.module.css
@@ -1,0 +1,11 @@
+.link {
+  color: inherit;
+  display: flex;
+  align-items: center;
+  padding: 0 0.75rem;
+  font-size: 1.125em;
+}
+
+.link:hover {
+  background-color: var(--secondary-light);
+}

--- a/src/h5web/visualizations/shared/ScreenshotButton.tsx
+++ b/src/h5web/visualizations/shared/ScreenshotButton.tsx
@@ -1,0 +1,32 @@
+import React, { ReactElement } from 'react';
+import { FiCamera } from 'react-icons/fi';
+import styles from './ScreenshotButton.module.css';
+
+function ScreenshotButton(): ReactElement {
+  return (
+    <a
+      className={styles.link}
+      href="/"
+      target="_blank"
+      aria-label="Screenshot"
+      onClick={evt => {
+        const canvas = document.querySelector('canvas');
+
+        // Create data URL from canvas
+        const screnshotUrl = canvas?.toDataURL();
+
+        if (screnshotUrl) {
+          // Let link open screenshot URL in new tab/window
+          evt.currentTarget.setAttribute('href', screnshotUrl);
+        } else {
+          // Don't follow link if canvas hasn't been rendered yet
+          evt.preventDefault();
+        }
+      }}
+    >
+      <FiCamera />
+    </a>
+  );
+}
+
+export default ScreenshotButton;

--- a/src/h5web/visualizations/shared/VisCanvas.tsx
+++ b/src/h5web/visualizations/shared/VisCanvas.tsx
@@ -34,7 +34,8 @@ function VisCanvas(props: Props): JSX.Element {
           <Canvas
             className={styles.canvasWrapper}
             orthographic
-            invalidateFrameloop
+            invalidateFrameloop // disable game loop
+            gl={{ preserveDrawingBuffer: true }} // for screenshot feature
           >
             <ambientLight />
             {axisDomains && (


### PR DESCRIPTION
Fix #95. The new toolbar button converts the canvas to a data URI and opens it in a new tab. This is the equivalent to <kbd>right click > View image</kbd>, which now also works consistently. The generated image can then be saved as PNG with <kbd>Ctrl+S</kbd>

Note that the generated image has the same dimension of the canvas, so you need to go full screen to export a bigger image. I think this is sufficient to meet the requirements for an image export feature, but we'll see with usage.

![ezgif-2-c2e920a66f15](https://user-images.githubusercontent.com/2936402/81176153-02593d00-8fa5-11ea-9d76-32bd18b82ff5.gif)

I've implemented the button as a shared component so it can be reused in the line vis toolbar. I also made the choice:

- to just query for the canvas in the DOM instead of trying to get a reference through React, as this would have complexified things significantly...
- to do nothing if the canvas is not in the DOM -- I doubt users will try to click on the button before actually seeing the rendered canvas;
- to assume that the DOM only contains one canvas -- we can add an ID if this ever changes;
- to use a link instead of a button in order to take advantage of `target="_blank"`, as opening a tab in JS is not trivial.