### PR TITLE
Show only integer ticks on index axes

### DIFF
--- a/src/h5web/visualizations/heatmap/HeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapVis.tsx
@@ -35,18 +35,16 @@ function HeatmapVis(): JSX.Element {
     <div className={styles.root}>
       <VisCanvas
         // -0.5 to have ticks at the center of pixels
-        abscissaConfig={{ indexDomain: [-0.5, cols - 0.5], showGrid }}
-        ordinateConfig={{ indexDomain: [-0.5, rows - 0.5], showGrid }}
+        abscissaConfig={{ indexDomain: [0, cols], showGrid }}
+        ordinateConfig={{ indexDomain: [0, rows], showGrid }}
         aspectRatio={aspectRatio}
       >
         {/* Provide context again - https://github.com/react-spring/react-three-fiber/issues/262 */}
         <HeatmapProvider {...props}>
           <TooltipMesh
-            formatIndex={([x, y]) =>
-              `x=${Math.floor(x + 0.5)}, y=${Math.floor(y + 0.5)}`
-            }
+            formatIndex={([x, y]) => `x=${Math.floor(x)}, y=${Math.floor(y)}`}
             formatValue={([x, y]) =>
-              format('.3')(data[Math.floor(y + 0.5)][Math.floor(x + 0.5)])
+              format('.3')(data[Math.floor(y)][Math.floor(x)])
             }
             guides="both"
           />

--- a/src/h5web/visualizations/shared/utils.test.ts
+++ b/src/h5web/visualizations/shared/utils.test.ts
@@ -1,4 +1,6 @@
-import { computeVisSize, findDomain } from './utils';
+import { tickStep } from 'd3-array';
+import { computeVisSize, findDomain, getTicksProp } from './utils';
+import { AxisConfig } from './models';
 
 describe('Shared visualization utilities', () => {
   describe('computeVisSize', () => {
@@ -63,6 +65,66 @@ describe('Shared visualization utilities', () => {
     it('should return undefined when the data is empty', () => {
       const domain = findDomain([]);
       expect(domain).toBeUndefined();
+    });
+  });
+
+  describe('getTicksProp', () => {
+    describe('with data axis config', () => {
+      const config: AxisConfig = { dataDomain: [0, 100] };
+
+      it('should return number of ticks allowed for available size regardless of visible domain', () => {
+        const prop1 = getTicksProp(config, [0, 1], 200);
+        expect(prop1).toEqual({ numTicks: 3 });
+
+        const prop2 = getTicksProp(config, [5, 20], 1000);
+        expect(prop2).toEqual({ numTicks: 10 });
+      });
+    });
+
+    describe('with index axis config', () => {
+      const config: AxisConfig = { indexDomain: [0, 100] };
+
+      it('should return zero tick values when visible domain spans zero indices', () => {
+        const prop1 = getTicksProp(config, [0.2, 0.8], 10);
+        expect(prop1).toEqual({ tickValues: [] });
+
+        const prop2 = getTicksProp(config, [5.01, 5.02], 10);
+        expect(prop2).toEqual({ tickValues: [] });
+      });
+
+      it('should return as many integer tick values as indices when space allows for it', () => {
+        const prop1 = getTicksProp(config, [0, 3], 1000);
+        expect(prop1).toEqual({ tickValues: [0, 1, 2, 3] });
+
+        const prop2 = getTicksProp(config, [5.4, 6.9], 1000);
+        expect(prop2).toEqual({ tickValues: [6] });
+      });
+
+      it('should return evenly-spaced tick values for available space', () => {
+        const prop1 = getTicksProp(config, [0.8, 20.2], 1000); // domain has 20 potential ticks but space allows for 10
+        expect(prop1).toEqual({
+          tickValues: [2, 4, 6, 8, 10, 12, 14, 16, 18, 20],
+        });
+
+        const prop2 = getTicksProp(config, [2, 7], 200); // domain has 8 potential ticks but space allows for 3
+        expect(prop2).toEqual({ tickValues: [2, 4, 6] });
+      });
+
+      it('should always return integer tick values', () => {
+        // Tick count is not always respected, which is acceptable
+        const prop1 = getTicksProp(config, [0, 4], 200); // domain has 5 potential ticks but space allows for 3
+        expect(prop1).toEqual({ tickValues: [0, 1, 2, 3, 4] });
+
+        // This is because `d3.tickStep` is not too worried about the count...
+        expect(tickStep(0, 4, 3)).toBe(1); // step should actually be 2 to end up with 3 ticks: `[0, 2, 4]`
+
+        // Unfortunately, this behaviour can lead to decimal tick values (i.e. step < 1)...
+        expect(tickStep(0, 2, 3)).toBe(0.5); // we'd end up with `[0, 0.5, 1, 1.5, 2]` instead of `[0, 1, 2]`
+
+        // So we specifically work around it by forcing the step to be greater than or equal to 1
+        const prop2 = getTicksProp(config, [0, 2], 200);
+        expect(prop2).toEqual({ tickValues: [0, 1, 2] });
+      });
     });
   });
 });


### PR DESCRIPTION
Fixes #146. The main fix is to ask for a number of ticks that matches the number of integer values in the visible domain. This works very well in most cases.

Unfortunately, [`d3.ticks()`](https://github.com/d3/d3-array#ticks) (used internally by d3-scale) doesn't always respect the requested number of ticks. For instance, `d3.ticks(0, 4, 3)` outputs 5 ticks instead of the requested 3. This is easy to check on https://observablehq.com/@d3/d3-ticks. 

This weird behaviour can lead to decimal tick values in some cases. For instance, `d3.ticks(0, 2, 3)`  returns `[0, 0.5, 1, 1.5, 2]`.

The problem comes from `d3.tickIncrement` (or its equivalent, `d3.tickSteps`), which is used internally by `d3.ticks()`. To work around the issue, I re-implemented a simplified version of `d3.ticks()` that calls `d3.tickSteps()`, but then clamps the returned step so it's never lower than 1.

I've done my best to document this in `utils.test.ts`.

---

The PR also includes the following changes which were coupled to the problem at hand:

- The ticks are no longer centered on the heatmap, which fixes #144.
- The grid columns and rows are now controlled independently based on the `showGrid` flag of their respective axis configs.