### PR TITLE
Improve display of log ticks

### DIFF
--- a/src/h5web/visualizations/line/LineVis.module.css
+++ b/src/h5web/visualizations/line/LineVis.module.css
@@ -2,5 +2,6 @@
   flex: 1 1 0%;
   display: flex;
   min-width: 0;
+  min-height: 0;
   margin: 1rem;
 }

--- a/src/h5web/visualizations/matrix/MatrixVis.module.css
+++ b/src/h5web/visualizations/matrix/MatrixVis.module.css
@@ -1,6 +1,7 @@
 .wrapper {
   flex: 1 1 0%;
   min-width: 0;
+  min-height: 0;
 }
 
 .grid {

--- a/src/h5web/visualizations/shared/AxisSystem.tsx
+++ b/src/h5web/visualizations/shared/AxisSystem.tsx
@@ -1,19 +1,17 @@
 import React, { useState, useContext } from 'react';
 import { useThree, useFrame } from 'react-three-fiber';
 import { AxisLeft, AxisBottom, TickRendererProps } from '@vx/axis';
-import { format } from 'd3-format';
 import { GridColumns, GridRows } from '@vx/grid';
 import { useUpdateEffect } from 'react-use';
 import Html from './Html';
 import styles from './AxisSystem.module.css';
 import type { AxisOffsets, Domain } from './models';
-import { getTicksProp, getAxisScale } from './utils';
+import { getTicksProp, getAxisScale, getTickFormatter } from './utils';
 import { AxisSystemContext } from './AxisSystemProvider';
 
 const AXIS_PROPS = {
   tickStroke: 'grey',
   hideAxisLine: true,
-  tickFormat: format('0'),
   tickClassName: styles.tick,
   tickComponent: ({ formattedValue, ...tickProps }: TickRendererProps) => (
     <text {...tickProps}>{formattedValue}</text>
@@ -80,6 +78,17 @@ function AxisSystem(props: Props): JSX.Element {
     ordinateInfo.isIndexAxis
   );
 
+  const xTickFormat = getTickFormatter(
+    visibleDomains[0],
+    width,
+    abscissaInfo.scaleType
+  );
+  const yTickFormat = getTickFormatter(
+    visibleDomains[1],
+    height,
+    ordinateInfo.scaleType
+  );
+
   return (
     <Html
       className={styles.axisSystem}
@@ -95,7 +104,12 @@ function AxisSystem(props: Props): JSX.Element {
     >
       <div className={styles.bottomAxisCell}>
         <svg className={styles.axis} data-orientation="bottom">
-          <AxisBottom scale={xTicksScale} {...xTicksProp} {...AXIS_PROPS} />
+          <AxisBottom
+            scale={xTicksScale}
+            tickFormat={xTickFormat}
+            {...xTicksProp}
+            {...AXIS_PROPS}
+          />
         </svg>
       </div>
       <div className={styles.leftAxisCell}>
@@ -103,6 +117,7 @@ function AxisSystem(props: Props): JSX.Element {
           <AxisLeft
             scale={yTicksScale}
             left={axisOffsets.left}
+            tickFormat={yTickFormat}
             {...yTicksProp}
             {...AXIS_PROPS}
           />

--- a/src/h5web/visualizations/shared/utils.ts
+++ b/src/h5web/visualizations/shared/utils.ts
@@ -161,14 +161,15 @@ export function getTickFormatter(
   }
 
   // If available size allows for all log ticks to be rendered without overlap, use default formatter
+  const [min, max] = domain[0] > 0 ? domain : [-domain[1], -[domain[0]]];
   const threshold = adaptedLogTicksThreshold(availableSize);
-  if (Math.log10(domain[1]) - Math.log10(domain[0]) < threshold) {
+  if (max / min < 10 ** threshold) {
     return TICK_FORMAT;
   }
 
   // Otherwise, use formatter that hides non-exact powers of 10
   return (val) => {
-    const loggedVal = Math.log10(val.valueOf());
+    const loggedVal = Math.log10(Math.abs(val.valueOf()));
     if (loggedVal !== Math.floor(loggedVal)) return '';
     return TICK_FORMAT(val);
   };

--- a/src/stories/LineVis.stories.tsx
+++ b/src/stories/LineVis.stories.tsx
@@ -56,6 +56,14 @@ LogScale.args = {
   scaleType: ScaleType.Log,
 };
 
+export const NegativeLogScale = Template.bind({});
+NegativeLogScale.storyName = 'Log Scale with negative values';
+NegativeLogScale.args = {
+  dataArray,
+  domain: [-20, -1],
+  scaleType: ScaleType.Log,
+};
+
 export const SymLogScale = Template.bind({});
 
 SymLogScale.args = {


### PR DESCRIPTION
Fix #183

I just had another crack at the issue, and it's looking good... 😤 

1. I log the min and max of the axis' visible domain and compute the difference.
1. I compare the result with a threshold, which I compute with a linear scale based on the space available to the axis (similarly to `adaptedNumTicks`).
1. If the logged extent of the domain spans less than the threshold, then it means that all ticks can be displayed without any overlap and I use the default tick formatter (`format('0')`).
1. Otherwise, I use a formatter that displays only exact powers of 10.

The only downside I see is that I don't check whether the visible ticks are far apart or close together; the threshold is computed on the assumption that the ticks are close together. As a result, there may be cases where zero or one tick is visible when there would be space to show more (e.g. on a narrow screen, a little above a power of 10). That being said, I don't think it matters and I believe matplotlib has the same downside (though this needs to be verified).

### Height of 465px

![image](https://user-images.githubusercontent.com/2936402/94926937-d8f3fd00-04c1-11eb-8a59-82ee7feb3807.png)

![image](https://user-images.githubusercontent.com/2936402/94926954-e1e4ce80-04c1-11eb-9daa-3bf2d8e025c3.png)

![image](https://user-images.githubusercontent.com/2936402/94926990-edd09080-04c1-11eb-8cee-eb1e337dda99.png)

### Height of 230px

![image](https://user-images.githubusercontent.com/2936402/94927017-f9bc5280-04c1-11eb-8f0a-9bc5751c8eaa.png)

![image](https://user-images.githubusercontent.com/2936402/94927034-017bf700-04c2-11eb-95a2-3b86d93717b0.png)

### Case where more ticks could be shown

![image](https://user-images.githubusercontent.com/2936402/94927687-e9f13e00-04c2-11eb-923c-1c7e7bdbef0c.png)
