### PR TITLE
Renamed drei's HTML into Html

### DIFF
--- a/src/h5web/visualizations/heatmap/Mesh.tsx
+++ b/src/h5web/visualizations/heatmap/Mesh.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, ReactElement } from 'react';
 import { useThree } from 'react-three-fiber';
 import { RGBFormat, MeshBasicMaterial, DataTexture } from 'three';
-import { HTML } from 'drei';
+import { Html } from 'drei';
 import { useTextureData } from './hooks';
 import styles from './HeatmapVis.module.css';
 import type { Domain, ScaleType } from '../shared/models';
@@ -49,13 +49,13 @@ function Mesh(props: Props): ReactElement {
         </mesh>
       )}
       {showLoader && (
-        <HTML>
+        <Html>
           <div
             className={styles.textureLoader}
             style={{ width, height }}
             data-visible={loading || undefined}
           />
-        </HTML>
+        </Html>
       )}
     </>
   );

--- a/src/h5web/visualizations/shared/AxisSystem.tsx
+++ b/src/h5web/visualizations/shared/AxisSystem.tsx
@@ -3,7 +3,7 @@ import { useThree, useFrame } from 'react-three-fiber';
 import { AxisLeft, AxisBottom, TickRendererProps } from '@vx/axis';
 import { format } from 'd3-format';
 import { GridColumns, GridRows } from '@vx/grid';
-import { HTML } from 'drei';
+import { Html } from 'drei';
 import { useUpdateEffect } from 'react-use';
 import styles from './AxisSystem.module.css';
 import type { AxisOffsets, Domain } from './models';
@@ -81,7 +81,7 @@ function AxisSystem(props: Props): JSX.Element {
   );
 
   return (
-    <HTML
+    <Html
       className={styles.axisSystem}
       style={{
         // Take over space reserved for axis by VisCanvas
@@ -134,7 +134,7 @@ function AxisSystem(props: Props): JSX.Element {
           </svg>
         </div>
       </>
-    </HTML>
+    </Html>
   );
 }
 

--- a/src/h5web/visualizations/shared/TooltipMesh.tsx
+++ b/src/h5web/visualizations/shared/TooltipMesh.tsx
@@ -3,7 +3,7 @@ import { PointerEvent, useThree } from 'react-three-fiber';
 import { TooltipWithBounds, useTooltip } from '@vx/tooltip';
 import { Line } from '@vx/shape';
 
-import { HTML } from 'drei';
+import { Html } from 'drei';
 import styles from './TooltipMesh.module.css';
 import { getAxisScale } from './utils';
 import { AxisSystemContext } from './AxisSystemProvider';
@@ -84,7 +84,7 @@ function TooltipMesh(props: Props): ReactElement {
       <mesh {...{ onPointerMove, onPointerOut, onPointerDown, onPointerUp }}>
         <planeBufferGeometry attach="geometry" args={[width, height]} />
       </mesh>
-      <HTML style={{ width, height }}>
+      <Html style={{ width, height }}>
         {tooltipOpen && tooltipData && value ? (
           <>
             <TooltipWithBounds
@@ -118,7 +118,7 @@ function TooltipMesh(props: Props): ReactElement {
         ) : (
           <></>
         )}
-      </HTML>
+      </Html>
     </>
   );
 }

--- a/src/h5web/visualizations/shared/VisCanvas.module.css
+++ b/src/h5web/visualizations/shared/VisCanvas.module.css
@@ -14,10 +14,10 @@
 /* R3F's root element */
 .canvasWrapper {
   overflow: visible !important; /* show child axis grid, which is bigger than canvas */
-  z-index: 0; /* stacking context for child `<HTML />` elements */
+  z-index: 0; /* stacking context for child `<Html />` elements */
 }
 
-/* R3F's <HTML /> element */
+/* R3F's <Html /> element */
 .canvasWrapper > div {
   transform: none !important;
   /* - Prevent panning/zooming from axis when zoomed in.


### PR DESCRIPTION
Fixes the following warning in the console as `<HTML />` component was renamed to `<Html />` (https://github.com/pmndrs/drei#html-):
![image](https://user-images.githubusercontent.com/42204205/93989142-d854bb80-fd89-11ea-9279-63af5683c950.png)
