### PR TITLE
Fix dim mapper not appearing on initial dataset selection

### DIFF
--- a/src/h5web/dataset-visualizer/DatasetVisualizer.tsx
+++ b/src/h5web/dataset-visualizer/DatasetVisualizer.tsx
@@ -15,10 +15,8 @@ function DatasetVisualizer(props: Props): ReactElement {
   const { dataset } = props;
 
   const supportedVis = useMemo(() => getSupportedVis(dataset), [dataset]);
-  const [prevDataset, setPrevDataset] = useState(dataset);
-  const [activeVis, setActiveVis] = useState<Vis>(
-    supportedVis[supportedVis.length - 1]
-  );
+  const [prevDataset, setPrevDataset] = useState<HDF5Dataset>();
+  const [activeVis, setActiveVis] = useState<Vis>();
 
   // Update active vis when dataset changes
   // https://reactjs.org/docs/hooks-faq.html#how-do-i-implement-getderivedstatefromprops

--- a/src/h5web/dataset-visualizer/VisDisplay.tsx
+++ b/src/h5web/dataset-visualizer/VisDisplay.tsx
@@ -15,13 +15,10 @@ interface Props {
 
 function VisDisplay(props: Props): JSX.Element {
   const { activeVis, dataset } = props;
-  const { Component: VisComponent } = VIS_DEFS[activeVis];
-
   const datasetDims = isSimpleShape(dataset.shape) ? dataset.shape.dims : [];
-  const [mapperState, setMapperState] = useState<DimensionMapping | undefined>(
-    undefined
-  );
-  const [prevVis, setPrevVis] = useState(activeVis);
+
+  const [prevVis, setPrevVis] = useState<Vis>();
+  const [mapperState, setMapperState] = useState<DimensionMapping>();
 
   // Update mapping when vis changes
   // https://reactjs.org/docs/hooks-faq.html#how-do-i-implement-getderivedstatefromprops
@@ -33,6 +30,8 @@ function VisDisplay(props: Props): JSX.Element {
         : undefined
     );
   }
+
+  const VisComponent = VIS_DEFS[activeVis].Component;
 
   return (
     <>

--- a/src/h5web/visualizations/line/hooks.ts
+++ b/src/h5web/visualizations/line/hooks.ts
@@ -9,7 +9,7 @@ import { useVisProps } from '../../dataset-visualizer/VisProvider';
 export function useData(): number[] {
   const { values, slicingIndices } = useVisProps();
 
-  if (slicingIndices) {
+  if (slicingIndices && slicingIndices.length > 0) {
     return (values as number[][])[slicingIndices[0]];
   }
 


### PR DESCRIPTION
When the first dataset I open is a 1D dataset (line vis by default), the dimension mapper doesn't appear. I have to switch to the matrix vis and come back to the line vis for the mapper to appear.

This commit fixes this issue, and applies the fix to the other use of the derived state pattern. It also fixes an issue with the line vis when `slicingIndices` is an empty array, which occurs when there are no indices to slice (e.g. line vis with 1D dataset).