### PR TITLE
NXSpectrum now uses the axes attribute to fetch the abscissa dataset to be used in the vis.

### DIFF
--- a/src/h5web/providers/Provider.tsx
+++ b/src/h5web/providers/Provider.tsx
@@ -17,12 +17,20 @@ function Provider(props: Props): JSX.Element {
     return <></>;
   }
 
+  const getValue = api.getValue.bind(api);
+
   return (
     <ProviderContext.Provider
       value={{
         domain: api.domain,
         metadata,
-        getValue: api.getValue.bind(api),
+        getValue,
+        getValues: (idsRecord) =>
+          Promise.all(
+            Object.entries(idsRecord).map(([name, id]) =>
+              getValue(id).then((val) => [name, val])
+            )
+          ).then(Object.fromEntries),
       }}
     >
       {children}

--- a/src/h5web/providers/context.ts
+++ b/src/h5web/providers/context.ts
@@ -11,4 +11,7 @@ export const ProviderContext = createContext<{
   domain: string;
   metadata: HDF5Metadata;
   getValue: ProviderAPI['getValue'];
+  getValues: (
+    idsRecord: Record<string, HDF5Id>
+  ) => Promise<Record<string, HDF5Value>>;
 }>({} as any); // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/src/h5web/visualizations/containers/HeatmapVisContainer.tsx
+++ b/src/h5web/visualizations/containers/HeatmapVisContainer.tsx
@@ -36,11 +36,7 @@ function HeatmapVisContainer(props: VisContainerProps): ReactElement {
         mapperState={mapperState}
         onChange={setMapperState}
       />
-      <MappedHeatmapVis
-        value={value}
-        dataset={entity}
-        mapperState={mapperState}
-      />
+      <MappedHeatmapVis value={value} dims={dims} mapperState={mapperState} />
     </>
   );
 }

--- a/src/h5web/visualizations/containers/LineVisContainer.tsx
+++ b/src/h5web/visualizations/containers/LineVisContainer.tsx
@@ -35,7 +35,7 @@ function LineVisContainer(props: VisContainerProps): ReactElement {
         mapperState={mapperState}
         onChange={setMapperState}
       />
-      <MappedLineVis value={value} dataset={entity} mapperState={mapperState} />
+      <MappedLineVis value={value} dims={dims} mapperState={mapperState} />
     </>
   );
 }

--- a/src/h5web/visualizations/containers/MatrixVisContainer.tsx
+++ b/src/h5web/visualizations/containers/MatrixVisContainer.tsx
@@ -30,11 +30,7 @@ function MatrixVisContainer(props: VisContainerProps): ReactElement {
         mapperState={mapperState}
         onChange={setMapperState}
       />
-      <MappedMatrixVis
-        value={value}
-        dataset={entity}
-        mapperState={mapperState}
-      />
+      <MappedMatrixVis value={value} dims={dims} mapperState={mapperState} />
     </>
   );
 }

--- a/src/h5web/visualizations/containers/NxImageContainer.tsx
+++ b/src/h5web/visualizations/containers/NxImageContainer.tsx
@@ -45,11 +45,7 @@ function NxImageContainer(props: VisContainerProps): ReactElement {
         mapperState={mapperState}
         onChange={setMapperState}
       />
-      <MappedHeatmapVis
-        value={value}
-        dataset={dataset}
-        mapperState={mapperState}
-      />
+      <MappedHeatmapVis value={value} dims={dims} mapperState={mapperState} />
     </>
   );
 }

--- a/src/h5web/visualizations/containers/NxSpectrumContainer.tsx
+++ b/src/h5web/visualizations/containers/NxSpectrumContainer.tsx
@@ -1,13 +1,17 @@
 import React, { ReactElement, useState, useContext } from 'react';
 import { range } from 'lodash-es';
