### PR TITLE
Only dims are now passed to Vis rather than the full dataset

### DIFF
--- a/src/h5web/dataset-visualizer/VisDisplay.tsx
+++ b/src/h5web/dataset-visualizer/VisDisplay.tsx
@@ -46,12 +46,13 @@ function VisDisplay(props: Props): ReactElement {
   }, [cancelLoadingFlag, dataset, getValue, mergeState, scheduleLoadingFlag]);
 
   const { Component: VisComponent } = VIS_DEFS[activeVis];
+  const rawDims = (dataset.shape as HDF5SimpleShape).dims;
 
   return (
     <>
       <DimensionMapper
         activeVis={activeVis}
-        rawDims={(dataset.shape as HDF5SimpleShape).dims}
+        rawDims={rawDims}
         mapperState={mapperState}
         onChange={(nextMapperState) => {
           mergeState({ mapperState: nextMapperState });
@@ -64,7 +65,7 @@ function VisDisplay(props: Props): ReactElement {
           <Profiler id={activeVis}>
             <VisComponent
               value={value}
-              dataset={dataset}
+              rawDims={rawDims}
               mapperState={mapperState}
             />
           </Profiler>

--- a/src/h5web/visualizations/heatmap/MappedHeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/MappedHeatmapVis.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useEffect } from 'react';
 import { usePrevious } from 'react-use';
-import type { HDF5Dataset, HDF5Value } from '../../providers/models';
+import type { HDF5Value } from '../../providers/models';
 import type { DimensionMapping } from '../../dataset-visualizer/models';
 import HeatmapVis from './HeatmapVis';
 import { assertArray } from '../shared/utils';
@@ -9,12 +9,12 @@ import { useHeatmapConfig } from './config';
 
 interface Props {
   value: HDF5Value;
-  dataset: HDF5Dataset;
+  rawDims: number[];
   mapperState: DimensionMapping;
 }
 
 function MappedHeatmapVis(props: Props): ReactElement {
-  const { value, dataset, mapperState } = props;
+  const { value, rawDims, mapperState } = props;
   assertArray<number>(value);
 
   const {
@@ -28,7 +28,7 @@ function MappedHeatmapVis(props: Props): ReactElement {
     disableAutoScale,
   } = useHeatmapConfig();
 
-  const baseArray = useBaseArray(dataset, value);
+  const baseArray = useBaseArray(value, rawDims);
   const dataArray = useMappedArray(baseArray, mapperState);
   const dataDomain = useDataDomain(
     (autoScale ? dataArray.data : baseArray.data) as number[]

--- a/src/h5web/visualizations/index.tsx
+++ b/src/h5web/visualizations/index.tsx
@@ -27,7 +27,7 @@ interface VisDef {
   Toolbar?: ElementType<{}>;
   Component: ElementType<{
     value: HDF5Value;
-    dataset: HDF5Dataset;
+    rawDims: number[];
     mapperState: DimensionMapping;
   }>;
   supportsDataset(dataset: HDF5Dataset): boolean;

--- a/src/h5web/visualizations/line/MappedLineVis.tsx
+++ b/src/h5web/visualizations/line/MappedLineVis.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useEffect } from 'react';
-import type { HDF5Dataset, HDF5Value } from '../../providers/models';
+import type { HDF5Value } from '../../providers/models';
 import type { DimensionMapping } from '../../dataset-visualizer/models';
 import LineVis from './LineVis';
 import { assertArray } from '../shared/utils';
@@ -8,12 +8,12 @@ import { useLineConfig } from './config';
 
 interface Props {
   value: HDF5Value;
-  dataset: HDF5Dataset;
+  rawDims: number[];
   mapperState: DimensionMapping;
 }
 
 function MappedLineVis(props: Props): ReactElement {
-  const { value, dataset, mapperState } = props;
+  const { value, rawDims, mapperState } = props;
   assertArray<number>(value);
 
   const {
@@ -24,7 +24,7 @@ function MappedLineVis(props: Props): ReactElement {
     disableAutoScale,
   } = useLineConfig();
 
-  const baseArray = useBaseArray(dataset, value);
+  const baseArray = useBaseArray(value, rawDims);
   const dataArray = useMappedArray(baseArray, mapperState);
 
   // Disable `autoScale` for 1D datasets (baseArray and dataArray are the same)

--- a/src/h5web/visualizations/matrix/MappedMatrixVis.tsx
+++ b/src/h5web/visualizations/matrix/MappedMatrixVis.tsx
@@ -1,21 +1,21 @@
 import React, { ReactElement } from 'react';
-import type { HDF5Dataset, HDF5Value } from '../../providers/models';
 import type { DimensionMapping } from '../../dataset-visualizer/models';
 import MatrixVis from './MatrixVis';
 import { assertArray } from '../shared/utils';
 import { useMappedArray, useBaseArray } from '../shared/hooks';
+import type { HDF5Value } from '../../providers/models';
 
 interface Props {
   value: HDF5Value;
-  dataset: HDF5Dataset;
+  rawDims: number[];
   mapperState: DimensionMapping;
 }
 
 function MappedMatrixVis(props: Props): ReactElement {
-  const { value, dataset, mapperState } = props;
+  const { value, rawDims, mapperState } = props;
   assertArray<number | string>(value);
 
-  const baseArray = useBaseArray(dataset, value);
+  const baseArray = useBaseArray(value, rawDims);
   const dataArray = useMappedArray(baseArray, mapperState);
   return <MatrixVis dataArray={dataArray} />;
 }

--- a/src/h5web/visualizations/shared/hooks.ts
+++ b/src/h5web/visualizations/shared/hooks.ts
@@ -4,13 +4,10 @@ import { isNumber } from 'lodash-es';
 import { assign } from 'ndarray-ops';
 import { createMemo } from 'react-use';
 import { useFrame } from 'react-three-fiber';
-import type { HDF5Dataset, HDF5SimpleShape } from '../../providers/models';
 import type { DimensionMapping } from '../../dataset-visualizer/models';
 import { findDomain, getSupportedDomain } from './utils';
 
-export function useBaseArray<T>(dataset: HDF5Dataset, value: T[]): ndarray<T> {
-  const rawDims = (dataset.shape as HDF5SimpleShape).dims;
-
+export function useBaseArray<T>(value: T[], rawDims: number[]): ndarray<T> {
   return useMemo(() => {
     return ndarray<T>(value.flat(Infinity) as T[], rawDims);
   }, [rawDims, value]);


### PR DESCRIPTION
A small refactoring as Vis components do not need the full dataset object but only the dimensions.

In fact, I think we could even make a single object/interface out of `value` and `rawDims` to be passed to vis components.

Your thoughts @axelboc ?