### PR TITLE
Fix no auto-scale behaviour with log scale and domain that crosses zero

### DIFF
--- a/src/h5web/visualizations/heatmap/HeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapVis.tsx
@@ -8,7 +8,6 @@ import TooltipMesh from '../shared/TooltipMesh';
 import PanZoomMesh from '../shared/PanZoomMesh';
 import VisCanvas from '../shared/VisCanvas';
 import { getDims } from './utils';
-import { useSupportedDomain } from '../shared/hooks';
 import { Domain, ScaleType } from '../shared/models';
 import type { ColorMap } from './models';
 
@@ -33,9 +32,6 @@ function HeatmapVis(props: Props): JSX.Element {
     showLoader = true,
   } = props;
 
-  const values = dataArray.data as number[];
-  const supportedDomain = useSupportedDomain(domain, scaleType, values);
-
   const { rows, cols } = getDims(dataArray);
   const aspectRatio = keepAspectRatio ? cols / rows : undefined; // width / height <=> cols / rows
 
@@ -56,24 +52,20 @@ function HeatmapVis(props: Props): JSX.Element {
           guides="both"
         />
         <PanZoomMesh />
-        {supportedDomain && (
+        {domain && (
           <Mesh
             rows={rows}
             cols={cols}
-            values={values}
-            domain={supportedDomain}
+            values={dataArray.data as number[]}
+            domain={domain}
             scaleType={scaleType}
             colorMap={colorMap}
             showLoader={showLoader}
           />
         )}
       </VisCanvas>
-      {supportedDomain && (
-        <ColorBar
-          domain={supportedDomain}
-          scaleType={scaleType}
-          colorMap={colorMap}
-        />
+      {domain && (
+        <ColorBar domain={domain} scaleType={scaleType} colorMap={colorMap} />
       )}
     </div>
   );

--- a/src/h5web/visualizations/heatmap/MappedHeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/MappedHeatmapVis.tsx
@@ -31,7 +31,8 @@ function MappedHeatmapVis(props: Props): ReactElement {
   const baseArray = useBaseArray(dataset, value);
   const dataArray = useMappedArray(baseArray, mapperState);
   const dataDomain = useDataDomain(
-    (autoScale ? dataArray.data : baseArray.data) as number[]
+    (autoScale ? dataArray.data : baseArray.data) as number[],
+    scaleType
   );
   const prevDataDomain = usePrevious(dataDomain);
 

--- a/src/h5web/visualizations/line/LineVis.tsx
+++ b/src/h5web/visualizations/line/LineVis.tsx
@@ -9,7 +9,6 @@ import TooltipMesh from '../shared/TooltipMesh';
 import { extendDomain } from '../shared/utils';
 import { ScaleType, Domain } from '../shared/models';
 import { CurveType } from './models';
-import { useSupportedDomain } from '../shared/hooks';
 
 const DEFAULT_DOMAIN: Domain = [0.1, 1];
 
@@ -30,15 +29,12 @@ function LineVis(props: Props): ReactElement {
     scaleType = ScaleType.Linear,
   } = props;
 
-  const values = dataArray.data as number[];
-  const supportedDomain = useSupportedDomain(domain, scaleType, values);
-
   const indexDomain = extendDomain([0, dataArray.size - 1], 0.01);
   const dataDomain = useMemo(() => {
-    return supportedDomain
-      ? extendDomain(supportedDomain, 0.05, scaleType === ScaleType.Log)
+    return domain
+      ? extendDomain(domain, 0.05, scaleType === ScaleType.Log)
       : DEFAULT_DOMAIN;
-  }, [scaleType, supportedDomain]);
+  }, [scaleType, domain]);
 
   return (
     <div className={styles.root}>
@@ -55,7 +51,12 @@ function LineVis(props: Props): ReactElement {
           guides="vertical"
         />
         <PanZoomMesh />
-        {dataDomain && <DataCurve curveType={curveType} values={values} />}
+        {dataDomain && (
+          <DataCurve
+            curveType={curveType}
+            values={dataArray.data as number[]}
+          />
+        )}
       </VisCanvas>
     </div>
   );

--- a/src/h5web/visualizations/line/MappedLineVis.tsx
+++ b/src/h5web/visualizations/line/MappedLineVis.tsx
@@ -33,7 +33,8 @@ function MappedLineVis(props: Props): ReactElement {
   }, [baseArray.shape, disableAutoScale]);
 
   const dataDomain = useDataDomain(
-    (autoScale ? dataArray.data : baseArray.data) as number[]
+    (autoScale ? dataArray.data : baseArray.data) as number[],
+    scaleType
   );
 
   return (

--- a/src/h5web/visualizations/shared/hooks.ts
+++ b/src/h5web/visualizations/shared/hooks.ts
@@ -6,7 +6,7 @@ import { createMemo } from 'react-use';
 import { useFrame } from 'react-three-fiber';
 import type { HDF5Dataset, HDF5SimpleShape } from '../../providers/models';
 import type { DimensionMapping } from '../../dataset-visualizer/models';
-import { findDomain, getSupportedDomain } from './utils';
+import { getDataDomain } from './utils';
 
 export function useBaseArray<T>(dataset: HDF5Dataset, value: T[]): ndarray<T> {
   const rawDims = (dataset.shape as HDF5SimpleShape).dims;
@@ -41,9 +41,7 @@ export function useMappedArray<T>(
   }, [mapperState, baseArray]);
 }
 
-export const useDataDomain = createMemo(findDomain);
-
-export const useSupportedDomain = createMemo(getSupportedDomain);
+export const useDataDomain = createMemo(getDataDomain);
 
 export function useFrameRendering(): void {
   const [, setNum] = useState();

--- a/src/h5web/visualizations/shared/utils.test.ts
+++ b/src/h5web/visualizations/shared/utils.test.ts
@@ -1,5 +1,6 @@
 import { tickStep } from 'd3-array';
-import { computeVisSize, findDomain, getIntegerTicks } from './utils';
+import { computeVisSize, getIntegerTicks, getDataDomain } from './utils';
+import { ScaleType } from './models';
 
 describe('Shared visualization utilities', () => {
   describe('computeVisSize', () => {
@@ -54,16 +55,33 @@ describe('Shared visualization utilities', () => {
     });
   });
 
-  describe('findDomain', () => {
-    it('should return the domain of the data', () => {
+  describe('getDataDomain', () => {
+    it('should return min and max values of data array', () => {
       const data = [2, 0, 10, 5, 2, -1];
-      const domain = findDomain(data);
+      const domain = getDataDomain(data);
       expect(domain).toEqual([-1, 10]);
     });
 
-    it('should return undefined when the data is empty', () => {
-      const domain = findDomain([]);
+    it('should return `undefined` if data is empty', () => {
+      const domain = getDataDomain([]);
       expect(domain).toBeUndefined();
+    });
+
+    describe('with log scale', () => {
+      it('should support negative domain', () => {
+        const domain = getDataDomain([-2, -10, -5, -2, -1], ScaleType.Log);
+        expect(domain).toEqual([-10, -1]);
+      });
+
+      it('should clamp domain min to first positive value when domain crosses zero', () => {
+        const domain = getDataDomain([2, 0, 10, 5, 2, -1], ScaleType.Log);
+        expect(domain).toEqual([2, 10]);
+      });
+
+      it('should return `undefined` if domain is not supported', () => {
+        const domain = getDataDomain([-2, 0, -10, -5, -2, -1], ScaleType.Log);
+        expect(domain).toBeUndefined();
+      });
     });
   });
 

--- a/src/packages/lib.ts
+++ b/src/packages/lib.ts
@@ -10,15 +10,11 @@ export { default as ColorBar } from '../h5web/visualizations/heatmap/ColorBar';
 // Utilities
 export {
   computeVisSize,
-  findDomain,
-  getSupportedDomain,
+  getDataDomain,
   extendDomain,
 } from '../h5web/visualizations/shared/utils';
 
-export {
-  useDataDomain,
-  useSupportedDomain,
-} from '../h5web/visualizations/shared/hooks';
+export { useDataDomain } from '../h5web/visualizations/shared/hooks';
 
 export {
   getDims,

--- a/src/stories/HeatmapVis.stories.tsx
+++ b/src/stories/HeatmapVis.stories.tsx
@@ -6,17 +6,18 @@ import FillHeight from '../../.storybook/decorators/FillHeight';
 import HeatmapVis, {
   HeatmapVisProps,
 } from '../h5web/visualizations/heatmap/HeatmapVis';
-import { findDomain } from '../h5web/visualizations/shared/utils';
 import { ScaleType } from '../h5web/visualizations/shared/models';
 import { INTERPOLATORS } from '../h5web/visualizations/heatmap/interpolators';
 import { getMockedDataset } from '../h5web/providers/mock/utils';
+import { getDataDomain } from '../packages/lib';
 
 // A 2D dataset
 const dataset = getMockedDataset<number[][]>('/nD/twoD');
 const values = dataset.value.flat(Infinity) as number[];
 
 const dataArray = ndarray<number>(values, dataset.dims).transpose(1, 0); // makes for a nicer-looking heatmap
-const domain = findDomain(values);
+const domain = getDataDomain(values);
+const logSafeDomain = getDataDomain(values, ScaleType.Log);
 
 const Template: Story<HeatmapVisProps> = (args): ReactElement => (
   <HeatmapVis {...args} />
@@ -48,7 +49,7 @@ export const LogScale = Template.bind({});
 
 LogScale.args = {
   dataArray,
-  domain,
+  domain: logSafeDomain,
   scaleType: ScaleType.Log,
 };
 

--- a/src/stories/Home.stories.mdx
+++ b/src/stories/Home.stories.mdx
@@ -101,10 +101,8 @@ const dataArray = ndarray<number>(values, dataset.dims);
 The library exposes a number of utility functions, which are documented below, as well as all the enums and types used by these utility functions.
 If you use only the top-level visualization components, the only utilities you need are `findDomain` and/or `useDataDomain`.
 
-- **`findDomain(data: number[]): Domain | undefined`** - Find the min and max values contained in a flat array of numbers. Uses [`extent`](https://github.com/d3/d3-array#extent) from `d3-array`.
-- **`useDataDomain(...args): Domain | undefined`** - Memoised React hook wrapper of `findDomain`.
-- **`getSupportedDomain(domain: Domain | undefined, scaleType: ScaleType, values: number[]): Domain | undefined`** - Check that a domain is supported by a given scale type. If the domain is not supported, find a domain that is (with `findDomain`).
-- **`useSupportedDomain(...args): Domain | undefined`** - Memoised React hook wrapper of `getSupportedDomain`.
+- **`getDataDomain(values: number[], scaleType: ScaleType = ScaleType.Linear): Domain | undefined`** - Find the min and max values contained in a flat array of numbers. If `scaleType` is `ScaleType.Log` and the domain crosses zero, clamp the min to the first positive value or return `undefined` if the domain is not supported (i.e. `[-x, 0]`).
+- **`useDataDomain(...args): Domain | undefined`** - Memoised React hook wrapper of `getDataDomain`.
 - **`extendDomain(bareDomain: Domain, extendFactor: number, isLog?: boolean): Domain`** - Extend a domain by a given factor.
 - **`computeVisSize(availableSize: Size, aspectRatio?: number): Size | undefined`** - Compute the optimal size for a visualization to fill the available space given an optional aspect ratio.
 - **`getDims(dataArray: DataArray): Dims`** - Get the dimensions of a `ndarray` as a `{ rows, cols }` object.

--- a/src/stories/LineVis.stories.tsx
+++ b/src/stories/LineVis.stories.tsx
@@ -2,17 +2,18 @@ import React, { ReactElement } from 'react';
 import type { Story } from '@storybook/react/types-6-0';
 import ndarray from 'ndarray';
 import FillHeight from '../../.storybook/decorators/FillHeight';
-import { findDomain } from '../h5web/visualizations/shared/utils';
 import { ScaleType } from '../h5web/visualizations/shared/models';
 import LineVis, { LineVisProps } from '../h5web/visualizations/line/LineVis';
 import { CurveType } from '../h5web/visualizations/line/models';
 import { getMockedDataset } from '../h5web/providers/mock/utils';
+import { getDataDomain } from '../packages/lib';
 
 const oneDimDataset = getMockedDataset<number[]>('/nD/oneD');
 const values = oneDimDataset.value;
 
 const dataArray = ndarray<number>(values, oneDimDataset.dims);
-const domain = findDomain(values);
+const domain = getDataDomain(values);
+const logSafeDomain = getDataDomain(values, ScaleType.Log);
 
 const Template: Story<LineVisProps> = (args): ReactElement => (
   <LineVis {...args} />
@@ -52,7 +53,7 @@ export const LogScale = Template.bind({});
 
 LogScale.args = {
   dataArray,
-  domain,
+  domain: logSafeDomain,
   scaleType: ScaleType.Log,
 };
 


### PR DESCRIPTION
Fix #246 

`getSupportedDomain` merges into `getDataDomain` so that `useDataDomain` now returns a supported domain right away. In other words, the visualizations no longer compute the supported domain themselves; they must now receive a supported domain as prop.

Passing an unsupported domain to a visualization fails silently (but not invisibly); it does not throw an error and break the app. This can be observed in the Storybook:

- with `LineVis`, the y axis and the curve are not rendered;
- with `HeatmapVis`, the textured mesh and the color bar's axis are not rendered.

I believe this behaviour to be adequate and sufficient.