### PR TITLE
Show loader while fetching datasets values

### DIFF
--- a/src/h5web/dataset-visualizer/Loader.module.css
+++ b/src/h5web/dataset-visualizer/Loader.module.css
@@ -1,0 +1,60 @@
+.loader {
+  flex: 1 1 0%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+}
+
+.grid {
+  --w: 2rem;
+  display: grid;
+  grid: var(--w) var(--w) var(--w) / var(--w) var(--w) var(--w);
+  width: calc(var(--w) * 3);
+  height: calc(var(--w) * 3);
+  margin-bottom: 1rem;
+}
+
+.grid > div {
+  background-color: var(--primary-dark-bg);
+  animation: scaleDelay 1.3s infinite ease-in-out;
+}
+
+.grid > div:nth-child(1) {
+  animation-delay: 0.2s;
+}
+.grid > div:nth-child(2) {
+  animation-delay: 0.3s;
+}
+.grid > div:nth-child(3) {
+  animation-delay: 0.4s;
+}
+.grid > div:nth-child(4) {
+  animation-delay: 0.1s;
+}
+.grid > div:nth-child(5) {
+  animation-delay: 0.2s;
+}
+.grid > div:nth-child(6) {
+  animation-delay: 0.3s;
+}
+.grid > div:nth-child(7) {
+  animation-delay: 0s;
+}
+.grid > div:nth-child(8) {
+  animation-delay: 0.1s;
+}
+.grid > div:nth-child(9) {
+  animation-delay: 0.2s;
+}
+
+@keyframes scaleDelay {
+  0%,
+  70%,
+  100% {
+    transform: scale3D(1, 1, 1);
+  }
+  35% {
+    transform: scale3D(0, 0, 1);
+  }
+}

--- a/src/h5web/dataset-visualizer/Loader.tsx
+++ b/src/h5web/dataset-visualizer/Loader.tsx
@@ -1,0 +1,29 @@
+import React, { ReactElement } from 'react';
+import styles from './Loader.module.css';
+
+interface Props {
+  message?: string;
+}
+
+function Loader(props: Props): ReactElement {
+  const { message = 'Loading' } = props;
+
+  return (
+    <div className={styles.loader}>
+      <div className={styles.grid}>
+        <div />
+        <div />
+        <div />
+        <div />
+        <div />
+        <div />
+        <div />
+        <div />
+        <div />
+      </div>
+      <p>{message}...</p>
+    </div>
+  );
+}
+
+export default Loader;

--- a/src/h5web/dataset-visualizer/VisDisplay.tsx
+++ b/src/h5web/dataset-visualizer/VisDisplay.tsx
@@ -8,17 +8,27 @@ import type {
 import { VIS_DEFS } from '../visualizations';
 import DimensionMapper from './mapper/DimensionMapper';
 import Profiler from '../Profiler';
+import Loader from './Loader';
 
 interface Props {
   activeVis: Vis;
   dataset: HDF5Dataset;
   value: HDF5Value;
+  loading: boolean;
   mapperState: DimensionMapping;
   onMapperStateChange(mapperState: DimensionMapping): void;
 }
 
 function VisDisplay(props: Props): ReactElement {
-  const { activeVis, dataset, value, mapperState, onMapperStateChange } = props;
+  const {
+    activeVis,
+    dataset,
+    value,
+    loading,
+    mapperState,
+    onMapperStateChange,
+  } = props;
+
   const { Component: VisComponent } = VIS_DEFS[activeVis];
 
   return (
@@ -29,14 +39,18 @@ function VisDisplay(props: Props): ReactElement {
         mapperState={mapperState}
         onChange={onMapperStateChange}
       />
-      {value !== undefined && (
-        <Profiler id={activeVis}>
-          <VisComponent
-            value={value}
-            dataset={dataset}
-            mapperState={mapperState}
-          />
-        </Profiler>
+      {loading ? (
+        <Loader message="Loading dataset" />
+      ) : (
+        value !== undefined && (
+          <Profiler id={activeVis}>
+            <VisComponent
+              value={value}
+              dataset={dataset}
+              mapperState={mapperState}
+            />
+          </Profiler>
+        )
       )}
     </>
   );


### PR DESCRIPTION
Fix #223 

To retrieve the value of a dataset, providers expose a function called `getValue` that returns a promise. The value is therefore retrieved asynchronously whether or not the provider already has access to it in memory. One challenge was to not flash the loader when this is the case.

I used react-use's `useAsyncFn` hook for this. Hopefully this is clear in the code, but the goal is to set the `loading` flag to `true` only if `getValue` takes more than 50ms to complete.

![ezgif-5-174754273f54](https://user-images.githubusercontent.com/2936402/94908496-092ba380-04a2-11eb-8b2f-6b408fcf093b.gif)