### PR TITLE
Implement simplified version of drei's `Html` component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@alloc/types": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@alloc/types/-/types-1.3.0.tgz",
-      "integrity": "sha512-mH7LiFiq9g6rX2tvt1LtwsclfG5hnsmtIfkZiauAGrm1AwXhoRS0sF2WrN9JGN7eV5vFXqNaB0eXZ3IvMsVi9g=="
-    },
     "@babel/code-frame": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -4135,57 +4130,6 @@
         "invariant": "^2.2.3",
         "prop-types": "^15.6.1",
         "react-lifecycles-compat": "^3.0.4"
-      }
-    },
-    "@react-spring/animated": {
-      "version": "9.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.0.0-rc.3.tgz",
-      "integrity": "sha512-dAvgtKhkYpzzr+EkmZ4ZuJ5CujxCW0LaT109DvO/2MQNk3EWIxcgl+ik4tSulSbgau1GN8RlkRKyDp0wISdQ3Q==",
-      "requires": {
-        "@babel/runtime": "^7.3.1",
-        "@react-spring/shared": "9.0.0-rc.3",
-        "react-layout-effect": "^1.0.1"
-      }
-    },
-    "@react-spring/core": {
-      "version": "9.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.0.0-rc.3.tgz",
-      "integrity": "sha512-3OzsVFxpfMJNkkQj8TwAH3NhUAX76AXu6WkslQF4EgBeEoG5eY3m+VvM9RsAsGWDuBKpscZ/wBpFt5Ih6KdGHA==",
-      "requires": {
-        "@babel/runtime": "^7.3.1",
-        "@react-spring/animated": "9.0.0-rc.3",
-        "@react-spring/shared": "9.0.0-rc.3",
-        "react-layout-effect": "^1.0.1",
-        "use-memo-one": "^1.1.0"
-      }
-    },
-    "@react-spring/shared": {
-      "version": "9.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.0.0-rc.3.tgz",
-      "integrity": "sha512-dd50TxwwMWd+dSB0InjndUN9w17cbnMCPy+0sag6zRxxKIo7eOyWSliOtLKxvufgmdC8Prm4M3GT5dmB1yxKEQ==",
-      "requires": {
-        "@alloc/types": "^1.2.1",
-        "@babel/runtime": "^7.3.1",
-        "fluids": "^0.1.6",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
-      }
-    },
-    "@react-spring/web": {
-      "version": "9.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-9.0.0-rc.3.tgz",
-      "integrity": "sha512-rEvipblmihiz8+Eo01zDp5dqWn6XfYk8q2rlN9c18YIOL4o6nuY/VplDoocUMHYfH4liurpO4o1QudKOO1nAiQ==",
-      "requires": {
-        "@babel/runtime": "^7.3.1",
-        "@react-spring/animated": "9.0.0-rc.3",
-        "@react-spring/core": "9.0.0-rc.3",
-        "@react-spring/shared": "9.0.0-rc.3"
       }
     },
     "@storybook/addon-actions": {
@@ -12731,44 +12675,6 @@
         "dotenv-defaults": "^1.0.2"
       }
     },
-    "drei": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/drei/-/drei-1.5.6.tgz",
-      "integrity": "sha512-e3ZjCmuzWZ8B8vpMzAUjePEK/ENLtkCvKB2tupR2eRmM8/GmNTKC5uX9WIAxl8tbue2juYAOBeSEOhSCtYF1RA==",
-      "requires": {
-        "@babel/runtime": "^7.11.2",
-        "@react-spring/web": "^9.0.0-rc.3",
-        "glsl-noise": "^0.0.0",
-        "lodash.omit": "^4.5.0",
-        "lodash.pick": "^4.4.0",
-        "r3f-troika": "^0.31.1",
-        "react-merge-refs": "^1.0.0",
-        "stats.js": "^0.17.0",
-        "troika-three-text": "^0.31.0",
-        "utility-types": "^3.10.0",
-        "zustand": "^3.0.3"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.11.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.13.7",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-        },
-        "zustand": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.1.2.tgz",
-          "integrity": "sha512-b9pbR29m/KYicTE33dF+SPQ3DoDnMT4ZHOS00QnzZ/SWArK7rn/3EVeSWWk3G2A9bexEHqj75Ob2w+GN547o/w=="
-        }
-      }
-    },
     "dup": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dup/-/dup-1.0.0.tgz",
@@ -14356,11 +14262,6 @@
       "integrity": "sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==",
       "dev": true
     },
