### PR TITLE
Adding story for the ColorBar

### DIFF
--- a/src/stories/ColorBar.stories.tsx
+++ b/src/stories/ColorBar.stories.tsx
@@ -1,0 +1,49 @@
+import React, { ReactElement } from 'react';
+import type { Story } from '@storybook/react/types-6-0';
+import FillHeight from '../../.storybook/decorators/FillHeight';
+import ColorBar from '../h5web/visualizations/heatmap/ColorBar';
+import { ScaleType } from '../h5web/visualizations/shared/models';
+import type { ColorMap } from '../h5web/visualizations/heatmap/models';
+
+interface Props {
+  domainMin: number;
+  domainMax: number;
+  scaleType: ScaleType;
+  colorMap: ColorMap;
+}
+
+const Template: Story<Props> = (args): ReactElement => {
+  const { domainMin: min, domainMax: max, ...colorBarArgs } = args;
+  return <ColorBar domain={[min, max]} {...colorBarArgs} />;
+};
+
+export const Default = Template.bind({});
+
+Default.args = {
+  domainMin: 0.1,
+  domainMax: 1,
+  scaleType: ScaleType.Linear,
+  colorMap: 'Viridis',
+};
+
+export default {
+  title: 'Visualizations/HeatmapVis/ColorBar',
+  component: ColorBar,
+  parameters: { layout: 'fullscreen' },
+  decorators: [FillHeight],
+  argTypes: {
+    domainMin: {
+      control: { type: 'range', min: -10, max: 10, step: 0.1 },
+    },
+    domainMax: {
+      control: { type: 'range', min: -10, max: 10, step: 0.1 },
+    },
+    domain: { control: { disable: true } },
+    scaleType: {
+      control: {
+        type: 'inline-radio',
+        options: [ScaleType.Linear, ScaleType.Log, ScaleType.SymLog],
+      },
+    },
+  },
+};


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/42204205/93306280-ecd00b80-f7ff-11ea-95d4-75b387d32c98.png)

To get used to Storybook, I had some fun to change the domain args into two sliders. But it may obfuscate the true `domain` arg so I can revert to a regular `domain` control.