### PR TITLE
Added Auto-scale for Heatmap

### DIFF
--- a/src/h5web/visualizations/MappedHeatmapVis.tsx
+++ b/src/h5web/visualizations/MappedHeatmapVis.tsx
@@ -24,12 +24,21 @@ function MappedHeatmapVis(props: Props): ReactElement {
     keepAspectRatio,
     showGrid,
     resetDomains,
+    autoScale,
+    disableAutoScale,
   } = useHeatmapConfig();
 
   const baseArray = useBaseArray(dataset, value);
   const dataArray = useMappedArray(baseArray, mapperState);
-  const dataDomain = useDataDomain(dataArray.data as number[]);
+  const dataDomain = useDataDomain(
+    (autoScale ? dataArray.data : baseArray.data) as number[]
+  );
   const prevDataDomain = usePrevious(dataDomain);
+
+  // Disable `autoScale` for 2D datasets (baseArray and dataArray span the same values)
+  useEffect(() => {
+    disableAutoScale(!baseArray.shape || baseArray.shape.length <= 2);
+  }, [baseArray.shape, disableAutoScale]);
 
   // Use `customDomain` if any, unless `dataDomain` just changed (in which case it is stale and needs to be reset - cf. `useEffect` below)
   const domain =

--- a/src/h5web/visualizations/heatmap/HeatmapToolbar.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapToolbar.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { MdAspectRatio, MdGridOn } from 'react-icons/md';
+import { MdAspectRatio, MdDomain, MdGridOn } from 'react-icons/md';
 import ToggleBtn from '../shared/ToggleBtn';
 import { useHeatmapConfig } from './config';
 import DomainSlider from './DomainSlider';
@@ -22,10 +22,23 @@ function HeatmapToolbar(): ReactElement {
     toggleAspectRatio,
     showGrid,
     toggleGrid,
+    autoScale,
+    toggleAutoScale,
+    isAutoScaleDisabled,
   } = useHeatmapConfig();
 
   return (
     <Toolbar>
+      <ToggleBtn
+        label="Auto-scale"
+        icon={MdDomain}
+        value={autoScale}
+        onChange={toggleAutoScale}
+        disabled={isAutoScaleDisabled}
+      />
+
+      <Separator />
+
       {dataDomain && (
         <DomainSlider
           dataDomain={dataDomain}

--- a/src/h5web/visualizations/heatmap/config.ts
+++ b/src/h5web/visualizations/heatmap/config.ts
@@ -10,11 +10,19 @@ type HeatmapConfig = {
   scaleType: ScaleType;
   keepAspectRatio: boolean;
   showGrid: boolean;
+  autoScale: boolean;
+  isAutoScaleDisabled: boolean;
 };
 
 const STORAGE_CONFIG: StorageConfig = {
   storageId: 'h5web:heatmap',
-  itemsToPersist: ['colorMap', 'scaleType', 'keepAspectRatio', 'showGrid'],
+  itemsToPersist: [
+    'colorMap',
+    'scaleType',
+    'keepAspectRatio',
+    'showGrid',
+    'autoScale',
+  ],
 };
 
 const INITIAL_STATE: HeatmapConfig = {
@@ -24,6 +32,8 @@ const INITIAL_STATE: HeatmapConfig = {
   scaleType: ScaleType.Linear,
   keepAspectRatio: true,
   showGrid: false,
+  autoScale: false,
+  isAutoScaleDisabled: false,
 };
 
 export const useHeatmapConfig = createPersistableState(
@@ -43,5 +53,10 @@ export const useHeatmapConfig = createPersistableState(
       set((state) => ({ keepAspectRatio: !state.keepAspectRatio })),
 
     toggleGrid: () => set((state) => ({ showGrid: !state.showGrid })),
+
+    toggleAutoScale: () => set((state) => ({ autoScale: !state.autoScale })),
+
+    disableAutoScale: (isAutoScaleDisabled: boolean) =>
+      set({ isAutoScaleDisabled }),
   }))
 );


### PR DESCRIPTION
Fix #221 

In terms of interaction with the custom domain:

- When autoscale is off, the custom domain is kept when moving through slices.
- When autoscale is on, the custom domain is set to the `dataDomain` (that is the domain of the slice) at each slice change. However, it can still be changed when looking at a single slice (same as before).
- When toggling the autoscale, the custom domain is reset