### PR TITLE
Implements Auto-scaling toggle

### DIFF
--- a/src/h5web/visualizations/MappedHeatmapVis.tsx
+++ b/src/h5web/visualizations/MappedHeatmapVis.tsx
@@ -4,7 +4,7 @@ import type { HDF5Dataset, HDF5Value } from '../providers/models';
 import type { DimensionMapping } from '../dataset-visualizer/models';
 import HeatmapVis from './heatmap/HeatmapVis';
 import { assertArray } from './shared/utils';
-import { useMappedArray, useDataDomain } from './shared/hooks';
+import { useMappedArray, useDataDomain, useBaseArray } from './shared/hooks';
 import { useHeatmapConfig } from './heatmap/config';
 
 interface Props {
@@ -26,7 +26,8 @@ function MappedHeatmapVis(props: Props): ReactElement {
     resetDomains,
   } = useHeatmapConfig();
 
-  const dataArray = useMappedArray(dataset, value, mapperState);
+  const baseArray = useBaseArray(dataset, value);
+  const dataArray = useMappedArray(baseArray, mapperState);
   const dataDomain = useDataDomain(dataArray.data as number[]);
   const prevDataDomain = usePrevious(dataDomain);
 

--- a/src/h5web/visualizations/MappedLineVis.tsx
+++ b/src/h5web/visualizations/MappedLineVis.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useEffect } from 'react';
 import type { HDF5Dataset, HDF5Value } from '../providers/models';
 import type { DimensionMapping } from '../dataset-visualizer/models';
 import LineVis from './line/LineVis';
