### PR TITLE
Refactor VisCanvas API

### DIFF
--- a/src/h5web/visualizations/heatmap/HeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapVis.tsx
@@ -35,9 +35,9 @@ function HeatmapVis(): JSX.Element {
     <div className={styles.root}>
       <VisCanvas
         // -0.5 to have ticks at the center of pixels
-        axisDomains={{ x: [-0.5, cols - 0.5], y: [-0.5, rows - 0.5] }}
+        abscissaConfig={{ indexDomain: [-0.5, cols - 0.5], showGrid }}
+        ordinateConfig={{ indexDomain: [-0.5, cols - 0.5], showGrid }}
         aspectRatio={aspectRatio}
-        showGrid={showGrid}
       >
         {/* Provide context again - https://github.com/react-spring/react-three-fiber/issues/262 */}
         <HeatmapProvider {...props}>

--- a/src/h5web/visualizations/line/LineVis.tsx
+++ b/src/h5web/visualizations/line/LineVis.tsx
@@ -5,27 +5,38 @@ import styles from './LineVis.module.css';
 import DataCurve from './DataCurve';
 import VisCanvas from '../shared/VisCanvas';
 import PanZoomMesh from '../shared/PanZoomMesh';
-import { useProps, useAxisDomains } from './hooks';
+import { useProps, useDataDomain } from './hooks';
 import LineProvider from './LineProvider';
 import { useLineConfig } from './config';
 import TooltipMesh from '../shared/TooltipMesh';
+import { extendDomain } from '../shared/utils';
 
 function LineVis(): JSX.Element {
   const props = useProps();
   const { data } = props;
+
   const [showGrid, hasYLogScale] = useLineConfig(
     state => [state.showGrid, state.hasYLogScale],
     shallow
   );
 
-  const axisDomains = useAxisDomains();
+  const dataDomain = useDataDomain();
+  if (!dataDomain) {
+    return <></>;
+  }
 
   return (
     <div className={styles.root}>
       <VisCanvas
-        axisDomains={axisDomains}
-        showGrid={showGrid}
-        hasYLogScale={hasYLogScale}
+        abscissaConfig={{
+          indexDomain: extendDomain([0, data.length - 1], 0.01),
+          showGrid,
+        }}
+        ordinateConfig={{
+          dataDomain: extendDomain(dataDomain, 0.01),
+          showGrid,
+          isLog: hasYLogScale,
+        }}
       >
         {/* Provide context again - https://github.com/react-spring/react-three-fiber/issues/262 */}
         <LineProvider {...props}>

--- a/src/h5web/visualizations/line/hooks.ts
+++ b/src/h5web/visualizations/line/hooks.ts
@@ -1,9 +1,8 @@
 import { useContext, useMemo } from 'react';
 import { Vector3 } from 'three';
 import { LineProps, LineContext } from './LineProvider';
-import { AxisDomains } from '../shared/models';
+import { Domain } from '../shared/models';
 import {
-  extendDomain,
   findDomain,
   useAbscissaScale,
   useOrdinateScale,
@@ -19,22 +18,15 @@ export function useProps(): LineProps {
   return props;
 }
 
-export function useAxisDomains(): AxisDomains | undefined {
+export function useDataDomain(): Domain | undefined {
   const { data } = useProps();
-  const dataDomain = useMemo(() => findDomain(data), [data]);
-
-  return dataDomain
-    ? {
-        x: extendDomain([0, data.length - 1], 0.01),
-        y: extendDomain(dataDomain, 0.01),
-      }
-    : undefined;
+  return useMemo(() => findDomain(data), [data]);
 }
 
 export function useDataPoints(): Vector3[] | undefined {
   const { data } = useProps();
-  const { abscissaScale } = useAbscissaScale();
-  const { ordinateScale } = useOrdinateScale();
+  const { scale: abscissaScale } = useAbscissaScale();
+  const { scale: ordinateScale } = useOrdinateScale();
 
   return useMemo(() => {
     return data.map(

--- a/src/h5web/visualizations/shared/AxisSystemProvider.tsx
+++ b/src/h5web/visualizations/shared/AxisSystemProvider.tsx
@@ -1,28 +1,24 @@
 import React, { createContext, ReactElement, ReactNode } from 'react';
-import { AxisDomains } from './models';
+import { AxisConfig } from './models';
 
 export interface DisplayAxisProps {
-  axisDomains: AxisDomains;
-  showGrid?: boolean;
-  hasXLogScale?: boolean;
-  hasYLogScale?: boolean;
+  abscissaConfig: AxisConfig;
+  ordinateConfig: AxisConfig;
 }
 
-export const AxisSystemContext = createContext<DisplayAxisProps>({
-  axisDomains: { x: [0, 1], y: [0, 1] },
-});
+export const AxisSystemContext = createContext<DisplayAxisProps>(
+  {} as DisplayAxisProps
+);
 
 type Props = DisplayAxisProps & {
   children: ReactNode;
 };
 
 function AxisSystemProvider(props: Props): ReactElement {
-  const { axisDomains, showGrid, hasXLogScale, hasYLogScale, children } = props;
+  const { children, ...valueProps } = props;
 
   return (
-    <AxisSystemContext.Provider
-      value={{ axisDomains, showGrid, hasXLogScale, hasYLogScale }}
-    >
+    <AxisSystemContext.Provider value={valueProps}>
       {children}
     </AxisSystemContext.Provider>
   );

--- a/src/h5web/visualizations/shared/TooltipMesh.tsx
+++ b/src/h5web/visualizations/shared/TooltipMesh.tsx
@@ -39,8 +39,8 @@ function TooltipMesh(props: Props): ReactElement {
   const horizontalGuide = guides === 'horizontal' || guides === 'both';
 
   // Scales to compute data coordinates from unprojected mesh coordinates
-  const { abscissaScale } = useAbscissaScale();
-  const { ordinateScale } = useOrdinateScale();
+  const { scale: abscissaScale } = useAbscissaScale();
+  const { scale: ordinateScale } = useOrdinateScale();
 
   // Update tooltip when pointer moves
   // When panning, events are handled and stopped by texture mesh and do not reach this mesh (which is behind)
@@ -49,13 +49,13 @@ function TooltipMesh(props: Props): ReactElement {
       const { zoom } = camera;
       const projectedPoint = camera.worldToLocal(evt.unprojectedPoint.clone());
 
-      const abscissa = abscissaScale.invert(evt.unprojectedPoint.x);
-      const ordinate = ordinateScale.invert(evt.unprojectedPoint.y);
+      const abscissaCoord = abscissaScale.invert(evt.unprojectedPoint.x);
+      const ordinateCoord = ordinateScale.invert(evt.unprojectedPoint.y);
 
       showTooltip({
         tooltipLeft: projectedPoint.x * zoom + width / 2,
         tooltipTop: -projectedPoint.y * zoom + height / 2,
-        tooltipData: [abscissa, ordinate],
+        tooltipData: [abscissaCoord, ordinateCoord],
       });
     },
     [camera, abscissaScale, ordinateScale, showTooltip, width, height]

--- a/src/h5web/visualizations/shared/VisCanvas.tsx
+++ b/src/h5web/visualizations/shared/VisCanvas.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from 'react';
 import { Canvas } from 'react-three-fiber';
 import { useMeasure } from 'react-use';
 import styles from './VisCanvas.module.css';
-import { AxisDomains } from './models';
+import { AxisConfig } from './models';
 import { computeVisSize } from './utils';
 import AxisSystem from './AxisSystem';
 import AxisSystemProvider from './AxisSystemProvider';
@@ -10,30 +10,21 @@ import AxisSystemProvider from './AxisSystemProvider';
 const AXIS_OFFSETS = { vertical: 72, horizontal: 36, fallback: 10 };
 
 interface Props {
-  axisDomains?: AxisDomains;
+  abscissaConfig: AxisConfig;
+  ordinateConfig: AxisConfig;
   aspectRatio?: number;
-  showGrid?: boolean;
-  hasXLogScale?: boolean;
-  hasYLogScale?: boolean;
   children: ReactNode;
 }
 
 function VisCanvas(props: Props): JSX.Element {
-  const {
-    axisDomains,
-    aspectRatio,
-    children,
-    showGrid,
-    hasXLogScale,
-    hasYLogScale,
-  } = props;
+  const { abscissaConfig, ordinateConfig, aspectRatio, children } = props;
   const [visAreaRef, visAreaSize] = useMeasure();
 
   const axisOffsets = {
-    left: axisDomains ? AXIS_OFFSETS.vertical : AXIS_OFFSETS.fallback,
+    left: AXIS_OFFSETS.vertical,
+    bottom: AXIS_OFFSETS.horizontal,
     right: AXIS_OFFSETS.fallback,
     top: AXIS_OFFSETS.fallback,
-    bottom: axisDomains ? AXIS_OFFSETS.horizontal : AXIS_OFFSETS.fallback,
   };
 
   const availableSize = {
@@ -64,17 +55,13 @@ function VisCanvas(props: Props): JSX.Element {
             gl={{ preserveDrawingBuffer: true }} // for screenshot feature
           >
             <ambientLight />
-            {axisDomains && (
-              <AxisSystemProvider
-                axisDomains={axisDomains}
-                showGrid={showGrid}
-                hasXLogScale={hasXLogScale}
-                hasYLogScale={hasYLogScale}
-              >
-                <AxisSystem axisOffsets={axisOffsets} />
-                {children}
-              </AxisSystemProvider>
-            )}
+            <AxisSystemProvider
+              abscissaConfig={abscissaConfig}
+              ordinateConfig={ordinateConfig}
+            >
+              <AxisSystem axisOffsets={axisOffsets} />
+              {children}
+            </AxisSystemProvider>
           </Canvas>
         </div>
       )}

--- a/src/h5web/visualizations/shared/models.ts
+++ b/src/h5web/visualizations/shared/models.ts
@@ -1,8 +1,28 @@
 import { ScaleLinear, ScaleSymLog, scaleSymlog, scaleLinear } from 'd3-scale';
 
+export type Size = { width: number; height: number };
+
 export type Domain = [number, number];
 
-export type Size = { width: number; height: number };
+export interface IndexAxisConfig {
+  indexDomain: Domain;
+  showGrid?: boolean;
+  isLog?: never; // invalid
+}
+
+export interface DataAxisConfig {
+  dataDomain: Domain;
+  showGrid?: boolean;
+  isLog?: boolean;
+}
+
+export type AxisConfig = IndexAxisConfig | DataAxisConfig;
+
+export interface AxisScale {
+  scale: DataScale;
+  scaleFn: DataScaleFn;
+  domain: Domain;
+}
 
 export type AxisOffsets = {
   left: number;
@@ -10,11 +30,6 @@ export type AxisOffsets = {
   right: number;
   top: number;
 };
-
-export interface AxisDomains {
-  x: Domain;
-  y: Domain;
-}
 
 export type DataScaleFn = typeof scaleSymlog | typeof scaleLinear;
 


### PR DESCRIPTION
The new API allows passing a config for each axis. It gets us one step closer to the axis-to-dimension mapping feature.

An axis config can declare either an "index" axis (i.e. ordinal) or a "data" axis (i.e. non-ordinal) -- this behaviour is based on the property used to pass the domain: `indexDomain` or `dataDomain`.

- A data axis config can have `isLog: true`, but not a index axis config.
- Both configs can have `showGrid: true`, but I haven't changed the current grid for now, so it's only visible if both axis configs have `showGrid: true`.
- There are no additional configuration options for now, although the goal will be to add `centerTicks` for index axis, and perhaps a `logType` enum for data axis, an `oppositeSide` boolean to move the axis to the top/right side, etc.