### PR TITLE
Fix default path processing

### DIFF
--- a/src/h5web/explorer/Explorer.module.css
+++ b/src/h5web/explorer/Explorer.module.css
@@ -12,7 +12,7 @@
   composes: btn-clean from global;
   display: block;
   width: 100%;
-  padding: 0.25rem 1rem 0.25rem calc(0.25rem + var(--level) * 0.75rem);
+  padding: 0.25rem 1rem 0.25rem calc(0.25rem + (var(--level) + 1) * 0.75rem);
 }
 
 .btn:hover,

--- a/src/h5web/explorer/TreeView.tsx
+++ b/src/h5web/explorer/TreeView.tsx
@@ -1,42 +1,33 @@
-import React, { useState, useEffect } from 'react';
-import { TreeNode } from './models';
+import React from 'react';
+import { TreeNode, ExpandedNodes } from './models';
 
 import styles from './Explorer.module.css';
 
-type ExpandedNodes = Record<string, boolean>;
-
 interface Props<T> {
+  level: number;
   nodes: TreeNode<T>[];
-  defaultPath: number[];
   selectedNode?: TreeNode<T>;
+  expandedNodes: ExpandedNodes;
   onSelect: (node: TreeNode<T>) => void;
   renderIcon: (data: T, isBranch: boolean, isExpanded: boolean) => JSX.Element;
 }
 
 function TreeView<T>(props: Props<T>): JSX.Element {
-  const { nodes, defaultPath, selectedNode, onSelect, renderIcon } = props;
-
-  // Find first node in default path, if any
-  const defaultNode = nodes[defaultPath[0] ?? -1];
-
-  const [expandedNodes, setExpandedNodes] = useState<ExpandedNodes>(
-    defaultNode && defaultNode.children ? { [defaultNode.uid]: true } : {}
-  );
-
-  useEffect(() => {
-    // Select default node if last in default path
-    if (defaultNode && defaultPath.length === 1) {
-      onSelect(defaultNode);
-    }
-  }, [defaultNode, defaultPath, onSelect]);
+  const {
+    level,
+    nodes,
+    selectedNode,
+    expandedNodes,
+    onSelect,
+    renderIcon,
+  } = props;
 
   return (
     <ul className={styles.group} role="group">
       {nodes.map(node => {
-        const { uid, label, level, data, children } = node;
+        const { uid, label, data, children } = node;
         const isBranch = !!children;
         const isExpanded = !!expandedNodes[node.uid];
-        const isSelected = node === selectedNode;
 
         return (
           <li
@@ -49,16 +40,9 @@ function TreeView<T>(props: Props<T>): JSX.Element {
               type="button"
               role="treeitem"
               aria-expanded={isExpanded}
-              aria-selected={isSelected}
+              aria-selected={node === selectedNode}
               onClick={() => {
                 onSelect(node);
-
-                if (isBranch && (!isExpanded || isSelected)) {
-                  setExpandedNodes({
-                    ...expandedNodes,
-                    [node.uid]: !isExpanded,
-                  });
-                }
               }}
             >
               {renderIcon(data, isBranch, isExpanded)}
@@ -67,9 +51,10 @@ function TreeView<T>(props: Props<T>): JSX.Element {
 
             {children && isExpanded && (
               <TreeView
+                level={level + 1}
                 nodes={children}
-                defaultPath={defaultPath.slice(1)} // slice default path relevant to sub-tree
                 selectedNode={selectedNode}
+                expandedNodes={expandedNodes}
                 onSelect={onSelect}
                 renderIcon={renderIcon}
               />

--- a/src/h5web/explorer/models.ts
+++ b/src/h5web/explorer/models.ts
@@ -1,8 +1,9 @@
 export interface TreeNode<T> {
   uid: string;
   label: string;
-  level: number;
   data: T;
   children?: TreeNode<T>[];
   parents: T[];
 }
+
+export type ExpandedNodes = Record<string, boolean>;

--- a/src/h5web/explorer/utils.test.ts
+++ b/src/h5web/explorer/utils.test.ts
@@ -1,0 +1,45 @@
+import { getNodesOnPath } from './utils';
+import { TreeNode } from './models';
+
+const dataA = {};
+const dataB = {};
+const dataC = {};
+
+const nodeC: TreeNode<{}> = {
+  uid: 'c',
+  label: 'C',
+  data: dataC,
+  parents: [dataB],
+};
+
+const nodeB: TreeNode<{}> = {
+  uid: 'b',
+  label: 'B',
+  data: dataB,
+  children: [nodeC],
+  parents: [dataA],
+};
+
+const nodeA: TreeNode<{}> = {
+  uid: 'a',
+  label: 'A',
+  data: dataA,
+  children: [nodeB],
+  parents: [],
+};
+
+describe('Explorer utilities', () => {
+  describe('getNodesOnPath', () => {
+    it('should return nodes on path', () => {
+      expect(getNodesOnPath(nodeA, [])).toEqual([]);
+      expect(getNodesOnPath(nodeA, [0])).toEqual([nodeB]);
+      expect(getNodesOnPath(nodeA, [0, 0])).toEqual([nodeB, nodeC]);
+    });
+
+    it('should process invalid path as far as possible', () => {
+      expect(getNodesOnPath(nodeA, [1, 0])).toEqual([]);
+      expect(getNodesOnPath(nodeA, [0, 1])).toEqual([nodeB]);
+      expect(getNodesOnPath(nodeA, [0, 0, 1])).toEqual([nodeB, nodeC]);
+    });
+  });
+});

--- a/src/h5web/explorer/utils.ts
+++ b/src/h5web/explorer/utils.ts
@@ -1,0 +1,9 @@
+import { TreeNode } from './models';
+
+export function getNodesOnPath<T>(
+  tree: TreeNode<T>,
+  path: number[]
+): TreeNode<T>[] {
+  const node = tree.children?.[path[0] ?? -1];
+  return node ? [node, ...getNodesOnPath(node, path.slice(1))] : [];
+}

--- a/src/h5web/providers/utils.test.ts
+++ b/src/h5web/providers/utils.test.ts
@@ -31,7 +31,6 @@ describe('Provider utilities', () => {
       expect(buildTree(emptyMetadata, domain)).toEqual({
         uid: expect.any(String),
         label: domain,
-        level: 0,
         data: rootLink,
         children: [],
         parents: [],
@@ -60,14 +59,12 @@ describe('Provider utilities', () => {
       expect(buildTree(simpleMetadata, domain)).toEqual({
         uid: expect.any(String),
         label: domain,
-        level: 0,
         data: rootLink,
         parents: [],
         children: [
           {
             uid: expect.any(String),
             label: link.title,
-            level: 1,
             data: link,
             parents: [rootLink],
           },
@@ -109,21 +106,18 @@ describe('Provider utilities', () => {
       expect(buildTree(nestedMetadata, domain)).toEqual({
         uid: expect.any(String),
         label: domain,
-        level: 0,
         data: rootLink,
         parents: [],
         children: [
           {
             uid: expect.any(String),
             label: link1.title,
-            level: 1,
             data: link1,
             parents: [rootLink],
             children: [
               {
                 uid: expect.any(String),
                 label: link2.title,
-                level: 2,
                 data: link2,
                 parents: [rootLink, link1],
               },

--- a/src/h5web/providers/utils.ts
+++ b/src/h5web/providers/utils.ts
@@ -66,8 +66,7 @@ export function isNumericType(type: HDF5Type): type is HDF5NumericType {
 function buildTreeNode(
   metadata: HDF5Metadata,
   link: HDF5Link,
-  parents: HDF5Link[],
-  level = 0
+  parents: HDF5Link[]
 ): TreeNode<HDF5Link> {
   const group =
     isReachable(link) && link.collection === HDF5Collection.Groups
@@ -77,13 +76,12 @@ function buildTreeNode(
   return {
     uid: nanoid(),
     label: link.title,
-    level,
     data: link,
     parents,
     ...(group
       ? {
           children: (group.links || []).map(lk =>
-            buildTreeNode(metadata, lk, [...parents, link], level + 1)
+            buildTreeNode(metadata, lk, [...parents, link])
           ),
         }
       : {}),


### PR DESCRIPTION
The default path set with `REACT_APP_DEFAULT_PATH` no longer prevents navigating the explorer tree.