### PR TITLE
Make breadcrumbs responsive

### DIFF
--- a/src/h5web/BreadcrumbsBar.module.css
+++ b/src/h5web/BreadcrumbsBar.module.css
@@ -7,19 +7,32 @@
 }
 
 .breadCrumbs {
+  flex: 1 1 0%;
   display: flex;
   align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  min-width: 0;
   margin-bottom: 0;
+  padding: 0 0.25rem;
   font-size: inherit;
   font-weight: inherit;
+  white-space: nowrap;
 }
 
 .crumb {
   margin: 0 0.125rem 0.125rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .crumb[data-current] {
+  flex: none; /* never shrink current breadcrumb */
   font-weight: 600;
+}
+
+.separator {
+  min-width: 0.75rem;
 }
 
 .modeToggler {

--- a/src/h5web/BreadcrumbsBar.tsx
+++ b/src/h5web/BreadcrumbsBar.tsx
@@ -40,7 +40,7 @@ function BreadcrumbsBar(props: Props): JSX.Element {
           {selectedNode?.parents.slice(firstParentIndex).map((member) => (
             <Fragment key={(member as HDF5HardLink).id}>
               <span className={styles.crumb}>{member.title}</span>
-              <FiChevronRight />
+              <FiChevronRight className={styles.separator} />
             </Fragment>
           ))}
           <span className={styles.crumb} data-current>


### PR DESCRIPTION
Fix #127 

Because of the resizable explorer panel, we can't rely on a simple CSS media query to hide crumbs. So to avoid measuring things with JS, I just went with `text-overflow: ellipsis;`.

Thanks to flexbox, the crumbs all shrink proportionately, so it actually looks great. I tell the last crumb to not shrink, though.

![image](https://user-images.githubusercontent.com/2936402/94900988-3b370880-0496-11eb-8801-0326ab223a1f.png)

If there's not enough space even for the last crumb, then a last-resort `overflow: hidden` comes into play:

![image](https://user-images.githubusercontent.com/2936402/94902437-72a6b480-0498-11eb-8870-4a0c2e46144b.png)