-    "fluids": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/fluids/-/fluids-0.1.9.tgz",
-      "integrity": "sha512-cA5WHsJZNjsMXzAp/lxl6KLAiOgXFTOwQ+QVf39LfCcoBgih8sqkRadtjN+6UTU6KoF0h0HdYJKI3GWuqRVdBw=="
-    },
     "flush-write-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -14943,11 +14844,6 @@
       "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
       "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
       "dev": true
-    },
-    "glsl-noise": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
-      "integrity": "sha1-NndF86MzgsDu7Ey1S36Zz8HXZws="
     },
     "good-listener": {
       "version": "1.2.2",
@@ -17198,16 +17094,6 @@
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
-    },
-    "lodash.omit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
-    },
-    "lodash.pick": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -20448,15 +20334,6 @@
         }
       }
     },
-    "r3f-troika": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/r3f-troika/-/r3f-troika-0.31.1.tgz",
-      "integrity": "sha512-d0AI2ZCpU5u9axqJ3I+KI786ltQNOJKimeuq+96Sir/sg0Nl2m5JNA9fBg+YEZ6fOR7+kcbyaycQcTbfTpYDDQ==",
-      "requires": {
-        "troika-three-utils": "^0.31.0",
-        "troika-worker-utils": "^0.31.0"
-      }
-    },
     "raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
@@ -21043,11 +20920,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
-    "react-layout-effect": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/react-layout-effect/-/react-layout-effect-1.0.5.tgz",
-      "integrity": "sha512-zdRXHuch+OBHU6bvjTelOGUCM+UDr/iCY+c0wXLEAc+G4/FlcJruD/hUOzlKH5XgO90Y/BUJPNhI/g9kl+VAsA=="
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
@@ -24148,11 +24020,6 @@
         }
       }
     },
-    "stats.js": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
-      "integrity": "sha1-scPcRtlEmLV4t/05hbgaznExzH0="
-    },
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
@@ -25130,25 +24997,6 @@
       "integrity": "sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA==",
       "dev": true
     },
-    "troika-three-text": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.31.0.tgz",
-      "integrity": "sha512-JpRO+AC9mLZ49IymBwwwFLcasN0xjjQmSkGO9tlzlpeHpexsK4JB80qs6d6vhtt+vmfdJi27/m+WYhaR6+OzaQ==",
-      "requires": {
-        "troika-three-utils": "^0.31.0",
-        "troika-worker-utils": "^0.31.0"
-      }
-    },
-    "troika-three-utils": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.31.0.tgz",
-      "integrity": "sha512-IUy61i+Kv0EjievWhOmIkqjDa1acIO2J98oO2tZ+PpEfA+Q0syRknH4SN+iiYpa/MNJH1gQz0WfZF4Vk1/pumQ=="
-    },
-    "troika-worker-utils": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.31.0.tgz",
-      "integrity": "sha512-WxHhfFmy6dWBMACUnzInBlqlR601Dy3c9hiRp4aAN+ACzSldwsv1SHOqix4X2+6HTz/pBtHtfJVDbwJiO+lbCw=="
-    },
     "trough": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
@@ -25668,11 +25516,6 @@
       "requires": {
         "use-isomorphic-layout-effect": "^1.0.0"
       }
-    },
-    "use-memo-one": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.1.tgz",
-      "integrity": "sha512-oFfsyun+bP7RX8X2AskHNTxu+R3QdE/RC5IefMbqptmACAA/gfol1KDD5KRzPsGMa62sWxGZw+Ui43u6x4ddoQ=="
     },
     "util": {
       "version": "0.10.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "d3-format": "^2.0.0",
     "d3-scale": "^3.2.2",
     "d3-scale-chromatic": "^2.0.0",
-    "drei": "^1.5.6",
     "lodash-es": "^4.17.15",
     "nanoid": "^2.1.11",
     "ndarray": "^1.0.19",

--- a/src/h5web/visualizations/heatmap/Mesh.tsx
+++ b/src/h5web/visualizations/heatmap/Mesh.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, ReactElement } from 'react';
 import { useThree } from 'react-three-fiber';
 import { RGBFormat, MeshBasicMaterial, DataTexture } from 'three';
-import { Html } from 'drei/misc/Html';
+import Html from '../shared/Html';
 import { useTextureData } from './hooks';
 import styles from './HeatmapVis.module.css';
 import type { Domain, ScaleType } from '../shared/models';
