### PR TITLE
Refactor update of active visualization

### DIFF
--- a/src/h5web/dataset-visualizer/DatasetVisualizer.tsx
+++ b/src/h5web/dataset-visualizer/DatasetVisualizer.tsx
@@ -1,17 +1,11 @@
-import React, { ElementType, useState, ReactElement, useMemo } from 'react';
+import React, { useState, ReactElement, useMemo } from 'react';
 import { HDF5Dataset } from '../providers/models';
 import styles from './DatasetVisualizer.module.css';
 import VisSelector from './VisSelector';
 import { getSupportedVis } from './utils';
 import VisDisplay from './VisDisplay';
 import { Vis } from './models';
-import LineToolbar from '../visualizations/line/LineToolbar';
-import HeatmapToolbar from '../visualizations/heatmap/HeatmapToolbar';
-
-const VIS_TOOLBARS: Record<string, ElementType> = {
-  [Vis.Line]: LineToolbar,
-  [Vis.Heatmap]: HeatmapToolbar,
-};
+import { VIS_DEFS } from '../visualizations';
 
 interface Props {
   dataset?: HDF5Dataset;
@@ -35,7 +29,7 @@ function DatasetVisualizer(props: Props): ReactElement {
     );
   }
 
-  const VisToolbar = activeVis && VIS_TOOLBARS[activeVis];
+  const VisToolbar = activeVis && VIS_DEFS[activeVis].Toolbar;
 
   return (
     <div className={styles.visualizer}>

--- a/src/h5web/dataset-visualizer/VisDisplay.tsx
+++ b/src/h5web/dataset-visualizer/VisDisplay.tsx
@@ -1,25 +1,11 @@
 import React, { useState } from 'react';
 import { range } from 'lodash-es';
 import { Vis, DimensionMapping } from './models';
-import {
-  RawVis,
-  ScalarVis,
-  MatrixVis,
-  LineVis,
-  HeatmapVis,
-} from '../visualizations';
 import DimensionMapper from './DimensionMapper';
 import VisProvider from './VisProvider';
 import { HDF5Dataset } from '../providers/models';
 import { isSimpleShape } from '../providers/utils';
-
-const VIS_COMPONENTS = {
-  [Vis.Raw]: RawVis,
-  [Vis.Scalar]: ScalarVis,
-  [Vis.Matrix]: MatrixVis,
-  [Vis.Line]: LineVis,
-  [Vis.Heatmap]: HeatmapVis,
-};
+import { VIS_DEFS } from '../visualizations';
 
 interface Props {
   key: string; // reset states when switching between datasets
@@ -29,7 +15,7 @@ interface Props {
 
 function VisDisplay(props: Props): JSX.Element {
   const { activeVis, dataset } = props;
-  const ActiveVis = VIS_COMPONENTS[activeVis];
+  const { Component: VisComponent } = VIS_DEFS[activeVis];
 
   const datasetDims = isSimpleShape(dataset.shape) ? dataset.shape.dims : [];
   const [dimensionMapping, setMapping] = useState<DimensionMapping>({
@@ -42,7 +28,7 @@ function VisDisplay(props: Props): JSX.Element {
   return (
     <VisProvider mapping={dimensionMapping} dataset={dataset}>
       <DimensionMapper activeVis={activeVis} onChange={setMapping} />
-      <ActiveVis />
+      <VisComponent />
     </VisProvider>
   );
 }

--- a/src/h5web/dataset-visualizer/VisSelector.tsx
+++ b/src/h5web/dataset-visualizer/VisSelector.tsx
@@ -1,16 +1,7 @@
 import React from 'react';
-import { FiCpu, FiGrid, FiCode, FiActivity, FiMap } from 'react-icons/fi';
-import { IconType } from 'react-icons';
 import { Vis } from './models';
 import styles from './VisSelector.module.css';
-
-const VIS_ICONS: Record<Vis, IconType> = {
-  [Vis.Raw]: FiCpu,
-  [Vis.Scalar]: FiCode,
-  [Vis.Matrix]: FiGrid,
-  [Vis.Line]: FiActivity,
-  [Vis.Heatmap]: FiMap,
-};
+import { VIS_DEFS } from '../visualizations';
 
 interface Props {
   activeVis?: Vis;
@@ -24,7 +15,7 @@ function VisSelector(props: Props): JSX.Element {
   return (
     <div className={styles.selector} role="tablist" aria-label="Visualization">
       {choices.map(vis => {
-        const Icon = VIS_ICONS[vis];
+        const { Icon } = VIS_DEFS[vis];
         return (
           <button
             key={vis}

--- a/src/h5web/dataset-visualizer/utils.ts
+++ b/src/h5web/dataset-visualizer/utils.ts
@@ -1,43 +1,15 @@
 import { Vis } from './models';
 import { HDF5Dataset } from '../providers/models';
-import {
-  isBaseType,
-  isSimpleShape,
-  hasSimpleDims,
-  isScalarShape,
-  isNumericType,
-} from '../providers/utils';
-
-type SupportFunction = (dataset: HDF5Dataset) => boolean;
-
-const SUPPORT_CHECKS: Record<Vis, SupportFunction> = {
-  [Vis.Raw]: () => true,
-  [Vis.Scalar]: dataset => {
-    const { type, shape } = dataset;
-    return isBaseType(type) && isScalarShape(shape);
-  },
-  [Vis.Matrix]: dataset => {
-    const { type, shape } = dataset;
-    return isBaseType(type) && isSimpleShape(shape) && hasSimpleDims(shape);
-  },
-  [Vis.Line]: dataset => {
-    const { type, shape } = dataset;
-    return isNumericType(type) && isSimpleShape(shape) && hasSimpleDims(shape);
-  },
-  [Vis.Heatmap]: dataset => {
-    const { type, shape } = dataset;
-    return (
-      isNumericType(type) && isSimpleShape(shape) && shape.dims.length === 2
-    );
-  },
-};
+import { VIS_DEFS } from '../visualizations';
 
 export function getSupportedVis(dataset?: HDF5Dataset): Vis[] {
   if (!dataset) {
     return [];
   }
-  const supported = Object.entries(SUPPORT_CHECKS).reduce<Vis[]>(
-    (arr, [vis, check]) => (check(dataset) ? [...arr, vis as Vis] : arr),
+  const supported = Object.entries(VIS_DEFS).reduce<Vis[]>(
+    (arr, [vis, { supportsDataset }]) => {
+      return supportsDataset(dataset) ? [...arr, vis as Vis] : arr;
+    },
     []
   );
 

--- a/src/h5web/dataset-visualizer/utils.ts
+++ b/src/h5web/dataset-visualizer/utils.ts
@@ -1,4 +1,3 @@
-import { useState, useEffect } from 'react';
 import { Vis } from './models';
 import { HDF5Dataset } from '../providers/models';
 import {
@@ -44,21 +43,4 @@ export function getSupportedVis(dataset?: HDF5Dataset): Vis[] {
 
   // Remove Raw vis if any other vis is supported
   return supported.length > 1 ? supported.slice(1) : supported;
-}
-
-export function useActiveVis(
-  supportedVis: Vis[]
-): [Vis | undefined, (vis: Vis) => void] {
-  const [activeVis, setActiveVis] = useState<Vis>();
-
-  // When switching between two datasets, `activeVis` may become stale for one render
-  const isValid = activeVis && supportedVis.includes(activeVis);
-
-  useEffect(() => {
-    if (!isValid) {
-      setActiveVis(supportedVis[supportedVis.length - 1]);
-    }
-  }, [isValid, supportedVis]);
-
-  return [isValid ? activeVis : undefined, setActiveVis];
 }

--- a/src/h5web/visualizations/index.ts
+++ b/src/h5web/visualizations/index.ts
@@ -1,5 +1,72 @@
-export { default as RawVis } from './RawVis';
-export { default as MatrixVis } from './matrix/MatrixVis';
-export { default as ScalarVis } from './ScalarVis';
-export { default as LineVis } from './line/LineVis';
-export { default as HeatmapVis } from './heatmap/HeatmapVis';
+import { ElementType } from 'react';
+import { FiCode, FiGrid, FiActivity, FiMap, FiCpu } from 'react-icons/fi';
+import { IconType } from 'react-icons';
+import RawVis from './RawVis';
+import MatrixVis from './matrix/MatrixVis';
+import ScalarVis from './ScalarVis';
+import LineVis from './line/LineVis';
+import HeatmapVis from './heatmap/HeatmapVis';
+import { Vis } from '../dataset-visualizer/models';
+import LineToolbar from './line/LineToolbar';
+import HeatmapToolbar from './heatmap/HeatmapToolbar';
+import { HDF5Dataset } from '../providers/models';
+import {
+  isScalarShape,
+  isBaseType,
+  isSimpleShape,
+  hasSimpleDims,
+  isNumericType,
+} from '../providers/utils';
+
+interface VisDef {
+  Component: ElementType;
+  Icon: IconType;
+  Toolbar?: ElementType;
+  supportsDataset(dataset: HDF5Dataset): boolean;
+}
+
+export const VIS_DEFS: Record<Vis, VisDef> = {
+  [Vis.Raw]: {
+    Component: RawVis,
+    Icon: FiCpu,
+    supportsDataset: () => true,
+  },
+  [Vis.Scalar]: {
+    Component: ScalarVis,
+    Icon: FiCode,
+    supportsDataset: dataset => {
+      const { type, shape } = dataset;
+      return isBaseType(type) && isScalarShape(shape);
+    },
+  },
+  [Vis.Matrix]: {
+    Component: MatrixVis,
+    Icon: FiGrid,
+    supportsDataset: dataset => {
+      const { type, shape } = dataset;
+      return isBaseType(type) && isSimpleShape(shape) && hasSimpleDims(shape);
+    },
+  },
+  [Vis.Line]: {
+    Component: LineVis,
+    Icon: FiActivity,
+    Toolbar: LineToolbar,
+    supportsDataset: dataset => {
+      const { type, shape } = dataset;
+      return (
+        isNumericType(type) && isSimpleShape(shape) && hasSimpleDims(shape)
+      );
+    },
+  },
+  [Vis.Heatmap]: {
+    Component: HeatmapVis,
+    Icon: FiMap,
+    Toolbar: HeatmapToolbar,
+    supportsDataset: dataset => {
+      const { type, shape } = dataset;
+      return (
+        isNumericType(type) && isSimpleShape(shape) && shape.dims.length === 2
+      );
+    },
+  },
+};


### PR DESCRIPTION
Previously, we had:

1. Dataset changes
1. `DatasetVisualizer` renders
    - `activeVis` is identified as invalid, so `undefined` is used instead;
    - `useEffect` schedules reset of `activeVis` state on next render.
1. Children of `DatasetVisualizer` render, but `VisDisplay` is removed from DOM because `activeVis` is `undefined`.
1. `DatasetVisualizer` renders again on next tick (because of change of `activeVis` state in `useEffect`) 
1. Children of `DatasetVisualizer` render, and `VisDisplay` is re-added to the DOM now that `activeVis` is valid again.

Now, we have:

1. Dataset changes
1. `DatasetVisualizer` renders
    - Change of dataset is detected, so `setActiveVis` is called right away (instead of being scheduled in `useEffect`) -- this cancels rendering of `DatasetVisualizer`'s children.
    - Value of `activeVis` still corresponds to previous dataset, but it doesn't matter since rendering of children is cancelled.
1. `DatasetVisualizer` renders again because of the call to `setActiveVis`.
1. Children of `DatasetVisualizer` render with `activeVis` which now corresponds to the current dataset.

Overall, it's a very minor optimisation: `VisDisplay` was previously removed from the DOM then re-added; now it's simply replaced. The code, however, is less hacky and more in line with React's recommendations on how to deal with derived state: https://reactjs.org/docs/hooks-faq.html#how-do-i-implement-getderivedstatefromprops