### PR TITLE
Upgrade to Prettier v2

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,7 +1,6 @@
 {
   "semi": true,
   "singleQuote": true,
-  "trailingComma": "es5",
   "overrides": [
     {
       "files": "*.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12303,9 +12303,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "run-p lint:*",
     "lint:eslint": "eslint \"**/*.{ts,tsx,js,jsx}\"",
     "lint:tsc": "tsc --noEmit",
-    "lint:prettier": "prettier --check \"**/*.{ts,tsx,js,jsx,css,json,md,yml}\""
+    "lint:prettier": "prettier --check ."
   },
   "dependencies": {
     "@vx/axis": "0.0.195",
@@ -73,7 +73,7 @@
     "@wsmd/eslint-config": "^1.2.0",
     "eslint": "^6.8.0",
     "npm-run-all": "^4.1.5",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.5",
     "react-scripts": "^3.4.1",
     "typescript": "^3.9.3",
     "worker-loader": "^2.0.0"

--- a/src/h5web/App.tsx
+++ b/src/h5web/App.tsx
@@ -3,12 +3,12 @@ import { ReflexContainer, ReflexSplitter, ReflexElement } from 'react-reflex';
 
 import Explorer from './explorer/Explorer';
 import DatasetVisualizer from './dataset-visualizer/DatasetVisualizer';
-import { HDF5Link, HDF5Dataset } from './providers/models';
+import type { HDF5Link, HDF5Dataset } from './providers/models';
 import MetadataViewer from './metadata-viewer/MetadataViewer';
 import styles from './App.module.css';
 import { isDataset } from './providers/utils';
 import { useEntity } from './providers/hooks';
-import { TreeNode } from './explorer/models';
+import type { TreeNode } from './explorer/models';
 import BreadcrumbsBar from './BreadcrumbsBar';
 
 function App(): JSX.Element {

--- a/src/h5web/BreadcrumbsBar.tsx
+++ b/src/h5web/BreadcrumbsBar.tsx
@@ -1,8 +1,8 @@
 import React, { Fragment } from 'react';
 import { FiSidebar, FiChevronRight } from 'react-icons/fi';
 import styles from './BreadcrumbsBar.module.css';
-import { TreeNode } from './explorer/models';
-import { HDF5Link, HDF5HardLink } from './providers/models';
+import type { TreeNode } from './explorer/models';
+import type { HDF5Link, HDF5HardLink } from './providers/models';
 import ToggleGroup from './visualizations/shared/ToggleGroup';
 import ToggleBtn from './visualizations/shared/ToggleBtn';
 

--- a/src/h5web/BreadcrumbsBar.tsx
+++ b/src/h5web/BreadcrumbsBar.tsx
@@ -37,7 +37,7 @@ function BreadcrumbsBar(props: Props): JSX.Element {
       />
       {selectedNode && (
         <h1 className={styles.breadCrumbs}>
-          {selectedNode?.parents.slice(firstParentIndex).map(member => (
+          {selectedNode?.parents.slice(firstParentIndex).map((member) => (
             <Fragment key={(member as HDF5HardLink).id}>
               <span className={styles.crumb}>{member.title}</span>
               <FiChevronRight />
@@ -52,7 +52,7 @@ function BreadcrumbsBar(props: Props): JSX.Element {
         role="tablist"
         ariaLabel="Viewer mode"
         value={String(isInspecting)}
-        onChange={val => {
+        onChange={(val) => {
           onChangeInspecting(val === 'true' || false);
         }}
       >

--- a/src/h5web/dataset-visualizer/DatasetVisualizer.tsx
+++ b/src/h5web/dataset-visualizer/DatasetVisualizer.tsx
@@ -1,10 +1,10 @@
 import React, { useState, ReactElement, useMemo } from 'react';
-import { HDF5Dataset } from '../providers/models';
+import type { HDF5Dataset } from '../providers/models';
 import styles from './DatasetVisualizer.module.css';
 import VisSelector from './VisSelector';
 import { getSupportedVis } from './utils';
 import VisDisplay from './VisDisplay';
-import { Vis } from './models';
+import type { Vis } from './models';
 import { VIS_DEFS } from '../visualizations';
 
 interface Props {

--- a/src/h5web/dataset-visualizer/DimensionMapper.tsx
+++ b/src/h5web/dataset-visualizer/DimensionMapper.tsx
@@ -36,7 +36,7 @@ function DimensionMapper(props: Props): JSX.Element {
             <div {...thumbProps}>{state.valueNow}</div>
           )}
           defaultValue={slicingIndex}
-          onChange={value => {
+          onChange={(value) => {
             if (!isNumber(value)) {
               return;
             }
@@ -63,7 +63,7 @@ function DimensionMapper(props: Props): JSX.Element {
           role="radiogroup"
           ariaLabel={`Dimension as ${axis} axis`}
           value={selectedDim.toString()}
-          onChange={val => {
+          onChange={(val) => {
             const newDim = Number(val);
             if (selectedDim !== newDim) {
               const newMapperState = mapperState.slice();
@@ -73,7 +73,7 @@ function DimensionMapper(props: Props): JSX.Element {
             }
           }}
         >
-          {Object.keys(rawDims).map(dimKey => (
+          {Object.keys(rawDims).map((dimKey) => (
             <ToggleGroup.Btn key={dimKey} label={`D${dimKey}`} value={dimKey} />
           ))}
         </ToggleGroup>

--- a/src/h5web/dataset-visualizer/DimensionMapper.tsx
+++ b/src/h5web/dataset-visualizer/DimensionMapper.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
 import ReactSlider from 'react-slider';
 import { isNumber } from 'lodash-es';
-import { Vis, DimensionMapping, MappingType } from './models';
+import type { Vis, DimensionMapping, MappingType } from './models';
 import styles from './DimensionMapper.module.css';
 import ToggleGroup from '../visualizations/shared/ToggleGroup';
 

--- a/src/h5web/dataset-visualizer/VisDisplay.tsx
+++ b/src/h5web/dataset-visualizer/VisDisplay.tsx
@@ -3,7 +3,7 @@ import { range } from 'lodash-es';
 import { Vis, DimensionMapping } from './models';
 import DimensionMapper from './DimensionMapper';
 import VisProvider from './VisProvider';
-import { HDF5Dataset } from '../providers/models';
+import type { HDF5Dataset } from '../providers/models';
 import { isSimpleShape } from '../providers/utils';
 import { VIS_DEFS } from '../visualizations';
 

--- a/src/h5web/dataset-visualizer/VisProvider.tsx
+++ b/src/h5web/dataset-visualizer/VisProvider.tsx
@@ -7,8 +7,8 @@ import React, {
 } from 'react';
 import { transpose } from 'd3-array';
 import { isNumber } from 'lodash-es';
-import { DimensionMapping, Vis } from './models';
-import { HDF5Dataset, HDF5Value } from '../providers/models';
+import type { DimensionMapping, Vis } from './models';
+import type { HDF5Dataset, HDF5Value } from '../providers/models';
 import { useValue } from '../providers/hooks';
 import { isSimpleShape } from '../providers/utils';
 

--- a/src/h5web/dataset-visualizer/VisSelector.tsx
+++ b/src/h5web/dataset-visualizer/VisSelector.tsx
@@ -14,7 +14,7 @@ function VisSelector(props: Props): JSX.Element {
 
   return (
     <div className={styles.selector} role="tablist" aria-label="Visualization">
-      {choices.map(vis => {
+      {choices.map((vis) => {
         const { Icon } = VIS_DEFS[vis];
         return (
           <button

--- a/src/h5web/dataset-visualizer/VisSelector.tsx
+++ b/src/h5web/dataset-visualizer/VisSelector.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Vis } from './models';
+import type { Vis } from './models';
 import styles from './VisSelector.module.css';
 import { VIS_DEFS } from '../visualizations';
 

--- a/src/h5web/dataset-visualizer/utils.test.ts
+++ b/src/h5web/dataset-visualizer/utils.test.ts
@@ -25,7 +25,7 @@ describe('Dataset Visualizer utilities', () => {
         },
       ];
 
-      supportedDatasets.forEach(dataset => {
+      supportedDatasets.forEach((dataset) => {
         expect(getSupportedVis(dataset)).toContain(Vis.Scalar);
       });
     });
@@ -44,7 +44,7 @@ describe('Dataset Visualizer utilities', () => {
         },
       ];
 
-      unsupportedDatasets.forEach(dataset => {
+      unsupportedDatasets.forEach((dataset) => {
         expect(getSupportedVis(dataset)).not.toContain(Vis.Scalar);
       });
     });
@@ -68,7 +68,7 @@ describe('Dataset Visualizer utilities', () => {
         },
       ];
 
-      supportedDatasets.forEach(dataset => {
+      supportedDatasets.forEach((dataset) => {
         expect(getSupportedVis(dataset)).toContain(Vis.Matrix);
       });
     });
@@ -97,7 +97,7 @@ describe('Dataset Visualizer utilities', () => {
         },
       ];
 
-      unsupportedDatasets.forEach(dataset => {
+      unsupportedDatasets.forEach((dataset) => {
         expect(getSupportedVis(dataset)).not.toContain(Vis.Matrix);
       });
     });
@@ -121,7 +121,7 @@ describe('Dataset Visualizer utilities', () => {
         },
       ];
 
-      supportedDatasets.forEach(dataset => {
+      supportedDatasets.forEach((dataset) => {
         expect(getSupportedVis(dataset)).toContain(Vis.Line);
       });
     });
@@ -150,7 +150,7 @@ describe('Dataset Visualizer utilities', () => {
         },
       ];
 
-      unsupportedDatasets.forEach(dataset => {
+      unsupportedDatasets.forEach((dataset) => {
         expect(getSupportedVis(dataset)).not.toContain(Vis.Line);
       });
     });
@@ -169,7 +169,7 @@ describe('Dataset Visualizer utilities', () => {
         },
       ];
 
-      supportedDatasets.forEach(dataset => {
+      supportedDatasets.forEach((dataset) => {
         expect(getSupportedVis(dataset)).toContain(Vis.Heatmap);
       });
     });
@@ -198,7 +198,7 @@ describe('Dataset Visualizer utilities', () => {
         },
       ];
 
-      unsupportedDatasets.forEach(dataset => {
+      unsupportedDatasets.forEach((dataset) => {
         expect(getSupportedVis(dataset)).not.toContain(Vis.Heatmap);
       });
     });

--- a/src/h5web/dataset-visualizer/utils.ts
+++ b/src/h5web/dataset-visualizer/utils.ts
@@ -1,5 +1,5 @@
-import { Vis } from './models';
-import { HDF5Dataset } from '../providers/models';
+import type { Vis } from './models';
+import type { HDF5Dataset } from '../providers/models';
 import { VIS_DEFS } from '../visualizations';
 
 export function getSupportedVis(dataset?: HDF5Dataset): Vis[] {

--- a/src/h5web/explorer/Explorer.tsx
+++ b/src/h5web/explorer/Explorer.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { FiFileText } from 'react-icons/fi';
-import { HDF5Link } from '../providers/models';
-import { TreeNode, ExpandedNodes } from './models';
+import type { HDF5Link } from '../providers/models';
+import type { TreeNode, ExpandedNodes } from './models';
 import TreeView from './TreeView';
 import styles from './Explorer.module.css';
 import Icon from './Icon';

--- a/src/h5web/explorer/Icon.tsx
+++ b/src/h5web/explorer/Icon.tsx
@@ -7,7 +7,7 @@ import {
   FiLayers,
   FiLink,
 } from 'react-icons/fi';
-import { IconType } from 'react-icons';
+import type { IconType } from 'react-icons';
 
 import { HDF5Link, HDF5Collection } from '../providers/models';
 

--- a/src/h5web/explorer/TreeView.tsx
+++ b/src/h5web/explorer/TreeView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TreeNode, ExpandedNodes } from './models';
+import type { TreeNode, ExpandedNodes } from './models';
 
 import styles from './Explorer.module.css';
 

--- a/src/h5web/explorer/TreeView.tsx
+++ b/src/h5web/explorer/TreeView.tsx
@@ -24,7 +24,7 @@ function TreeView<T>(props: Props<T>): JSX.Element {
 
   return (
     <ul className={styles.group} role="group">
-      {nodes.map(node => {
+      {nodes.map((node) => {
         const { uid, label, data, children } = node;
         const isBranch = !!children;
         const isExpanded = !!expandedNodes[node.uid];

--- a/src/h5web/explorer/utils.test.ts
+++ b/src/h5web/explorer/utils.test.ts
@@ -1,5 +1,5 @@
 import { getNodesOnPath } from './utils';
-import { TreeNode } from './models';
+import type { TreeNode } from './models';
 
 const dataA = {};
 const dataB = {};

--- a/src/h5web/explorer/utils.ts
+++ b/src/h5web/explorer/utils.ts
@@ -1,4 +1,4 @@
-import { TreeNode } from './models';
+import type { TreeNode } from './models';
 
 export function getNodesOnPath<T>(
   tree: TreeNode<T>,

--- a/src/h5web/metadata-viewer/AttributesInfo.tsx
+++ b/src/h5web/metadata-viewer/AttributesInfo.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { HDF5Attribute } from '../providers/models';
+import type { HDF5Attribute } from '../providers/models';
 import styles from './MetadataViewer.module.css';
 
 interface Props {

--- a/src/h5web/metadata-viewer/EntityInfo.tsx
+++ b/src/h5web/metadata-viewer/EntityInfo.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { HDF5Entity } from '../providers/models';
+import type { HDF5Entity } from '../providers/models';
 import styles from './MetadataViewer.module.css';
 import { isBaseType, isSimpleShape } from '../providers/utils';
 import { renderShapeDims } from './utils';

--- a/src/h5web/metadata-viewer/MetadataViewer.tsx
+++ b/src/h5web/metadata-viewer/MetadataViewer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { HDF5Link, HDF5Entity } from '../providers/models';
+import type { HDF5Link, HDF5Entity } from '../providers/models';
 import AttributesInfo from './AttributesInfo';
 import LinkInfo from './LinkInfo';
 import EntityInfo from './EntityInfo';

--- a/src/h5web/metadata-viewer/RawInspector.tsx
+++ b/src/h5web/metadata-viewer/RawInspector.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { HDF5Link, HDF5Entity } from '../providers/models';
+import type { HDF5Link, HDF5Entity } from '../providers/models';
 
 import styles from './RawInspector.module.css';
 

--- a/src/h5web/providers/context.ts
+++ b/src/h5web/providers/context.ts
@@ -1,5 +1,5 @@
 import { createContext } from 'react';
-import { HDF5Id, HDF5Value, HDF5Metadata } from './models';
+import type { HDF5Id, HDF5Value, HDF5Metadata } from './models';
 
 export abstract class ProviderAPI {
   abstract getDomain: () => string;

--- a/src/h5web/providers/hooks.ts
+++ b/src/h5web/providers/hooks.ts
@@ -16,7 +16,7 @@ export function useMetadataTree(): TreeNode<HDF5Link> | undefined {
 
   useEffect(() => {
     getMetadata()
-      .then(metadata => buildTree(metadata, domain))
+      .then((metadata) => buildTree(metadata, domain))
       .then(setTree);
   }, [domain, getMetadata]);
 
@@ -33,7 +33,7 @@ export function useEntity(link?: HDF5Link): HDF5Entity | undefined {
       return;
     }
 
-    getMetadata().then(metadata => {
+    getMetadata().then((metadata) => {
       const { collection, id } = link;
       const dict = metadata[collection];
       setEntity(dict && dict[id]);

--- a/src/h5web/providers/hooks.ts
+++ b/src/h5web/providers/hooks.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useContext } from 'react';
-import { HDF5Link, HDF5Entity, HDF5Id, HDF5Value } from './models';
-import { TreeNode } from '../explorer/models';
+import type { HDF5Link, HDF5Entity, HDF5Id, HDF5Value } from './models';
+import type { TreeNode } from '../explorer/models';
 import { ProviderContext } from './context';
 import { buildTree, isReachable } from './utils';
 

--- a/src/h5web/providers/hsds/api.ts
+++ b/src/h5web/providers/hsds/api.ts
@@ -104,13 +104,13 @@ export class HsdsApi implements ProviderAPI {
       `/${entityCollection}/${entityId}/attributes`,
       this.config
     );
-    const attrsPromises = data.attributes.map(attr =>
+    const attrsPromises = data.attributes.map((attr) =>
       this.client
         .get<HsdsAttributeWithValueResponse>(
           `/${entityCollection}/${entityId}/attributes/${attr.name}`,
           this.config
         )
-        .then(response => response.data)
+        .then((response) => response.data)
     );
     return Promise.all(attrsPromises);
   }

--- a/src/h5web/providers/hsds/api.ts
+++ b/src/h5web/providers/hsds/api.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
-import {
+import type {
   HsdsDatasetResponse,
   HsdsDatatypeResponse,
   HsdsGroupResponse,
@@ -23,7 +23,7 @@ import {
   HDF5Link,
 } from '../models';
 import { isReachable } from '../utils';
-import { ProviderAPI } from '../context';
+import type { ProviderAPI } from '../context';
 
 export class HsdsApi implements ProviderAPI {
   private readonly client: AxiosInstance;

--- a/src/h5web/providers/hsds/models.ts
+++ b/src/h5web/providers/hsds/models.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   HDF5Id,
   HDF5Shape,
   HDF5Type,

--- a/src/h5web/providers/mock/api.ts
+++ b/src/h5web/providers/mock/api.ts
@@ -1,5 +1,5 @@
-import { ProviderAPI } from '../context';
-import { HDF5Id, HDF5Value, HDF5Metadata } from '../models';
+import type { ProviderAPI } from '../context';
+import type { HDF5Id, HDF5Value, HDF5Metadata } from '../models';
 
 /**
  * File mocked: `bsa_002_000-integrate-sub.h5`

--- a/src/h5web/providers/silx/api.ts
+++ b/src/h5web/providers/silx/api.ts
@@ -1,8 +1,8 @@
 import axios, { AxiosInstance } from 'axios';
 import { mapValues } from 'lodash-es';
-import { ProviderAPI } from '../context';
+import type { ProviderAPI } from '../context';
 import { HDF5Id, HDF5Value, HDF5Metadata, HDF5Collection } from '../models';
-import { SilxValuesResponse, SilxMetadataResponse } from './models';
+import type { SilxValuesResponse, SilxMetadataResponse } from './models';
 
 export class SilxApi implements ProviderAPI {
   private readonly client: AxiosInstance;

--- a/src/h5web/providers/utils.ts
+++ b/src/h5web/providers/utils.ts
@@ -80,7 +80,7 @@ function buildTreeNode(
     parents,
     ...(group
       ? {
-          children: (group.links || []).map(lk =>
+          children: (group.links || []).map((lk) =>
             buildTreeNode(metadata, lk, [...parents, link])
           ),
         }

--- a/src/h5web/providers/utils.ts
+++ b/src/h5web/providers/utils.ts
@@ -17,7 +17,7 @@ import {
   HDF5ScalarShape,
   HDF5NumericType,
 } from './models';
-import { TreeNode } from '../explorer/models';
+import type { TreeNode } from '../explorer/models';
 
 export function isHardLink(link: HDF5Link): link is HDF5HardLink {
   return link.class === HDF5LinkClass.Hard;

--- a/src/h5web/storage-utils.ts
+++ b/src/h5web/storage-utils.ts
@@ -31,7 +31,7 @@ export function createPersistableState<S extends State>(
     // Invoke provided state creator to retrieve initial state
     const initialState = createState(
       // Monkey patch `set` to persist state on every call
-      args => {
+      (args) => {
         set(args);
 
         // Retrieve new state to persist, keeping only the relevant keys

--- a/src/h5web/visualizations/heatmap/ColorBar.tsx
+++ b/src/h5web/visualizations/heatmap/ColorBar.tsx
@@ -10,7 +10,7 @@ import { generateCSSLinearGradient, getDataScaleFn } from './utils';
 
 function ColorBar(): JSX.Element {
   const [dataDomain, customDomain, hasLogScale] = useHeatmapConfig(
-    state => [state.dataDomain, state.customDomain, state.hasLogScale],
+    (state) => [state.dataDomain, state.customDomain, state.hasLogScale],
     shallow
   );
 

--- a/src/h5web/visualizations/heatmap/ColorMapSelector.tsx
+++ b/src/h5web/visualizations/heatmap/ColorMapSelector.tsx
@@ -5,7 +5,7 @@ import { MdArrowDropDown } from 'react-icons/md';
 import { useWindowSize } from 'react-use';
 import styles from './ColorMapSelector.module.css';
 import { INTERPOLATOR_GROUPS, INTERPOLATORS } from './interpolators';
-import { ColorMap, D3Interpolator } from './models';
+import type { ColorMap, D3Interpolator } from './models';
 import { generateCSSLinearGradient } from './utils';
 
 const MENU_IDEAL_HEIGHT = 320; // 20rem

--- a/src/h5web/visualizations/heatmap/DomainSlider.tsx
+++ b/src/h5web/visualizations/heatmap/DomainSlider.tsx
@@ -17,7 +17,7 @@ function DomainSlider(): JSX.Element {
     dataDomain,
     customDomain,
     setCustomDomain,
-  ] = useHeatmapConfig(state => [
+  ] = useHeatmapConfig((state) => [
     state.dataDomain,
     state.customDomain,
     state.setCustomDomain,
@@ -31,8 +31,8 @@ function DomainSlider(): JSX.Element {
   const [extendedMin, extendedMax] = extendDomain(dataDomain, EXTEND_FACTOR);
   const step = Math.max((extendedMax - extendedMin) / 100, 10 ** -NB_DECIMALS);
 
-  const updateCustomDomain = debounce(values => {
-    const roundedDomain = (values as number[]).map(value =>
+  const updateCustomDomain = debounce((values) => {
+    const roundedDomain = (values as number[]).map((value) =>
       round(value, NB_DECIMALS)
     ) as Domain;
     setCustomDomain(roundedDomain);

--- a/src/h5web/visualizations/heatmap/DomainSlider.tsx
+++ b/src/h5web/visualizations/heatmap/DomainSlider.tsx
@@ -6,7 +6,7 @@ import { round, debounce } from 'lodash-es';
 import { FiRotateCcw } from 'react-icons/fi';
 import styles from './DomainSlider.module.css';
 import { useHeatmapConfig } from './config';
-import { Domain } from '../shared/models';
+import type { Domain } from '../shared/models';
 import { extendDomain } from '../shared/utils';
 
 const EXTEND_FACTOR = 0.2;

--- a/src/h5web/visualizations/heatmap/HeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapVis.tsx
@@ -16,7 +16,7 @@ function HeatmapVis(): JSX.Element {
   const [rows, cols] = dims;
 
   const [keepAspectRatio, showGrid] = useHeatmapConfig(
-    state => [state.keepAspectRatio, state.showGrid],
+    (state) => [state.keepAspectRatio, state.showGrid],
     shallow
   );
 
@@ -24,7 +24,7 @@ function HeatmapVis(): JSX.Element {
   const aspectRatio = keepAspectRatio ? cols / rows : undefined;
 
   const values = useValues();
-  const initDataDomain = useHeatmapConfig(state => state.initDataDomain);
+  const initDataDomain = useHeatmapConfig((state) => state.initDataDomain);
 
   useEffect(() => {
     initDataDomain(values);

--- a/src/h5web/visualizations/heatmap/config.ts
+++ b/src/h5web/visualizations/heatmap/config.ts
@@ -30,7 +30,7 @@ const STORAGE_CONFIG: StorageConfig = {
 
 export const [useHeatmapConfig] = createPersistableState<HeatmapConfig>(
   STORAGE_CONFIG,
-  set => ({
+  (set) => ({
     dataDomain: undefined,
     initDataDomain: (values: number[]) => {
       set({
@@ -47,13 +47,13 @@ export const [useHeatmapConfig] = createPersistableState<HeatmapConfig>(
     setColorMap: (colorMap: ColorMap) => set({ colorMap }),
 
     hasLogScale: false,
-    toggleLogScale: () => set(state => ({ hasLogScale: !state.hasLogScale })),
+    toggleLogScale: () => set((state) => ({ hasLogScale: !state.hasLogScale })),
 
     keepAspectRatio: true,
     toggleAspectRatio: () =>
-      set(state => ({ keepAspectRatio: !state.keepAspectRatio })),
+      set((state) => ({ keepAspectRatio: !state.keepAspectRatio })),
 
     showGrid: false,
-    toggleGrid: () => set(state => ({ showGrid: !state.showGrid })),
+    toggleGrid: () => set((state) => ({ showGrid: !state.showGrid })),
   })
 );

--- a/src/h5web/visualizations/heatmap/config.ts
+++ b/src/h5web/visualizations/heatmap/config.ts
@@ -1,5 +1,5 @@
-import { ColorMap } from './models';
-import { Domain } from '../shared/models';
+import type { ColorMap } from './models';
+import type { Domain } from '../shared/models';
 import { StorageConfig, createPersistableState } from '../../storage-utils';
 import { findDomain } from '../shared/utils';
 

--- a/src/h5web/visualizations/heatmap/hooks.ts
+++ b/src/h5web/visualizations/heatmap/hooks.ts
@@ -8,9 +8,9 @@ import shallow from 'zustand/shallow';
 import Worker from 'worker-loader!./worker';
 
 import { useHeatmapConfig } from './config';
-import { D3Interpolator, Dims } from './models';
+import type { D3Interpolator, Dims } from './models';
 import { INTERPOLATORS } from './interpolators';
-import { TextureWorker } from './worker';
+import type { TextureWorker } from './worker';
 import { useVisProps } from '../../dataset-visualizer/VisProvider';
 
 export function useData(): number[][] {

--- a/src/h5web/visualizations/heatmap/hooks.ts
+++ b/src/h5web/visualizations/heatmap/hooks.ts
@@ -35,7 +35,7 @@ export function useValues(): number[] {
 }
 
 export function useInterpolator(): D3Interpolator {
-  const colorMap = useHeatmapConfig(state => state.colorMap);
+  const colorMap = useHeatmapConfig((state) => state.colorMap);
   return INTERPOLATORS[colorMap];
 }
 
@@ -46,7 +46,7 @@ export interface TextureDataState {
 
 export function useTextureData(): TextureDataState {
   const [dataDomain, customDomain, hasLogScale, colorMap] = useHeatmapConfig(
-    state => [
+    (state) => [
       state.dataDomain,
       state.customDomain,
       state.hasLogScale,

--- a/src/h5web/visualizations/heatmap/models.ts
+++ b/src/h5web/visualizations/heatmap/models.ts
@@ -1,5 +1,5 @@
-import { scaleSymlog, scaleLinear } from 'd3-scale';
-import { INTERPOLATORS } from './interpolators';
+import type { scaleSymlog, scaleLinear } from 'd3-scale';
+import type { INTERPOLATORS } from './interpolators';
 
 export type Dims = [number, number];
 

--- a/src/h5web/visualizations/heatmap/utils.ts
+++ b/src/h5web/visualizations/heatmap/utils.ts
@@ -1,6 +1,6 @@
 import { range } from 'lodash-es';
 import { scaleSymlog, scaleLinear } from 'd3-scale';
-import { D3Interpolator, DataScaleFn } from './models';
+import type { D3Interpolator, DataScaleFn } from './models';
 
 export function generateCSSLinearGradient(
   interpolator: D3Interpolator,

--- a/src/h5web/visualizations/heatmap/worker.ts
+++ b/src/h5web/visualizations/heatmap/worker.ts
@@ -1,9 +1,9 @@
 import { expose, transfer } from 'comlink';
 import { rgb } from 'd3-color';
 import { scaleSequential } from 'd3-scale';
-import { ColorMap } from './models';
+import type { ColorMap } from './models';
 import { INTERPOLATORS } from './interpolators';
-import { Domain } from '../shared/models';
+import type { Domain } from '../shared/models';
 import { getDataScaleFn } from './utils';
 
 function computeTextureData(

--- a/src/h5web/visualizations/index.ts
+++ b/src/h5web/visualizations/index.ts
@@ -34,7 +34,7 @@ export const VIS_DEFS: Record<Vis, VisDef> = {
   [Vis.Scalar]: {
     Component: ScalarVis,
     Icon: FiCode,
-    supportsDataset: dataset => {
+    supportsDataset: (dataset) => {
       const { type, shape } = dataset;
       return isBaseType(type) && isScalarShape(shape);
     },
@@ -42,7 +42,7 @@ export const VIS_DEFS: Record<Vis, VisDef> = {
   [Vis.Matrix]: {
     Component: MatrixVis,
     Icon: FiGrid,
-    supportsDataset: dataset => {
+    supportsDataset: (dataset) => {
       const { type, shape } = dataset;
       return isBaseType(type) && isSimpleShape(shape) && hasSimpleDims(shape);
     },
@@ -51,7 +51,7 @@ export const VIS_DEFS: Record<Vis, VisDef> = {
     Component: LineVis,
     Icon: FiActivity,
     Toolbar: LineToolbar,
-    supportsDataset: dataset => {
+    supportsDataset: (dataset) => {
       const { type, shape } = dataset;
       return (
         isNumericType(type) && isSimpleShape(shape) && hasSimpleDims(shape)
@@ -62,7 +62,7 @@ export const VIS_DEFS: Record<Vis, VisDef> = {
     Component: HeatmapVis,
     Icon: FiMap,
     Toolbar: HeatmapToolbar,
-    supportsDataset: dataset => {
+    supportsDataset: (dataset) => {
       const { type, shape } = dataset;
       return (
         isNumericType(type) && isSimpleShape(shape) && shape.dims.length === 2

--- a/src/h5web/visualizations/index.ts
+++ b/src/h5web/visualizations/index.ts
@@ -1,6 +1,6 @@
-import { ElementType } from 'react';
+import type { ElementType } from 'react';
 import { FiCode, FiGrid, FiActivity, FiMap, FiCpu } from 'react-icons/fi';
-import { IconType } from 'react-icons';
+import type { IconType } from 'react-icons';
 import RawVis from './RawVis';
 import MatrixVis from './matrix/MatrixVis';
 import ScalarVis from './ScalarVis';
@@ -9,7 +9,7 @@ import HeatmapVis from './heatmap/HeatmapVis';
 import { Vis } from '../dataset-visualizer/models';
 import LineToolbar from './line/LineToolbar';
 import HeatmapToolbar from './heatmap/HeatmapToolbar';
-import { HDF5Dataset } from '../providers/models';
+import type { HDF5Dataset } from '../providers/models';
 import {
   isScalarShape,
   isBaseType,

--- a/src/h5web/visualizations/line/DataCurve.tsx
+++ b/src/h5web/visualizations/line/DataCurve.tsx
@@ -18,7 +18,7 @@ function DataCurve(): JSX.Element {
     return geometry;
   }, [points]);
 
-  const curveType = useLineConfig(state => state.curveType);
+  const curveType = useLineConfig((state) => state.curveType);
   const showLine = curveType !== CurveType.GlyphsOnly;
   const showGlyphs = curveType !== CurveType.LineOnly;
 

--- a/src/h5web/visualizations/line/LineVis.tsx
+++ b/src/h5web/visualizations/line/LineVis.tsx
@@ -14,7 +14,7 @@ function LineVis(): JSX.Element {
   const data = useData();
 
   const [showGrid, hasYLogScale] = useLineConfig(
-    state => [state.showGrid, state.hasYLogScale],
+    (state) => [state.showGrid, state.hasYLogScale],
     shallow
   );
 

--- a/src/h5web/visualizations/line/config.ts
+++ b/src/h5web/visualizations/line/config.ts
@@ -17,13 +17,13 @@ const STORAGE_CONFIG: StorageConfig = {
 
 export const [useLineConfig] = createPersistableState<LineConfig>(
   STORAGE_CONFIG,
-  set => ({
+  (set) => ({
     curveType: CurveType.LineOnly,
     setCurveType: (type: CurveType) => set({ curveType: type }),
     showGrid: true,
-    toggleGrid: () => set(state => ({ showGrid: !state.showGrid })),
+    toggleGrid: () => set((state) => ({ showGrid: !state.showGrid })),
     hasYLogScale: false,
     toggleYLogScale: () =>
-      set(state => ({ hasYLogScale: !state.hasYLogScale })),
+      set((state) => ({ hasYLogScale: !state.hasYLogScale })),
   })
 );

--- a/src/h5web/visualizations/line/hooks.ts
+++ b/src/h5web/visualizations/line/hooks.ts
@@ -1,7 +1,7 @@
 import { useMemo, useContext } from 'react';
 import { Vector3 } from 'three';
 import { useThree } from 'react-three-fiber';
-import { Domain } from '../shared/models';
+import type { Domain } from '../shared/models';
 import { findDomain, getAxisScale } from '../shared/utils';
 import { AxisSystemContext } from '../shared/AxisSystemProvider';
 import { useVisProps } from '../../dataset-visualizer/VisProvider';

--- a/src/h5web/visualizations/matrix/Cell.tsx
+++ b/src/h5web/visualizations/matrix/Cell.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { GridChildComponentProps } from 'react-window';
+import type { GridChildComponentProps } from 'react-window';
 import { format } from 'd3-format';
 import styles from './MatrixVis.module.css';
 import { GridSettingsContext } from './GridSettingsContext';

--- a/src/h5web/visualizations/matrix/GridSettingsContext.tsx
+++ b/src/h5web/visualizations/matrix/GridSettingsContext.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, createContext } from 'react';
-import { HDF5Value } from '../../providers/models';
-import { Size } from '../shared/models';
+import type { HDF5Value } from '../../providers/models';
+import type { Size } from '../shared/models';
 
 export interface GridSettings {
   cellSize: Size;

--- a/src/h5web/visualizations/matrix/IndexTrack.tsx
+++ b/src/h5web/visualizations/matrix/IndexTrack.tsx
@@ -16,7 +16,7 @@ function IndexTrack(props: Props): JSX.Element {
   return (
     <div className={className}>
       {children}
-      {range(cellCount).map(index => (
+      {range(cellCount).map((index) => (
         <div
           key={index.toString()}
           className={styles.indexCell}

--- a/src/h5web/visualizations/matrix/MatrixVis.tsx
+++ b/src/h5web/visualizations/matrix/MatrixVis.tsx
@@ -25,7 +25,7 @@ function MatrixVis(): JSX.Element {
       rowCount={rowCount}
       columnCount={columnCount}
       valueAccessor={
-        dims.length === 1 ? row => data[row] : (row, col) => data[row][col]
+        dims.length === 1 ? (row) => data[row] : (row, col) => data[row][col]
       }
     >
       <div ref={divRef} className={styles.wrapper}>

--- a/src/h5web/visualizations/shared/AxisSystem.tsx
+++ b/src/h5web/visualizations/shared/AxisSystem.tsx
@@ -2,11 +2,11 @@ import React, { useState, useContext } from 'react';
 import { useThree, useFrame } from 'react-three-fiber';
 import { AxisLeft, AxisBottom } from '@vx/axis';
 import { format } from 'd3-format';
-import { TickRendererProps } from '@vx/axis/lib/types';
+import type { TickRendererProps } from '@vx/axis/lib/types';
 import { GridColumns, GridRows } from '@vx/grid';
 import { HTML } from 'drei';
 import styles from './AxisSystem.module.css';
-import { AxisOffsets, Domain } from './models';
+import type { AxisOffsets, Domain } from './models';
 import { getTicksProp, getAxisScale } from './utils';
 import { AxisSystemContext } from './AxisSystemProvider';
 

--- a/src/h5web/visualizations/shared/AxisSystemProvider.tsx
+++ b/src/h5web/visualizations/shared/AxisSystemProvider.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, ReactNode, createContext } from 'react';
 import { scaleLinear, scaleSymlog } from 'd3-scale';
-import { AxisConfig, AxisInfo } from './models';
+import type { AxisConfig, AxisInfo } from './models';
 import { isIndexAxisConfig } from './utils';
 
 export interface AxisConfigs {

--- a/src/h5web/visualizations/shared/PanZoomMesh.tsx
+++ b/src/h5web/visualizations/shared/PanZoomMesh.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useCallback, useEffect } from 'react';
-import { Vector3 } from 'three';
+import type { Vector3 } from 'three';
 import { PointerEvent, useThree } from 'react-three-fiber';
 import { clamp } from 'lodash-es';
 

--- a/src/h5web/visualizations/shared/ScreenshotButton.tsx
+++ b/src/h5web/visualizations/shared/ScreenshotButton.tsx
@@ -9,7 +9,7 @@ function ScreenshotButton(): ReactElement {
       href="/"
       target="_blank"
       aria-label="Screenshot"
-      onClick={evt => {
+      onClick={(evt) => {
         const canvas = document.querySelector('canvas');
 
         // Create data URL from canvas

--- a/src/h5web/visualizations/shared/ToggleBtn.tsx
+++ b/src/h5web/visualizations/shared/ToggleBtn.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconType } from 'react-icons';
+import type { IconType } from 'react-icons';
 import styles from './ToggleBtn.module.css';
 
 interface Props {

--- a/src/h5web/visualizations/shared/ToggleGroup.tsx
+++ b/src/h5web/visualizations/shared/ToggleGroup.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, ReactNode, ReactElement } from 'react';
-import { IconType } from 'react-icons';
+import type { IconType } from 'react-icons';
 import styles from './ToggleGroup.module.css';
 
 interface ToggleGroupProps {

--- a/src/h5web/visualizations/shared/VisCanvas.tsx
+++ b/src/h5web/visualizations/shared/VisCanvas.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from 'react';
 import { Canvas } from 'react-three-fiber';
 import { useMeasure } from 'react-use';
 import styles from './VisCanvas.module.css';
-import { AxisConfig } from './models';
+import type { AxisConfig } from './models';
 import { computeVisSize } from './utils';
 import AxisSystem from './AxisSystem';
 import AxisSystemProvider from './AxisSystemProvider';

--- a/src/h5web/visualizations/shared/models.ts
+++ b/src/h5web/visualizations/shared/models.ts
@@ -1,4 +1,9 @@
-import { ScaleLinear, ScaleSymLog, scaleSymlog, scaleLinear } from 'd3-scale';
+import type {
+  ScaleLinear,
+  ScaleSymLog,
+  scaleSymlog,
+  scaleLinear,
+} from 'd3-scale';
 
 export type Size = { width: number; height: number };
 

--- a/src/h5web/visualizations/shared/utils.test.ts
+++ b/src/h5web/visualizations/shared/utils.test.ts
@@ -1,6 +1,6 @@
 import { tickStep } from 'd3-array';
 import { computeVisSize, findDomain, getTicksProp } from './utils';
-import { AxisInfo } from './models';
+import type { AxisInfo } from './models';
 
 describe('Shared visualization utilities', () => {
   describe('computeVisSize', () => {

--- a/src/h5web/visualizations/shared/utils.ts
+++ b/src/h5web/visualizations/shared/utils.ts
@@ -1,6 +1,6 @@
 import { scaleLinear } from 'd3-scale';
 import { extent, tickStep } from 'd3-array';
-import {
+import type {
   Size,
   Domain,
   AxisConfig,

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom';
 
 // Avoids Re-flex warning
 // https://github.com/leefsmp/Re-Flex/issues/27
-['offsetWidth', 'offsetHeight'].forEach(prop => {
+['offsetWidth', 'offsetHeight'].forEach((prop) => {
   Object.defineProperty(HTMLElement.prototype, prop, {
     configurable: true,
     value: 500,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
+    "importsNotUsedAsValues": "error",
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,


### PR DESCRIPTION
[Prettier v2](https://prettier.io/blog/2020/03/21/2.0.0.html#typescript) supports TypeScript 3.8, so we can start using TypeScript's [`import type` feature](https://devblogs.microsoft.com/typescript/announcing-typescript-3-8/#type-only-imports-exports). I've updated `tsconfig.json` to force the use of `import type` when importing types (except when used as values - e.g. `Object.entries(SomeEnum)` or `extends SomeClass`) with  `"importsNotUsedAsValues": "error"`.

Prettier v2 brings a couple other changes:
- `"trailingComma": "es5"` can be removed from `.prettierrc.json` since it is the new default
- `lint:prettier` script in `package.json` can be simplified with `.` (to look for every supported file automatically)
- Arrow function parameters are now always wrapped in parens -- it's sometimes a bit ugly, but it's a huge gain when developing, as you often have to manually add the parens in order to add types or destructuring expressions.