@@ -49,13 +49,10 @@ function Mesh(props: Props): ReactElement {
         </mesh>
       )}
       {showLoader && (
-        <Html>
-          <div
-            className={styles.textureLoader}
-            style={{ width, height }}
-            data-visible={loading || undefined}
-          />
-        </Html>
+        <Html
+          className={styles.textureLoader}
+          data-visible={loading || undefined}
+        />
       )}
     </>
   );

--- a/src/h5web/visualizations/shared/AxisSystem.module.css
+++ b/src/h5web/visualizations/shared/AxisSystem.module.css
@@ -1,11 +1,13 @@
 .axisSystem {
-  position: relative;
-  top: 0;
   display: grid;
   grid-template-areas:
     '. top-axis .'
     'left-axis axis-grid right-axis'
     '. bottom-axis .';
+
+  /* - Prevent panning/zooming from axis when zoomed in.
+   * - Prevent text selection of tick labels when panning with touchpad. */
+  pointer-events: none;
 }
 
 .leftAxisCell {

--- a/src/h5web/visualizations/shared/AxisSystem.tsx
+++ b/src/h5web/visualizations/shared/AxisSystem.tsx
@@ -3,8 +3,8 @@ import { useThree, useFrame } from 'react-three-fiber';
 import { AxisLeft, AxisBottom, TickRendererProps } from '@vx/axis';
 import { format } from 'd3-format';
 import { GridColumns, GridRows } from '@vx/grid';
-import { Html } from 'drei/misc/Html';
 import { useUpdateEffect } from 'react-use';
+import Html from './Html';
 import styles from './AxisSystem.module.css';
 import type { AxisOffsets, Domain } from './models';
 import { getTicksProp, getAxisScale } from './utils';
@@ -85,55 +85,53 @@ function AxisSystem(props: Props): JSX.Element {
       className={styles.axisSystem}
       style={{
         // Take over space reserved for axis by VisCanvas
-        width: width + axisOffsets.left + axisOffsets.right,
-        height: height + axisOffsets.bottom + axisOffsets.top,
         top: -axisOffsets.top,
         left: -axisOffsets.left,
+        width: width + axisOffsets.left + axisOffsets.right,
+        height: height + axisOffsets.bottom + axisOffsets.top,
         gridTemplateColumns: `${axisOffsets.left}px 1fr ${axisOffsets.right}px`,
         gridTemplateRows: `${axisOffsets.top}px 1fr ${axisOffsets.bottom}px`,
       }}
     >
-      <>
-        <div className={styles.bottomAxisCell}>
-          <svg className={styles.axis} data-orientation="bottom">
-            <AxisBottom scale={xTicksScale} {...xTicksProp} {...AXIS_PROPS} />
-          </svg>
-        </div>
-        <div className={styles.leftAxisCell}>
-          <svg className={styles.axis} data-orientation="left">
-            <AxisLeft
-              scale={yTicksScale}
-              left={axisOffsets.left}
-              {...yTicksProp}
-              {...AXIS_PROPS}
+      <div className={styles.bottomAxisCell}>
+        <svg className={styles.axis} data-orientation="bottom">
+          <AxisBottom scale={xTicksScale} {...xTicksProp} {...AXIS_PROPS} />
+        </svg>
+      </div>
+      <div className={styles.leftAxisCell}>
+        <svg className={styles.axis} data-orientation="left">
+          <AxisLeft
+            scale={yTicksScale}
+            left={axisOffsets.left}
+            {...yTicksProp}
+            {...AXIS_PROPS}
+          />
+        </svg>
+      </div>
+      <div className={styles.axisGridCell}>
+        <svg width={width} height={height}>
+          {abscissaInfo.showGrid && (
+            <GridColumns
+              scale={xTicksScale}
+              {...xTicksProp}
+              width={width}
+              height={height}
+              stroke={AXIS_PROPS.tickStroke}
+              strokeOpacity={0.33}
             />
-          </svg>
-        </div>
-        <div className={styles.axisGridCell}>
-          <svg width={width} height={height}>
-            {abscissaInfo.showGrid && (
-              <GridColumns
-                scale={xTicksScale}
-                {...xTicksProp}
-                width={width}
-                height={height}
-                stroke={AXIS_PROPS.tickStroke}
-                strokeOpacity={0.33}
-              />
-            )}
-            {ordinateInfo.showGrid && (
-              <GridRows
-                scale={yTicksScale}
-                {...yTicksProp}
-                width={width}
-                height={height}
-                stroke={AXIS_PROPS.tickStroke}
-                strokeOpacity={0.33}
-              />
-            )}
-          </svg>
-        </div>
-      </>
+          )}
+          {ordinateInfo.showGrid && (
+            <GridRows
+              scale={yTicksScale}
+              {...yTicksProp}
+              width={width}
+              height={height}
+              stroke={AXIS_PROPS.tickStroke}
+              strokeOpacity={0.33}
+            />
+          )}
+        </svg>
+      </div>
     </Html>
   );
 }

