### PR TITLE
Heatmap is working with LogScale with invalid values (set to white)

### DIFF
--- a/src/h5web/visualizations/heatmap/ColorBar.tsx
+++ b/src/h5web/visualizations/heatmap/ColorBar.tsx
@@ -1,29 +1,30 @@
 import React from 'react';
 import { AxisRight } from '@vx/axis';
 import { useMeasure } from 'react-use';
-import shallow from 'zustand/shallow';
 import { adaptedNumTicks } from '../shared/utils';
-import { useInterpolator } from './hooks';
-import { useHeatmapConfig } from './config';
 import styles from './HeatmapVis.module.css';
 import { generateCSSLinearGradient } from './utils';
-import { SCALE_FUNCTIONS } from '../shared/models';
+import { SCALE_FUNCTIONS, ScaleType, Domain } from '../shared/models';
+import type { ColorMap } from './models';
+import { INTERPOLATORS } from './interpolators';
 
-function ColorBar(): JSX.Element {
-  const [dataDomain, customDomain, scaleType] = useHeatmapConfig(
-    (state) => [state.dataDomain, state.customDomain, state.scaleType],
-    shallow
-  );
+interface Props {
+  domain?: Domain;
+  scaleType: ScaleType;
+  colorMap: ColorMap;
+}
 
-  const interpolator = useInterpolator();
+function ColorBar(props: Props): JSX.Element {
+  const { domain, scaleType, colorMap } = props;
+  const interpolator = INTERPOLATORS[colorMap];
   const [gradientRef, { height: gradientHeight }] = useMeasure();
 
-  if (!dataDomain) {
+  if (!domain) {
     return <></>;
   }
 
   const axisScale = SCALE_FUNCTIONS[scaleType]();
-  axisScale.domain(customDomain || dataDomain);
+  axisScale.domain(domain);
   axisScale.range([gradientHeight, 0]);
 
   return (

--- a/src/h5web/visualizations/heatmap/Mesh.tsx
+++ b/src/h5web/visualizations/heatmap/Mesh.tsx
@@ -4,20 +4,32 @@ import { RGBFormat, MeshBasicMaterial, DataTexture } from 'three';
 import { HTML } from 'drei';
 import { useTextureData } from './hooks';
 import styles from './HeatmapVis.module.css';
+import type { Domain, ScaleType } from '../shared/models';
+import type { ColorMap } from './models';
 
 interface Props {
   rows: number;
   cols: number;
   values: number[];
+  domain: Domain | undefined;
+  scaleType: ScaleType;
+  colorMap: ColorMap;
 }
 
 function Mesh(props: Props): ReactElement {
-  const { rows, cols, values } = props;
+  const { rows, cols, values, domain, scaleType, colorMap } = props;
 
   const { size } = useThree();
   const { width, height } = size;
 
-  const { textureData, loading } = useTextureData(rows, cols, values);
+  const { textureData, loading } = useTextureData(
+    rows,
+    cols,
+    values,
+    domain,
+    scaleType,
+    colorMap
+  );
 
   const material = useMemo(() => {
     return (

--- a/src/h5web/visualizations/heatmap/hooks.ts
+++ b/src/h5web/visualizations/heatmap/hooks.ts
@@ -2,20 +2,13 @@ import { useEffect } from 'react';
 import { transfer } from 'comlink';
 import { useComlink } from 'react-use-comlink';
 import { useSetState } from 'react-use';
-import shallow from 'zustand/shallow';
 
 // @ts-ignore
 import Worker from 'worker-loader!./worker';
 
-import { useHeatmapConfig } from './config';
-import type { D3Interpolator } from './models';
-import { INTERPOLATORS } from './interpolators';
 import type { TextureWorker } from './worker';
-
-export function useInterpolator(): D3Interpolator {
-  const colorMap = useHeatmapConfig((state) => state.colorMap);
-  return INTERPOLATORS[colorMap];
-}
+import type { Domain, ScaleType } from '../shared/models';
+import type { ColorMap } from './models';
 
 export interface TextureDataState {
   loading?: boolean;
@@ -26,20 +19,11 @@ export interface TextureDataState {
 export function useTextureData(
   rows: number,
   cols: number,
-  values: number[]
+  values: number[],
+  domain: Domain | undefined,
+  scaleType: ScaleType,
+  colorMap: ColorMap
 ): TextureDataState {
-  const [dataDomain, customDomain, scaleType, colorMap] = useHeatmapConfig(
-    (state) => [
-      state.dataDomain,
-      state.customDomain,
-      state.scaleType,
-      state.colorMap,
-    ],
-    shallow
-  );
-
-  const domain = customDomain || dataDomain;
-
   const { proxy } = useComlink<TextureWorker>(() => new Worker(), []);
   const [state, mergeState] = useSetState<TextureDataState>({});
 

--- a/src/h5web/visualizations/heatmap/utils.ts
+++ b/src/h5web/visualizations/heatmap/utils.ts
@@ -1,6 +1,9 @@
 import { range } from 'lodash-es';
+import { createMemo } from 'react-use';
 import type { D3Interpolator, Dims } from './models';
 import type { DataArray } from '../../dataset-visualizer/models';
+import { ScaleType, Domain } from '../shared/models';
+import { findDomain } from '../shared/utils';
 
 export function getDims(dataArray: DataArray): Dims {
   const [rows, cols] = dataArray.shape;
@@ -17,3 +20,32 @@ export function generateCSSLinearGradient(
 
   return `linear-gradient(to ${direction},${gradientColors})`;
 }
+
+function getColorScaleDomain(
+  scaleType: ScaleType,
+  values: number[],
+  dataDomain?: Domain,
+  customDomain?: Domain
+): Domain | undefined {
+  const domain = customDomain || dataDomain;
+  if (!domain) {
+    return undefined;
+  }
+
+  // If the scale is not log or if the domain does not cross zero, the domain does not need to be adjusted
+  if (scaleType !== ScaleType.Log || domain[0] * domain[1] > 0) {
+    return domain;
+  }
+
+  // Log only supports positives values.
+  // Given the condition above, supportedDomain is only undefined if the domain is [-X, 0].
+  const supportedDomain = findDomain(values.filter((x) => x > 0));
+  if (supportedDomain && customDomain) {
+    // Clamp custom domain minimum to the first positive value
+    return [supportedDomain[0], customDomain[1]] as Domain;
+  }
+
+  return supportedDomain;
+}
+
+export const useMemoColorScaleDomain = createMemo(getColorScaleDomain);

--- a/src/h5web/visualizations/heatmap/worker.ts
+++ b/src/h5web/visualizations/heatmap/worker.ts
@@ -18,7 +18,10 @@ function computeTextureData(
 
   // Compute RGB color array for each datapoint `[[<r>, <g>, <b>], [<r>, <g>, <b>], ...]`
   const colors = values.reduce<number[]>((acc, val) => {
-    const { r, g, b } = rgb(colorScale(dataScale(val))); // `colorScale` returns CSS RGB strings
+    const dataValue = dataScale(val);
+    const { r, g, b } = Number.isFinite(dataValue)
+      ? rgb(colorScale(dataScale(val)))
+      : rgb(255, 255, 255); // `colorScale` returns CSS RGB strings
     acc.push(r, g, b);
     return acc;
   }, []);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/42204205/93084326-25eb6d00-f694-11ea-8f72-4b1cb10ef088.png)


After our discussion in #184, I finally settled for the following behaviour:
- Pixels with invalid values are set to white color*
- The store is untouched: the `supportedDomain` is computed in the `HeatmapVis` as the single source of truth and passed to the components needing it.
- As a consequence, `customDomain` and its associated slider do **not** reflect the changes in `supportedDomain`

_* This is the behaviour in matplotlib so I expect users to be used to it:_
![image](https://user-images.githubusercontent.com/42204205/93083884-8c23c000-f693-11ea-9c07-603e60b353f2.png)
