### PR TITLE
Allow profiling visualisations

### DIFF
--- a/.env
+++ b/.env
@@ -15,3 +15,6 @@ REACT_APP_HSDS_URL=
 REACT_APP_HSDS_USERNAME=
 REACT_APP_HSDS_PASSWORD=
 REACT_APP_HSDS_FILEPATH=
+
+# Rendering performance profiling (local development only)
+REACT_APP_PROFILING_ENABLED=false

--- a/src/h5web/Profiler.tsx
+++ b/src/h5web/Profiler.tsx
@@ -1,0 +1,35 @@
+import React, { Profiler as ReactProfiler, ReactElement } from 'react';
+
+interface Props {
+  id: string;
+  children: ReactElement;
+}
+
+function Profiler(props: Props): ReactElement {
+  const { id, children } = props;
+
+  if (!process.env.REACT_APP_PROFILING_ENABLED) {
+    return children;
+  }
+
+  return (
+    <ReactProfiler
+      id={id}
+      onRender={(_, phase, actualDuration, baseDuration) => {
+        // eslint-disable-next-line no-console
+        console.debug(
+          id,
+          phase,
+          '- duration =',
+          actualDuration,
+          '- worst-case =',
+          baseDuration
+        );
+      }}
+    >
+      {children}
+    </ReactProfiler>
+  );
+}
+
+export default Profiler;

--- a/src/h5web/dataset-visualizer/VisDisplay.tsx
+++ b/src/h5web/dataset-visualizer/VisDisplay.tsx
@@ -7,6 +7,7 @@ import type {
 } from '../providers/models';
 import { VIS_DEFS } from '../visualizations';
 import DimensionMapper from './mapper/DimensionMapper';
+import Profiler from '../Profiler';
 
 interface Props {
   activeVis: Vis;
@@ -28,7 +29,11 @@ function VisDisplay(props: Props): ReactElement {
         mapperState={mapperState}
         onChange={onMapperStateChange}
       />
-      {value !== undefined && renderVis(value, dataset, mapperState)}
+      {value !== undefined && (
+        <Profiler id={activeVis}>
+          {renderVis(value, dataset, mapperState)}
+        </Profiler>
+      )}
     </>
   );
 }


### PR DESCRIPTION
- Add env var to enable profiling in development (use of React's Profiler are automatically removed by React when building for production).
- Create component to wrap a tree with React's `Profiler` based on the new env var.
- Wrap the visualizations render call in `VisDisplay` with a profiler to profile every visualization.

![image](https://user-images.githubusercontent.com/2936402/93107132-77eebb80-f6b1-11ea-89fe-17420203fb8c.png)
