### PR TITLE
Add default path configuration to select explorer node on mount

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,10 @@
 EXTEND_ESLINT=true
+
+#####
+# APP CONFIGURATION
+# Copy and configure the variables below in your own `.env.local` file
+#####
+
+# Path of Explorer node to select on first mount.
+# Provide an array of indices (e.g. [0,2,1,0]) or leave blank to select root node.
+REACT_APP_DEFAULT_PATH=

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 /build
 /node_modules
-npm-debug.log*
 
+/.env.*
+
+npm-debug.log*
 *.log
+Thumbs.db
+.DS_Store

--- a/src/h5web/explorer/Explorer.tsx
+++ b/src/h5web/explorer/Explorer.tsx
@@ -7,6 +7,10 @@ import styles from './Explorer.module.css';
 import Icon from './Icon';
 import { useDomain, useMetadataTree } from '../providers/hooks';
 
+const DEFAULT_PATH: number[] = JSON.parse(
+  process.env.REACT_APP_DEFAULT_PATH || '[]'
+);
+
 interface Props {
   onSelect: (node: TreeNode<HDF5Link>) => void;
   selectedNode?: TreeNode<HDF5Link>;
@@ -19,8 +23,8 @@ function Explorer(props: Props): JSX.Element {
   const tree = useMetadataTree();
 
   useEffect(() => {
-    if (tree) {
-      // Select root node when tree is ready
+    if (tree && DEFAULT_PATH.length === 0) {
+      // Select root node when tree is ready and default path is empty
       onSelect(tree);
     }
   }, [onSelect, tree]);
@@ -56,6 +60,7 @@ function Explorer(props: Props): JSX.Element {
         <TreeView
           nodes={tree.children}
           selectedNode={selectedNode}
+          defaultPath={DEFAULT_PATH}
           onSelect={onSelect}
           renderIcon={(data, isBranch, isExpanded) => (
             <Icon data={data} isBranch={isBranch} isExpanded={isExpanded} />

--- a/src/h5web/explorer/TreeView.tsx
+++ b/src/h5web/explorer/TreeView.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { TreeNode } from './models';
 
 import styles from './Explorer.module.css';
@@ -7,14 +7,28 @@ type ExpandedNodes = Record<string, boolean>;
 
 interface Props<T> {
   nodes: TreeNode<T>[];
+  defaultPath: number[];
   selectedNode?: TreeNode<T>;
   onSelect: (node: TreeNode<T>) => void;
   renderIcon: (data: T, isBranch: boolean, isExpanded: boolean) => JSX.Element;
 }
 
 function TreeView<T>(props: Props<T>): JSX.Element {
-  const { nodes, selectedNode, onSelect, renderIcon } = props;
-  const [expandedNodes, setExpandedNodes] = useState<ExpandedNodes>({});
+  const { nodes, defaultPath, selectedNode, onSelect, renderIcon } = props;
+
+  // Find first node in default path, if any
+  const defaultNode = nodes[defaultPath[0] ?? -1];
+
+  const [expandedNodes, setExpandedNodes] = useState<ExpandedNodes>(
+    defaultNode && defaultNode.children ? { [defaultNode.uid]: true } : {}
+  );
+
+  useEffect(() => {
+    // Select default node if last in default path
+    if (defaultNode && defaultPath.length === 1) {
+      onSelect(defaultNode);
+    }
+  }, [defaultNode, defaultPath, onSelect]);
 
   return (
     <ul className={styles.group} role="group">
@@ -54,6 +68,7 @@ function TreeView<T>(props: Props<T>): JSX.Element {
             {children && isExpanded && (
               <TreeView
                 nodes={children}
+                defaultPath={defaultPath.slice(1)} // slice default path relevant to sub-tree
                 selectedNode={selectedNode}
                 onSelect={onSelect}
                 renderIcon={renderIcon}


### PR DESCRIPTION
Fix #122 

I went for an environment variable in `.env.local` for now, as it is not version controlled. This means we don't have to be careful not to stage the change on every commit anymore...

So for instance, to select the `intensity_normed` dataset on mount, create a file called `.env.local` at the root and paste the following config:

```
REACT_APP_DEFAULT_PATH=[0,2,1,0]
```