### PR TITLE
Add top and right padding to visualisation area

### DIFF
--- a/src/h5web/dataset-visualizer/VisDisplay.tsx
+++ b/src/h5web/dataset-visualizer/VisDisplay.tsx
@@ -10,11 +10,8 @@ import {
 } from '../visualizations';
 import { useValue } from '../providers/hooks';
 import HeatmapProvider from '../visualizations/heatmap/HeatmapProvider';
-import { AxisOffsets } from '../visualizations/shared/models';
 import { Dims } from '../visualizations/heatmap/models';
 import LineProvider from '../visualizations/line/LineProvider';
-
-const AXIS_OFFSETS: AxisOffsets = { left: 72, bottom: 36 };
 
 interface Props {
   key: string; // reset states when switching between datasets
@@ -46,7 +43,7 @@ function VisDisplay(props: Props): JSX.Element {
 
   if (vis === Vis.Line) {
     return (
-      <LineProvider axisOffsets={AXIS_OFFSETS} data={value}>
+      <LineProvider data={value}>
         <LineVis />
       </LineProvider>
     );
@@ -57,7 +54,6 @@ function VisDisplay(props: Props): JSX.Element {
       <HeatmapProvider
         dims={(dataset.shape as HDF5SimpleShape).dims as Dims}
         data={value}
-        axisOffsets={AXIS_OFFSETS}
       >
         <HeatmapVis />
       </HeatmapProvider>

--- a/src/h5web/visualizations/heatmap/HeatmapProvider.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapProvider.tsx
@@ -1,11 +1,9 @@
 import React, { createContext, ReactElement, ReactNode } from 'react';
 import { Dims } from './models';
-import { AxisOffsets } from '../shared/models';
 
 export interface HeatmapProps {
   dims: Dims;
   data: number[][];
-  axisOffsets: AxisOffsets;
 }
 
 export const HeatmapContext = createContext<HeatmapProps | undefined>(
@@ -17,10 +15,10 @@ type Props = HeatmapProps & {
 };
 
 function HeatmapProvider(props: Props): ReactElement {
-  const { dims, data, axisOffsets, children } = props;
+  const { dims, data, children } = props;
 
   return (
-    <HeatmapContext.Provider value={{ dims, data, axisOffsets }}>
+    <HeatmapContext.Provider value={{ dims, data }}>
       {children}
     </HeatmapContext.Provider>
   );

--- a/src/h5web/visualizations/heatmap/HeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapVis.tsx
@@ -12,7 +12,7 @@ import VisCanvas from '../shared/VisCanvas';
 
 function HeatmapVis(): JSX.Element {
   const props = useProps();
-  const { dims, axisOffsets, data } = props;
+  const { dims, data } = props;
   const [rows, cols] = dims;
 
   const [keepAspectRatio, showGrid] = useHeatmapConfig(
@@ -32,8 +32,7 @@ function HeatmapVis(): JSX.Element {
     <div className={styles.root}>
       <VisCanvas
         // -0.5 to have ticks at the center of pixels
-        axisDomains={{ left: [-0.5, rows - 0.5], bottom: [-0.5, cols - 0.5] }}
-        axisOffsets={axisOffsets}
+        axisDomains={{ bottom: [-0.5, cols - 0.5], left: [-0.5, rows - 0.5] }}
         aspectRatio={aspectRatio}
         showGrid={showGrid}
       >

--- a/src/h5web/visualizations/line/LineProvider.tsx
+++ b/src/h5web/visualizations/line/LineProvider.tsx
@@ -1,9 +1,7 @@
 import React, { createContext, ReactElement, ReactNode } from 'react';
-import { AxisOffsets } from '../shared/models';
 
 export interface LineProps {
   data: number[];
-  axisOffsets: AxisOffsets;
 }
 
 export const LineContext = createContext<LineProps | undefined>(undefined);
@@ -13,12 +11,10 @@ type Props = LineProps & {
 };
 
 function LineProvider(props: Props): ReactElement {
-  const { data, axisOffsets, children } = props;
+  const { data, children } = props;
 
   return (
-    <LineContext.Provider value={{ data, axisOffsets }}>
-      {children}
-    </LineContext.Provider>
+    <LineContext.Provider value={{ data }}>{children}</LineContext.Provider>
   );
 }
 

--- a/src/h5web/visualizations/line/LineVis.tsx
+++ b/src/h5web/visualizations/line/LineVis.tsx
@@ -9,18 +9,13 @@ import { useLineConfig } from './config';
 
 function LineVis(): JSX.Element {
   const props = useProps();
-  const { axisOffsets } = props;
   const showGrid = useLineConfig(state => state.showGrid);
 
   const axisDomains = useAxisDomains();
 
   return (
     <div className={styles.root}>
-      <VisCanvas
-        axisOffsets={axisOffsets}
-        axisDomains={axisDomains}
-        showGrid={showGrid}
-      >
+      <VisCanvas axisDomains={axisDomains} showGrid={showGrid}>
         {/* Provide context again - https://github.com/react-spring/react-three-fiber/issues/262 */}
         <LineProvider {...props}>
           <PanZoomMesh />

--- a/src/h5web/visualizations/shared/AxisSystem.module.css
+++ b/src/h5web/visualizations/shared/AxisSystem.module.css
@@ -3,8 +3,9 @@
   top: 0;
   display: grid;
   grid-template-areas:
-    'left-axis axis-grid'
-    '. bottom-axis';
+    '. top-axis .'
+    'left-axis axis-grid right-axis'
+    '. bottom-axis .';
 }
 
 .leftAxisCell {

--- a/src/h5web/visualizations/shared/AxisSystem.tsx
+++ b/src/h5web/visualizations/shared/AxisSystem.tsx
@@ -6,7 +6,7 @@ import { format } from 'd3-format';
 import { TickRendererProps } from '@vx/axis/lib/types';
 import { Grid } from '@vx/grid';
 import styles from './AxisSystem.module.css';
-import { Domain, AxisOffsets, AxisDomains, TwoDimScale } from './models';
+import { AxisOffsets, AxisDomains, TwoDimScale } from './models';
 import { adaptedNumTicks, computeAxisScales } from './utils';
 
 interface Props {
@@ -21,28 +21,22 @@ function AxisSystem(props: Props): JSX.Element {
   const { camera, size } = useThree();
   const { width, height } = size;
 
-  // Axis bounds in R3F camera coordinates
-  const axisCoords = {
-    x: [-width / 2, width / 2] as Domain,
-    y: [-height / 2, height / 2] as Domain,
-  };
-
   // Scales R3F camera coordinates to data bounds
   const cameraToBounds = {
     x: scaleLinear()
-      .domain(axisCoords.x)
+      .domain([-width / 2, width / 2])
       .range(axisDomains.bottom),
     y: scaleLinear()
-      .domain(axisCoords.y)
+      .domain([-height / 2, height / 2])
       .range(axisDomains.left),
   };
 
   const [axisScales, setAxisScales] = useState<TwoDimScale>(
-    computeAxisScales(camera, size, cameraToBounds, axisCoords)
+    computeAxisScales(camera, size, cameraToBounds)
   );
 
   useFrame(() => {
-    setAxisScales(computeAxisScales(camera, size, cameraToBounds, axisCoords));
+    setAxisScales(computeAxisScales(camera, size, cameraToBounds));
   });
 
   const sharedAxisProps = {
@@ -65,11 +59,12 @@ function AxisSystem(props: Props): JSX.Element {
       className={styles.axisSystem}
       style={{
         // Take over space reserved for axis by VisCanvas
-        width: width + axisOffsets.left,
-        height: height + axisOffsets.bottom,
+        width: width + axisOffsets.left + axisOffsets.right,
+        height: height + axisOffsets.bottom + axisOffsets.top,
+        top: -axisOffsets.top,
         left: -axisOffsets.left,
-        gridTemplateColumns: `${axisOffsets.left}px 1fr`,
-        gridTemplateRows: `1fr ${axisOffsets.bottom}px`,
+        gridTemplateColumns: `${axisOffsets.left}px 1fr ${axisOffsets.right}px`,
+        gridTemplateRows: `${axisOffsets.top}px 1fr ${axisOffsets.bottom}px`,
       }}
     >
       <>

--- a/src/h5web/visualizations/shared/VisCanvas.tsx
+++ b/src/h5web/visualizations/shared/VisCanvas.tsx
@@ -2,12 +2,13 @@ import React, { ReactNode } from 'react';
 import { Canvas } from 'react-three-fiber';
 import { useMeasure } from 'react-use';
 import styles from './VisCanvas.module.css';
-import { AxisOffsets, AxisDomains } from './models';
+import { AxisDomains } from './models';
 import { computeVisSize } from './utils';
 import AxisSystem from './AxisSystem';
 
+const AXIS_OFFSETS = { vertical: 72, horizontal: 36, fallback: 10 };
+
 interface Props {
-  axisOffsets: AxisOffsets;
   axisDomains?: AxisDomains;
   aspectRatio?: number;
   showGrid?: boolean;
@@ -15,11 +16,31 @@ interface Props {
 }
 
 function VisCanvas(props: Props): JSX.Element {
-  const { axisDomains, axisOffsets, aspectRatio, children, showGrid } = props;
+  const { axisDomains, aspectRatio, children, showGrid } = props;
   const [visAreaRef, visAreaSize] = useMeasure();
+
+  const axisOffsets = {
+    left:
+      axisDomains && axisDomains.left
+        ? AXIS_OFFSETS.vertical
+        : AXIS_OFFSETS.fallback,
+    right:
+      axisDomains && axisDomains.right
+        ? AXIS_OFFSETS.vertical
+        : AXIS_OFFSETS.fallback,
+    top:
+      axisDomains && axisDomains.top
+        ? AXIS_OFFSETS.horizontal
+        : AXIS_OFFSETS.fallback,
+    bottom:
+      axisDomains && axisDomains.bottom
+        ? AXIS_OFFSETS.horizontal
+        : AXIS_OFFSETS.fallback,
+  };
+
   const availableSize = {
-    width: visAreaSize.width - axisOffsets.left,
-    height: visAreaSize.height - axisOffsets.bottom,
+    width: visAreaSize.width - axisOffsets.left - axisOffsets.right,
+    height: visAreaSize.height - axisOffsets.bottom - axisOffsets.top,
   };
 
   const visSize = computeVisSize(availableSize, aspectRatio);
@@ -33,6 +54,8 @@ function VisCanvas(props: Props): JSX.Element {
             ...visSize,
             paddingBottom: axisOffsets.bottom,
             paddingLeft: axisOffsets.left,
+            paddingTop: axisOffsets.top,
+            paddingRight: axisOffsets.right,
             boxSizing: 'content-box',
           }}
         >

--- a/src/h5web/visualizations/shared/models.ts
+++ b/src/h5web/visualizations/shared/models.ts
@@ -4,11 +4,18 @@ export type Domain = [number, number];
 
 export type Size = { width: number; height: number };
 
-export type AxisOffsets = { left: number; bottom: number };
+export type AxisOffsets = {
+  left: number;
+  bottom: number;
+  right: number;
+  top: number;
+};
 
 export interface AxisDomains {
   left: Domain;
   bottom: Domain;
+  right?: number;
+  top?: number;
 }
 
 export interface TwoDimScale {

--- a/src/h5web/visualizations/shared/utils.ts
+++ b/src/h5web/visualizations/shared/utils.ts
@@ -47,18 +47,19 @@ export function findDomain(data: number[]): Domain | undefined {
 export function computeAxisScales(
   camera: Camera,
   size: Size,
-  cameraToBounds: TwoDimScale,
-  axisCoords: { x: Domain; y: Domain }
+  cameraToBounds: TwoDimScale
 ): TwoDimScale {
   const { position, zoom } = camera;
   const { width, height } = size;
 
-  const xBounds = axisCoords.x.map(bound =>
-    cameraToBounds.x(bound / zoom + position.x)
-  );
-  const yBounds = axisCoords.y.map(bound =>
-    cameraToBounds.y(bound / zoom + position.y)
-  );
+  const xBounds = [
+    cameraToBounds.x(-width / (2 * zoom) + position.x),
+    cameraToBounds.x(width / (2 * zoom) + position.x),
+  ];
+  const yBounds = [
+    cameraToBounds.y(-height / (2 * zoom) + position.y),
+    cameraToBounds.y(height / (2 * zoom) + position.y),
+  ];
 
   return {
     x: scaleLinear()


### PR DESCRIPTION
Reopening of #128 due to my mistaken push.

This has several advantages:
- Fixing #104 
- Generalizing the axis placement: putting xAxis on the top or yAxis on the right can be done more easily.
- Adding some breathing room between the canvas and the toolbar:
    * Previously:
![image](https://user-images.githubusercontent.com/42204205/81297553-b3c6a400-9073-11ea-93ae-570f82dcedb7.png)
    * Now:
![image](https://user-images.githubusercontent.com/42204205/81297448-8bd74080-9073-11ea-9214-874f545a754b.png)
