### PR TITLE
Fetch metadata in provider before rendering app

### DIFF
--- a/src/h5web/App.test.tsx
+++ b/src/h5web/App.test.tsx
@@ -43,7 +43,7 @@ test('switch between "display" and "inspect" modes', async () => {
     queryByText,
   } = renderApp();
 
-  const inspectBtn = getByRole('tab', { name: 'Inspect' });
+  const inspectBtn = await findByRole('tab', { name: 'Inspect' });
   const displayBtn = getByRole('tab', { name: 'Display' });
 
   // Switch to "inspect" mode
@@ -127,12 +127,8 @@ test('navigate groups in explorer', async () => {
   fireEvent.click(groupBtn);
 
   expect(queryByRole('treeitem', { name: '1_cormap' })).not.toBeInTheDocument();
-
-  // `waitFor` avoids warning due to async work occurring after completion of test
-  await waitFor(() => {
-    expect(groupBtn).toHaveAttribute('aria-selected', 'true');
-    expect(groupBtn).toHaveAttribute('aria-expanded', 'false');
-  });
+  expect(groupBtn).toHaveAttribute('aria-selected', 'true');
+  expect(groupBtn).toHaveAttribute('aria-expanded', 'false');
 });
 
 test('visualise a scalar dataset', async () => {
@@ -175,10 +171,13 @@ test('switch visualisations', async () => {
   expect(matrixTab).toBeVisible();
   expect(matrixTab).toHaveAttribute('aria-selected', 'false');
 
-  // Switching visualisations
+  // Switch to Matrix visualisation
   fireEvent.click(matrixTab);
-  expect(matrixTab).toHaveAttribute('aria-selected', 'true');
-  expect(lineTab).toHaveAttribute('aria-selected', 'false');
+
+  await waitFor(() => {
+    expect(matrixTab).toHaveAttribute('aria-selected', 'true');
+    expect(lineTab).toHaveAttribute('aria-selected', 'false');
+  });
 });
 
 test('inspect a dataset', async () => {
@@ -233,10 +232,13 @@ test('display mapping for X axis when visualizing 2D dataset as Line', async () 
 
   // Ensure that the swap from [0, 'x'] to ['x', 0] works
   fireEvent.click(xDimsButtons[0]);
-  expect(xDimsButtons[0]).toBeChecked();
-  expect(xDimsButtons[1]).not.toBeChecked();
-  const D1Slider = getByRole('slider');
-  expect(D1Slider).toHaveAttribute('aria-valueNow', '0');
+
+  await waitFor(() => {
+    expect(xDimsButtons[0]).toBeChecked();
+    expect(xDimsButtons[1]).not.toBeChecked();
+    const D1Slider = getByRole('slider');
+    expect(D1Slider).toHaveAttribute('aria-valueNow', '0');
+  });
 });
 
 test('display mappings for X and Y axes when visualizing 2D dataset as Heatmap', async () => {
@@ -274,7 +276,12 @@ test('display mappings for X and Y axes when visualizing 2D dataset as Heatmap',
 });
 
 test('display one dimension slider and mappings for X and Y axes when visualizing 3D dataset as Matrix', async () => {
-  const { getByRole, getByLabelText, findByRole } = renderApp();
+  const {
+    getByRole,
+    getByLabelText,
+    findByRole,
+    findByLabelText,
+  } = renderApp();
 
   // Select the 3D dataset nD/threeD
   fireEvent.click(await findByRole('treeitem', { name: 'nD' }));
@@ -284,7 +291,7 @@ test('display one dimension slider and mappings for X and Y axes when visualizin
   fireEvent.click(await findByRole('tab', { name: 'Matrix' }));
 
   // Ensure that the dimension mapper is visible for X and Y
-  const xRadioGroup = getByLabelText('Dimension as x axis');
+  const xRadioGroup = await findByLabelText('Dimension as x axis');
   expect(xRadioGroup).toBeVisible();
   const xDimsButtons = getAllByRoleInElement(xRadioGroup, 'radio');
   expect(xDimsButtons).toHaveLength(3);

--- a/src/h5web/dataset-visualizer/DatasetVisualizer.tsx
+++ b/src/h5web/dataset-visualizer/DatasetVisualizer.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState, memo } from 'react';
+import React, { ReactElement, useState } from 'react';
 import type { HDF5Dataset } from '../providers/models';
 import styles from '../Visualizer.module.css';
 import VisSelector from './VisSelector';
@@ -44,5 +44,4 @@ function DatasetVisualizer(props: Props): ReactElement {
   );
 }
 
-// Optimise consecutive renders when selecting a link in the explorer
-export default memo(DatasetVisualizer);
+export default DatasetVisualizer;

--- a/src/h5web/dataset-visualizer/VisDisplay.tsx
+++ b/src/h5web/dataset-visualizer/VisDisplay.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useContext, useEffect } from 'react';
-import { useSetState, useTimeoutFn } from 'react-use';
+import { useSetState, useTimeoutFn, usePromise } from 'react-use';
 import type { Vis, DimensionMapping } from './models';
 import type {
   HDF5Dataset,
@@ -31,6 +31,7 @@ function VisDisplay(props: Props): ReactElement {
   });
 
   const { getValue } = useContext(ProviderContext);
+  const ifMounted = usePromise();
   const [scheduleLoadingFlag, cancelLoadingFlag] = useTimeoutFn(() => {
     mergeState({ loading: true });
   }, 50);
@@ -39,11 +40,18 @@ function VisDisplay(props: Props): ReactElement {
   useEffect(() => {
     scheduleLoadingFlag(); // in case retrieving value takes too long (e.g. initial fetch of `SilxProvider`)
 
-    getValue(dataset.id).then((val) => {
+    ifMounted(getValue(dataset.id)).then((val) => {
       cancelLoadingFlag();
       mergeState({ value: val, loading: false });
     });
-  }, [cancelLoadingFlag, dataset, getValue, mergeState, scheduleLoadingFlag]);
+  }, [
+    cancelLoadingFlag,
+    dataset,
+    getValue,
+    mergeState,
+    ifMounted,
+    scheduleLoadingFlag,
+  ]);
 
   const { Component: VisComponent } = VIS_DEFS[activeVis];
 

--- a/src/h5web/explorer/Explorer.tsx
+++ b/src/h5web/explorer/Explorer.tsx
@@ -1,12 +1,13 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo, useContext } from 'react';
 import { FiFileText } from 'react-icons/fi';
 import type { HDF5Link } from '../providers/models';
 import type { TreeNode, ExpandedNodes } from './models';
 import TreeView from './TreeView';
 import styles from './Explorer.module.css';
 import Icon from './Icon';
-import { useDomain, useMetadataTree } from '../providers/hooks';
 import { getNodesOnPath } from './utils';
+import { buildTree } from '../providers/utils';
+import { ProviderContext } from '../providers/context';
 
 const DEFAULT_PATH: number[] = JSON.parse(
   process.env.REACT_APP_DEFAULT_PATH || '[]'
@@ -20,8 +21,8 @@ interface Props {
 function Explorer(props: Props): JSX.Element {
   const { onSelect, selectedNode } = props;
 
-  const domain = useDomain();
-  const tree = useMetadataTree();
+  const { domain, metadata } = useContext(ProviderContext);
+  const tree = useMemo(() => buildTree(metadata, domain), [domain, metadata]);
 
   const [expandedNodes, setExpandedNodes] = useState<ExpandedNodes>({});
 

--- a/src/h5web/providers/Provider.tsx
+++ b/src/h5web/providers/Provider.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode } from 'react';
+import { useAsync } from 'react-use';
 import { ProviderAPI, ProviderContext } from './context';
 
 interface Props {
@@ -9,15 +10,18 @@ interface Props {
 function Provider(props: Props): JSX.Element {
   const { api, children } = props;
 
-  if (!api) {
+  // Wait until metadata is fetched before rendering app
+  const { value: metadata } = useAsync(async () => api?.getMetadata(), [api]);
+
+  if (!api || !metadata) {
     return <></>;
   }
 
   return (
     <ProviderContext.Provider
       value={{
-        getDomain: api.getDomain.bind(api),
-        getMetadata: api.getMetadata.bind(api),
+        domain: api.domain,
+        metadata,
         getValue: api.getValue.bind(api),
       }}
     >

--- a/src/h5web/providers/context.ts
+++ b/src/h5web/providers/context.ts
@@ -2,19 +2,13 @@ import { createContext } from 'react';
 import type { HDF5Id, HDF5Value, HDF5Metadata } from './models';
 
 export abstract class ProviderAPI {
-  abstract getDomain: () => string;
-  abstract getMetadata: () => Promise<HDF5Metadata>;
-  abstract getValue: (id: HDF5Id) => Promise<HDF5Value>;
+  abstract domain: string;
+  abstract async getMetadata(): Promise<HDF5Metadata>;
+  abstract async getValue(id: HDF5Id): Promise<HDF5Value>;
 }
 
-function missing(): never {
-  throw new Error(
-    'Missing data provider context; please wrap `<H5Web />` with one of the available providers.'
-  );
-}
-
-export const ProviderContext = createContext<ProviderAPI>({
-  getDomain: missing as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-  getMetadata: missing as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-  getValue: missing as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-});
+export const ProviderContext = createContext<{
+  domain: string;
+  metadata: HDF5Metadata;
+  getValue: ProviderAPI['getValue'];
+}>({} as any); // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/src/h5web/providers/hooks.ts
+++ b/src/h5web/providers/hooks.ts
@@ -1,44 +1,16 @@
-import { useState, useEffect, useContext } from 'react';
+import { useContext } from 'react';
 import type { HDF5Link, HDF5Entity } from './models';
-import type { TreeNode } from '../explorer/models';
 import { ProviderContext } from './context';
-import { buildTree, isReachable } from './utils';
-
-export function useDomain(): string {
-  const { getDomain } = useContext(ProviderContext);
-  return getDomain();
-}
-
-export function useMetadataTree(): TreeNode<HDF5Link> | undefined {
-  const { getMetadata } = useContext(ProviderContext);
-  const [tree, setTree] = useState<TreeNode<HDF5Link>>();
-  const domain = useDomain();
-
-  useEffect(() => {
-    getMetadata()
-      .then((metadata) => buildTree(metadata, domain))
-      .then(setTree);
-  }, [domain, getMetadata]);
-
-  return tree;
-}
+import { isReachable } from './utils';
 
 export function useEntity(link?: HDF5Link): HDF5Entity | undefined {
-  const { getMetadata } = useContext(ProviderContext);
-  const [entity, setEntity] = useState<HDF5Entity>();
+  const { metadata } = useContext(ProviderContext);
 
-  useEffect(() => {
-    if (!link || !isReachable(link)) {
-      setEntity(undefined);
-      return;
-    }
+  if (!link || !isReachable(link)) {
+    return undefined;
+  }
 
-    getMetadata().then((metadata) => {
-      const { collection, id } = link;
-      const dict = metadata[collection];
-      setEntity(dict && dict[id]);
-    });
-  }, [link, getMetadata]);
-
-  return entity;
+  const { collection, id } = link;
+  const dict = metadata[collection];
+  return dict && dict[id];
 }

--- a/src/h5web/providers/mock/api.ts
+++ b/src/h5web/providers/mock/api.ts
@@ -27,11 +27,7 @@ function addMissingProperties<T extends HDF5Entity>(
 }
 
 export class MockApi implements ProviderAPI {
-  constructor(private readonly domain: string) {}
-
-  public getDomain(): string {
-    return this.domain;
-  }
+  constructor(public readonly domain: string) {}
 
   public async getMetadata(): Promise<HDF5Metadata> {
     const typedMockData = mockData as MockHDF5Metadata;

--- a/src/h5web/providers/silx/api.ts
+++ b/src/h5web/providers/silx/api.ts
@@ -5,32 +5,23 @@ import { HDF5Id, HDF5Value, HDF5Metadata, HDF5Collection } from '../models';
 import type { SilxValuesResponse, SilxMetadataResponse } from './models';
 
 export class SilxApi implements ProviderAPI {
+  public readonly domain: string;
   private readonly client: AxiosInstance;
-
-  private metadata?: HDF5Metadata;
   private values?: Record<string, HDF5Value>;
 
-  constructor(private readonly domain: string) {
+  constructor(domain: string) {
+    this.domain = domain;
     this.client = axios.create({
       baseURL: `https://www.silx.org/pub/h5web/${this.domain}`,
     });
   }
 
-  public getDomain(): string {
-    return this.domain;
-  }
-
   public async getMetadata(): Promise<HDF5Metadata> {
-    if (this.metadata) {
-      return this.metadata;
-    }
-
     const { data } = await this.client.get<SilxMetadataResponse>(
       '/metadata.json'
     );
 
-    this.metadata = this.transformMetadata(data);
-    return this.metadata;
+    return this.transformMetadata(data);
   }
 
   public async getValue(id: HDF5Id): Promise<HDF5Value> {

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,5 +1,4 @@
-// https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom'; // https://github.com/testing-library/jest-dom
 
 // Define properties not supported by JSDOM to avoid Re-flex warnings
 // https://github.com/leefsmp/Re-Flex/issues/27
@@ -9,4 +8,25 @@ import '@testing-library/jest-dom';
     configurable: true,
     value: 500,
   });
+});
+
+// Fail if error or warning has been logged to the console (notably by React or React Testing Library)
+// Inpsired by https://github.com/facebook/jest/issues/6121#issuecomment-493529970
+let consoleHasErrorOrWarning = false;
+const { error, warn } = console;
+
+global.console.error = (...args) => {
+  consoleHasErrorOrWarning = true;
+  error(...args);
+};
+global.console.warn = (...args) => {
+  consoleHasErrorOrWarning = true;
+  warn(...args);
+};
+
+afterEach(() => {
+  if (consoleHasErrorOrWarning) {
+    consoleHasErrorOrWarning = false;
+    throw new Error('Console has error or warning');
+  }
 });


### PR DESCRIPTION
This allows the metadata to be provided synchronously to components, which simplifies a bunch of code.

`useEntity` no longer contains an async state, which means that in no longer triggers an extra rendering of `App`, which makes the use of `React.memo` in `DatasetVisualizer` obsolete. I was tempted to turn `useEntity(link)` into `getEntity(metadata, link)` to be able to call the function more freely, but I'll leave that until I actually need the flexbiity (e.g. to find the `default` NeXus group).