### PR TITLE
Refactor axis system and fix re-rendering bug

### DIFF
--- a/src/h5web/visualizations/shared/Axis.tsx
+++ b/src/h5web/visualizations/shared/Axis.tsx
@@ -1,0 +1,70 @@
+import React, { ReactElement, ReactType } from 'react';
+import { AxisLeft, AxisBottom, TickRendererProps } from '@vx/axis';
+import { GridColumns, GridRows } from '@vx/grid';
+import styles from './AxisSystem.module.css';
+import type { AxisInfo, AxisScale, Domain, Size } from './models';
+import { adaptedNumTicks, getIntegerTicks, getTickFormatter } from './utils';
+
+const AXIS_PROPS = {
+  tickStroke: 'grey',
+  hideAxisLine: true,
+  tickClassName: styles.tick,
+  tickComponent: ({ formattedValue, ...tickProps }: TickRendererProps) => (
+    <text {...tickProps}>{formattedValue}</text>
+  ),
+};
+
+const COMPONENTS: Record<string, [ReactType, ReactType]> = {
+  abscissa: [AxisBottom, GridColumns],
+  ordinate: [AxisLeft, GridRows],
+};
+
+interface Props {
+  type: 'abscissa' | 'ordinate';
+  scale: AxisScale;
+  domain: Domain;
+  info: AxisInfo;
+  canvasSize: Size;
+}
+
+function Axis(props: Props): ReactElement {
+  const { type, scale, domain, info, canvasSize } = props;
+  const { scaleType, showGrid, isIndexAxis } = info;
+
+  const { width, height } = canvasSize;
+  const axisLength = type === 'abscissa' ? width : height;
+
+  const [AxisComponent, GridComponent] = COMPONENTS[type];
+
+  const numTicks = adaptedNumTicks(axisLength);
+  const ticksProp = isIndexAxis
+    ? { tickValues: getIntegerTicks(domain, numTicks) }
+    : { numTicks };
+
+  return (
+    <>
+      <svg className={styles.axis} data-type={type}>
+        <AxisComponent
+          scale={scale}
+          tickFormat={getTickFormatter(domain, axisLength, scaleType)}
+          {...ticksProp}
+          {...AXIS_PROPS}
+        />
+      </svg>
+      {showGrid && (
+        <svg className={styles.grid}>
+          <GridComponent
+            scale={scale}
+            {...ticksProp}
+            width={width}
+            height={height}
+            stroke={AXIS_PROPS.tickStroke}
+            strokeOpacity={0.33}
+          />
+        </svg>
+      )}
+    </>
+  );
+}
+
+export default Axis;

--- a/src/h5web/visualizations/shared/AxisSystem.module.css
+++ b/src/h5web/visualizations/shared/AxisSystem.module.css
@@ -2,7 +2,7 @@
   display: grid;
   grid-template-areas:
     '. top-axis .'
