### PR TITLE
Fix out-of-bound error with Heatmap tooltip

### DIFF
--- a/src/h5web/visualizations/heatmap/HeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapVis.tsx
@@ -41,9 +41,11 @@ function HeatmapVis(): JSX.Element {
         {/* Provide context again - https://github.com/react-spring/react-three-fiber/issues/262 */}
         <TooltipMesh
           formatIndex={([x, y]) => `x=${Math.floor(x)}, y=${Math.floor(y)}`}
-          formatValue={([x, y]) =>
-            format('.3')(data[Math.floor(y)][Math.floor(x)])
-          }
+          formatValue={([x, y]) => {
+            return x < cols && y < rows
+              ? format('.3')(data[Math.floor(y)][Math.floor(x)])
+              : undefined;
+          }}
           guides="both"
         />
         <PanZoomMesh />


### PR DESCRIPTION
I was getting errors when leaving/entering the heatmap at the top. `formatValue` was receiving a `y` data coordinate equal to the number of rows, when the max should be `rows - 1`.

This happens because we pass `[0 rows]` as ordinate domain. The tooltip uses the same scale as the axis instead of a scale with a domain of `[0, rows[`.

Can't think of a better solution for now...