### PR TITLE
Implemented LogScale for LineVis (disabled if the values are not supported)

### DIFF
--- a/src/h5web/visualizations/line/LineToolbar.tsx
+++ b/src/h5web/visualizations/line/LineToolbar.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { MdGridOn, MdLinearScale } from 'react-icons/md';
+import { MdGridOn, MdGraphicEq, MdSort, MdFilterList } from 'react-icons/md';
 import ToggleBtn from '../shared/ToggleBtn';
 import { useLineConfig } from './config';
 import { CurveType } from './models';
 import ToggleGroup from '../shared/ToggleGroup';
 import Toolbar from '../shared/Toolbar';
 import Separator from '../shared/Separator';
+import { ScaleType } from '../shared/models';
 
 function LineToolbar(): JSX.Element {
   const {
@@ -13,8 +14,8 @@ function LineToolbar(): JSX.Element {
     setCurveType,
     showGrid,
     toggleGrid,
-    hasYLogScale,
-    toggleYLogScale,
+    scaleType,
+    setScaleType,
   } = useLineConfig();
 
   return (
@@ -32,12 +33,31 @@ function LineToolbar(): JSX.Element {
 
       <Separator />
 
-      <ToggleBtn
-        label="Symlog"
-        icon={MdLinearScale}
-        value={hasYLogScale}
-        onChange={toggleYLogScale}
-      />
+      <ToggleGroup
+        role="radiogroup"
+        ariaLabel="Scale type"
+        value={scaleType}
+        onChange={setScaleType}
+      >
+        <ToggleGroup.Btn
+          icon={MdSort}
+          label="Linear"
+          value={ScaleType.Linear}
+        />
+        <ToggleGroup.Btn
+          icon={MdFilterList}
+          label="Log"
+          value={ScaleType.Log}
+        />
+        <ToggleGroup.Btn
+          icon={(props) => <MdGraphicEq {...props} transform="rotate(90)" />}
+          label="SymLog"
+          value={ScaleType.SymLog}
+        />
+      </ToggleGroup>
+
+      <Separator />
+
       <ToggleBtn
         label="Grid"
         icon={MdGridOn}

--- a/src/h5web/visualizations/line/LineVis.tsx
+++ b/src/h5web/visualizations/line/LineVis.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useMemo } from 'react';
+import React, { ReactElement } from 'react';
 import shallow from 'zustand/shallow';
 import { format } from 'd3-format';
 import type ndarray from 'ndarray';
@@ -8,7 +8,8 @@ import VisCanvas from '../shared/VisCanvas';
 import PanZoomMesh from '../shared/PanZoomMesh';
 import { useLineConfig } from './config';
 import TooltipMesh from '../shared/TooltipMesh';
-import { extendDomain, findDomain } from '../shared/utils';
+import { extendDomain } from '../shared/utils';
+import { useAxisDomain } from './hooks';
 
 interface Props {
   dataArray: ndarray<number>;
@@ -17,14 +18,12 @@ interface Props {
 function LineVis(props: Props): ReactElement {
   const { dataArray } = props;
 
-  const [showGrid, hasYLogScale] = useLineConfig(
-    (state) => [state.showGrid, state.hasYLogScale],
+  const [showGrid, scaleType] = useLineConfig(
+    (state) => [state.showGrid, state.scaleType],
     shallow
   );
 
-  const dataDomain = useMemo(() => {
-    return findDomain(dataArray.data as number[]);
-  }, [dataArray]);
+  const dataDomain = useAxisDomain(dataArray, scaleType);
 
   if (!dataDomain) {
     return <></>;
@@ -38,9 +37,9 @@ function LineVis(props: Props): ReactElement {
           showGrid,
         }}
         ordinateConfig={{
-          dataDomain: extendDomain(dataDomain, 0.01),
+          dataDomain,
           showGrid,
-          isLog: hasYLogScale,
+          scaleType,
         }}
       >
         <TooltipMesh

--- a/src/h5web/visualizations/line/config.ts
+++ b/src/h5web/visualizations/line/config.ts
@@ -1,18 +1,21 @@
 import { StorageConfig, createPersistableState } from '../../storage-utils';
 import { CurveType } from './models';
+import { ScaleType } from '../shared/models';
 
 type LineConfig = {
   curveType: CurveType;
   setCurveType: (type: CurveType) => void;
+
   showGrid: boolean;
   toggleGrid: () => void;
-  hasYLogScale: boolean;
-  toggleYLogScale: () => void;
+
+  scaleType: ScaleType;
+  setScaleType: (type: ScaleType) => void;
 };
 
 const STORAGE_CONFIG: StorageConfig = {
   storageId: 'h5web:line',
-  itemsToPersist: ['curveType', 'showGrid', 'hasYLogScale'],
+  itemsToPersist: ['curveType', 'showGrid', 'scaleType'],
 };
 
 export const [useLineConfig] = createPersistableState<LineConfig>(
@@ -20,10 +23,11 @@ export const [useLineConfig] = createPersistableState<LineConfig>(
   (set) => ({
     curveType: CurveType.LineOnly,
     setCurveType: (type: CurveType) => set({ curveType: type }),
+
     showGrid: true,
     toggleGrid: () => set((state) => ({ showGrid: !state.showGrid })),
-    hasYLogScale: false,
-    toggleYLogScale: () =>
-      set((state) => ({ hasYLogScale: !state.hasYLogScale })),
+
+    scaleType: ScaleType.Linear,
+    setScaleType: (type: ScaleType) => set({ scaleType: type }),
   })
 );

--- a/src/h5web/visualizations/line/hooks.ts
+++ b/src/h5web/visualizations/line/hooks.ts
@@ -1,0 +1,18 @@
+import type ndarray from 'ndarray';
+import { useMemo } from 'react';
+import { ScaleType, Domain } from '../shared/models';
+import { findDomain, extendDomain } from '../shared/utils';
+
+export function useAxisDomain(
+  dataArray: ndarray,
+  scaleType: ScaleType
+): Domain | undefined {
+  return useMemo(() => {
+    const isLogScale = scaleType === ScaleType.Log;
+    const rawDomain = isLogScale
+      ? findDomain((dataArray.data as number[]).filter((x) => x > 0))
+      : findDomain(dataArray.data as number[]);
+
+    return rawDomain && extendDomain(rawDomain, 0.05, isLogScale);
+  }, [dataArray.data, scaleType]);
+}

--- a/src/h5web/visualizations/shared/AxisSystemProvider.tsx
+++ b/src/h5web/visualizations/shared/AxisSystemProvider.tsx
@@ -1,7 +1,13 @@
 import React, { ReactElement, ReactNode, createContext } from 'react';
-import { scaleLinear, scaleSymlog } from 'd3-scale';
-import type { AxisConfig, AxisInfo } from './models';
+import { scaleLinear, scaleLog, scaleSymlog } from 'd3-scale';
+import { AxisConfig, AxisInfo, ScaleType, AxisScaleFn } from './models';
 import { isIndexAxisConfig } from './utils';
+
+const SCALE_FUNCTIONS: Record<ScaleType, AxisScaleFn> = {
+  [ScaleType.Linear]: scaleLinear,
+  [ScaleType.Log]: scaleLog,
+  [ScaleType.SymLog]: scaleSymlog,
+};
 
 export interface AxisConfigs {
   abscissaInfo: AxisInfo;
@@ -17,17 +23,17 @@ function getAxisInfo(config: AxisConfig): AxisInfo {
       isIndexAxis: true,
       scaleFn: scaleLinear,
       domain: indexDomain,
-      isLog: false,
+      scaleType: ScaleType.Linear,
       showGrid,
     };
   }
 
-  const { dataDomain, isLog = false, showGrid = false } = config;
+  const { dataDomain, scaleType = ScaleType.Linear, showGrid = false } = config;
   return {
     isIndexAxis: false,
-    scaleFn: isLog ? scaleSymlog : scaleLinear,
+    scaleFn: SCALE_FUNCTIONS[scaleType],
     domain: dataDomain,
-    isLog,
+    scaleType,
     showGrid,
   };
 }

--- a/src/h5web/visualizations/shared/ToggleGroup.tsx
+++ b/src/h5web/visualizations/shared/ToggleGroup.tsx
@@ -26,14 +26,16 @@ interface BtnProps {
   label: string;
   value: string;
   icon?: IconType;
+  disabled?: boolean;
 }
 
 function Btn(props: BtnProps): ReactElement {
-  const { label, value, icon: Icon } = props;
+  const { label, value, icon: Icon, disabled = false } = props;
   const { role, value: selectedValue, onChange } = useToggleGroupProps();
 
   return (
     <button
+      disabled={disabled}
       className={styles.btn}
       type="button"
       role={role === 'tablist' ? 'tab' : 'radio'}

--- a/src/h5web/visualizations/shared/Toolbar.module.css
+++ b/src/h5web/visualizations/shared/Toolbar.module.css
@@ -12,7 +12,7 @@
 }
 
 .btn:disabled {
-  opacity: 0.3;
+  opacity: 0.5;
   pointer-events: none;
 }
 

--- a/src/h5web/visualizations/shared/models.ts
+++ b/src/h5web/visualizations/shared/models.ts
@@ -1,9 +1,17 @@
 import type {
   ScaleLinear,
+  ScaleLogarithmic,
   ScaleSymLog,
-  scaleSymlog,
+  scaleLog,
   scaleLinear,
+  scaleSymlog,
 } from 'd3-scale';
+
+export enum ScaleType {
+  Linear = 'Linear',
+  Log = 'Log',
+  SymLog = 'SymLog',
+}
 
 export type Size = { width: number; height: number };
 
@@ -12,28 +20,32 @@ export type Domain = [number, number];
 export interface IndexAxisConfig {
   indexDomain: Domain;
   showGrid?: boolean;
-  isLog?: never; // invalid
+  scaleType?: never; // invalid
 }
 
 export interface DataAxisConfig {
   dataDomain: Domain;
   showGrid?: boolean;
-  isLog?: boolean;
+  scaleType?: ScaleType;
 }
 
 export type AxisConfig = IndexAxisConfig | DataAxisConfig;
 
-export type AxisScaleFn = typeof scaleSymlog | typeof scaleLinear;
+export type AxisScaleFn =
+  | typeof scaleLinear
+  | typeof scaleLog
+  | typeof scaleSymlog;
 
 export type AxisScale =
   | ScaleLinear<number, number>
+  | ScaleLogarithmic<number, number>
   | ScaleSymLog<number, number>;
 
 export interface AxisInfo {
   isIndexAxis: boolean;
   scaleFn: AxisScaleFn;
   domain: Domain;
-  isLog: boolean;
+  scaleType: ScaleType;
   showGrid: boolean;
 }
 

--- a/src/h5web/visualizations/shared/utils.ts
+++ b/src/h5web/visualizations/shared/utils.ts
@@ -37,10 +37,18 @@ export function computeVisSize(
     : { width, height: width / aspectRatio };
 }
 
-export function extendDomain(bareDomain: Domain, extendFactor: number): Domain {
+export function extendDomain(
+  bareDomain: Domain,
+  extendFactor: number,
+  log?: boolean
+): Domain {
   const [min, max] = bareDomain;
-  const extension = (max - min) * extendFactor;
 
+  if (log) {
+    return [min / (1 + extendFactor), max * (1 + extendFactor)];
+  }
+
+  const extension = (max - min) * extendFactor;
   return [min - extension, max + extension];
 }
 
@@ -70,7 +78,7 @@ export function getAxisScale(info: AxisInfo, rangeSize: number): AxisScale {
 /**
  * We can't rely on the axis scale's `ticks` method to get integer tick values because
  * `d3.tickStep` sometimes returns incoherent step values - e.g. `d3.tickStep(0, 2, 3)`
- * returns 0.5 intead of 1.
+ * returns 0.5 instead of 1.
  *
  * So we implement our own, simplified version of `d3.ticks` that always outputs integer values.
  */


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/42204205/84367597-c3865a80-abd4-11ea-90bd-832649359036.png)


Following our discussion on #74, I choose the following implementation:
> 1.Deactivate the log scale button when the data contain negative or null values.

This PR achieves that by implementing the following:
- Refactor to implement multiple scaleTypes in AxisConfig
- Add the possibility to disable buttons of ToggleGroup
- Disable Log button if the domain does not allow it.

The last item was a bit tricky as it meant that we had to propagate information coming from the data to the `LineToolbar` that was until now completely decoupled from the data. 
The propagation was done by adding a boolean to the `LineConfig` that tells if the log button should be disabled. This boolean is reset at each data change in `LineVis`.
I felt this was the best solution as `LineConfig` is the only entry point of `LineToolbar` but I am happy to get feedback.