-    'left-axis axis-grid right-axis'
+    '. axis-grid right-axis'
     '. bottom-axis .';
 
   /* - Prevent panning/zooming from axis when zoomed in.
@@ -10,37 +10,24 @@
   pointer-events: none;
 }
 
-.leftAxisCell {
-  grid-area: left-axis;
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-}
-
-.bottomAxisCell {
-  grid-area: bottom-axis;
-  display: flex;
-}
-
-.axisGridCell {
-  grid-area: axis-grid;
-  display: flex;
-}
-
+.grid,
 .axis {
   display: block;
   overflow: visible;
-  flex: 1 1 0%;
 }
 
-.axis[data-orientation='left'] {
-  text-anchor: end;
-  min-height: 0;
-}
-
-.axis[data-orientation='bottom'] {
-  min-width: 0;
+.axis[data-type='abscissa'] {
+  grid-area: bottom-axis;
   text-anchor: middle;
+}
+
+.axis[data-type='ordinate'] {
+  grid-area: axis-grid; /* `AxisLeft` aligns ticks to the outer left of its own bounding box  */
+  text-anchor: end;
+}
+
+.grid {
+  grid-area: axis-grid;
 }
 
 .tick > text {

--- a/src/h5web/visualizations/shared/AxisSystem.tsx
+++ b/src/h5web/visualizations/shared/AxisSystem.tsx
@@ -1,22 +1,12 @@
 import React, { useContext } from 'react';
 import { useThree } from 'react-three-fiber';
-import { AxisLeft, AxisBottom, TickRendererProps } from '@vx/axis';
-import { GridColumns, GridRows } from '@vx/grid';
 import Html from './Html';
 import styles from './AxisSystem.module.css';
 import type { AxisOffsets, Domain } from './models';
-import { getTicksProp, getAxisScale, getTickFormatter } from './utils';
+import { getAxisScale } from './utils';
 import { AxisSystemContext } from './AxisSystemProvider';
 import { useFrameRendering } from './hooks';
-
-const AXIS_PROPS = {
-  tickStroke: 'grey',
-  hideAxisLine: true,
-  tickClassName: styles.tick,
-  tickComponent: ({ formattedValue, ...tickProps }: TickRendererProps) => (
-    <text {...tickProps}>{formattedValue}</text>
-  ),
-};
+import Axis from './Axis';
 
 interface Props {
   axisOffsets: AxisOffsets;
@@ -57,28 +47,6 @@ function AxisSystem(props: Props): JSX.Element {
   // Re-render on every R3F frame (i.e. on every change of camera zoom/position)
   useFrameRendering();
 
-  const xTicksProp = getTicksProp(
-    xVisibleDomain,
-    width,
-    abscissaInfo.isIndexAxis
-  );
-  const yTicksProp = getTicksProp(
-    yVisibleDomain,
-    height,
-    ordinateInfo.isIndexAxis
-  );
-
-  const xTickFormat = getTickFormatter(
-    xVisibleDomain,
-    width,
-    abscissaInfo.scaleType
-  );
-  const yTickFormat = getTickFormatter(
-    yVisibleDomain,
-    height,
-    ordinateInfo.scaleType
-  );
-
   return (
     <Html
       className={styles.axisSystem}
@@ -92,51 +60,20 @@ function AxisSystem(props: Props): JSX.Element {
         gridTemplateRows: `${axisOffsets.top}px 1fr ${axisOffsets.bottom}px`,
       }}
     >
-      <div className={styles.bottomAxisCell}>
-        <svg className={styles.axis} data-orientation="bottom">
-          <AxisBottom
-            scale={xTicksScale}
-            tickFormat={xTickFormat}
-            {...xTicksProp}
-            {...AXIS_PROPS}
-          />
-        </svg>
-      </div>
-      <div className={styles.leftAxisCell}>
-        <svg className={styles.axis} data-orientation="left">
-          <AxisLeft
-            scale={yTicksScale}
-            left={axisOffsets.left}
-            tickFormat={yTickFormat}
-            {...yTicksProp}
-            {...AXIS_PROPS}
-          />
-        </svg>
-      </div>
-      <div className={styles.axisGridCell}>
-        <svg width={width} height={height}>
-          {abscissaInfo.showGrid && (
-            <GridColumns
-              scale={xTicksScale}
-              {...xTicksProp}
-              width={width}
-              height={height}
-              stroke={AXIS_PROPS.tickStroke}
-              strokeOpacity={0.33}
-            />
-          )}
-          {ordinateInfo.showGrid && (
-            <GridRows
-              scale={yTicksScale}
-              {...yTicksProp}
-              width={width}
-              height={height}
-              stroke={AXIS_PROPS.tickStroke}
-              strokeOpacity={0.33}
-            />
-          )}
-        </svg>
-      </div>
+      <Axis
+        type="abscissa"
+        scale={xTicksScale}
+        domain={xVisibleDomain}
+        info={abscissaInfo}
+        canvasSize={size}
+      />
+      <Axis
+        type="ordinate"
+        scale={yTicksScale}
+        domain={yVisibleDomain}
+        info={ordinateInfo}
+        canvasSize={size}
+      />
     </Html>
   );
 }

--- a/src/h5web/visualizations/shared/hooks.ts
+++ b/src/h5web/visualizations/shared/hooks.ts
@@ -1,8 +1,9 @@
 import ndarray from 'ndarray';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { isNumber } from 'lodash-es';
 import { assign } from 'ndarray-ops';
 import { createMemo } from 'react-use';
+import { useFrame } from 'react-three-fiber';
 import type { HDF5Dataset, HDF5SimpleShape } from '../../providers/models';
 import type { DimensionMapping } from '../../dataset-visualizer/models';
 import { findDomain, getSupportedDomain } from './utils';
@@ -43,3 +44,11 @@ export function useMappedArray<T>(
 export const useDataDomain = createMemo(findDomain);
 
 export const useSupportedDomain = createMemo(getSupportedDomain);
+
+export function useFrameRendering(): void {
+  const [, setNum] = useState();
+
+  useFrame(() => {
+    setNum(Math.random());
+  });
+}

--- a/src/h5web/visualizations/shared/utils.ts
+++ b/src/h5web/visualizations/shared/utils.ts
@@ -112,7 +112,7 @@ export function getAxisScale(info: AxisInfo, rangeSize: number): AxisScale {
  *
  * So we implement our own, simplified version of `d3.ticks` that always outputs integer values.
  */
-function getIntegerTicks(domain: Domain, count: number): number[] {
+export function getIntegerTicks(domain: Domain, count: number): number[] {
   const [min, max] = domain;
   const intMin = Math.ceil(min);
   const intMax = Math.floor(max);
@@ -137,18 +137,6 @@ function getIntegerTicks(domain: Domain, count: number): number[] {
   }
 
   return ticks;
-}
-
-export function getTicksProp(
-  visibleDomain: Domain,
-  availableSize: number,
-  onlyIntegers?: boolean
-): { tickValues: number[] } | { numTicks: number } {
-  const numTicks = adaptedNumTicks(availableSize);
-
-  return onlyIntegers
-    ? { tickValues: getIntegerTicks(visibleDomain, numTicks) }
-    : { numTicks };
 }
 
 export function getTickFormatter(


### PR DESCRIPTION
I've split the fix/refactor in two commits:

1. In the first commit, I fix the bug where the axes were being temporarily reset on any change, like the color map.

    The bug occurs because of the `useUpdateEffect` in `AxisSystem`, which resets the visible domains to the initial axis domains any time the latter changed ... which happens on every render of `HeatmapVis` and `LineVis` since we pass inline arrays as domains - e.g. `[0, rows]`.

    I could have fixed this by computing the visible domains in the `useUpdateEffect` (in addition to computing them in `useFrame`), but this led to an incoherent state for one render when the newly calculated scale would no longer be coherent with the yet-to-be-calculated visible domains.

    I then realised that storing the visible domains in the state was effectively useless and that a better solution would be to just compute them on every render and to force the `AxisSystem` to re-render on every R3F frame directly. We still re-render as many times as we did with `useFrame` and `useUpdateEffect`; the difference is just that we compute the visible domains synchronously during the render rather than asynchronously inside an effect. It's a lot simpler, really.

2. In the second commit, I refactor `AxisSystem` by ntroducing a new `Axis` component that takes care of rendering the VX axis and grid components. The computation of the scales and visible domains stays in `AxisSystem`, as each axis has specificities that are difficult to abstract out.