### PR TITLE
Implemented LogScale for LineVis (hide points if the values are not supported)

### DIFF
--- a/src/h5web/visualizations/line/DataCurve.tsx
+++ b/src/h5web/visualizations/line/DataCurve.tsx
@@ -19,21 +19,29 @@ function DataCurve(props: Props): JSX.Element {
   const { values, color = DEFAULT_COLOR } = props;
 
   const { abscissaInfo, ordinateInfo } = useContext(AxisSystemContext);
-  const { size } = useThree();
+  const { camera, size } = useThree();
   const { width, height } = size;
 
   const dataGeometry = useMemo(() => {
     const abscissaScale = getAxisScale(abscissaInfo, width);
     const ordinateScale = getAxisScale(ordinateInfo, height);
 
-    const points = values.map(
-      (val, index) => new Vector3(abscissaScale(index), ordinateScale(val), 0)
-    );
+    const points = values.map((val, index) => {
+      const ordinate = ordinateScale(val);
+      return new Vector3(
+        abscissaScale(index),
+        // This is to avoid a three.js warning when ordinateScale(val) is Infinity
+        Number.isFinite(ordinate) ? ordinate : 0,
+        // Move NaN/Infinity out of the camera FOV (negative val for logScale).
+        // This allows to have only curve segments for the positive values
+        Number.isFinite(ordinate) ? 0 : camera.far
+      );
+    });
 
     const geometry = new BufferGeometry();
     geometry.setFromPoints(points);
     return geometry;
-  }, [abscissaInfo, height, ordinateInfo, values, width]);
+  }, [abscissaInfo, camera, height, ordinateInfo, values, width]);
 
   const curveType = useLineConfig((state) => state.curveType);
   const showLine = curveType !== CurveType.GlyphsOnly;

--- a/src/h5web/visualizations/line/LineToolbar.tsx
+++ b/src/h5web/visualizations/line/LineToolbar.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { MdGridOn, MdLinearScale } from 'react-icons/md';
+import { MdGridOn, MdGraphicEq, MdSort, MdFilterList } from 'react-icons/md';
 import ToggleBtn from '../shared/ToggleBtn';
 import { useLineConfig } from './config';
 import { CurveType } from './models';
 import ToggleGroup from '../shared/ToggleGroup';
 import Toolbar from '../shared/Toolbar';
 import Separator from '../shared/Separator';
