### PR TITLE
Added tooltip guides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2698,6 +2698,34 @@
         "@vx/text": "0.0.195",
         "classnames": "^2.2.5",
         "prop-types": "^15.6.0"
+      },
+      "dependencies": {
+        "@vx/curve": {
+          "version": "0.0.195",
+          "resolved": "https://registry.npmjs.org/@vx/curve/-/curve-0.0.195.tgz",
+          "integrity": "sha512-fQXvd1530ou/K5v6fzH/RWy8HjXCKKScmtk9DfSdp/wkhm5u+1jkoe6r53PLAdJhUnMI6U8OsiVlaLF8nADuMw==",
+          "requires": {
+            "@types/d3-shape": "^1.3.1",
+            "d3-shape": "^1.0.6"
+          }
+        },
+        "@vx/shape": {
+          "version": "0.0.195",
+          "resolved": "https://registry.npmjs.org/@vx/shape/-/shape-0.0.195.tgz",
+          "integrity": "sha512-14I1E0t25hWx4/NCVj6cggm7ewD5a5UDMndXmcpUkV/wx/4SYkXhQ7uDdbAuYNcb/dh0wsFh8vmqmMJxm7DA/w==",
+          "requires": {
+            "@types/classnames": "^2.2.9",
+            "@types/d3-path": "^1.0.8",
+            "@types/d3-shape": "^1.3.1",
+            "@types/react": "*",
+            "@vx/curve": "0.0.195",
+            "@vx/group": "0.0.195",
+            "classnames": "^2.2.5",
+            "d3-path": "^1.0.5",
+            "d3-shape": "^1.2.0",
+            "prop-types": "^15.5.10"
+          }
+        }
       }
     },
     "@vx/bounds": {
@@ -2711,9 +2739,9 @@
       }
     },
     "@vx/curve": {
-      "version": "0.0.195",
-      "resolved": "https://registry.npmjs.org/@vx/curve/-/curve-0.0.195.tgz",
-      "integrity": "sha512-fQXvd1530ou/K5v6fzH/RWy8HjXCKKScmtk9DfSdp/wkhm5u+1jkoe6r53PLAdJhUnMI6U8OsiVlaLF8nADuMw==",
+      "version": "0.0.196",
+      "resolved": "https://registry.npmjs.org/@vx/curve/-/curve-0.0.196.tgz",
+      "integrity": "sha512-uGucJuuAOa0ezrSTqQE8BHkyNPAwGV1bNB8BP1V5Ln1GA7o0LBkqwHOdzShkFzsVoeDadRRGy2mNga6gHDGh8A==",
       "requires": {
         "@types/d3-shape": "^1.3.1",
         "d3-shape": "^1.0.6"
@@ -2794,20 +2822,33 @@
       "integrity": "sha512-2m16lfs4v8BwjWMhGNDC4lBBOwaimRL4BapFTS1UQWYSV12y0KlsJGD17fPdR6X9RzYWJTnOL/yaQuGCBa9AdQ=="
     },
     "@vx/shape": {
-      "version": "0.0.195",
-      "resolved": "https://registry.npmjs.org/@vx/shape/-/shape-0.0.195.tgz",
-      "integrity": "sha512-14I1E0t25hWx4/NCVj6cggm7ewD5a5UDMndXmcpUkV/wx/4SYkXhQ7uDdbAuYNcb/dh0wsFh8vmqmMJxm7DA/w==",
+      "version": "0.0.196",
+      "resolved": "https://registry.npmjs.org/@vx/shape/-/shape-0.0.196.tgz",
+      "integrity": "sha512-09s4yv0IKmUrB/z/bRLW936DzbhbsxExHv0ocowh2Zv3zgObAaeyf0MkkLyr1nDTqKDCZlfwOEM+1moOyBFQBA==",
       "requires": {
         "@types/classnames": "^2.2.9",
         "@types/d3-path": "^1.0.8",
         "@types/d3-shape": "^1.3.1",
         "@types/react": "*",
-        "@vx/curve": "0.0.195",
-        "@vx/group": "0.0.195",
+        "@vx/curve": "0.0.196",
+        "@vx/group": "0.0.196",
         "classnames": "^2.2.5",
         "d3-path": "^1.0.5",
         "d3-shape": "^1.2.0",
         "prop-types": "^15.5.10"
+      },
+      "dependencies": {
+        "@vx/group": {
+          "version": "0.0.196",
+          "resolved": "https://registry.npmjs.org/@vx/group/-/group-0.0.196.tgz",
+          "integrity": "sha512-neWYucGoyrWloEali12yEn//5pRVwSBtKpuzKlQ43yYTav8OLa869DtCSVeRlDG8TIcPvg9YWfWKKhGWKXRCtg==",
+          "requires": {
+            "@types/classnames": "^2.2.9",
+            "@types/react": "*",
+            "classnames": "^2.2.5",
+            "prop-types": "^15.6.2"
+          }
+        }
       }
     },
     "@vx/text": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@vx/axis": "0.0.195",
     "@vx/grid": "0.0.196",
+    "@vx/shape": "0.0.196",
     "@vx/tooltip": "0.0.195",
     "axios": "^0.19.2",
     "classnames": "^2.2.6",

--- a/src/h5web/visualizations/heatmap/HeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapVis.tsx
@@ -48,6 +48,7 @@ function HeatmapVis(): JSX.Element {
             formatValue={([x, y]) =>
               format('.3')(data[Math.floor(y + 0.5)][Math.floor(x + 0.5)])
             }
+            guides="both"
           />
           <PanZoomMesh />
           <Mesh />

--- a/src/h5web/visualizations/line/LineVis.tsx
+++ b/src/h5web/visualizations/line/LineVis.tsx
@@ -36,6 +36,7 @@ function LineVis(): JSX.Element {
                 ? format('.3f')(data[Math.floor(x)])
                 : undefined
             }
+            guides="vertical"
           />
           <PanZoomMesh />
           <DataCurve />

--- a/src/h5web/visualizations/shared/TooltipMesh.tsx
+++ b/src/h5web/visualizations/shared/TooltipMesh.tsx
@@ -1,19 +1,22 @@
 import React, { ReactElement, useCallback } from 'react';
 import { Dom, PointerEvent, useThree } from 'react-three-fiber';
 import { TooltipWithBounds, useTooltip } from '@vx/tooltip';
+import { Line } from '@vx/shape';
 
 import styles from './TooltipMesh.module.css';
 import { useAbscissaScale, useOrdinateScale } from './utils';
 
 type Coords = [number, number];
+type Guides = 'horizontal' | 'vertical' | 'both';
 
 interface Props {
   formatIndex: (t: Coords) => string;
   formatValue: (t: Coords) => string | undefined;
+  guides?: Guides;
 }
 
 function TooltipMesh(props: Props): ReactElement {
-  const { formatIndex, formatValue } = props;
+  const { formatIndex, formatValue, guides } = props;
 
   const { camera, size } = useThree();
   const { width, height } = size;
@@ -26,6 +29,14 @@ function TooltipMesh(props: Props): ReactElement {
     showTooltip,
     hideTooltip,
   } = useTooltip<Coords>();
+
+  const guideAspect = {
+    stroke: 'gray',
+    strokeWidth: 1.5,
+    strokeOpacity: 0.5,
+  };
+  const verticalGuide = guides === 'vertical' || guides === 'both';
+  const horizontalGuide = guides === 'horizontal' || guides === 'both';
 
   // Scales to compute data coordinates from unprojected mesh coordinates
   const { abscissaScale } = useAbscissaScale();
@@ -63,15 +74,35 @@ function TooltipMesh(props: Props): ReactElement {
       </mesh>
       <Dom style={{ width, height }}>
         {tooltipOpen && tooltipData && value ? (
-          <TooltipWithBounds
-            key={Math.random()}
-            className={styles.tooltip}
-            top={tooltipTop}
-            left={tooltipLeft}
-          >
-            {formatIndex(tooltipData)}
-            <span className={styles.tooltipValue}>{value}</span>
-          </TooltipWithBounds>
+          <>
+            <TooltipWithBounds
+              key={Math.random()}
+              className={styles.tooltip}
+              top={tooltipTop}
+              left={tooltipLeft}
+            >
+              {formatIndex(tooltipData)}
+              <span className={styles.tooltipValue}>{value}</span>
+            </TooltipWithBounds>
+            {guides && (
+              <svg width={width} height={height}>
+                {verticalGuide && (
+                  <Line
+                    from={{ x: tooltipLeft, y: 0 }}
+                    to={{ x: tooltipLeft, y: height }}
+                    {...guideAspect}
+                  />
+                )}
+                {horizontalGuide && (
+                  <Line
+                    from={{ x: 0, y: tooltipTop }}
+                    to={{ x: width, y: tooltipTop }}
+                    {...guideAspect}
+                  />
+                )}
+              </svg>
+            )}
+          </>
         ) : (
           <></>
         )}


### PR DESCRIPTION
![image32](https://user-images.githubusercontent.com/42204205/82026559-2e567b80-9693-11ea-9341-e3a50c5170a0.png)

Vertical for `LineVis`. Both directions for `HeatmatVis`. Uses `Line` from `@vx/shape`

More fancy things such as constraining the guide to the data and adding a marker must wait until axes domains/scales are refactored.
As a consequence, it is not necessary to merge this right now.