### PR TITLE
Optimize ndarray uses in MappedVis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16471,6 +16471,14 @@
         "is-buffer": "^1.0.2"
       }
     },
+    "ndarray-ops": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ndarray-ops/-/ndarray-ops-1.2.2.tgz",
+      "integrity": "sha1-WeiNLDKn7ryxvGkPrhQVeVV6YU4=",
+      "requires": {
+        "cwise-compiler": "^1.0.0"
+      }
+    },
     "ndarray-unpack": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ndarray-unpack/-/ndarray-unpack-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "lodash-es": "^4.17.15",
     "nanoid": "^2.1.11",
     "ndarray": "^1.0.19",
+    "ndarray-ops": "^1.2.2",
     "ndarray-unpack": "^1.0.0",
     "normalize.css": "^8.0.1",
     "react": "^16.13.1",

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -8,3 +8,9 @@ declare module 'ndarray-unpack' {
 
   export = unpack;
 }
+
+declare module 'ndarray-ops' {
+  function assign(a: ndarray<T>, b: ndarray<T>);
+
+  export = { assign };
+}


### PR DESCRIPTION
A revised version of #178 to fix #170.

> Split useMemo in two in VisProvider (one for ndarray creation, one for slicing).

The `useMemo` now lives in `MappedVis` that replaced `VisProvider`. But it was done.
> Simplify unpack(mappedView).flat() by unpacking a flat array directly.

Done with `ndarray-ops` (https://github.com/scijs/ndarray/issues/32#issuecomment-253972844)

Other tasks were not considered as they depend on `cwise` which does not seem actively maintained [as I pointed out](https://github.com/silx-kit/h5web/issues/170#issuecomment-643970544).

