### PR TITLE
NxSpectrum now shows the axis label for x and y

### DIFF
--- a/src/h5web/visualizations/containers/NxSpectrumContainer.tsx
+++ b/src/h5web/visualizations/containers/NxSpectrumContainer.tsx
@@ -8,20 +8,23 @@ import { DimensionMapping } from '../../dimension-mapper/models';
 import MappedLineVis from '../line/MappedLineVis';
 import { ProviderContext } from '../../providers/context';
 import {
-  getSignalDataset,
+  getAttributeValue,
   getLinkedEntity,
   getAxesLabels,
 } from '../nexus/utils';
 import { VisContainerProps } from './models';
+import { assertStr } from '../shared/utils';
 
 function NxSpectrumContainer(props: VisContainerProps): ReactElement {
   const { entity } = props;
   assertGroup(entity);
 
   const { metadata } = useContext(ProviderContext);
-  const signalDataset = getSignalDataset(entity, metadata);
+  const signal = getAttributeValue(entity, 'signal');
+  assertStr(signal);
+  const signalDataset = getLinkedEntity(entity, metadata, signal);
 
-  if (!signalDataset) {
+  if (!signalDataset || !isDataset(signalDataset)) {
     throw new Error('Signal dataset not found');
   }
 
@@ -64,6 +67,7 @@ function NxSpectrumContainer(props: VisContainerProps): ReactElement {
       />
       <MappedLineVis
         value={values.signal}
+        valueLabel={signal}
         axesLabels={axesLabels}
         axesValues={values}
         dims={dims}

--- a/src/h5web/visualizations/index.tsx
+++ b/src/h5web/visualizations/index.tsx
@@ -15,9 +15,9 @@ import {
 import type { VisContainerProps } from './containers/models';
 import {
   isNxDataGroup,
-  getSignalDataset,
   getAttributeValue,
   isNxInterpretation,
+  getLinkedEntity,
 } from './nexus/utils';
 import { NxInterpretation } from './nexus/models';
 import {
@@ -116,8 +116,12 @@ export const VIS_DEFS: Record<Vis, VisDef> = {
         return false;
       }
 
-      const dataset = getSignalDataset(entity, metadata);
-      if (!dataset) {
+      const signal = getAttributeValue(entity, 'signal');
+      if (typeof signal !== 'string') {
+        return false;
+      }
+      const dataset = getLinkedEntity(entity, metadata, signal);
+      if (!dataset || !isDataset(dataset)) {
         return false;
       }
 
@@ -143,8 +147,12 @@ export const VIS_DEFS: Record<Vis, VisDef> = {
         return false;
       }
 
-      const dataset = getSignalDataset(entity, metadata);
-      if (!dataset) {
+      const signal = getAttributeValue(entity, 'signal');
+      if (typeof signal !== 'string') {
+        return false;
+      }
+      const dataset = getLinkedEntity(entity, metadata, signal);
+      if (!dataset || !isDataset(dataset)) {
         return false;
       }
 

--- a/src/h5web/visualizations/line/LineVis.tsx
+++ b/src/h5web/visualizations/line/LineVis.tsx
@@ -7,7 +7,7 @@ import DataCurve from './DataCurve';
 import VisCanvas from '../shared/VisCanvas';
 import PanZoomMesh from '../shared/PanZoomMesh';
 import TooltipMesh from '../shared/TooltipMesh';
-import { ScaleType, Domain } from '../shared/models';
+import { ScaleType, Domain, AxisParams } from '../shared/models';
 import { CurveType } from './models';
 import { getValueToIndexScale, getDomain, extendDomain } from '../shared/utils';
 
@@ -19,7 +19,8 @@ interface Props {
   scaleType?: ScaleType;
   curveType?: CurveType;
   showGrid?: boolean;
-  abscissas?: number[];
+  abscissaParams?: AxisParams;
+  ordinateLabel?: string;
 }
 
 function LineVis(props: Props): ReactElement {
@@ -29,8 +30,14 @@ function LineVis(props: Props): ReactElement {
     curveType = CurveType.LineOnly,
     showGrid = true,
     scaleType = ScaleType.Linear,
-    abscissas = range(dataArray.size),
+    abscissaParams = {},
+    ordinateLabel,
   } = props;
+
+  const {
+    label: abscissaLabel,
+    values: abscissas = range(dataArray.size),
+  } = abscissaParams;
 
   if (abscissas.length !== dataArray.size) {
     throw new Error(
@@ -62,16 +69,20 @@ function LineVis(props: Props): ReactElement {
           domain: abscissaDomain,
           showGrid,
           isIndexAxis: !abscissas,
+          label: abscissaLabel,
         }}
         ordinateConfig={{
           domain: dataDomain,
           showGrid,
           scaleType,
+          label: ordinateLabel,
         }}
       >
         <TooltipMesh
           formatIndex={([x]) =>
-            `x=${format('0')(abscissas[abscissaToIndex(x)])}`
+            `${abscissaLabel || 'x'}=${format('0')(
+              abscissas[abscissaToIndex(x)]
+            )}`
           }
           formatValue={([x]) => {
             const value = dataArray.get(abscissaToIndex(x));

--- a/src/h5web/visualizations/line/MappedLineVis.tsx
+++ b/src/h5web/visualizations/line/MappedLineVis.tsx
@@ -10,12 +10,20 @@ interface Props {
   value: HDF5Value;
   dims: number[];
   mapperState: DimensionMapping;
+  valueLabel?: string;
   axesLabels?: (string | undefined)[];
   axesValues?: Record<string, HDF5Value>;
 }
 
 function MappedLineVis(props: Props): ReactElement {
-  const { value, axesLabels = [], axesValues = {}, dims, mapperState } = props;
+  const {
+    value,
+    valueLabel,
+    axesLabels = [],
+    axesValues = {},
+    dims,
+    mapperState,
+  } = props;
   assertArray<number>(value);
 
   const {
@@ -40,19 +48,23 @@ function MappedLineVis(props: Props): ReactElement {
   );
 
   const abscissaLabel = mapperState && axesLabels[mapperState.indexOf('x')];
-  const abscissas = abscissaLabel && axesValues[abscissaLabel];
-  if (abscissas) {
-    assertArray<number>(abscissas);
+  const abscissasValue = abscissaLabel && axesValues[abscissaLabel];
+  if (abscissasValue) {
+    assertArray<number>(abscissasValue);
   }
 
   return (
     <LineVis
       dataArray={dataArray}
-      abscissas={abscissas as number[]}
       domain={dataDomain}
       scaleType={scaleType}
       curveType={curveType}
       showGrid={showGrid}
+      abscissaParams={{
+        label: abscissaLabel,
+        values: abscissasValue as number[],
+      }}
+      ordinateLabel={valueLabel}
     />
   );
 }

--- a/src/h5web/visualizations/nexus/utils.ts
+++ b/src/h5web/visualizations/nexus/utils.ts
@@ -5,9 +5,9 @@ import type {
   HDF5Value,
   HDF5Entity,
 } from '../../providers/models';
-import { getEntity, isDataset } from '../../providers/utils';
+import { getEntity } from '../../providers/utils';
 import { NxAttribute, NX_INTERPRETATIONS } from './models';
-import { assertArray, assertStr } from '../shared/utils';
+import { assertArray } from '../shared/utils';
 
 export function isNxDataGroup(group: HDF5Group): boolean {
   return !!group.attributes?.find(({ value }) => value === 'NXdata');
@@ -40,21 +40,6 @@ export function getLinkedEntity(
   const childLink = group.links?.find((l) => l.title === entityName);
 
   return getEntity(childLink, metadata);
-}
-
-export function getSignalDataset(
-  group: HDF5Group,
-  metadata: HDF5Metadata
-): HDF5Dataset | undefined {
-  const signal = getAttributeValue(group, 'signal');
-  if (!signal) {
-    return undefined;
-  }
-
-  assertStr(signal);
-  const signalDataset = getLinkedEntity(group, metadata, signal);
-
-  return signalDataset && isDataset(signalDataset) ? signalDataset : undefined;
 }
 
 export function getAxesLabels(group: HDF5Group): Array<string | undefined> {

--- a/src/h5web/visualizations/shared/Axis.tsx
+++ b/src/h5web/visualizations/shared/Axis.tsx
@@ -9,6 +9,9 @@ const AXIS_PROPS = {
   tickStroke: 'grey',
   hideAxisLine: true,
   tickClassName: styles.tick,
+  labelClassName: styles.label,
+  labelProps: {}, // To avoid any styling props on the parent svg
+  labelOffset: 32,
   tickComponent: ({ formattedValue, ...tickProps }: TickRendererProps) => (
     <text {...tickProps}>{formattedValue}</text>
   ),
@@ -47,6 +50,7 @@ function Axis(props: Props): ReactElement {
         <AxisComponent
           scale={scale}
           tickFormat={getTickFormatter(domain, axisLength, scaleType)}
+          label={info.label}
           {...ticksProp}
           {...AXIS_PROPS}
         />

--- a/src/h5web/visualizations/shared/AxisSystem.module.css
+++ b/src/h5web/visualizations/shared/AxisSystem.module.css
@@ -37,3 +37,10 @@
   text-anchor: inherit;
   dominant-baseline: inherit;
 }
+
+.label {
+  fill: darkslategrey;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: 600;
+}

--- a/src/h5web/visualizations/shared/AxisSystemProvider.tsx
+++ b/src/h5web/visualizations/shared/AxisSystemProvider.tsx
@@ -15,6 +15,7 @@ function getAxisInfo(config: AxisConfig): AxisInfo {
     scaleType = ScaleType.Linear,
     isIndexAxis,
     showGrid = false,
+    label,
   } = config;
 
   return {
@@ -23,6 +24,7 @@ function getAxisInfo(config: AxisConfig): AxisInfo {
     scaleType: isIndexAxis ? ScaleType.Linear : scaleType,
     showGrid,
     domain,
+    label,
   };
 }
 

--- a/src/h5web/visualizations/shared/VisCanvas.tsx
+++ b/src/h5web/visualizations/shared/VisCanvas.tsx
@@ -23,7 +23,9 @@ function VisCanvas(props: Props): JSX.Element {
 
   const axisOffsets = {
     left: AXIS_OFFSETS.vertical,
-    bottom: AXIS_OFFSETS.horizontal,
+    bottom: abscissaConfig.label
+      ? AXIS_OFFSETS.horizontal + AXIS_OFFSETS.fallback
+      : AXIS_OFFSETS.horizontal,
     right: AXIS_OFFSETS.fallback,
     top: AXIS_OFFSETS.fallback,
   };

--- a/src/h5web/visualizations/shared/models.ts
+++ b/src/h5web/visualizations/shared/models.ts
@@ -28,6 +28,7 @@ export interface AxisConfig {
   domain: Domain;
   showGrid?: boolean;
   scaleType?: ScaleType;
+  label?: string;
 }
 
 export type ScaleFn = typeof scaleLinear | typeof scaleLog | typeof scaleSymlog;
@@ -43,6 +44,7 @@ export interface AxisInfo {
   domain: Domain;
   scaleType: ScaleType;
   showGrid: boolean;
+  label?: string;
 }
 
 export type AxisOffsets = {
@@ -51,3 +53,8 @@ export type AxisOffsets = {
   right: number;
   top: number;
 };
+
+export interface AxisParams {
+  label?: string;
+  values?: number[];
+}

--- a/src/stories/AxisSystem.stories.tsx
+++ b/src/stories/AxisSystem.stories.tsx
@@ -56,11 +56,28 @@ NoGrid.args = {
   ordinateConfig: { domain: [0, 2], showGrid: false },
 };
 
+export const AxesLabels = Template.bind({});
+
+AxesLabels.args = {
+  abscissaConfig: { domain: [0, 3], showGrid: true, label: 'Abscissas' },
+  ordinateConfig: { domain: [50, 100], showGrid: true, label: 'Ordinates' },
+};
+
 export const InheritedStyles = Template.bind({});
 
 InheritedStyles.args = {
-  abscissaConfig: { domain: [0, 50], showGrid: true, isIndexAxis: true },
-  ordinateConfig: { domain: [0, 3], showGrid: true, isIndexAxis: true },
+  abscissaConfig: {
+    domain: [0, 50],
+    showGrid: true,
+    isIndexAxis: true,
+    label: 'X values',
+  },
+  ordinateConfig: {
+    domain: [0, 3],
+    showGrid: true,
+    isIndexAxis: true,
+    label: 'Y values',
+  },
 };
 
 InheritedStyles.decorators = [

--- a/src/stories/LineVis.stories.tsx
+++ b/src/stories/LineVis.stories.tsx
@@ -86,9 +86,20 @@ export const CustomAbscissas = Template.bind({});
 CustomAbscissas.args = {
   dataArray,
   domain,
-  abscissas: Array(dataArray.size)
-    .fill(0)
-    .map((x, i) => -10 + 0.5 * i),
+  abscissaParams: {
+    values: Array(dataArray.size)
+      .fill(0)
+      .map((_, i) => -10 + 0.5 * i),
+  },
+};
+
+export const WithAxesLabels = Template.bind({});
+
+WithAxesLabels.args = {
+  dataArray,
+  domain,
+  abscissaParams: { label: 'Time' },
+  ordinateLabel: 'Position',
 };
 
 export default {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/42204205/96887377-d400e880-1484-11eb-8d6a-4e43c331a6f9.png)

Updates also the tooltip.

I also added some stories showing this for `LineVis` and `AxisSystem`