@@ -16,11 +16,25 @@ function MappedLineVis(props: Props): ReactElement {
   const { value, dataset, mapperState } = props;
   assertArray<number>(value);
 
-  const { scaleType, curveType, showGrid } = useLineConfig();
+  const {
+    scaleType,
+    curveType,
+    showGrid,
+    autoScale,
+    disableAutoScale,
+  } = useLineConfig();
 
   const baseArray = useBaseArray(dataset, value);
   const dataArray = useMappedArray(baseArray, mapperState);
-  const dataDomain = useDataDomain(dataArray.data as number[]);
+
+  // Disable `autoScale` for 1D datasets (baseArray and dataArray are the same)
+  useEffect(() => {
+    disableAutoScale(!baseArray.shape || baseArray.shape.length <= 1);
+  }, [baseArray.shape, disableAutoScale]);
+
+  const dataDomain = useDataDomain(
+    (autoScale ? dataArray.data : baseArray.data) as number[]
+  );
 
   return (
     <LineVis

--- a/src/h5web/visualizations/MappedLineVis.tsx
+++ b/src/h5web/visualizations/MappedLineVis.tsx
@@ -3,7 +3,7 @@ import type { HDF5Dataset, HDF5Value } from '../providers/models';
 import type { DimensionMapping } from '../dataset-visualizer/models';
 import LineVis from './line/LineVis';
 import { assertArray } from './shared/utils';
-import { useMappedArray, useDataDomain } from './shared/hooks';
+import { useMappedArray, useDataDomain, useBaseArray } from './shared/hooks';
 import { useLineConfig } from './line/config';
 
 interface Props {
@@ -18,7 +18,8 @@ function MappedLineVis(props: Props): ReactElement {
 
   const { scaleType, curveType, showGrid } = useLineConfig();
 
-  const dataArray = useMappedArray(dataset, value, mapperState);
+  const baseArray = useBaseArray(dataset, value);
+  const dataArray = useMappedArray(baseArray, mapperState);
   const dataDomain = useDataDomain(dataArray.data as number[]);
 
   return (

--- a/src/h5web/visualizations/MappedMatrixVis.tsx
+++ b/src/h5web/visualizations/MappedMatrixVis.tsx
@@ -3,7 +3,7 @@ import type { HDF5Dataset, HDF5Value } from '../providers/models';
 import type { DimensionMapping } from '../dataset-visualizer/models';
 import MatrixVis from './matrix/MatrixVis';
 import { assertArray } from './shared/utils';
-import { useMappedArray } from './shared/hooks';
+import { useMappedArray, useBaseArray } from './shared/hooks';
 
 interface Props {
   value: HDF5Value;
@@ -15,7 +15,8 @@ function MappedMatrixVis(props: Props): ReactElement {
   const { value, dataset, mapperState } = props;
   assertArray<number | string>(value);
 
-  const dataArray = useMappedArray(dataset, value, mapperState);
+  const baseArray = useBaseArray(dataset, value);
+  const dataArray = useMappedArray(baseArray, mapperState);
   return <MatrixVis dataArray={dataArray} />;
 }
 

--- a/src/h5web/visualizations/line/LineToolbar.tsx
+++ b/src/h5web/visualizations/line/LineToolbar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MdGridOn } from 'react-icons/md';
+import { MdGridOn, MdDomain } from 'react-icons/md';
 import ToggleBtn from '../shared/ToggleBtn';
 import { useLineConfig } from './config';
 import { CurveType } from './models';
@@ -16,10 +16,23 @@ function LineToolbar(): JSX.Element {
     toggleGrid,
     scaleType,
     setScaleType,
+    autoScale,
+    toggleAutoScale,
+    isAutoScaleDisabled,
   } = useLineConfig();
 
   return (
     <Toolbar>
+      <ToggleBtn
+        label="Auto-scale"
+        icon={MdDomain}
+        value={autoScale}
+        onChange={toggleAutoScale}
+        disabled={isAutoScaleDisabled}
+      />
+
+      <Separator />
+
       <ToggleGroup
         role="radiogroup"
         ariaLabel="Curve type"

--- a/src/h5web/visualizations/line/config.ts
+++ b/src/h5web/visualizations/line/config.ts
@@ -7,17 +7,21 @@ type LineConfig = {
   curveType: CurveType;
   showGrid: boolean;
   scaleType: ScaleType;
+  autoScale: boolean;
+  isAutoScaleDisabled: boolean;
 };
 
 const STORAGE_CONFIG: StorageConfig = {
   storageId: 'h5web:line',
-  itemsToPersist: ['curveType', 'showGrid', 'scaleType'],
+  itemsToPersist: ['curveType', 'showGrid', 'scaleType', 'autoScale'],
 };
 
 const INITIAL_STATE: LineConfig = {
   curveType: CurveType.LineOnly,
   showGrid: true,
   scaleType: ScaleType.Linear,
+  autoScale: false,
+  isAutoScaleDisabled: false,
 };
 
 export const useLineConfig = createPersistableState(
@@ -26,5 +30,8 @@ export const useLineConfig = createPersistableState(
     setCurveType: (type: CurveType) => set({ curveType: type }),
     toggleGrid: () => set((state) => ({ showGrid: !state.showGrid })),
     setScaleType: (type: ScaleType) => set({ scaleType: type }),
+    toggleAutoScale: () => set((state) => ({ autoScale: !state.autoScale })),
+    disableAutoScale: (isAutoScaleDisabled: boolean) =>
+      set({ isAutoScaleDisabled }),
   }))
 );

--- a/src/h5web/visualizations/shared/ToggleBtn.tsx
+++ b/src/h5web/visualizations/shared/ToggleBtn.tsx
@@ -8,10 +8,11 @@ interface Props {
   iconOnly?: boolean;
   value: boolean;
   onChange: () => void;
+  disabled?: boolean;
 }
 
 function ToggleBtn(props: Props): JSX.Element {
-  const { label, icon: Icon, iconOnly, value, onChange } = props;
+  const { label, icon: Icon, iconOnly, value, onChange, disabled } = props;
 
   return (
     <button
@@ -20,6 +21,7 @@ function ToggleBtn(props: Props): JSX.Element {
       aria-label={iconOnly ? label : undefined}
       aria-pressed={value}
       onClick={onChange}
+      disabled={disabled}
     >
       <span className={styles.btnLike}>
         {Icon && <Icon className={styles.icon} />}

--- a/src/h5web/visualizations/shared/hooks.ts
+++ b/src/h5web/visualizations/shared/hooks.ts
@@ -7,17 +7,18 @@ import type { HDF5Dataset, HDF5SimpleShape } from '../../providers/models';
 import type { DimensionMapping } from '../../dataset-visualizer/models';
 import { findDomain, getSupportedDomain } from './utils';
 
-export function useMappedArray<T>(
-  dataset: HDF5Dataset,
-  value: T[],
-  mapperState: DimensionMapping
-): ndarray<T> {
+export function useBaseArray<T>(dataset: HDF5Dataset, value: T[]): ndarray<T> {
   const rawDims = (dataset.shape as HDF5SimpleShape).dims;
 
-  const baseArray = useMemo(() => {
+  return useMemo(() => {
     return ndarray<T>(value.flat(Infinity) as T[], rawDims);
   }, [rawDims, value]);
+}
 
+export function useMappedArray<T>(
+  baseArray: ndarray<T>,
+  mapperState: DimensionMapping
+): ndarray<T> {
   return useMemo(() => {
     if (mapperState === undefined) {
       return baseArray;


### PR DESCRIPTION
Fix #182 

It bothers me a bit though: this toggle serves no purpose when the array is not mapped and I did not find any easy way to disable it in this case. 

Also I find that the label `Auto scale` does not convey the true purpose of this button.