--- a/src/h5web/visualizations/shared/Html.tsx
+++ b/src/h5web/visualizations/shared/Html.tsx
@@ -1,0 +1,56 @@
+import React, { useState, useEffect, ReactElement } from 'react';
+import ReactDOM from 'react-dom';
+import { useThree } from 'react-three-fiber';
+
+// Simplified version of `drei`'s `<Html>` component
+// https://github.com/pmndrs/drei/blob/master/src/misc/Html.tsx
+function Html(props: React.HTMLAttributes<HTMLDivElement>): ReactElement {
+  const { className, style, children, ...divProps } = props;
+
+  const { gl, size } = useThree();
+  const { width, height } = size;
+  const { parentElement } = gl.domElement;
+
+  // Container `div` for ReactDOM to render into, appended next to R3F's `canvas`
+  const [el] = useState(() => document.createElement('div'));
+
+  useEffect(() => {
+    el.style.cssText = `position: absolute; top: 0; left: 0; z-index: 0;`;
+
+    if (parentElement) {
+      parentElement.appendChild(el);
+    }
+
+    return () => {
+      if (parentElement) {
+        parentElement.removeChild(el);
+      }
+
+      ReactDOM.unmountComponentAtNode(el);
+    };
+  }, [el, parentElement]);
+
+  useEffect(() => {
+    ReactDOM.render(
+      <div
+        className={className}
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width,
+          height,
+          ...style,
+        }}
+        {...divProps}
+      >
+        {children}
+      </div>,
+      el
+    );
+  }, [children, className, el, height, width, style, divProps]);
+
+  return <></>;
+}
+
+export default Html;

--- a/src/h5web/visualizations/shared/TooltipMesh.tsx
+++ b/src/h5web/visualizations/shared/TooltipMesh.tsx
@@ -2,8 +2,7 @@ import React, { ReactElement, useCallback, useContext } from 'react';
 import { PointerEvent, useThree } from 'react-three-fiber';
 import { TooltipWithBounds, useTooltip } from '@vx/tooltip';
 import { Line } from '@vx/shape';
-
-import { Html } from 'drei/misc/Html';
+import Html from './Html';
 import styles from './TooltipMesh.module.css';
 import { getAxisScale } from './utils';
 import { AxisSystemContext } from './AxisSystemProvider';
@@ -84,8 +83,8 @@ function TooltipMesh(props: Props): ReactElement {
       <mesh {...{ onPointerMove, onPointerOut, onPointerDown, onPointerUp }}>
         <planeBufferGeometry attach="geometry" args={[width, height]} />
       </mesh>
-      <Html style={{ width, height }}>
-        {tooltipOpen && tooltipData && value ? (
+      <Html>
+        {tooltipOpen && tooltipData && value && (
           <>
             <TooltipWithBounds
               key={Math.random()}
@@ -115,8 +114,6 @@ function TooltipMesh(props: Props): ReactElement {
               </svg>
             )}
           </>
-        ) : (
-          <></>
         )}
       </Html>
     </>

--- a/src/h5web/visualizations/shared/VisCanvas.module.css
+++ b/src/h5web/visualizations/shared/VisCanvas.module.css
@@ -14,13 +14,4 @@
 /* R3F's root element */
 .canvasWrapper {
   overflow: visible !important; /* show child axis grid, which is bigger than canvas */
-  z-index: 0; /* stacking context for child `<Html />` elements */
-}
-
-/* R3F's <Html /> element */
-.canvasWrapper > div {
-  transform: none !important;
-  /* - Prevent panning/zooming from axis when zoomed in.
-   * - Prevent text selection of tick labels when panning with touchpad. */
-  pointer-events: none;
 }


### PR DESCRIPTION
If you recall, drei's `Html` element is meant to "follow" the camera zoom and position. There are a couple of props like `center` and `fullscreen`, but they don't do what we need: make a `div` fill the canvas regardless of camera zoom and position.

I couldn't make `createPortal` work (neither ReactDOM's nor R3F's `createPortal`) to replace drei's `Html` element, as suggested in #204, so I decided to implement my own, simplified version of the component.

This allowed me to simplify a number of things in the codebase. For instance, we no longer need to pass a width and height to `Html` or its children, since, by default, it fills the space of the canvas.