-import { HDF5SimpleShape } from '../../providers/models';
-import { useDatasetValue } from './hooks';
-import { assertGroup } from '../../providers/utils';
+import { HDF5SimpleShape, HDF5Id } from '../../providers/models';
+import { useDatasetValues } from './hooks';
+import { assertGroup, isDataset } from '../../providers/utils';
 import DimensionMapper from '../../dimension-mapper/DimensionMapper';
 import { DimensionMapping } from '../../dimension-mapper/models';
 import MappedLineVis from '../line/MappedLineVis';
 import { ProviderContext } from '../../providers/context';
-import { getSignalDataset } from '../nexus/utils';
+import {
+  getSignalDataset,
+  getLinkedEntity,
+  getAxesLabels,
+} from '../nexus/utils';
 import { VisContainerProps } from './models';
 
 function NxSpectrumContainer(props: VisContainerProps): ReactElement {
@@ -15,25 +19,39 @@ function NxSpectrumContainer(props: VisContainerProps): ReactElement {
   assertGroup(entity);
 
   const { metadata } = useContext(ProviderContext);
-  const dataset = getSignalDataset(entity, metadata);
+  const signalDataset = getSignalDataset(entity, metadata);
 
-  if (!dataset) {
+  if (!signalDataset) {
     throw new Error('Signal dataset not found');
   }
 
-  const { dims } = dataset.shape as HDF5SimpleShape;
+  const { dims } = signalDataset.shape as HDF5SimpleShape;
   if (dims.length < 1) {
     throw new Error('Expected dataset with at least one dimension');
   }
+
+  const axesLabels = getAxesLabels(entity);
+
+  const axesIds = axesLabels.reduce<Record<string, HDF5Id>>((acc, axis) => {
+    if (!axis) {
+      return acc;
+    }
+
+    const dataset = getLinkedEntity(entity, metadata, axis);
+    if (dataset && isDataset(dataset)) {
+      acc[axis] = dataset.id;
+    }
+    return acc;
+  }, {});
 
   const [mapperState, setMapperState] = useState<DimensionMapping>([
     ...range(dims.length - 1).fill(0),
     'x',
   ]);
 
-  const value = useDatasetValue(dataset.id);
+  const values = useDatasetValues({ signal: signalDataset.id, ...axesIds });
 
-  if (!value) {
+  if (!values || !values.signal) {
     return <></>;
   }
 
@@ -45,8 +63,10 @@ function NxSpectrumContainer(props: VisContainerProps): ReactElement {
         onChange={setMapperState}
       />
       <MappedLineVis
-        value={value}
-        dataset={dataset}
+        value={values.signal}
+        axesLabels={axesLabels}
+        axesValues={values}
+        dims={dims}
         mapperState={mapperState}
       />
     </>

--- a/src/h5web/visualizations/containers/hooks.ts
+++ b/src/h5web/visualizations/containers/hooks.ts
@@ -8,3 +8,12 @@ export function useDatasetValue(id: HDF5Id): HDF5Value | undefined {
   const [valueReader] = useAsyncResource(getValue, id);
   return valueReader();
 }
+
+export function useDatasetValues(
+  datasetsRecord: Record<string, HDF5Id>
+): Record<string, HDF5Value> | undefined {
+  const { getValues } = useContext(ProviderContext);
+  const [valuesReader] = useAsyncResource(getValues, datasetsRecord);
+
+  return valuesReader();
+}

--- a/src/h5web/visualizations/heatmap/MappedHeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/MappedHeatmapVis.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useEffect } from 'react';
 import { usePrevious } from 'react-use';
-import type { HDF5Dataset, HDF5Value } from '../../providers/models';
+import type { HDF5Value } from '../../providers/models';
 import type { DimensionMapping } from '../../dimension-mapper/models';
 import HeatmapVis from './HeatmapVis';
 import { assertArray } from '../shared/utils';
@@ -9,12 +9,12 @@ import { useHeatmapConfig } from './config';
 
 interface Props {
   value: HDF5Value;
-  dataset: HDF5Dataset;
+  dims: number[];
   mapperState: DimensionMapping;
 }
 
 function MappedHeatmapVis(props: Props): ReactElement {
-  const { value, dataset, mapperState } = props;
+  const { value, dims, mapperState } = props;
   assertArray<number>(value);
 
   const {
@@ -28,7 +28,7 @@ function MappedHeatmapVis(props: Props): ReactElement {
     disableAutoScale,
   } = useHeatmapConfig();
 
-  const baseArray = useBaseArray(dataset, value);
+  const baseArray = useBaseArray(value, dims);
   const dataArray = useMappedArray(baseArray, mapperState);
   const dataDomain = useDomain(
     (autoScale ? dataArray.data : baseArray.data) as number[],

--- a/src/h5web/visualizations/line/MappedLineVis.tsx
+++ b/src/h5web/visualizations/line/MappedLineVis.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useEffect } from 'react';
-import type { HDF5Dataset, HDF5Value } from '../../providers/models';
+import type { HDF5Value } from '../../providers/models';
 import type { DimensionMapping } from '../../dimension-mapper/models';
 import LineVis from './LineVis';
 import { assertArray } from '../shared/utils';
@@ -8,12 +8,14 @@ import { useLineConfig } from './config';
 
 interface Props {
   value: HDF5Value;
-  dataset: HDF5Dataset;
+  dims: number[];
   mapperState: DimensionMapping;
+  axesLabels?: (string | undefined)[];
+  axesValues?: Record<string, HDF5Value>;
 }
 
 function MappedLineVis(props: Props): ReactElement {
-  const { value, dataset, mapperState } = props;
+  const { value, axesLabels = [], axesValues = {}, dims, mapperState } = props;
   assertArray<number>(value);
 
   const {
@@ -24,7 +26,7 @@ function MappedLineVis(props: Props): ReactElement {
     disableAutoScale,
   } = useLineConfig();
 
-  const baseArray = useBaseArray(dataset, value);
+  const baseArray = useBaseArray(value, dims);
   const dataArray = useMappedArray(baseArray, mapperState);
 
   // Disable `autoScale` for 1D datasets (baseArray and dataArray are the same)
@@ -37,9 +39,16 @@ function MappedLineVis(props: Props): ReactElement {
     scaleType
   );
 
+  const abscissaLabel = mapperState && axesLabels[mapperState.indexOf('x')];
+  const abscissas = abscissaLabel && axesValues[abscissaLabel];
+  if (abscissas) {
+    assertArray<number>(abscissas);
+  }
+
   return (
     <LineVis
       dataArray={dataArray}
+      abscissas={abscissas as number[]}
       domain={dataDomain}
       scaleType={scaleType}
       curveType={curveType}

--- a/src/h5web/visualizations/matrix/MappedMatrixVis.tsx
+++ b/src/h5web/visualizations/matrix/MappedMatrixVis.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import type { HDF5Dataset, HDF5Value } from '../../providers/models';
+import type { HDF5Value } from '../../providers/models';
 import type { DimensionMapping } from '../../dimension-mapper/models';
 import MatrixVis from './MatrixVis';
 import { assertArray } from '../shared/utils';
@@ -7,15 +7,15 @@ import { useMappedArray, useBaseArray } from '../shared/hooks';
 
 interface Props {
   value: HDF5Value;
-  dataset: HDF5Dataset;
+  dims: number[];
   mapperState: DimensionMapping;
 }
 
 function MappedMatrixVis(props: Props): ReactElement {
-  const { value, dataset, mapperState } = props;
+  const { value, dims, mapperState } = props;
   assertArray<number | string>(value);
 
-  const baseArray = useBaseArray(dataset, value);
+  const baseArray = useBaseArray(value, dims);
   const dataArray = useMappedArray(baseArray, mapperState);
   return <MatrixVis dataArray={dataArray} />;
 }

--- a/src/h5web/visualizations/nexus/models.ts
+++ b/src/h5web/visualizations/nexus/models.ts
@@ -1,4 +1,4 @@
-export type NxAttribute = 'signal' | 'interpretation';
+export type NxAttribute = 'signal' | 'interpretation' | 'axes';
 
 export enum NxInterpretation {
   Spectrum = 'spectrum',

--- a/src/h5web/visualizations/nexus/utils.ts
+++ b/src/h5web/visualizations/nexus/utils.ts
@@ -3,9 +3,11 @@ import type {
   HDF5Metadata,
   HDF5Dataset,
   HDF5Value,
+  HDF5Entity,
 } from '../../providers/models';
 import { getEntity, isDataset } from '../../providers/utils';
 import { NxAttribute, NX_INTERPRETATIONS } from './models';
+import { assertArray, assertStr } from '../shared/utils';
 
 export function isNxDataGroup(group: HDF5Group): boolean {
   return !!group.attributes?.find(({ value }) => value === 'NXdata');
@@ -30,13 +32,40 @@ export function getAttributeValue(
   return entity.attributes.find((attr) => attr.name === attributeName)?.value;
 }
 
+export function getLinkedEntity(
+  group: HDF5Group,
+  metadata: HDF5Metadata,
+  entityName: string
+): HDF5Entity | undefined {
+  const childLink = group.links?.find((l) => l.title === entityName);
+
+  return getEntity(childLink, metadata);
+}
+
 export function getSignalDataset(
   group: HDF5Group,
   metadata: HDF5Metadata
 ): HDF5Dataset | undefined {
   const signal = getAttributeValue(group, 'signal');
-  const signalLink = signal && group.links?.find((l) => l.title === signal);
+  if (!signal) {
+    return undefined;
+  }
 
-  const signalDataset = getEntity(signalLink, metadata);
+  assertStr(signal);
+  const signalDataset = getLinkedEntity(group, metadata, signal);
+
   return signalDataset && isDataset(signalDataset) ? signalDataset : undefined;
+}
+
+export function getAxesLabels(group: HDF5Group): Array<string | undefined> {
+  const axesList = getAttributeValue(group, 'axes');
+
+  if (!axesList) {
+    return [];
+  }
+
+  const axes = typeof axesList === 'string' ? [axesList] : axesList;
+  assertArray<string>(axes);
+
+  return axes.map((a) => (a === '.' ? undefined : a));
 }

--- a/src/h5web/visualizations/shared/hooks.ts
+++ b/src/h5web/visualizations/shared/hooks.ts
@@ -4,13 +4,10 @@ import { isNumber } from 'lodash-es';
 import { assign } from 'ndarray-ops';
 import { createMemo } from 'react-use';
 import { useFrame } from 'react-three-fiber';
-import type { HDF5Dataset, HDF5SimpleShape } from '../../providers/models';
 import type { DimensionMapping } from '../../dimension-mapper/models';
 import { getDomain } from './utils';
 
-export function useBaseArray<T>(dataset: HDF5Dataset, value: T[]): ndarray<T> {
-  const rawDims = (dataset.shape as HDF5SimpleShape).dims;
-
+export function useBaseArray<T>(value: T[], rawDims: number[]): ndarray<T> {
   return useMemo(() => {
     return ndarray<T>(value.flat(Infinity) as T[], rawDims);
   }, [rawDims, value]);

--- a/src/h5web/visualizations/shared/utils.ts
+++ b/src/h5web/visualizations/shared/utils.ts
@@ -170,6 +170,12 @@ export function getTickFormatter(
   };
 }
 
+export function assertStr(val: unknown): asserts val is string {
+  if (typeof val !== 'string') {
+    throw new Error('Expected string');
+  }
+}
+
 export function assertNumOrStr(val: unknown): asserts val is number | string {
   if (typeof val !== 'number' && typeof val !== 'string') {
     throw new Error('Expected number or string');


### PR DESCRIPTION
Fix #236

Even with the heavy refactoring of #251, this ended up more complex than expected.

`NXSpectrum` uses now the `MappedLineVis` and not the `LineVis` which means I had to implement a way to determine the correct dataset as abscissas to use given its position in the `axes` list.