### PR TITLE
Pass axes info through axis system context instead of raw config

### DIFF
--- a/src/h5web/visualizations/heatmap/ColorBar.tsx
+++ b/src/h5web/visualizations/heatmap/ColorBar.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { AxisRight } from '@vx/axis';
 import { useMeasure } from 'react-use';
 import shallow from 'zustand/shallow';
-import { adaptedNumTicks, getDataScaleFn } from '../shared/utils';
+import { adaptedNumTicks } from '../shared/utils';
 import { useInterpolator } from './hooks';
 import { useHeatmapConfig } from './config';
 import styles from './HeatmapVis.module.css';
-import { generateCSSLinearGradient } from './utils';
+import { generateCSSLinearGradient, getDataScaleFn } from './utils';
 
 function ColorBar(): JSX.Element {
   const [dataDomain, customDomain, hasLogScale] = useHeatmapConfig(

--- a/src/h5web/visualizations/heatmap/models.ts
+++ b/src/h5web/visualizations/heatmap/models.ts
@@ -1,3 +1,4 @@
+import { scaleSymlog, scaleLinear } from 'd3-scale';
 import { INTERPOLATORS } from './interpolators';
 
 export type Dims = [number, number];
@@ -10,3 +11,5 @@ export type ColorMapOption = {
   label: ColorMap;
   value: ColorMap;
 };
+
+export type DataScaleFn = typeof scaleSymlog | typeof scaleLinear;

--- a/src/h5web/visualizations/heatmap/utils.ts
+++ b/src/h5web/visualizations/heatmap/utils.ts
@@ -1,5 +1,11 @@
 import { range } from 'lodash-es';
-import { D3Interpolator, ColorMapOption, ColorMap } from './models';
+import { scaleSymlog, scaleLinear } from 'd3-scale';
+import {
+  D3Interpolator,
+  ColorMapOption,
+  ColorMap,
+  DataScaleFn,
+} from './models';
 
 export function generateCSSLinearGradient(
   interpolator: D3Interpolator,
@@ -10,6 +16,10 @@ export function generateCSSLinearGradient(
     .reduce((acc, val) => `${acc},${val}`);
 
   return `linear-gradient(to ${direction},${gradientColors})`;
+}
+
+export function getDataScaleFn(isLog: boolean): DataScaleFn {
+  return isLog ? scaleSymlog : scaleLinear;
 }
 
 export function convertToOptions(

--- a/src/h5web/visualizations/heatmap/worker.ts
+++ b/src/h5web/visualizations/heatmap/worker.ts
@@ -1,10 +1,10 @@
 import { expose, transfer } from 'comlink';
 import { rgb } from 'd3-color';
 import { scaleSequential } from 'd3-scale';
-import { getDataScaleFn } from '../shared/utils';
 import { ColorMap } from './models';
 import { INTERPOLATORS } from './interpolators';
 import { Domain } from '../shared/models';
+import { getDataScaleFn } from './utils';
 
 function computeTextureData(
   values: Float64Array,
@@ -14,6 +14,7 @@ function computeTextureData(
 ): Uint8Array | undefined {
   const dataScale = getDataScaleFn(hasLogScale)();
   dataScale.domain(domain);
+
   const colorScale = scaleSequential(INTERPOLATORS[colorMap]);
 
   // Compute RGB color array for each datapoint `[[<r>, <g>, <b>], [<r>, <g>, <b>], ...]`

--- a/src/h5web/visualizations/line/hooks.ts
+++ b/src/h5web/visualizations/line/hooks.ts
@@ -1,12 +1,10 @@
 import { useContext, useMemo } from 'react';
 import { Vector3 } from 'three';
+import { useThree } from 'react-three-fiber';
 import { LineProps, LineContext } from './LineProvider';
 import { Domain } from '../shared/models';
-import {
-  findDomain,
-  useAbscissaScale,
-  useOrdinateScale,
-} from '../shared/utils';
+import { findDomain, getAxisScale } from '../shared/utils';
+import { AxisSystemContext } from '../shared/AxisSystemProvider';
 
 export function useProps(): LineProps {
   const props = useContext(LineContext);
@@ -25,8 +23,13 @@ export function useDataDomain(): Domain | undefined {
 
 export function useDataPoints(): Vector3[] | undefined {
   const { data } = useProps();
-  const { scale: abscissaScale } = useAbscissaScale();
-  const { scale: ordinateScale } = useOrdinateScale();
+
+  const { abscissaInfo, ordinateInfo } = useContext(AxisSystemContext);
+  const { size } = useThree();
+  const { width, height } = size;
+
+  const abscissaScale = getAxisScale(abscissaInfo, width);
+  const ordinateScale = getAxisScale(ordinateInfo, height);
 
   return useMemo(() => {
     return data.map(

--- a/src/h5web/visualizations/shared/AxisSystemProvider.tsx
+++ b/src/h5web/visualizations/shared/AxisSystemProvider.tsx
@@ -1,24 +1,51 @@
-import React, { createContext, ReactElement, ReactNode } from 'react';
-import { AxisConfig } from './models';
+import React, { ReactElement, ReactNode, createContext } from 'react';
+import { scaleLinear, scaleSymlog } from 'd3-scale';
+import { AxisConfig, AxisInfo } from './models';
+import { isIndexAxisConfig } from './utils';
 
-export interface DisplayAxisProps {
-  abscissaConfig: AxisConfig;
-  ordinateConfig: AxisConfig;
+export interface AxisConfigs {
+  abscissaInfo: AxisInfo;
+  ordinateInfo: AxisInfo;
 }
 
-export const AxisSystemContext = createContext<DisplayAxisProps>(
-  {} as DisplayAxisProps
-);
+export const AxisSystemContext = createContext<AxisConfigs>({} as AxisConfigs);
 
-type Props = DisplayAxisProps & {
+function getAxisInfo(config: AxisConfig): AxisInfo {
+  if (isIndexAxisConfig(config)) {
+    const { indexDomain, showGrid = false } = config;
+    return {
+      isIndexAxis: true,
+      scaleFn: scaleLinear,
+      domain: indexDomain,
+      isLog: false,
+      showGrid,
+    };
+  }
+
+  const { dataDomain, isLog = false, showGrid = false } = config;
+  return {
+    isIndexAxis: false,
+    scaleFn: isLog ? scaleSymlog : scaleLinear,
+    domain: dataDomain,
+    isLog,
+    showGrid,
+  };
+}
+
+type Props = {
+  abscissaConfig: AxisConfig;
+  ordinateConfig: AxisConfig;
   children: ReactNode;
 };
 
 function AxisSystemProvider(props: Props): ReactElement {
-  const { children, ...valueProps } = props;
+  const { abscissaConfig, ordinateConfig, children } = props;
+
+  const abscissaInfo = getAxisInfo(abscissaConfig);
+  const ordinateInfo = getAxisInfo(ordinateConfig);
 
   return (
-    <AxisSystemContext.Provider value={valueProps}>
+    <AxisSystemContext.Provider value={{ abscissaInfo, ordinateInfo }}>
       {children}
     </AxisSystemContext.Provider>
   );

--- a/src/h5web/visualizations/shared/models.ts
+++ b/src/h5web/visualizations/shared/models.ts
@@ -18,10 +18,18 @@ export interface DataAxisConfig {
 
 export type AxisConfig = IndexAxisConfig | DataAxisConfig;
 
-export interface AxisScale {
-  scale: DataScale;
-  scaleFn: DataScaleFn;
+export type AxisScaleFn = typeof scaleSymlog | typeof scaleLinear;
+
+export type AxisScale =
+  | ScaleLinear<number, number>
+  | ScaleSymLog<number, number>;
+
+export interface AxisInfo {
+  isIndexAxis: boolean;
+  scaleFn: AxisScaleFn;
   domain: Domain;
+  isLog: boolean;
+  showGrid: boolean;
 }
 
 export type AxisOffsets = {
@@ -30,9 +38,3 @@ export type AxisOffsets = {
   right: number;
   top: number;
 };
-
-export type DataScaleFn = typeof scaleSymlog | typeof scaleLinear;
-
-export type DataScale =
-  | ScaleLinear<number, number>
-  | ScaleSymLog<number, number>;

--- a/src/h5web/visualizations/shared/utils.test.ts
+++ b/src/h5web/visualizations/shared/utils.test.ts
@@ -1,6 +1,6 @@
 import { tickStep } from 'd3-array';
 import { computeVisSize, findDomain, getTicksProp } from './utils';
-import { AxisConfig } from './models';
+import { AxisInfo } from './models';
 
 describe('Shared visualization utilities', () => {
   describe('computeVisSize', () => {
@@ -70,49 +70,49 @@ describe('Shared visualization utilities', () => {
 
   describe('getTicksProp', () => {
     describe('with data axis config', () => {
-      const config: AxisConfig = { dataDomain: [0, 100] };
+      const axisInfo = { isIndexAxis: false } as AxisInfo;
 
       it('should return number of ticks allowed for available size regardless of visible domain', () => {
-        const prop1 = getTicksProp(config, [0, 1], 200);
+        const prop1 = getTicksProp(axisInfo, [0, 1], 200);
         expect(prop1).toEqual({ numTicks: 3 });
 
-        const prop2 = getTicksProp(config, [5, 20], 1000);
+        const prop2 = getTicksProp(axisInfo, [5, 20], 1000);
         expect(prop2).toEqual({ numTicks: 10 });
       });
     });
 
     describe('with index axis config', () => {
-      const config: AxisConfig = { indexDomain: [0, 100] };
+      const axisInfo = { isIndexAxis: true } as AxisInfo;
 
       it('should return zero tick values when visible domain spans zero indices', () => {
-        const prop1 = getTicksProp(config, [0.2, 0.8], 10);
+        const prop1 = getTicksProp(axisInfo, [0.2, 0.8], 10);
         expect(prop1).toEqual({ tickValues: [] });
 
-        const prop2 = getTicksProp(config, [5.01, 5.02], 10);
+        const prop2 = getTicksProp(axisInfo, [5.01, 5.02], 10);
         expect(prop2).toEqual({ tickValues: [] });
       });
 
       it('should return as many integer tick values as indices when space allows for it', () => {
-        const prop1 = getTicksProp(config, [0, 3], 1000);
+        const prop1 = getTicksProp(axisInfo, [0, 3], 1000);
         expect(prop1).toEqual({ tickValues: [0, 1, 2, 3] });
 
-        const prop2 = getTicksProp(config, [5.4, 6.9], 1000);
+        const prop2 = getTicksProp(axisInfo, [5.4, 6.9], 1000);
         expect(prop2).toEqual({ tickValues: [6] });
       });
 
       it('should return evenly-spaced tick values for available space', () => {
-        const prop1 = getTicksProp(config, [0.8, 20.2], 1000); // domain has 20 potential ticks but space allows for 10
+        const prop1 = getTicksProp(axisInfo, [0.8, 20.2], 1000); // domain has 20 potential ticks but space allows for 10
         expect(prop1).toEqual({
           tickValues: [2, 4, 6, 8, 10, 12, 14, 16, 18, 20],
         });
 
-        const prop2 = getTicksProp(config, [2, 7], 200); // domain has 8 potential ticks but space allows for 3
+        const prop2 = getTicksProp(axisInfo, [2, 7], 200); // domain has 8 potential ticks but space allows for 3
         expect(prop2).toEqual({ tickValues: [2, 4, 6] });
       });
 
       it('should always return integer tick values', () => {
         // Tick count is not always respected, which is acceptable
-        const prop1 = getTicksProp(config, [0, 4], 200); // domain has 5 potential ticks but space allows for 3
+        const prop1 = getTicksProp(axisInfo, [0, 4], 200); // domain has 5 potential ticks but space allows for 3
         expect(prop1).toEqual({ tickValues: [0, 1, 2, 3, 4] });
 
         // This is because `d3.tickStep` is not too worried about the count...
@@ -122,7 +122,7 @@ describe('Shared visualization utilities', () => {
         expect(tickStep(0, 2, 3)).toBe(0.5); // we'd end up with `[0, 0.5, 1, 1.5, 2]` instead of `[0, 1, 2]`
 
         // So we specifically work around it by forcing the step to be greater than or equal to 1
-        const prop2 = getTicksProp(config, [0, 2], 200);
+        const prop2 = getTicksProp(axisInfo, [0, 2], 200);
         expect(prop2).toEqual({ tickValues: [0, 1, 2] });
       });
     });


### PR DESCRIPTION
The main goal of this refactoring is to simplify the code that relies on the axis configs passed to `VisCanvas`. From now on, `AxisSystemProvider` converts the two configs into two `AxisInfo` objects. These objects have two jobs:

- to represent the configs in a format common to both index and data axes (e.g. `domain` instead of `indexDomain` and `dataDomain`, `isLog` always present but always `false` for index axes, etc.);
- to store any information that can be deduced from the configs so the child components don't have to deduce them themselves (e.g. `isIndexAxis`, `scaleFn`).

This implementation allows `VisCanvas` to keep a simple, type-safe, public API, while also reducing a lot of the complexity in our internal components.