### PR TITLE
 LineVis and HeatmapVis now accept arrays of values for x and y

### DIFF
--- a/src/h5web/visualizations/heatmap/HeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapVis.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { format } from 'd3-format';
 import type ndarray from 'ndarray';
+import { range } from 'd3-array';
 import styles from './HeatmapVis.module.css';
 import ColorBar from './ColorBar';
 import Mesh from './Mesh';
@@ -10,6 +11,7 @@ import VisCanvas from '../shared/VisCanvas';
 import { getDims } from './utils';
 import { Domain, ScaleType } from '../shared/models';
 import type { ColorMap } from './models';
+import { getDomain, getValueToIndexScale } from '../shared/utils';
 
 interface Props {
   dataArray: ndarray<number>;
@@ -19,6 +21,8 @@ interface Props {
   keepAspectRatio?: boolean;
   showGrid?: boolean;
   showLoader?: boolean;
+  abscissas?: number[];
+  ordinates?: number[];
 }
 
 function HeatmapVis(props: Props): JSX.Element {
@@ -35,19 +39,66 @@ function HeatmapVis(props: Props): JSX.Element {
   const { rows, cols } = getDims(dataArray);
   const aspectRatio = keepAspectRatio ? cols / rows : undefined; // width / height <=> cols / rows
 
+  const { abscissas = range(cols + 1), ordinates = range(rows + 1) } = props;
+
+  if (abscissas.length !== cols + 1) {
+    throw new Error(
+      `Abscissas size (${
+        abscissas.length
+      }) does not match data length along X (${cols + 1})`
+    );
+  }
+  if (ordinates.length !== rows + 1) {
+    throw new Error(
+      `Ordinate size (${
+        ordinates.length
+      }) does not match data length along Y (${rows + 1})`
+    );
+  }
+
+  const abscissaToIndex = getValueToIndexScale(abscissas);
+
+  const abscissaDomain = useMemo(() => {
+    return getDomain(abscissas);
+  }, [abscissas]);
+  if (abscissaDomain === undefined) {
+    throw new Error(`Abscissas (${abscissas}) have an empty domain`);
+  }
+
+  const ordinateToIndex = getValueToIndexScale(ordinates);
+
+  const ordinateDomain = useMemo(() => {
+    return getDomain(ordinates);
+  }, [ordinates]);
+  if (ordinateDomain === undefined) {
+    throw new Error(`Ordinates (${ordinates}) have an empty domain`);
+  }
+
   return (
     <div className={styles.root}>
       <VisCanvas
-        abscissaConfig={{ indexDomain: [0, cols], showGrid }}
-        ordinateConfig={{ indexDomain: [0, rows], showGrid }}
+        abscissaConfig={{
+          domain: abscissaDomain,
+          showGrid,
+          isIndexAxis: !abscissas,
+        }}
+        ordinateConfig={{
+          domain: ordinateDomain,
+          showGrid,
+          isIndexAxis: !ordinates,
+        }}
         aspectRatio={aspectRatio}
       >
         <TooltipMesh
-          formatIndex={([x, y]) => `x=${Math.floor(x)}, y=${Math.floor(y)}`}
+          formatIndex={([x, y]) => {
+            return `x=${abscissas[abscissaToIndex(x)]}, y=${
+              ordinates[ordinateToIndex(y)]
+            }`;
+          }}
           formatValue={([x, y]) => {
-            return x < cols && y < rows
-              ? format('.3')(dataArray.get(Math.floor(y), Math.floor(x)))
-              : undefined;
+            return format('.3')(
+              dataArray.get(ordinateToIndex(y), abscissaToIndex(x))
+            );
           }}
           guides="both"
         />

--- a/src/h5web/visualizations/heatmap/MappedHeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/MappedHeatmapVis.tsx
@@ -4,7 +4,7 @@ import type { HDF5Dataset, HDF5Value } from '../../providers/models';
 import type { DimensionMapping } from '../../dataset-visualizer/models';
 import HeatmapVis from './HeatmapVis';
 import { assertArray } from '../shared/utils';
-import { useMappedArray, useDataDomain, useBaseArray } from '../shared/hooks';
+import { useMappedArray, useDomain, useBaseArray } from '../shared/hooks';
 import { useHeatmapConfig } from './config';
 
 interface Props {
@@ -30,7 +30,7 @@ function MappedHeatmapVis(props: Props): ReactElement {
 
   const baseArray = useBaseArray(dataset, value);
   const dataArray = useMappedArray(baseArray, mapperState);
-  const dataDomain = useDataDomain(
+  const dataDomain = useDomain(
     (autoScale ? dataArray.data : baseArray.data) as number[],
     scaleType
   );

--- a/src/h5web/visualizations/line/DataCurve.tsx
+++ b/src/h5web/visualizations/line/DataCurve.tsx
@@ -10,14 +10,16 @@ import { getAxisScale } from '../shared/utils';
 const DEFAULT_COLOR = '#1b998b';
 
 interface Props {
-  values: number[];
+  abscissas: number[];
+  ordinates: number[];
   color?: string;
   curveType?: CurveType;
 }
 
 function DataCurve(props: Props): JSX.Element {
   const {
-    values,
+    abscissas,
+    ordinates,
     color = DEFAULT_COLOR,
     curveType = CurveType.LineOnly,
   } = props;
@@ -30,10 +32,10 @@ function DataCurve(props: Props): JSX.Element {
     const abscissaScale = getAxisScale(abscissaInfo, width);
     const ordinateScale = getAxisScale(ordinateInfo, height);
 
-    const points = values.map((val, index) => {
+    const points = ordinates.map((val, index) => {
       const ordinate = ordinateScale(val);
       return new Vector3(
-        abscissaScale(index),
+        abscissaScale(abscissas[index]),
         // This is to avoid a three.js warning when ordinateScale(val) is Infinity
         Number.isFinite(ordinate) ? ordinate : 0,
         // Move NaN/Infinity out of the camera FOV (negative val for logScale).
@@ -45,7 +47,7 @@ function DataCurve(props: Props): JSX.Element {
     const geometry = new BufferGeometry();
     geometry.setFromPoints(points);
     return geometry;
-  }, [abscissaInfo, camera, height, ordinateInfo, values, width]);
+  }, [abscissaInfo, abscissas, camera, height, ordinateInfo, ordinates, width]);
 
   const showLine = curveType !== CurveType.GlyphsOnly;
   const showGlyphs = curveType !== CurveType.LineOnly;

--- a/src/h5web/visualizations/line/LineVis.tsx
+++ b/src/h5web/visualizations/line/LineVis.tsx
@@ -1,23 +1,25 @@
 import React, { ReactElement, useMemo } from 'react';
 import { format } from 'd3-format';
 import type ndarray from 'ndarray';
+import { range } from 'd3-array';
 import styles from './LineVis.module.css';
 import DataCurve from './DataCurve';
 import VisCanvas from '../shared/VisCanvas';
 import PanZoomMesh from '../shared/PanZoomMesh';
 import TooltipMesh from '../shared/TooltipMesh';
-import { extendDomain } from '../shared/utils';
 import { ScaleType, Domain } from '../shared/models';
 import { CurveType } from './models';
+import { getValueToIndexScale, getDomain, extendDomain } from '../shared/utils';
 
 const DEFAULT_DOMAIN: Domain = [0.1, 1];
 
 interface Props {
   dataArray: ndarray<number>;
-  domain: Domain | undefined;
+  domain?: Domain;
   scaleType?: ScaleType;
   curveType?: CurveType;
   showGrid?: boolean;
+  abscissas?: number[];
 }
 
 function LineVis(props: Props): ReactElement {
@@ -27,9 +29,26 @@ function LineVis(props: Props): ReactElement {
     curveType = CurveType.LineOnly,
     showGrid = true,
     scaleType = ScaleType.Linear,
+    abscissas = range(dataArray.size),
   } = props;
 
-  const indexDomain = extendDomain([0, dataArray.size - 1], 0.01);
+  if (abscissas.length !== dataArray.size) {
+    throw new Error(
+      `Abscissas size (${abscissas.length}) does not match data length (${dataArray.size})`
+    );
+  }
+
+  const abscissaToIndex = getValueToIndexScale(abscissas, true);
+
+  const abscissaDomain = useMemo(() => {
+    const rawDomain = getDomain(abscissas);
+    return rawDomain && extendDomain(rawDomain, 0.01);
+  }, [abscissas]);
+
+  if (abscissaDomain === undefined) {
+    throw new Error(`Abscissas (${abscissas}) have an empty domain`);
+  }
+
   const dataDomain = useMemo(() => {
     return domain
       ? extendDomain(domain, 0.05, scaleType === ScaleType.Log)
@@ -39,24 +58,33 @@ function LineVis(props: Props): ReactElement {
   return (
     <div className={styles.root}>
       <VisCanvas
-        abscissaConfig={{ indexDomain, showGrid }}
-        ordinateConfig={{ dataDomain, showGrid, scaleType }}
+        abscissaConfig={{
+          domain: abscissaDomain,
+          showGrid,
+          isIndexAxis: !abscissas,
+        }}
+        ordinateConfig={{
+          domain: dataDomain,
+          showGrid,
+          scaleType,
+        }}
       >
         <TooltipMesh
-          formatIndex={([x]) => `x=${Math.round(x)}`}
+          formatIndex={([x]) =>
+            `x=${format('0')(abscissas[abscissaToIndex(x)])}`
+          }
           formatValue={([x]) => {
-            const value = dataArray.get(Math.round(x));
+            const value = dataArray.get(abscissaToIndex(x));
             return value !== undefined ? format('.3f')(value) : undefined;
           }}
           guides="vertical"
         />
         <PanZoomMesh />
-        {dataDomain && (
-          <DataCurve
-            curveType={curveType}
-            values={dataArray.data as number[]}
-          />
-        )}
+        <DataCurve
+          curveType={curveType}
+          abscissas={abscissas}
+          ordinates={dataArray.data as number[]}
+        />
       </VisCanvas>
     </div>
   );

--- a/src/h5web/visualizations/line/MappedLineVis.tsx
+++ b/src/h5web/visualizations/line/MappedLineVis.tsx
@@ -3,7 +3,7 @@ import type { HDF5Dataset, HDF5Value } from '../../providers/models';
 import type { DimensionMapping } from '../../dataset-visualizer/models';
 import LineVis from './LineVis';
 import { assertArray } from '../shared/utils';
-import { useMappedArray, useDataDomain, useBaseArray } from '../shared/hooks';
+import { useMappedArray, useDomain, useBaseArray } from '../shared/hooks';
 import { useLineConfig } from './config';
 
 interface Props {
@@ -32,7 +32,7 @@ function MappedLineVis(props: Props): ReactElement {
     disableAutoScale(!baseArray.shape || baseArray.shape.length <= 1);
   }, [baseArray.shape, disableAutoScale]);
 
-  const dataDomain = useDataDomain(
+  const dataDomain = useDomain(
     (autoScale ? dataArray.data : baseArray.data) as number[],
     scaleType
   );

--- a/src/h5web/visualizations/shared/Axis.tsx
+++ b/src/h5web/visualizations/shared/Axis.tsx
@@ -29,7 +29,7 @@ interface Props {
 
 function Axis(props: Props): ReactElement {
   const { type, scale, domain, info, canvasSize } = props;
-  const { scaleType, showGrid, isIndexAxis } = info;
+  const { scaleType, showGrid, onlyIntegers } = info;
 
   const { width, height } = canvasSize;
   const axisLength = type === 'abscissa' ? width : height;
@@ -37,7 +37,7 @@ function Axis(props: Props): ReactElement {
   const [AxisComponent, GridComponent] = COMPONENTS[type];
 
   const numTicks = adaptedNumTicks(axisLength);
-  const ticksProp = isIndexAxis
+  const ticksProp = onlyIntegers
     ? { tickValues: getIntegerTicks(domain, numTicks) }
     : { numTicks };
 

--- a/src/h5web/visualizations/shared/AxisSystemProvider.tsx
+++ b/src/h5web/visualizations/shared/AxisSystemProvider.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement, ReactNode, createContext } from 'react';
 import { scaleLinear } from 'd3-scale';
 import { AxisConfig, AxisInfo, ScaleType, SCALE_FUNCTIONS } from './models';
-import { isIndexAxisConfig } from './utils';
 
 export interface AxisInfos {
   abscissaInfo: AxisInfo;
@@ -11,24 +10,19 @@ export interface AxisInfos {
 export const AxisSystemContext = createContext<AxisInfos>({} as AxisInfos);
 
 function getAxisInfo(config: AxisConfig): AxisInfo {
-  if (isIndexAxisConfig(config)) {
-    const { indexDomain, showGrid = false } = config;
-    return {
-      isIndexAxis: true,
-      scaleFn: scaleLinear,
-      domain: indexDomain,
-      scaleType: ScaleType.Linear,
-      showGrid,
-    };
-  }
+  const {
+    domain,
+    scaleType = ScaleType.Linear,
+    isIndexAxis,
+    showGrid = false,
+  } = config;
 
-  const { dataDomain, scaleType = ScaleType.Linear, showGrid = false } = config;
   return {
-    isIndexAxis: false,
-    scaleFn: SCALE_FUNCTIONS[scaleType],
-    domain: dataDomain,
-    scaleType,
+    onlyIntegers: isIndexAxis,
+    scaleFn: isIndexAxis ? scaleLinear : SCALE_FUNCTIONS[scaleType],
+    scaleType: isIndexAxis ? ScaleType.Linear : scaleType,
     showGrid,
+    domain,
   };
 }
 

--- a/src/h5web/visualizations/shared/hooks.ts
+++ b/src/h5web/visualizations/shared/hooks.ts
@@ -6,7 +6,7 @@ import { createMemo } from 'react-use';
 import { useFrame } from 'react-three-fiber';
 import type { HDF5Dataset, HDF5SimpleShape } from '../../providers/models';
 import type { DimensionMapping } from '../../dataset-visualizer/models';
-import { getDataDomain } from './utils';
+import { getDomain } from './utils';
 
 export function useBaseArray<T>(dataset: HDF5Dataset, value: T[]): ndarray<T> {
   const rawDims = (dataset.shape as HDF5SimpleShape).dims;
@@ -41,7 +41,7 @@ export function useMappedArray<T>(
   }, [mapperState, baseArray]);
 }
 
-export const useDataDomain = createMemo(getDataDomain);
+export const useDomain = createMemo(getDomain);
 
 export function useFrameRendering(): void {
   const [, setNum] = useState();

--- a/src/h5web/visualizations/shared/models.ts
+++ b/src/h5web/visualizations/shared/models.ts
@@ -23,19 +23,12 @@ export type Size = { width: number; height: number };
 
 export type Domain = [number, number];
 
-export interface IndexAxisConfig {
-  indexDomain: Domain;
-  showGrid?: boolean;
-  scaleType?: never; // invalid
-}
-
-export interface DataAxisConfig {
-  dataDomain: Domain;
+export interface AxisConfig {
+  isIndexAxis?: boolean;
+  domain: Domain;
   showGrid?: boolean;
   scaleType?: ScaleType;
 }
-
-export type AxisConfig = IndexAxisConfig | DataAxisConfig;
 
 export type ScaleFn = typeof scaleLinear | typeof scaleLog | typeof scaleSymlog;
 
@@ -45,7 +38,7 @@ export type AxisScale =
   | ScaleSymLog<number, number>;
 
 export interface AxisInfo {
-  isIndexAxis: boolean;
+  onlyIntegers?: boolean;
   scaleFn: ScaleFn;
   domain: Domain;
   scaleType: ScaleType;

--- a/src/h5web/visualizations/shared/utils.test.ts
+++ b/src/h5web/visualizations/shared/utils.test.ts
@@ -1,5 +1,5 @@
 import { tickStep } from 'd3-array';
-import { computeVisSize, getIntegerTicks, getDataDomain } from './utils';
+import { computeVisSize, getIntegerTicks, getDomain } from './utils';
 import { ScaleType } from './models';
 
 describe('Shared visualization utilities', () => {
@@ -55,31 +55,31 @@ describe('Shared visualization utilities', () => {
     });
   });
 
-  describe('getDataDomain', () => {
+  describe('getDomain', () => {
     it('should return min and max values of data array', () => {
       const data = [2, 0, 10, 5, 2, -1];
-      const domain = getDataDomain(data);
+      const domain = getDomain(data);
       expect(domain).toEqual([-1, 10]);
     });
 
     it('should return `undefined` if data is empty', () => {
-      const domain = getDataDomain([]);
+      const domain = getDomain([]);
       expect(domain).toBeUndefined();
     });
 
     describe('with log scale', () => {
       it('should support negative domain', () => {
-        const domain = getDataDomain([-2, -10, -5, -2, -1], ScaleType.Log);
+        const domain = getDomain([-2, -10, -5, -2, -1], ScaleType.Log);
         expect(domain).toEqual([-10, -1]);
       });
 
       it('should clamp domain min to first positive value when domain crosses zero', () => {
-        const domain = getDataDomain([2, 0, 10, 5, 2, -1], ScaleType.Log);
+        const domain = getDomain([2, 0, 10, 5, 2, -1], ScaleType.Log);
         expect(domain).toEqual([2, 10]);
       });
 
       it('should return `undefined` if domain is not supported', () => {
-        const domain = getDataDomain([-2, 0, -10, -5, -2, -1], ScaleType.Log);
+        const domain = getDomain([-2, 0, -10, -5, -2, -1], ScaleType.Log);
         expect(domain).toBeUndefined();
       });
     });

--- a/src/packages/lib.ts
+++ b/src/packages/lib.ts
@@ -10,11 +10,11 @@ export { default as ColorBar } from '../h5web/visualizations/heatmap/ColorBar';
 // Utilities
 export {
   computeVisSize,
-  getDataDomain,
+  getDomain,
   extendDomain,
 } from '../h5web/visualizations/shared/utils';
 
-export { useDataDomain } from '../h5web/visualizations/shared/hooks';
+export { useDomain } from '../h5web/visualizations/shared/hooks';
 
 export {
   getDims,
@@ -29,8 +29,6 @@ export type {
   Domain,
   Size,
   AxisConfig,
-  IndexAxisConfig,
-  DataAxisConfig,
   AxisOffsets,
 } from '../h5web/visualizations/shared/models';
 

--- a/src/stories/AxisSystem.stories.tsx
+++ b/src/stories/AxisSystem.stories.tsx
@@ -15,27 +15,27 @@ const Template: Story<VisCanvasProps> = (args): ReactElement => (
 export const IndexDomains = Template.bind({});
 
 IndexDomains.args = {
-  abscissaConfig: { indexDomain: [0, 3], showGrid: true },
-  ordinateConfig: { indexDomain: [50, 100], showGrid: true },
+  abscissaConfig: { domain: [0, 3], showGrid: true, isIndexAxis: true },
+  ordinateConfig: { domain: [50, 100], showGrid: true, isIndexAxis: true },
 };
 
-export const DataDomains = Template.bind({});
+export const ArbitraryDomains = Template.bind({});
 
-DataDomains.args = {
-  abscissaConfig: { dataDomain: [0, 3], showGrid: true },
-  ordinateConfig: { dataDomain: [50, 100], showGrid: true },
+ArbitraryDomains.args = {
+  abscissaConfig: { domain: [0, 3], showGrid: true },
+  ordinateConfig: { domain: [50, 100], showGrid: true },
 };
 
 export const LogScales = Template.bind({});
 
 LogScales.args = {
   abscissaConfig: {
-    dataDomain: [1, 10],
+    domain: [1, 10],
     showGrid: true,
     scaleType: ScaleType.Log,
   },
   ordinateConfig: {
-    dataDomain: [-10, 10],
+    domain: [-10, 10],
     showGrid: true,
     scaleType: ScaleType.SymLog,
   },
@@ -44,23 +44,23 @@ LogScales.args = {
 export const AspectRatio = Template.bind({});
 
 AspectRatio.args = {
-  abscissaConfig: { indexDomain: [0, 10], showGrid: true },
-  ordinateConfig: { indexDomain: [0, 2], showGrid: true },
+  abscissaConfig: { domain: [0, 10], showGrid: true, isIndexAxis: true },
+  ordinateConfig: { domain: [0, 2], showGrid: true, isIndexAxis: true },
   aspectRatio: 10 / 2,
 };
 
 export const NoGrid = Template.bind({});
 
 NoGrid.args = {
-  abscissaConfig: { indexDomain: [-5, 20], showGrid: false },
-  ordinateConfig: { dataDomain: [0, 2], showGrid: false },
+  abscissaConfig: { domain: [-5, 20], showGrid: false, isIndexAxis: true },
+  ordinateConfig: { domain: [0, 2], showGrid: false },
 };
 
 export const InheritedStyles = Template.bind({});
 
 InheritedStyles.args = {
-  abscissaConfig: { indexDomain: [0, 50], showGrid: true },
-  ordinateConfig: { indexDomain: [0, 3], showGrid: true },
+  abscissaConfig: { domain: [0, 50], showGrid: true, isIndexAxis: true },
+  ordinateConfig: { domain: [0, 3], showGrid: true, isIndexAxis: true },
 };
 
 InheritedStyles.decorators = [

--- a/src/stories/HeatmapVis.stories.tsx
+++ b/src/stories/HeatmapVis.stories.tsx
@@ -10,7 +10,7 @@ import HeatmapVis, {
 import { ScaleType } from '../h5web/visualizations/shared/models';
 import { INTERPOLATORS } from '../h5web/visualizations/heatmap/interpolators';
 import { getMockedDataset } from '../h5web/providers/mock/utils';
-import { getDataDomain } from '../packages/lib';
+import { getDomain } from '../packages/lib';
 
 // A 2D dataset
 const dataset = getMockedDataset<number[][]>('/nD/twoD');
@@ -20,8 +20,8 @@ const transposedArray = ndarray<number>(values, dataset.dims).transpose(1, 0); /
 // Work with the real array and not the transposed view
 const dataArray = ndarray<number>([], transposedArray.shape);
 assign(dataArray, transposedArray);
-const domain = getDataDomain(values);
-const logSafeDomain = getDataDomain(values, ScaleType.Log);
+const domain = getDomain(values);
+const logSafeDomain = getDomain(values, ScaleType.Log);
 
 const Template: Story<HeatmapVisProps> = (args): ReactElement => (
   <HeatmapVis {...args} />
@@ -101,6 +101,19 @@ LiveDataWithoutLoader.args = {
   dataArray,
   domain,
   showLoader: false,
+};
+
+export const CustomCoordinates = Template.bind({});
+
+CustomCoordinates.args = {
+  dataArray,
+  domain,
+  abscissas: Array(dataArray.shape[1] + 1)
+    .fill(0)
+    .map((x, i) => 100 + 10 * i),
+  ordinates: Array(dataArray.shape[0] + 1)
+    .fill(0)
+    .map((x, i) => -5 + 0.5 * i),
 };
 
 export default {

--- a/src/stories/Home.stories.mdx
+++ b/src/stories/Home.stories.mdx
@@ -99,10 +99,10 @@ const dataArray = ndarray<number>(values, dataset.dims);
 ## Utilities
 
 The library exposes a number of utility functions, which are documented below, as well as all the enums and types used by these utility functions.
-If you use only the top-level visualization components, the only utilities you need are `findDomain` and/or `useDataDomain`.
+If you use only the top-level visualization components, the only utilities you need are `findDomain` and/or `useDomain`.
 
-- **`getDataDomain(values: number[], scaleType: ScaleType = ScaleType.Linear): Domain | undefined`** - Find the min and max values contained in a flat array of numbers. If `scaleType` is `ScaleType.Log` and the domain crosses zero, clamp the min to the first positive value or return `undefined` if the domain is not supported (i.e. `[-x, 0]`).
-- **`useDataDomain(...args): Domain | undefined`** - Memoised React hook wrapper of `getDataDomain`.
+- **`getDomain(values: number[], scaleType: ScaleType = ScaleType.Linear): Domain | undefined`** - Find the min and max values contained in a flat array of numbers. If `scaleType` is `ScaleType.Log` and the domain crosses zero, clamp the min to the first positive value or return `undefined` if the domain is not supported (i.e. `[-x, 0]`).
+- **`useDomain(...args): Domain | undefined`** - Memoised React hook wrapper of `getDomain`.
 - **`extendDomain(bareDomain: Domain, extendFactor: number, isLog?: boolean): Domain`** - Extend a domain by a given factor.
 - **`computeVisSize(availableSize: Size, aspectRatio?: number): Size | undefined`** - Compute the optimal size for a visualization to fill the available space given an optional aspect ratio.
 - **`getDims(dataArray: DataArray): Dims`** - Get the dimensions of a `ndarray` as a `{ rows, cols }` object.

--- a/src/stories/LineVis.stories.tsx
+++ b/src/stories/LineVis.stories.tsx
@@ -6,14 +6,14 @@ import { ScaleType } from '../h5web/visualizations/shared/models';
 import LineVis, { LineVisProps } from '../h5web/visualizations/line/LineVis';
 import { CurveType } from '../h5web/visualizations/line/models';
 import { getMockedDataset } from '../h5web/providers/mock/utils';
-import { getDataDomain } from '../packages/lib';
+import { getDomain } from '../packages/lib';
 
 const oneDimDataset = getMockedDataset<number[]>('/nD/oneD');
 const values = oneDimDataset.value;
 
 const dataArray = ndarray<number>(values, oneDimDataset.dims);
-const domain = getDataDomain(values);
-const logSafeDomain = getDataDomain(values, ScaleType.Log);
+const domain = getDomain(values);
+const logSafeDomain = getDomain(values, ScaleType.Log);
 
 const Template: Story<LineVisProps> = (args): ReactElement => (
   <LineVis {...args} />
@@ -79,6 +79,16 @@ NoGrid.args = {
   dataArray,
   domain,
   showGrid: false,
+};
+
+export const CustomAbscissas = Template.bind({});
+
+CustomAbscissas.args = {
+  dataArray,
+  domain,
+  abscissas: Array(dataArray.size)
+    .fill(0)
+    .map((x, i) => -10 + 0.5 * i),
 };
 
 export default {


### PR DESCRIPTION
... and falls back to indices when arrays are not supplied (previous behaviour)

<s>We may want to discuss a change that may be seen as a regression: the tooltip on the LineVis now shows the X/Y values of the closest point to the left and not of the closest point.
Ex: Previously, moving the mouse to X=28.75 showed the X/Y values for X=29. Now it shows the X/Y values for X=28.

The reason is that the previous behaviour can not be easily reproduced when X represents arbitrary values and not indices.</s>

**EDIT**: Actually, I found a way to do this ! See the end of https://github.com/silx-kit/h5web/pull/251#discussion_r506201340

I will fix the `AxisSystem` story after the first round of discussions.