### PR TITLE
Remove AxisInfo from getTickProps

### DIFF
--- a/src/h5web/visualizations/shared/AxisSystem.tsx
+++ b/src/h5web/visualizations/shared/AxisSystem.tsx
@@ -70,8 +70,16 @@ function AxisSystem(props: Props): JSX.Element {
   yTicksScale.domain(visibleDomains[1]);
   yTicksScale.range([height, 0]);
 
-  const xTicksProp = getTicksProp(abscissaInfo, visibleDomains[0], width);
-  const yTicksProp = getTicksProp(ordinateInfo, visibleDomains[1], height);
+  const xTicksProp = getTicksProp(
+    visibleDomains[0],
+    width,
+    abscissaInfo.isIndexAxis
+  );
+  const yTicksProp = getTicksProp(
+    visibleDomains[1],
+    height,
+    ordinateInfo.isIndexAxis
+  );
 
   return (
     <HTML

--- a/src/h5web/visualizations/shared/utils.test.ts
+++ b/src/h5web/visualizations/shared/utils.test.ts
@@ -1,6 +1,5 @@
 import { tickStep } from 'd3-array';
 import { computeVisSize, findDomain, getTicksProp } from './utils';
-import type { AxisInfo } from './models';
 
 describe('Shared visualization utilities', () => {
   describe('computeVisSize', () => {
@@ -69,50 +68,48 @@ describe('Shared visualization utilities', () => {
   });
 
   describe('getTicksProp', () => {
-    describe('with data axis config', () => {
-      const axisInfo = { isIndexAxis: false } as AxisInfo;
-
+    describe('without forcing to integers', () => {
       it('should return number of ticks allowed for available size regardless of visible domain', () => {
-        const prop1 = getTicksProp(axisInfo, [0, 1], 200);
+        const prop1 = getTicksProp([0, 1], 200);
         expect(prop1).toEqual({ numTicks: 3 });
 
-        const prop2 = getTicksProp(axisInfo, [5, 20], 1000);
+        const prop2 = getTicksProp([5, 20], 1000);
         expect(prop2).toEqual({ numTicks: 10 });
       });
     });
 
-    describe('with index axis config', () => {
-      const axisInfo = { isIndexAxis: true } as AxisInfo;
+    describe('with only integers', () => {
+      const onlyIntegers = true;
 
       it('should return zero tick values when visible domain spans zero indices', () => {
-        const prop1 = getTicksProp(axisInfo, [0.2, 0.8], 10);
+        const prop1 = getTicksProp([0.2, 0.8], 10, onlyIntegers);
         expect(prop1).toEqual({ tickValues: [] });
 
-        const prop2 = getTicksProp(axisInfo, [5.01, 5.02], 10);
+        const prop2 = getTicksProp([5.01, 5.02], 10, onlyIntegers);
         expect(prop2).toEqual({ tickValues: [] });
       });
 
       it('should return as many integer tick values as indices when space allows for it', () => {
-        const prop1 = getTicksProp(axisInfo, [0, 3], 1000);
+        const prop1 = getTicksProp([0, 3], 1000, onlyIntegers);
         expect(prop1).toEqual({ tickValues: [0, 1, 2, 3] });
 
-        const prop2 = getTicksProp(axisInfo, [5.4, 6.9], 1000);
+        const prop2 = getTicksProp([5.4, 6.9], 1000, onlyIntegers);
         expect(prop2).toEqual({ tickValues: [6] });
       });
 
       it('should return evenly-spaced tick values for available space', () => {
-        const prop1 = getTicksProp(axisInfo, [0.8, 20.2], 1000); // domain has 20 potential ticks but space allows for 10
+        const prop1 = getTicksProp([0.8, 20.2], 1000, onlyIntegers); // domain has 20 potential ticks but space allows for 10
         expect(prop1).toEqual({
           tickValues: [2, 4, 6, 8, 10, 12, 14, 16, 18, 20],
         });
 
-        const prop2 = getTicksProp(axisInfo, [2, 7], 200); // domain has 8 potential ticks but space allows for 3
+        const prop2 = getTicksProp([2, 7], 200, onlyIntegers); // domain has 8 potential ticks but space allows for 3
         expect(prop2).toEqual({ tickValues: [2, 4, 6] });
       });
 
       it('should always return integer tick values', () => {
         // Tick count is not always respected, which is acceptable
-        const prop1 = getTicksProp(axisInfo, [0, 4], 200); // domain has 5 potential ticks but space allows for 3
+        const prop1 = getTicksProp([0, 4], 200, onlyIntegers); // domain has 5 potential ticks but space allows for 3
         expect(prop1).toEqual({ tickValues: [0, 1, 2, 3, 4] });
 
         // This is because `d3.tickStep` is not too worried about the count...
@@ -122,7 +119,7 @@ describe('Shared visualization utilities', () => {
         expect(tickStep(0, 2, 3)).toBe(0.5); // we'd end up with `[0, 0.5, 1, 1.5, 2]` instead of `[0, 1, 2]`
 
         // So we specifically work around it by forcing the step to be greater than or equal to 1
-        const prop2 = getTicksProp(axisInfo, [0, 2], 200);
+        const prop2 = getTicksProp([0, 2], 200, onlyIntegers);
         expect(prop2).toEqual({ tickValues: [0, 1, 2] });
       });
     });

--- a/src/h5web/visualizations/shared/utils.ts
+++ b/src/h5web/visualizations/shared/utils.ts
@@ -3,10 +3,10 @@ import { extent, tickStep } from 'd3-array';
 import type {
   Size,
   Domain,
-  AxisConfig,
-  IndexAxisConfig,
   AxisScale,
+  AxisConfig,
   AxisInfo,
+  IndexAxisConfig,
 } from './models';
 
 export const adaptedNumTicks = scaleLinear()
@@ -110,13 +110,13 @@ function getIntegerTicks(domain: Domain, count: number): number[] {
 }
 
 export function getTicksProp(
-  info: AxisInfo,
   visibleDomain: Domain,
-  availableSize: number
+  availableSize: number,
+  onlyIntegers?: boolean
 ): { tickValues: number[] } | { numTicks: number } {
   const numTicks = adaptedNumTicks(availableSize);
 
-  return info.isIndexAxis
+  return onlyIntegers
     ? { tickValues: getIntegerTicks(visibleDomain, numTicks) }
     : { numTicks };
 }


### PR DESCRIPTION
<s>
## Motivation
Getting back to the integer ticks problems, I felt that the current implementation was sometimes hard to follow:
- `AxisInfo` and `AxisConfig` are quite similar but used for different purposes
- The distinction between `IndexAxisConfig` and `DataAxisConfig` leads to additional code (different types, a type guard) as both are again very similar. Also, it is not clear from first approach that `IndexAxisConfig` forces the axis to contain only integers.

Reading the code, I found myself sometimes misdirected by all these different but similar types.

## Refactor
To address these points, I did the following:
- I removed `AxisInfo`. `AxisConfig` is used instead with a new boolean member `onlyIntegers`.
- The boolean `onlyIntegers` makes the distinction between `IndexAxisConfig` and `DataAxisConfig` superfluous. Both are merged in `AxisConfig` by changing `dataDomain` and `indexDomain` to `domain`.
- Rather than passing the whole config to `getTicksProp`, only `onlyIntegers` is passed as arg.

## Aftermath
- I hope it makes the code clearer as we don't have anymore to compare `AxisInfo` and `AxisConfig` to show what does what. The same object is used from start to finish.
- The introduction of the boolean `onlyIntegers` should also render the config more readable and easily usable.
- See other comments below
</s>

In the end, the refactor didn't feel right:
 - To keep the API safe (that is forcing linear scale for index/integer axis), I ended up needing to mutate `AxisConfig`, which conceptually, was the purpose of `AxisInfo`... 
- Also, for the same reason, `IndexAxisConfig` and `DataAxisConfig` typings could not be easily merged as `scaleType` serves no purpose when `isIndexAxis` is `true`.

 In the end, I just changed the arg in `getTickProps` :smile: 