### PR TITLE
Fix custom domain resetting

### DIFF
--- a/src/h5web/visualizations/heatmap/ColorBar.tsx
+++ b/src/h5web/visualizations/heatmap/ColorBar.tsx
@@ -9,7 +9,7 @@ import type { ColorMap } from './models';
 import { INTERPOLATORS } from './interpolators';
 
 interface Props {
-  domain?: Domain;
+  domain: Domain;
   scaleType: ScaleType;
   colorMap: ColorMap;
 }
@@ -18,10 +18,6 @@ function ColorBar(props: Props): JSX.Element {
   const { domain, scaleType, colorMap } = props;
   const interpolator = INTERPOLATORS[colorMap];
   const [gradientRef, { height: gradientHeight }] = useMeasure();
-
-  if (!domain) {
-    return <></>;
-  }
 
   const axisScale = SCALE_FUNCTIONS[scaleType]();
   axisScale.domain(domain);

--- a/src/h5web/visualizations/heatmap/DomainSlider.tsx
+++ b/src/h5web/visualizations/heatmap/DomainSlider.tsx
@@ -22,7 +22,7 @@ function DomainSlider(props: Props): ReactElement {
   const [extendedMin, extendedMax] = extendDomain(dataDomain, EXTEND_FACTOR);
   const step = Math.max((extendedMax - extendedMin) / 100, 10 ** -NB_DECIMALS);
 
-  const updateCustomDomain = debounce((bounds) => {
+  const updateDomain = debounce((bounds) => {
     const roundedDomain = (bounds as number[]).map((val) =>
       round(val, NB_DECIMALS)
     ) as Domain;
@@ -54,7 +54,7 @@ function DomainSlider(props: Props): ReactElement {
           </div>
         )}
         value={[...(value || dataDomain)]}
-        onChange={updateCustomDomain}
+        onChange={updateDomain}
         min={extendedMin}
         max={extendedMax}
         step={step}

--- a/src/h5web/visualizations/heatmap/HeatmapToolbar.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapToolbar.tsx
@@ -12,8 +12,8 @@ import ScaleSelector from '../shared/ScaleSelector';
 function HeatmapToolbar(): ReactElement {
   const {
     dataDomain,
-    customDomain,
-    setCustomDomain,
+    requestedDomain,
+    setRequestedDomain,
     colorMap,
     setColorMap,
     scaleType,
@@ -29,8 +29,8 @@ function HeatmapToolbar(): ReactElement {
       {dataDomain && (
         <DomainSlider
           dataDomain={dataDomain}
-          value={customDomain}
-          onChange={setCustomDomain}
+          value={requestedDomain}
+          onChange={setRequestedDomain}
         />
       )}
 

--- a/src/h5web/visualizations/heatmap/HeatmapVis.module.css
+++ b/src/h5web/visualizations/heatmap/HeatmapVis.module.css
@@ -47,3 +47,8 @@
   flex: 1 0 auto;
   border: 1px solid black;
 }
+
+.domainError {
+  padding: 1em;
+  color: var(--danger);
+}

--- a/src/h5web/visualizations/heatmap/HeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapVis.tsx
@@ -56,6 +56,10 @@ function HeatmapVis(props: Props): JSX.Element {
   // width / height <=> cols / rows
   const aspectRatio = keepAspectRatio ? cols / rows : undefined;
 
+  if (!domain) {
+    return <p className={styles.domainError}>Unable to compute domain</p>;
+  }
+
   return (
     <div className={styles.root}>
       <VisCanvas

--- a/src/h5web/visualizations/heatmap/Mesh.tsx
+++ b/src/h5web/visualizations/heatmap/Mesh.tsx
@@ -11,7 +11,7 @@ interface Props {
   rows: number;
   cols: number;
   values: number[];
-  domain: Domain | undefined;
+  domain: Domain;
   scaleType: ScaleType;
   colorMap: ColorMap;
 }

--- a/src/h5web/visualizations/heatmap/config.ts
+++ b/src/h5web/visualizations/heatmap/config.ts
@@ -1,14 +1,13 @@
 import type { ColorMap } from './models';
 import { Domain, ScaleType } from '../shared/models';
 import { StorageConfig, createPersistableState } from '../../storage-utils';
-import { findDomain } from '../shared/utils';
 
 interface HeatmapConfig {
   dataDomain: Domain | undefined;
-  initDataDomain: (values: number[]) => void;
+  resetDomains: (dataDomain: Domain | undefined) => void;
 
-  customDomain: Domain | undefined;
-  setCustomDomain: (customDomain: Domain | undefined) => void;
+  requestedDomain: Domain | undefined;
+  setRequestedDomain: (requestedDomain: Domain | undefined) => void;
 
   colorMap: ColorMap;
   setColorMap: (colorMap: ColorMap) => void;
@@ -32,16 +31,16 @@ export const [useHeatmapConfig] = createPersistableState<HeatmapConfig>(
   STORAGE_CONFIG,
   (set) => ({
     dataDomain: undefined,
-    initDataDomain: (values: number[]) => {
+    resetDomains: (dataDomain: Domain | undefined) => {
       set({
-        dataDomain: findDomain(values),
-        customDomain: undefined, // reset custom domain
+        dataDomain,
+        requestedDomain: undefined,
       });
     },
 
-    customDomain: undefined,
-    setCustomDomain: (customDomain: Domain | undefined) =>
-      set({ customDomain }),
+    requestedDomain: undefined,
+    setRequestedDomain: (requestedDomain: Domain | undefined) =>
+      set({ requestedDomain }),
 
     colorMap: 'Viridis',
     setColorMap: (colorMap: ColorMap) => set({ colorMap }),

--- a/src/h5web/visualizations/heatmap/hooks.ts
+++ b/src/h5web/visualizations/heatmap/hooks.ts
@@ -21,7 +21,7 @@ export function useTextureData(
   rows: number,
   cols: number,
   values: number[],
-  domain: Domain | undefined,
+  domain: Domain,
   scaleType: ScaleType,
   colorMap: ColorMap
 ): TextureDataState {
@@ -37,10 +37,6 @@ export function useTextureData(
   const deps = [colorMap, domain, scaleType, proxy, mergeState];
 
   useEffect(() => {
-    if (!domain) {
-      return;
-    }
-
     // Keep existing texture data, if any
     mergeState({ loading: true });
 

--- a/src/h5web/visualizations/heatmap/hooks.ts
+++ b/src/h5web/visualizations/heatmap/hooks.ts
@@ -28,14 +28,6 @@ export function useTextureData(
   const { proxy } = useComlink<TextureWorker>(() => new Worker(), []);
   const [state, mergeState] = useSetState<TextureDataState>({});
 
-  /*
-   * Dependencies that trigger a recomputation of the texture.
-   * > Note that `values` is purposely not included. When `values` changes, a first render
-   * > is triggered, during which `dataDomain` has not yet been recomputed. We must wait for
-   * > `domain` to be updated before recomputing the texture.
-   */
-  const deps = [colorMap, domain, scaleType, proxy, mergeState];
-
   useEffect(() => {
     // Keep existing texture data, if any
     mergeState({ loading: true });
@@ -54,7 +46,7 @@ export function useTextureData(
         ),
       });
     })();
-  }, deps); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [colorMap, domain, scaleType, proxy, mergeState, values]);
 
   // Reset texture when dimensions change to avoid rendering glitch while computing new texture
   const dims = `${rows}x${cols}`;

--- a/src/h5web/visualizations/heatmap/hooks.ts
+++ b/src/h5web/visualizations/heatmap/hooks.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { transfer } from 'comlink';
 import { useComlink } from 'react-use-comlink';
-import { useSetState } from 'react-use';
+import { useSetState, createMemo } from 'react-use';
 
 // @ts-ignore
 import Worker from 'worker-loader!./worker';
@@ -9,6 +9,7 @@ import Worker from 'worker-loader!./worker';
 import type { TextureWorker } from './worker';
 import type { Domain, ScaleType } from '../shared/models';
 import type { ColorMap } from './models';
+import { getColorScaleDomain } from './utils';
 
 export interface TextureDataState {
   loading?: boolean;
@@ -67,3 +68,5 @@ export function useTextureData(
 
   return state;
 }
+
+export const useMemoColorScaleDomain = createMemo(getColorScaleDomain);

--- a/src/h5web/visualizations/heatmap/utils.ts
+++ b/src/h5web/visualizations/heatmap/utils.ts
@@ -1,5 +1,4 @@
 import { range } from 'lodash-es';
-import { createMemo } from 'react-use';
 import type { D3Interpolator, Dims } from './models';
 import type { DataArray } from '../../dataset-visualizer/models';
 import { ScaleType, Domain } from '../shared/models';
@@ -21,7 +20,7 @@ export function generateCSSLinearGradient(
   return `linear-gradient(to ${direction},${gradientColors})`;
 }
 
-function getColorScaleDomain(
+export function getColorScaleDomain(
   scaleType: ScaleType,
   values: number[],
   dataDomain?: Domain,
@@ -47,5 +46,3 @@ function getColorScaleDomain(
 
   return supportedDomain;
 }
-
-export const useMemoColorScaleDomain = createMemo(getColorScaleDomain);

--- a/src/styles/vars.css
+++ b/src/styles/vars.css
@@ -12,6 +12,7 @@
   --secondary-darker: #0e5846;
   --secondary-bg: #d9f4ec;
   --secondary-light-bg: #ecfaf6;
+  --danger: #99231b;
   --monospace: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier,
     monospace;
   --sans-serif: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',


### PR DESCRIPTION
The texture flickering issue is gone for good!

- Compute data domain in `HeatmapVis` instead of config (in `useMemo` to avoid unnecessary recomputations).
- Make `HeatmapVis` the source of truth for the custom domain whenever `values` prop changes (because for one render, the config may have a stale custom domain).
- Use effect hook to update data domain and reset custom domain in config when `values` prop changes.

Since the domain is no longer computed asynchronously, we can also:

- remove the workaround that used to avoid consecutive texture recomputations;
- render an error message and return early when the domain can be computed from the current `values`.