+import { ScaleType } from '../shared/models';
 
 function LineToolbar(): JSX.Element {
   const {
@@ -13,8 +14,8 @@ function LineToolbar(): JSX.Element {
     setCurveType,
     showGrid,
     toggleGrid,
-    hasYLogScale,
-    toggleYLogScale,
+    scaleType,
+    setScaleType,
   } = useLineConfig();
 
   return (
@@ -32,12 +33,31 @@ function LineToolbar(): JSX.Element {
 
       <Separator />
 
-      <ToggleBtn
-        label="Symlog"
-        icon={MdLinearScale}
-        value={hasYLogScale}
-        onChange={toggleYLogScale}
-      />
+      <ToggleGroup
+        role="radiogroup"
+        ariaLabel="Scale type"
+        value={scaleType}
+        onChange={setScaleType}
+      >
+        <ToggleGroup.Btn
+          icon={MdSort}
+          label="Linear"
+          value={ScaleType.Linear}
+        />
+        <ToggleGroup.Btn
+          icon={MdFilterList}
+          label="Log"
+          value={ScaleType.Log}
+        />
+        <ToggleGroup.Btn
+          icon={(props) => <MdGraphicEq {...props} transform="rotate(90)" />}
+          label="SymLog"
+          value={ScaleType.SymLog}
+        />
+      </ToggleGroup>
+
+      <Separator />
+
       <ToggleBtn
         label="Grid"
         icon={MdGridOn}

--- a/src/h5web/visualizations/line/LineVis.tsx
+++ b/src/h5web/visualizations/line/LineVis.tsx
@@ -9,6 +9,7 @@ import PanZoomMesh from '../shared/PanZoomMesh';
 import { useLineConfig } from './config';
 import TooltipMesh from '../shared/TooltipMesh';
 import { extendDomain, findDomain } from '../shared/utils';
+import { ScaleType } from '../shared/models';
 
 interface Props {
   dataArray: ndarray<number>;
@@ -17,14 +18,20 @@ interface Props {
 function LineVis(props: Props): ReactElement {
   const { dataArray } = props;
 
-  const [showGrid, hasYLogScale] = useLineConfig(
-    (state) => [state.showGrid, state.hasYLogScale],
+  const [showGrid, scaleType] = useLineConfig(
+    (state) => [state.showGrid, state.scaleType],
     shallow
   );
 
+  const values = dataArray.data as number[];
   const dataDomain = useMemo(() => {
-    return findDomain(dataArray.data as number[]);
-  }, [dataArray]);
+    const isLogScale = scaleType === ScaleType.Log;
+    const rawDomain = findDomain(
+      isLogScale ? values.filter((x) => x > 0) : values
+    );
+
+    return rawDomain && extendDomain(rawDomain, 0.05, isLogScale);
+  }, [scaleType, values]);
 
   if (!dataDomain) {
     return <></>;
@@ -38,9 +45,9 @@ function LineVis(props: Props): ReactElement {
           showGrid,
         }}
         ordinateConfig={{
-          dataDomain: extendDomain(dataDomain, 0.01),
+          dataDomain,
           showGrid,
-          isLog: hasYLogScale,
+          scaleType,
         }}
       >
         <TooltipMesh

--- a/src/h5web/visualizations/line/LineVis.tsx
+++ b/src/h5web/visualizations/line/LineVis.tsx
@@ -33,10 +33,6 @@ function LineVis(props: Props): ReactElement {
     return rawDomain && extendDomain(rawDomain, 0.05, isLogScale);
   }, [scaleType, values]);
 
-  if (!dataDomain) {
-    return <></>;
-  }
-
   return (
     <div className={styles.root}>
       <VisCanvas
@@ -45,7 +41,7 @@ function LineVis(props: Props): ReactElement {
           showGrid,
         }}
         ordinateConfig={{
-          dataDomain,
+          dataDomain: dataDomain || [0.1, 1],
           showGrid,
           scaleType,
         }}
@@ -59,7 +55,7 @@ function LineVis(props: Props): ReactElement {
           guides="vertical"
         />
         <PanZoomMesh />
-        <DataCurve values={dataArray.data as number[]} />
+        {dataDomain && <DataCurve values={dataArray.data as number[]} />}
       </VisCanvas>
     </div>
   );

--- a/src/h5web/visualizations/line/config.ts
+++ b/src/h5web/visualizations/line/config.ts
@@ -1,18 +1,21 @@
 import { StorageConfig, createPersistableState } from '../../storage-utils';
 import { CurveType } from './models';
+import { ScaleType } from '../shared/models';
 
 type LineConfig = {
   curveType: CurveType;
   setCurveType: (type: CurveType) => void;
+
   showGrid: boolean;
   toggleGrid: () => void;
-  hasYLogScale: boolean;
-  toggleYLogScale: () => void;
+
+  scaleType: ScaleType;
+  setScaleType: (type: ScaleType) => void;
 };
 
 const STORAGE_CONFIG: StorageConfig = {
   storageId: 'h5web:line',
-  itemsToPersist: ['curveType', 'showGrid', 'hasYLogScale'],
+  itemsToPersist: ['curveType', 'showGrid', 'scaleType'],
 };
 
 export const [useLineConfig] = createPersistableState<LineConfig>(
@@ -20,10 +23,11 @@ export const [useLineConfig] = createPersistableState<LineConfig>(
   (set) => ({
     curveType: CurveType.LineOnly,
     setCurveType: (type: CurveType) => set({ curveType: type }),
+
     showGrid: true,
     toggleGrid: () => set((state) => ({ showGrid: !state.showGrid })),
-    hasYLogScale: false,
-    toggleYLogScale: () =>
-      set((state) => ({ hasYLogScale: !state.hasYLogScale })),
+
+    scaleType: ScaleType.Linear,
+    setScaleType: (type: ScaleType) => set({ scaleType: type }),
   })
 );

--- a/src/h5web/visualizations/shared/AxisSystemProvider.tsx
+++ b/src/h5web/visualizations/shared/AxisSystemProvider.tsx
@@ -1,7 +1,13 @@
 import React, { ReactElement, ReactNode, createContext } from 'react';
-import { scaleLinear, scaleSymlog } from 'd3-scale';
-import type { AxisConfig, AxisInfo } from './models';
+import { scaleLinear, scaleLog, scaleSymlog } from 'd3-scale';
+import { AxisConfig, AxisInfo, ScaleType, AxisScaleFn } from './models';
 import { isIndexAxisConfig } from './utils';
+
+const SCALE_FUNCTIONS: Record<ScaleType, AxisScaleFn> = {
+  [ScaleType.Linear]: scaleLinear,
+  [ScaleType.Log]: scaleLog,
+  [ScaleType.SymLog]: scaleSymlog,
+};
 
 export interface AxisConfigs {
   abscissaInfo: AxisInfo;
@@ -17,17 +23,17 @@ function getAxisInfo(config: AxisConfig): AxisInfo {
       isIndexAxis: true,
       scaleFn: scaleLinear,
       domain: indexDomain,
-      isLog: false,
+      scaleType: ScaleType.Linear,
       showGrid,
     };
   }
 
-  const { dataDomain, isLog = false, showGrid = false } = config;
+  const { dataDomain, scaleType = ScaleType.Linear, showGrid = false } = config;
   return {
     isIndexAxis: false,
-    scaleFn: isLog ? scaleSymlog : scaleLinear,
+    scaleFn: SCALE_FUNCTIONS[scaleType],
     domain: dataDomain,
-    isLog,
+    scaleType,
     showGrid,
   };
 }

--- a/src/h5web/visualizations/shared/ToggleGroup.tsx
+++ b/src/h5web/visualizations/shared/ToggleGroup.tsx
@@ -26,14 +26,16 @@ interface BtnProps {
   label: string;
   value: string;
   icon?: IconType;
+  disabled?: boolean;
 }
 
 function Btn(props: BtnProps): ReactElement {
-  const { label, value, icon: Icon } = props;
+  const { label, value, icon: Icon, disabled = false } = props;
   const { role, value: selectedValue, onChange } = useToggleGroupProps();
 
   return (
     <button
+      disabled={disabled}
       className={styles.btn}
       type="button"
       role={role === 'tablist' ? 'tab' : 'radio'}

--- a/src/h5web/visualizations/shared/Toolbar.module.css
+++ b/src/h5web/visualizations/shared/Toolbar.module.css
@@ -12,7 +12,7 @@
 }
 
 .btn:disabled {
-  opacity: 0.3;
+  opacity: 0.5;
   pointer-events: none;
 }
 

--- a/src/h5web/visualizations/shared/models.ts
+++ b/src/h5web/visualizations/shared/models.ts
@@ -1,9 +1,17 @@
 import type {
   ScaleLinear,
+  ScaleLogarithmic,
   ScaleSymLog,
-  scaleSymlog,
+  scaleLog,
   scaleLinear,
+  scaleSymlog,
 } from 'd3-scale';
+
+export enum ScaleType {
+  Linear = 'Linear',
+  Log = 'Log',
+  SymLog = 'SymLog',
+}
 
 export type Size = { width: number; height: number };
 
@@ -12,28 +20,32 @@ export type Domain = [number, number];
 export interface IndexAxisConfig {
   indexDomain: Domain;
   showGrid?: boolean;
-  isLog?: never; // invalid
+  scaleType?: never; // invalid
 }
 
 export interface DataAxisConfig {
   dataDomain: Domain;
   showGrid?: boolean;
-  isLog?: boolean;
+  scaleType?: ScaleType;
 }
 
 export type AxisConfig = IndexAxisConfig | DataAxisConfig;
 
-export type AxisScaleFn = typeof scaleSymlog | typeof scaleLinear;
+export type AxisScaleFn =
+  | typeof scaleLinear
+  | typeof scaleLog
+  | typeof scaleSymlog;
 
 export type AxisScale =
   | ScaleLinear<number, number>
+  | ScaleLogarithmic<number, number>
   | ScaleSymLog<number, number>;
 
 export interface AxisInfo {
   isIndexAxis: boolean;
   scaleFn: AxisScaleFn;
   domain: Domain;
-  isLog: boolean;
+  scaleType: ScaleType;
   showGrid: boolean;
 }
 

--- a/src/h5web/visualizations/shared/utils.ts
+++ b/src/h5web/visualizations/shared/utils.ts
@@ -37,10 +37,18 @@ export function computeVisSize(
     : { width, height: width / aspectRatio };
 }
 
-export function extendDomain(bareDomain: Domain, extendFactor: number): Domain {
+export function extendDomain(
+  bareDomain: Domain,
+  extendFactor: number,
+  isLog?: boolean
+): Domain {
   const [min, max] = bareDomain;
-  const extension = (max - min) * extendFactor;
 
+  if (isLog) {
+    return [min / (1 + extendFactor), max * (1 + extendFactor)];
+  }
+
+  const extension = (max - min) * extendFactor;
   return [min - extension, max + extension];
 }
 
@@ -70,7 +78,7 @@ export function getAxisScale(info: AxisInfo, rangeSize: number): AxisScale {
 /**
  * We can't rely on the axis scale's `ticks` method to get integer tick values because
  * `d3.tickStep` sometimes returns incoherent step values - e.g. `d3.tickStep(0, 2, 3)`
- * returns 0.5 intead of 1.
+ * returns 0.5 instead of 1.
  *
  * So we implement our own, simplified version of `d3.ticks` that always outputs integer values.
  */


### PR DESCRIPTION
Another go at the log scale but the approach is different than the one in #176. Here I choose the following implementation (discussed in #74):
> 2. Display only the positive values on which the log transformation was able to be done.

There are things already discussed in #176 but I feel it was cleaner to open a new PR.