### PR TITLE
Use mock data generation utilities in tests

### DIFF
--- a/src/h5web/providers/mock/data.ts
+++ b/src/h5web/providers/mock/data.ts
@@ -1,0 +1,180 @@
+import {
+  HDF5Id,
+  HDF5LinkClass,
+  HDF5Collection,
+  HDF5Attribute,
+  HDF5Dataset,
+  HDF5Metadata,
+  HDF5Values,
+  HDF5TypeClass,
+  HDF5IntegerType,
+  HDF5FloatType,
+  HDF5StringType,
+  HDF5AdvancedType,
+  HDF5SimpleShape,
+  HDF5Dims,
+  HDF5ShapeClass,
+  HDF5ScalarShape,
+  HDF5Type,
+  HDF5Shape,
+  HDF5Group,
+  HDF5Link,
+  HDF5Datatype,
+  HDF5Value,
+  HDF5HardLink,
+} from '../models';
+
+/* ----------------- */
+/* ----- TYPES ----- */
+
+export const intType: HDF5IntegerType = {
+  class: HDF5TypeClass.Integer,
+  base: 'H5T_STD_I32LE',
+};
+
+export const floatType: HDF5FloatType = {
+  class: HDF5TypeClass.Float,
+  base: 'H5T_IEEE_F64LE',
+};
+
+export const stringType: HDF5StringType = {
+  class: HDF5TypeClass.String,
+  charSet: 'H5T_CSET_ASCII',
+  strPad: 'H5T_STR_NULLPAD',
+  length: 1,
+};
+
+export const advancedType: HDF5AdvancedType = {
+  class: HDF5TypeClass.Compound,
+  fields: [],
+};
+
+/* ------------------ */
+/* ----- SHAPES ----- */
+
+export const scalarShape: HDF5ScalarShape = { class: HDF5ShapeClass.Scalar };
+
+export function makeSimpleShape(dims: HDF5Dims): HDF5SimpleShape {
+  return { class: HDF5ShapeClass.Simple, dims };
+}
+
+/* ---------------------- */
+/* ----- ATTRIBUTES ----- */
+
+export function makeStrAttr(name: string, value: HDF5Value): HDF5Attribute {
+  return { name, value, type: stringType, shape: scalarShape };
+}
+
+/* -------------------- */
+/* ----- ENTITIES ----- */
+
+export function makeDataset(
+  id: HDF5Id,
+  type: HDF5Type,
+  shape: HDF5Shape,
+  attributes?: HDF5Attribute[]
+): HDF5Dataset {
+  return { id, collection: HDF5Collection.Datasets, type, shape, attributes };
+}
+
+export function makeSimpleDataset(
+  id: HDF5Id,
+  type: HDF5Type,
+  dims: HDF5Dims,
+  attributes?: HDF5Attribute[]
+): HDF5Dataset {
+  return makeDataset(id, type, makeSimpleShape(dims), attributes);
+}
+
+export function makeGroup(
+  id: HDF5Id,
+  attributes?: HDF5Attribute[],
+  links?: HDF5Link[]
+): HDF5Group {
+  return { id, collection: HDF5Collection.Groups, attributes, links };
+}
+
+export function makeDatatype(id: HDF5Id, type: HDF5Type): HDF5Datatype {
+  return { id, collection: HDF5Collection.Datatypes, type };
+}
+
+export function withAttributes<T extends HDF5Dataset | HDF5Group>(
+  datasetOrGroup: T,
+  attributes: HDF5Attribute[]
+): T {
+  return {
+    ...datasetOrGroup,
+    attributes: [...(datasetOrGroup.attributes || []), ...attributes],
+  };
+}
+
+/* ----------------- */
+/* ----- LINKS ----- */
+
+export function makeDatasetHardLink(title: string, id: string): HDF5HardLink {
+  return {
+    class: HDF5LinkClass.Hard,
+    title,
+    collection: HDF5Collection.Datasets,
+    id,
+  };
+}
+
+export function makeGroupHardLink(title: string, id: string): HDF5HardLink {
+  return {
+    class: HDF5LinkClass.Hard,
+    title,
+    collection: HDF5Collection.Groups,
+    id,
+  };
+}
+
+/* ----------------- */
+/* ----- NEXUS ----- */
+
+export function makeNxDataGroup(
+  id: string,
+  opts: {
+    signal: string;
+    axes?: string | string[];
+    ids?: Record<string, HDF5Id>;
+  }
+): HDF5Group {
+  const { signal, axes, ids = {} } = opts;
+
+  return makeGroup(
+    id,
+    [
+      makeStrAttr('NX_class', 'NXdata'),
+      makeStrAttr('signal', signal),
+      ...(axes ? [makeStrAttr('axes', axes)] : []),
+    ],
+    Object.entries(ids).map(([...args]) => makeDatasetHardLink(...args))
+  );
+}
+
+/* -------------------- */
+/* ----- METADATA ----- */
+
+export function makeMetadata(
+  opts: {
+    root?: HDF5Id;
+    datasets?: HDF5Dataset[];
+    groups?: HDF5Group[];
+    datatypes?: HDF5Datatype[];
+  } = {}
+): HDF5Metadata {
+  const { root = '', datasets = [], groups = [], datatypes = [] } = opts;
+
+  return {
+    root,
+    datasets: Object.fromEntries(datasets.map((ds) => [ds.id, ds])),
+    groups: Object.fromEntries(groups.map((gr) => [gr.id, gr])),
+    datatypes: Object.fromEntries(datatypes.map((dt) => [dt.id, dt])),
+  };
+}
+
+/* ------------------ */
+/* ----- VALUES ----- */
+
+export const mockValues: HDF5Values = {};

--- a/src/h5web/providers/models.ts
+++ b/src/h5web/providers/models.ts
@@ -3,6 +3,8 @@
 
 export type HDF5Id = string;
 export type HDF5Value = unknown;
+export type HDF5Values = Record<HDF5Id, HDF5Value>;
+export type HDF5Dims = number[];
 
 export enum HDF5Collection {
   Groups = 'groups',
@@ -109,8 +111,8 @@ export enum HDF5ShapeClass {
 
 export interface HDF5SimpleShape {
   class: HDF5ShapeClass.Simple;
-  dims: number[];
-  maxdims?: number[];
+  dims: HDF5Dims;
+  maxdims?: HDF5Dims;
 }
 
 export interface HDF5ScalarShape {
@@ -130,7 +132,7 @@ export type HDF5Type = HDF5BaseType | HDF5AdvancedType;
 export type HDF5BaseType = HDF5NumericType | HDF5StringType;
 export type HDF5NumericType = HDF5IntegerType | HDF5FloatType;
 
-type HDF5AdvancedType =
+export type HDF5AdvancedType =
   | HDF5Id
   | HDF5ArrayType
   | HDF5VLenType
@@ -145,7 +147,7 @@ export enum HDF5TypeClass {
   Compound = 'H5T_COMPOUND',
 }
 
-interface HDF5IntegerType {
+export interface HDF5IntegerType {
   class: HDF5TypeClass.Integer;
   base:
     | 'H5T_STD_I8BE'
@@ -174,7 +176,7 @@ interface HDF5IntegerType {
     | 'H5T_STD_B64LE';
 }
 
-interface HDF5FloatType {
+export interface HDF5FloatType {
   class: HDF5TypeClass.Float;
   base:
     | 'H5T_IEEE_F32BE'
@@ -183,7 +185,7 @@ interface HDF5FloatType {
     | 'H5T_IEEE_F64LE';
 }
 
-interface HDF5StringType {
+export interface HDF5StringType {
   class: HDF5TypeClass.String;
   charSet: 'H5T_CSET_ASCII' | 'H5T_CSET_UTF8';
   strPad: 'H5T_STR_SPACEPAD' | 'H5T_STR_NULLTERM' | 'H5T_STR_NULLPAD';
@@ -193,7 +195,7 @@ interface HDF5StringType {
 interface HDF5ArrayType {
   class: HDF5TypeClass.Array;
   base: HDF5BaseType;
-  dims: number[];
+  dims: HDF5Dims;
 }
 
 interface HDF5VLenType {

--- a/src/h5web/providers/silx/api.ts
+++ b/src/h5web/providers/silx/api.ts
@@ -1,13 +1,19 @@
 import axios, { AxiosInstance } from 'axios';
 import { mapValues } from 'lodash-es';
 import type { ProviderAPI } from '../context';
-import { HDF5Id, HDF5Value, HDF5Metadata, HDF5Collection } from '../models';
-import type { SilxValuesResponse, SilxMetadataResponse } from './models';
+import {
+  HDF5Id,
+  HDF5Value,
+  HDF5Metadata,
+  HDF5Collection,
+  HDF5Values,
+} from '../models';
+import type { SilxMetadataResponse } from './models';
 
 export class SilxApi implements ProviderAPI {
   public readonly domain: string;
   private readonly client: AxiosInstance;
-  private values?: Record<string, HDF5Value>;
+  private values?: HDF5Values;
 
   constructor(domain: string) {
     this.domain = domain;
@@ -29,7 +35,7 @@ export class SilxApi implements ProviderAPI {
       return this.values[id];
     }
 
-    const { data } = await this.client.get<SilxValuesResponse>('/values.json');
+    const { data } = await this.client.get<HDF5Values>('/values.json');
 
     this.values = data;
     return this.values[id];

--- a/src/h5web/providers/silx/models.ts
+++ b/src/h5web/providers/silx/models.ts
@@ -1,5 +1,4 @@
 import {
-  HDF5Value,
   HDF5Id,
   HDF5Collection,
   HDF5Entity,
@@ -16,5 +15,3 @@ export interface SilxMetadataResponse {
   [HDF5Collection.Datasets]?: Record<HDF5Id, BareEntity<HDF5Dataset>>;
   [HDF5Collection.Datatypes]?: Record<HDF5Id, BareEntity<HDF5Datatype>>;
 }
-
-export type SilxValuesResponse = Record<string, HDF5Value>;

--- a/src/h5web/visualizations/index.test.ts
+++ b/src/h5web/visualizations/index.test.ts
@@ -1,559 +1,457 @@
-import {
-  HDF5Collection,
-  HDF5TypeClass,
-  HDF5ShapeClass,
-  HDF5Metadata,
-  HDF5Entity,
-  HDF5Attribute,
-  HDF5LinkClass,
-} from '../providers/models';
+import { HDF5Metadata, HDF5Entity } from '../providers/models';
 import { Vis, VIS_DEFS } from '.';
 import { NxInterpretation } from './nexus/models';
+import {
+  makeSimpleDataset,
+  intType,
+  makeGroup,
+  makeDatatype,
+  advancedType,
+  makeDataset,
+  scalarShape,
+  makeSimpleShape,
+  stringType,
+  makeStrAttr,
+  makeMetadata,
+  withAttributes,
+  makeDatasetHardLink,
+  makeNxDataGroup,
+  floatType,
+} from '../providers/mock/data';
 
-const baseGroup = { id: 'group', collection: HDF5Collection.Groups as const };
-const baseDataset = {
-  id: 'dataset',
-  collection: HDF5Collection.Datasets as const,
-};
-const baseDatatype = {
-  id: 'datatype',
-  collection: HDF5Collection.Datatypes as const,
-};
+const datasetIntScalar = makeDataset('dataset_int', intType, scalarShape);
+const datasetFltScalar = makeDataset('dataset_flt', floatType, scalarShape);
+const datasetStrScalar = makeDataset('dataset_flt', stringType, scalarShape);
+const datasetInt0D = makeSimpleDataset('dataset_int_0d', intType, []);
+const datasetInt1D = makeSimpleDataset('dataset_int_1d', intType, [5]);
+const datasetInt2D = makeSimpleDataset('dataset_int_2d', intType, [5, 3]);
+const datasetStr1D = makeSimpleDataset('dataset_str_1d', stringType, [5]);
+const datasetStr2D = makeSimpleDataset('dataset_str_2d', stringType, [5, 3]);
+const datasetFlt3D = makeSimpleDataset('dataset_flt_3d', intType, [5, 3, 1]);
 
-const nxDataGroup = {
-  ...baseGroup,
-  attributes: [
-    { name: 'NX_class', value: 'NXdata' },
-    { name: 'signal', value: 'my_signal' },
-  ] as HDF5Attribute[],
-  links: [
-    {
-      class: HDF5LinkClass.Hard as const,
-      title: 'my_signal',
-      collection: HDF5Collection.Datasets,
-      id: baseDataset.id,
-    },
-  ],
-};
+const groupEmpty = makeGroup('group_empty');
+const datatypeInt = makeDatatype('datatype_int', intType);
 
-function supportsEntity(
-  vis: Vis,
-  entity: HDF5Entity,
-  metadata = {} as HDF5Metadata
-): boolean {
-  return VIS_DEFS[vis].supportsEntity(entity, metadata);
+function makeSupportFn(
+  vis: Vis
+): (entity: HDF5Entity, metadata?: HDF5Metadata) => boolean {
+  return (entity: HDF5Entity, metadata = {} as HDF5Metadata) =>
+    VIS_DEFS[vis].supportsEntity(entity, metadata);
 }
 
 describe('Visualization definitions', () => {
   describe('Vis.Raw', () => {
-    it('should support any dataset', () => {
-      const supportedDatasets: HDF5Entity[] = [
-        { ...baseDataset, type: '', shape: { class: HDF5ShapeClass.Null } },
-      ];
+    const supportsEntity = makeSupportFn(Vis.Raw);
 
-      supportedDatasets.forEach((dataset) => {
-        expect(supportsEntity(Vis.Raw, dataset)).toBe(true);
-      });
+    it('should support any dataset', () => {
+      expect(supportsEntity(datasetInt1D)).toBe(true);
     });
 
     it('should not support group and datatype', () => {
-      const unsupportedEntities: HDF5Entity[] = [
-        { ...baseGroup },
-        { ...baseDatatype, type: '' },
-      ];
-
-      unsupportedEntities.forEach((entity) => {
-        expect(supportsEntity(Vis.Raw, entity)).toBe(false);
-      });
+      expect(supportsEntity(groupEmpty)).toBe(false);
+      expect(supportsEntity(datatypeInt)).toBe(false);
     });
   });
 
   describe('Vis.Scalar', () => {
-    it('should support dataset with base type and scalar shape', () => {
-      const supportedDatasets: HDF5Entity[] = [
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Integer, base: 'H5T_STD_I32LE' },
-          shape: { class: HDF5ShapeClass.Scalar },
-        },
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Float, base: 'H5T_IEEE_F64LE' },
-          shape: { class: HDF5ShapeClass.Scalar },
-        },
-      ];
+    const supportsEntity = makeSupportFn(Vis.Scalar);
 
-      supportedDatasets.forEach((dataset) => {
-        expect(supportsEntity(Vis.Scalar, dataset)).toBe(true);
-      });
+    it('should support dataset with base type and scalar shape', () => {
+      expect(supportsEntity(datasetIntScalar)).toBe(true);
+      expect(supportsEntity(datasetFltScalar)).toBe(true);
+      expect(supportsEntity(datasetStrScalar)).toBe(true);
     });
 
-    it('should not support dataset with complex type or non-scalar shape', () => {
-      const unsupportedDatasets: HDF5Entity[] = [
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Integer, base: 'H5T_STD_I32LE' },
-          shape: { class: HDF5ShapeClass.Null }, // shape class not supported
-        },
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Compound, fields: [] }, // type class not supported
-          shape: { class: HDF5ShapeClass.Scalar },
-        },
-      ];
+    it('should not support dataset with advanced type', () => {
+      const dataset = makeDataset('foo', advancedType, scalarShape);
+      expect(supportsEntity(dataset)).toBe(false);
+    });
 
-      unsupportedDatasets.forEach((dataset) => {
-        expect(supportsEntity(Vis.Scalar, dataset)).toBe(false);
-      });
+    it('should not support dataset with non-scalar shape', () => {
+      expect(supportsEntity(datasetInt1D)).toBe(false);
     });
 
     it('should not support group and datatype', () => {
-      const unsupportedEntities: HDF5Entity[] = [
-        { ...baseGroup },
-        { ...baseDatatype, type: '' },
-      ];
-
-      unsupportedEntities.forEach((entity) => {
-        expect(supportsEntity(Vis.Scalar, entity)).toBe(false);
-      });
+      expect(supportsEntity(groupEmpty)).toBe(false);
+      expect(supportsEntity(datatypeInt)).toBe(false);
     });
   });
 
   describe('Vis.Matrix', () => {
-    it('should support dataset with base type, simple shape and at least one dimension', () => {
-      const supportedDatasets: HDF5Entity[] = [
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Integer, base: 'H5T_STD_I32LE' },
-          shape: { class: HDF5ShapeClass.Simple, dims: [4] },
-        },
-        {
-          ...baseDataset,
-          type: {
-            class: HDF5TypeClass.String,
-            charSet: 'H5T_CSET_ASCII',
-            strPad: 'H5T_STR_NULLPAD',
-            length: 1,
-          },
-          shape: { class: HDF5ShapeClass.Simple, dims: [10, 12345] },
-        },
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Float, base: 'H5T_IEEE_F64LE' },
-          shape: { class: HDF5ShapeClass.Simple, dims: [4, 2, 3] }, // dims length supported with mapping
-        },
-      ];
+    const supportsEntity = makeSupportFn(Vis.Matrix);
 
-      supportedDatasets.forEach((dataset) => {
-        expect(supportsEntity(Vis.Matrix, dataset)).toBe(true);
-      });
+    it('should support dataset with base type, simple shape and at least one dimension', () => {
+      expect(supportsEntity(datasetInt1D)).toBe(true);
+      expect(supportsEntity(datasetStr2D)).toBe(true);
+      expect(supportsEntity(datasetFlt3D)).toBe(true);
     });
 
-    it('should not support dataset with complex type, non-simple shape or no dimension', () => {
-      const unsupportedDatasets: HDF5Entity[] = [
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Compound, fields: [] }, // type class not supported
-          shape: { class: HDF5ShapeClass.Simple, dims: [4] },
-        },
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Float, base: 'H5T_IEEE_F64LE' },
-          shape: { class: HDF5ShapeClass.Scalar }, // shape class not supported
-        },
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Integer, base: 'H5T_STD_I32LE' },
-          shape: { class: HDF5ShapeClass.Simple, dims: [] }, // dims length not supported
-        },
-      ];
+    it('should not support dataset with advanced type', () => {
+      const dataset = makeDataset('foo', advancedType, makeSimpleShape([1]));
+      expect(supportsEntity(dataset)).toBe(false);
+    });
 
-      unsupportedDatasets.forEach((dataset) => {
-        expect(supportsEntity(Vis.Matrix, dataset)).toBe(false);
-      });
+    it('should not support dataset with non-simple shape', () => {
+      expect(supportsEntity(datasetIntScalar)).toBe(false);
+    });
+
+    it('should not support dataset with no dimension', () => {
+      expect(supportsEntity(datasetInt0D)).toBe(false);
     });
 
     it('should not support group and datatype', () => {
-      const unsupportedEntities: HDF5Entity[] = [
-        { ...baseGroup },
-        { ...baseDatatype, type: '' },
-      ];
-
-      unsupportedEntities.forEach((entity) => {
-        expect(supportsEntity(Vis.Matrix, entity)).toBe(false);
-      });
+      expect(supportsEntity(groupEmpty)).toBe(false);
+      expect(supportsEntity(datatypeInt)).toBe(false);
     });
   });
 
   describe('Vis.Line', () => {
-    it('should support dataset with numeric type, simple shape and at least one dimension', () => {
-      const supportedDatasets: HDF5Entity[] = [
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Integer, base: 'H5T_STD_I32LE' },
-          shape: { class: HDF5ShapeClass.Simple, dims: [4] },
-        },
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Float, base: 'H5T_IEEE_F64LE' },
-          shape: { class: HDF5ShapeClass.Simple, dims: [15] },
-        },
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Float, base: 'H5T_IEEE_F64LE' },
-          shape: { class: HDF5ShapeClass.Simple, dims: [4, 2] }, // dims length supported with mapping
-        },
-      ];
+    const supportsEntity = makeSupportFn(Vis.Line);
 
-      supportedDatasets.forEach((dataset) => {
-        expect(supportsEntity(Vis.Line, dataset)).toBe(true);
-      });
+    it('should support dataset with numeric type, simple shape and at least one dimension', () => {
+      expect(supportsEntity(datasetInt1D)).toBe(true);
+      expect(supportsEntity(datasetFlt3D)).toBe(true);
     });
 
-    it('should not support dataset with non-numeric type, non-simple shape or no dimension', () => {
-      const unsupportedDatasets: HDF5Entity[] = [
-        {
-          ...baseDataset,
-          type: {
-            class: HDF5TypeClass.String, // type class not supported
-            charSet: 'H5T_CSET_ASCII',
-            strPad: 'H5T_STR_NULLPAD',
-            length: 1,
-          },
-          shape: { class: HDF5ShapeClass.Simple, dims: [4] },
-        },
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Float, base: 'H5T_IEEE_F64LE' },
-          shape: { class: HDF5ShapeClass.Scalar }, // shape class not supported
-        },
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Integer, base: 'H5T_STD_I32LE' },
-          shape: { class: HDF5ShapeClass.Simple, dims: [] }, // dims length not supported
-        },
-      ];
+    it('should not support dataset with non-numeric type', () => {
+      expect(supportsEntity(datasetStr2D)).toBe(false);
+    });
 
-      unsupportedDatasets.forEach((dataset) => {
-        expect(supportsEntity(Vis.Line, dataset)).toBe(false);
-      });
+    it('should not support dataset with non-simple shape', () => {
+      expect(supportsEntity(datasetIntScalar)).toBe(false);
+    });
+
+    it('should not support dataset with no dimension', () => {
+      expect(supportsEntity(datasetInt0D)).toBe(false);
     });
 
     it('should not support group and datatype', () => {
-      const unsupportedEntities: HDF5Entity[] = [
-        { ...baseGroup },
-        { ...baseDatatype, type: '' },
-      ];
-
-      unsupportedEntities.forEach((entity) => {
-        expect(supportsEntity(Vis.Line, entity)).toBe(false);
-      });
+      expect(supportsEntity(groupEmpty)).toBe(false);
+      expect(supportsEntity(datatypeInt)).toBe(false);
     });
   });
 
   describe('Vis.Heatmap', () => {
-    it('should support dataset with numeric type, simple shape and at least two dimensions', () => {
-      const supportedDatasets: HDF5Entity[] = [
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Integer, base: 'H5T_STD_I32LE' },
-          shape: { class: HDF5ShapeClass.Simple, dims: [15, 4] },
-        },
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Float, base: 'H5T_IEEE_F64LE' },
-          shape: { class: HDF5ShapeClass.Simple, dims: [4, 15] },
-        },
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Float, base: 'H5T_IEEE_F64LE' },
-          shape: { class: HDF5ShapeClass.Simple, dims: [4, 2, 5] }, // dims length supported with mapping
-        },
-      ];
+    const supportsEntity = makeSupportFn(Vis.Heatmap);
 
-      supportedDatasets.forEach((dataset) => {
-        expect(supportsEntity(Vis.Heatmap, dataset)).toBe(true);
-      });
+    it('should support dataset with numeric type, simple shape and at least two dimensions', () => {
+      expect(supportsEntity(datasetInt2D)).toBe(true);
+      expect(supportsEntity(datasetFlt3D)).toBe(true);
     });
 
-    it('should not support dataset with non-numeric type, non-simple shape or less than two dimensions', () => {
-      const unsupportedDatasets: HDF5Entity[] = [
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Compound, fields: [] }, // type class not supported
-          shape: { class: HDF5ShapeClass.Simple, dims: [4, 15] },
-        },
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Float, base: 'H5T_IEEE_F64LE' },
-          shape: { class: HDF5ShapeClass.Scalar }, // shape class not supported
-        },
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Integer, base: 'H5T_STD_I32LE' },
-          shape: { class: HDF5ShapeClass.Simple, dims: [1] }, // dims length not supported
-        },
-      ];
+    it('should not support dataset with non-numeric type', () => {
+      expect(supportsEntity(datasetStr2D)).toBe(false);
+    });
 
-      unsupportedDatasets.forEach((dataset) => {
-        expect(supportsEntity(Vis.Heatmap, dataset)).toBe(false);
-      });
+    it('should not support dataset with non-simple shape', () => {
+      expect(supportsEntity(datasetIntScalar)).toBe(false);
+    });
+
+    it('should not support dataset with less than two dimensions', () => {
+      expect(supportsEntity(datasetInt1D)).toBe(false);
     });
 
     it('should not support group and datatype', () => {
-      const unsupportedEntities: HDF5Entity[] = [
-        { ...baseGroup },
-        { ...baseDatatype, type: '' },
-      ];
-
-      unsupportedEntities.forEach((entity) => {
-        expect(supportsEntity(Vis.Heatmap, entity)).toBe(false);
-      });
+      expect(supportsEntity(groupEmpty)).toBe(false);
+      expect(supportsEntity(datatypeInt)).toBe(false);
     });
   });
 
   describe('Vis.NxSpectrum', () => {
-    const nxSpectrumDef = VIS_DEFS[Vis.NxSpectrum];
+    const supportsEntity = makeSupportFn(Vis.NxSpectrum);
 
     it('should support NXdata group referencing signal with spectrum interpretation', () => {
-      const metadata = {
-        datasets: {
-          [baseDataset.id]: {
-            ...baseDataset,
-            attributes: [
-              { name: 'interpretation', value: NxInterpretation.Spectrum },
-            ],
-          },
-        },
-      } as HDF5Metadata;
+      const group = makeNxDataGroup('foo', {
+        signal: 'my_signal',
+        ids: { my_signal: datasetInt1D.id },
+      });
 
-      const supported = nxSpectrumDef.supportsEntity(nxDataGroup, metadata);
-      expect(supported).toBe(true);
+      const metadata = makeMetadata({
+        datasets: [
+          withAttributes(datasetInt1D, [
+            makeStrAttr('interpretation', NxInterpretation.Spectrum),
+          ]),
+        ],
+      });
+
+      expect(supportsEntity(group, metadata)).toBe(true);
     });
 
-    it('should support NXdata group referencing signal with numeric type, simple shape, one dimension and no or unknown interpretation', () => {
-      const supportedSignals: HDF5Entity[] = [
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Integer, base: 'H5T_STD_I32LE' },
-          shape: { class: HDF5ShapeClass.Simple, dims: [1] },
-          attributes: [], // no interpretation
-        },
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Float, base: 'H5T_IEEE_F32BE' },
-          shape: { class: HDF5ShapeClass.Simple, dims: [1] },
-          attributes: [
-            { name: 'interpretation', value: 'unknown' } as HDF5Attribute, // unknown interpretation
-          ],
-        },
-      ];
-
-      supportedSignals.forEach((signal) => {
-        const metadata = {
-          datasets: { [baseDataset.id]: signal },
-        } as HDF5Metadata;
-
-        const supported = nxSpectrumDef.supportsEntity(nxDataGroup, metadata);
-        expect(supported).toBe(true);
+    it('should support NXdata group referencing signal with numeric type, simple shape, one dimension and no interpretation', () => {
+      const group = makeNxDataGroup('foo', {
+        signal: 'my_signal',
+        ids: { my_signal: datasetInt1D.id },
       });
+
+      const metadata = makeMetadata({ datasets: [datasetInt1D] });
+      expect(supportsEntity(group, metadata)).toBe(true);
     });
 
-    it('should not support NXdata group referencing signal with non-numeric type, non-simple shape, no dimension or non-spectrum interpretation', () => {
-      const unsupportedSignals: HDF5Entity[] = [
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Compound, fields: [] }, // type class not supported
-          shape: { class: HDF5ShapeClass.Simple, dims: [4] },
-        },
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Float, base: 'H5T_IEEE_F64LE' },
-          shape: { class: HDF5ShapeClass.Scalar }, // shape class not supported
-        },
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Integer, base: 'H5T_STD_I32LE' },
-          shape: { class: HDF5ShapeClass.Simple, dims: [] }, // dims length not supported
-        },
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Float, base: 'H5T_IEEE_F64LE' },
-          shape: { class: HDF5ShapeClass.Simple, dims: [4] },
-          attributes: [
-            {
-              name: 'interpretation',
-              value: NxInterpretation.Image, // known, non-spectrum interpretation
-            } as HDF5Attribute,
-          ],
-        },
-      ];
-
-      unsupportedSignals.forEach((signal) => {
-        const metadata = {
-          datasets: { [baseDataset.id]: signal },
-        } as HDF5Metadata;
-
-        const supported = nxSpectrumDef.supportsEntity(nxDataGroup, metadata);
-        expect(supported).toBe(false);
+    it('should support NXdata group referencing signal with numeric type, simple shape, one dimension and unknown interpretation', () => {
+      const group = makeNxDataGroup('foo', {
+        signal: 'my_signal',
+        ids: { my_signal: datasetInt1D.id },
       });
+
+      const metadata = makeMetadata({
+        datasets: [
+          withAttributes(datasetInt1D, [
+            makeStrAttr('interpretation', 'unknown'),
+          ]),
+        ],
+      });
+
+      expect(supportsEntity(group, metadata)).toBe(true);
+    });
+
+    it('should not support NXdata group referencing signal with non-numeric type', () => {
+      const group = makeNxDataGroup('foo', {
+        signal: 'my_signal',
+        ids: { my_signal: datasetStr1D.id },
+      });
+
+      const metadata = makeMetadata({ datasets: [datasetStr1D] });
+      expect(supportsEntity(group, metadata)).toBe(false);
+    });
+
+    it('should not support NXdata group referencing signal with non-simple shape', () => {
+      const group = makeNxDataGroup('foo', {
+        signal: 'my_signal',
+        ids: { my_signal: datasetIntScalar.id },
+      });
+
+      const metadata = makeMetadata({ datasets: [datasetIntScalar] });
+      expect(supportsEntity(group, metadata)).toBe(false);
+    });
+
+    it('should not support NXdata group referencing signal with no dimension', () => {
+      const group = makeNxDataGroup('foo', {
+        signal: 'my_signal',
+        ids: { my_signal: datasetInt0D.id },
+      });
+
+      const metadata = makeMetadata({ datasets: [datasetInt0D] });
+      expect(supportsEntity(group, metadata)).toBe(false);
+    });
+
+    it('should not support NXdata group referencing signal with non-spectrum interpretation', () => {
+      const group = makeNxDataGroup('foo', {
+        signal: 'my_signal',
+        ids: { my_signal: datasetInt1D.id },
+      });
+
+      const metadata = makeMetadata({
+        datasets: [
+          withAttributes(datasetInt1D, [
+            makeStrAttr('interpretation', NxInterpretation.Image),
+          ]),
+        ],
+      });
+
+      expect(supportsEntity(group, metadata)).toBe(false);
+    });
+
+    it('should not support NXdata group referencing signal with spectrum interpretation but non-supported type/shape', () => {
+      const group = makeNxDataGroup('foo', {
+        signal: 'my_signal',
+        ids: { my_signal: datasetIntScalar.id },
+      });
+
+      const metadata = makeMetadata({
+        datasets: [
+          withAttributes(datasetIntScalar, [
+            makeStrAttr('interpretation', NxInterpretation.Spectrum),
+          ]),
+        ],
+      });
+
+      expect(supportsEntity(group, metadata)).toBe(false);
     });
 
     it('should not support NXdata group referencing inexistent signal', () => {
-      const metadata = {} as HDF5Metadata;
-      const supported = nxSpectrumDef.supportsEntity(nxDataGroup, metadata);
-      expect(supported).toBe(false);
+      const group = makeNxDataGroup('foo', {
+        signal: 'my_signal',
+        ids: { my_signal: datasetInt1D.id },
+      });
+
+      const metadata = makeMetadata();
+      expect(supportsEntity(group, metadata)).toBe(false);
     });
 
     it('should not support NXdata group with missing signal link', () => {
-      const supported = nxSpectrumDef.supportsEntity(
-        { ...nxDataGroup, links: [] },
-        {} as HDF5Metadata
-      );
-
-      expect(supported).toBe(false);
+      const group = makeNxDataGroup('foo', { signal: 'my_signal' });
+      const metadata = makeMetadata({ datasets: [datasetInt1D] });
+      expect(supportsEntity(group, metadata)).toBe(false);
     });
 
-    it('should not support dataset, datatype and non-NXdata group', () => {
-      const unsupportedEntities: HDF5Entity[] = [
-        { ...baseDataset, type: '', shape: { class: HDF5ShapeClass.Null } },
-        { ...baseDatatype, type: '' },
-        { ...baseGroup },
-      ];
+    it('should not support non-NXdata group', () => {
+      const group = makeGroup(
+        'foo',
+        [makeStrAttr('signal', 'my_signal')],
+        [makeDatasetHardLink('my_signal', datasetInt1D.id)]
+      );
 
-      unsupportedEntities.forEach((entity) => {
-        expect(supportsEntity(Vis.NxSpectrum, entity)).toBe(false);
-      });
+      const metadata = makeMetadata({ datasets: [datasetInt1D] });
+      expect(supportsEntity(group, metadata)).toBe(false);
+    });
+
+    it('should not support dataset with NXdata attributes', () => {
+      const group = withAttributes(datasetInt1D, [
+        makeStrAttr('NX_class', 'NXdata'),
+        makeStrAttr('signal', 'my_signal'),
+      ]);
+
+      const metadata = makeMetadata({ datasets: [datasetInt1D] });
+      expect(supportsEntity(group, metadata)).toBe(false);
     });
   });
 
   describe('Vis.NxImage', () => {
-    const nxImageDef = VIS_DEFS[Vis.NxImage];
+    const supportsEntity = makeSupportFn(Vis.NxImage);
 
     it('should support NXdata group referencing signal with image interpretation', () => {
-      const metadata = {
-        datasets: {
-          [baseDataset.id]: {
-            ...baseDataset,
-            attributes: [
-              { name: 'interpretation', value: NxInterpretation.Image },
-            ],
-          },
-        },
-      } as HDF5Metadata;
+      const group = makeNxDataGroup('foo', {
+        signal: 'my_signal',
+        ids: { my_signal: datasetInt2D.id },
+      });
 
-      const supported = nxImageDef.supportsEntity(nxDataGroup, metadata);
-      expect(supported).toBe(true);
+      const metadata = makeMetadata({
+        datasets: [
+          withAttributes(datasetInt2D, [
+            makeStrAttr('interpretation', NxInterpretation.Image),
+          ]),
+        ],
+      });
+
+      expect(supportsEntity(group, metadata)).toBe(true);
     });
 
     it('should support NXdata group referencing signal with numeric type, simple shape, two dimensions and no interpretation', () => {
-      const metadata = {
-        datasets: {
-          [baseDataset.id]: {
-            ...baseDataset,
-            type: { class: HDF5TypeClass.Integer, base: 'H5T_STD_I32LE' },
-            shape: { class: HDF5ShapeClass.Simple, dims: [1, 2] },
-          },
-        },
-      } as HDF5Metadata;
+      const group = makeNxDataGroup('foo', {
+        signal: 'my_signal',
+        ids: { my_signal: datasetInt2D.id },
+      });
 
-      const supported = nxImageDef.supportsEntity(nxDataGroup, metadata);
-      expect(supported).toBe(true);
+      const metadata = makeMetadata({ datasets: [datasetInt2D] });
+      expect(supportsEntity(group, metadata)).toBe(true);
     });
 
-    it('should support NXdata group referencing signal with numeric type, simple shape, more than two dimensions and no or unknown interpretation', () => {
-      const supportedSignals: HDF5Entity[] = [
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Integer, base: 'H5T_STD_I32LE' },
-          shape: { class: HDF5ShapeClass.Simple, dims: [1, 2] },
-          attributes: [], // no attributes
-        },
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Float, base: 'H5T_IEEE_F32BE' },
-          shape: { class: HDF5ShapeClass.Simple, dims: [1, 2, 3, 4] },
-          attributes: [
-            { name: 'interpretation', value: 'unknown' } as HDF5Attribute,
-          ], // unknown interpretation
-        },
-      ];
-
-      supportedSignals.forEach((signal) => {
-        const metadata = {
-          datasets: { [baseDataset.id]: signal },
-        } as HDF5Metadata;
-
-        const supported = nxImageDef.supportsEntity(nxDataGroup, metadata);
-        expect(supported).toBe(true);
+    it('should support NXdata group referencing signal with numeric type, simple shape, more than two dimensions and unknown interpretation', () => {
+      const group = makeNxDataGroup('foo', {
+        signal: 'my_signal',
+        ids: { my_signal: datasetFlt3D.id },
       });
+
+      const metadata = makeMetadata({
+        datasets: [
+          withAttributes(datasetFlt3D, [
+            makeStrAttr('interpretation', 'unknown'),
+          ]),
+        ],
+      });
+
+      expect(supportsEntity(group, metadata)).toBe(true);
     });
 
-    it('should not support NXdata group referencing signal with non-numeric type, non-simple shape, less than two dimensions or non-image interpretation', () => {
-      const unsupportedSignals: HDF5Entity[] = [
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Compound, fields: [] }, // type class not supported
-          shape: { class: HDF5ShapeClass.Simple, dims: [4, 15] },
-        },
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Float, base: 'H5T_IEEE_F64LE' },
-          shape: { class: HDF5ShapeClass.Scalar }, // shape class not supported
-        },
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Integer, base: 'H5T_STD_I32LE' },
-          shape: { class: HDF5ShapeClass.Simple, dims: [1] }, // dims length not supported
-        },
-        {
-          ...baseDataset,
-          type: { class: HDF5TypeClass.Integer, base: 'H5T_STD_I32LE' },
-          shape: { class: HDF5ShapeClass.Simple, dims: [4, 15] },
-          attributes: [
-            {
-              name: 'interpretation',
-              value: NxInterpretation.Spectrum,
-            } as HDF5Attribute, // known, non-image interpretation
-          ],
-        },
-      ];
-
-      unsupportedSignals.forEach((signal) => {
-        const metadata = {
-          datasets: { [baseDataset.id]: signal },
-        } as HDF5Metadata;
-
-        const supported = nxImageDef.supportsEntity(nxDataGroup, metadata);
-        expect(supported).toBe(false);
+    it('should not support NXdata group referencing signal with non-numeric type', () => {
+      const group = makeNxDataGroup('foo', {
+        signal: 'my_signal',
+        ids: { my_signal: datasetStr2D.id },
       });
+
+      const metadata = makeMetadata({ datasets: [datasetStr2D] });
+      expect(supportsEntity(group, metadata)).toBe(false);
+    });
+
+    it('should not support NXdata group referencing signal with non-simple shape', () => {
+      const group = makeNxDataGroup('foo', {
+        signal: 'my_signal',
+        ids: { my_signal: datasetIntScalar.id },
+      });
+
+      const metadata = makeMetadata({ datasets: [datasetIntScalar] });
+      expect(supportsEntity(group, metadata)).toBe(false);
+    });
+
+    it('should not support NXdata group referencing signal with less than two dimensions', () => {
+      const group = makeNxDataGroup('foo', {
+        signal: 'my_signal',
+        ids: { my_signal: datasetInt1D.id },
+      });
+
+      const metadata = makeMetadata({ datasets: [datasetInt1D] });
+      expect(supportsEntity(group, metadata)).toBe(false);
+    });
+
+    it('should not support NXdata group referencing signal with non-image interpretation', () => {
+      const group = makeNxDataGroup('foo', {
+        signal: 'my_signal',
+        ids: { my_signal: datasetInt2D.id },
+      });
+
+      const metadata = makeMetadata({
+        datasets: [
+          withAttributes(datasetInt2D, [
+            makeStrAttr('interpretation', NxInterpretation.Spectrum),
+          ]),
+        ],
+      });
+
+      expect(supportsEntity(group, metadata)).toBe(false);
+    });
+
+    it('should not support NXdata group referencing signal with image interpretation but non-supported type/shape', () => {
+      const group = makeNxDataGroup('foo', {
+        signal: 'my_signal',
+        ids: { my_signal: datasetIntScalar.id },
+      });
+
+      const metadata = makeMetadata({
+        datasets: [
+          withAttributes(datasetIntScalar, [
+            makeStrAttr('interpretation', NxInterpretation.Image),
+          ]),
+        ],
+      });
+
+      expect(supportsEntity(group, metadata)).toBe(false);
     });
 
     it('should not support NXdata group referencing inexistent signal', () => {
-      const metadata = {} as HDF5Metadata;
-      const supported = nxImageDef.supportsEntity(nxDataGroup, metadata);
-      expect(supported).toBe(false);
+      const group = makeNxDataGroup('foo', {
+        signal: 'my_signal',
+        ids: { my_signal: datasetInt1D.id },
+      });
+
+      const metadata = makeMetadata();
+      expect(supportsEntity(group, metadata)).toBe(false);
     });
 
     it('should not support NXdata group with missing signal link', () => {
-      const supported = nxImageDef.supportsEntity(
-        { ...nxDataGroup, links: [] },
-        {} as HDF5Metadata
-      );
-
-      expect(supported).toBe(false);
+      const group = makeNxDataGroup('foo', { signal: 'my_signal' });
+      const metadata = makeMetadata({ datasets: [datasetInt2D] });
+      expect(supportsEntity(group, metadata)).toBe(false);
     });
 
-    it('should not support dataset, datatype and non-NXdata group', () => {
-      const unsupportedEntities: HDF5Entity[] = [
-        { ...baseDataset, type: '', shape: { class: HDF5ShapeClass.Null } },
-        { ...baseDatatype, type: '' },
-        { ...baseGroup },
-      ];
+    it('should not support non-NXdata group', () => {
+      const group = makeGroup(
+        'foo',
+        [makeStrAttr('signal', 'my_signal')],
+        [makeDatasetHardLink('my_signal', datasetInt2D.id)]
+      );
 
-      unsupportedEntities.forEach((entity) => {
-        expect(supportsEntity(Vis.NxImage, entity)).toBe(false);
-      });
+      const metadata = makeMetadata({ datasets: [datasetInt2D] });
+      expect(supportsEntity(group, metadata)).toBe(false);
+    });
+
+    it('should not support dataset with NXdata attributes', () => {
+      const group = withAttributes(datasetInt2D, [
+        makeStrAttr('NX_class', 'NXdata'),
+        makeStrAttr('signal', 'my_signal'),
+      ]);
+
+      const metadata = makeMetadata({ datasets: [datasetInt2D] });
+      expect(supportsEntity(group, metadata)).toBe(false);
     });
   });
 });

--- a/src/h5web/visualizations/index.tsx
+++ b/src/h5web/visualizations/index.tsx
@@ -120,20 +120,26 @@ export const VIS_DEFS: Record<Vis, VisDef> = {
       if (typeof signal !== 'string') {
         return false;
       }
+
       const dataset = getLinkedEntity(entity, metadata, signal);
-      if (!dataset || !isDataset(dataset)) {
+      if (
+        !dataset ||
+        !isDataset(dataset) ||
+        !isNumericType(dataset.type) ||
+        !isSimpleShape(dataset.shape)
+      ) {
+        return false;
+      }
+
+      const dimsCount = dataset.shape.dims.length;
+      if (dimsCount === 0) {
         return false;
       }
 
       const interpretation = getAttributeValue(dataset, 'interpretation');
-      if (isNxInterpretation(interpretation)) {
-        return interpretation === NxInterpretation.Spectrum;
-      }
-
       return (
-        isNumericType(dataset.type) &&
-        isSimpleShape(dataset.shape) &&
-        dataset.shape.dims.length === 1
+        (!isNxInterpretation(interpretation) && dimsCount === 1) || // NxImage already suports datasets with 2+ dimensions
+        interpretation === NxInterpretation.Spectrum
       );
     },
   },
@@ -151,20 +157,26 @@ export const VIS_DEFS: Record<Vis, VisDef> = {
       if (typeof signal !== 'string') {
         return false;
       }
+
       const dataset = getLinkedEntity(entity, metadata, signal);
-      if (!dataset || !isDataset(dataset)) {
+      if (
+        !dataset ||
+        !isDataset(dataset) ||
+        !isNumericType(dataset.type) ||
+        !isSimpleShape(dataset.shape)
+      ) {
+        return false;
+      }
+
+      const dimsCount = dataset.shape.dims.length;
+      if (dimsCount < 2) {
         return false;
       }
 
       const interpretation = getAttributeValue(dataset, 'interpretation');
-      if (isNxInterpretation(interpretation)) {
-        return interpretation === NxInterpretation.Image;
-      }
-
       return (
-        isNumericType(dataset.type) &&
-        isSimpleShape(dataset.shape) &&
-        dataset.shape.dims.length >= 2
+        !isNxInterpretation(interpretation) ||
+        interpretation === NxInterpretation.Image
       );
     },
   },


### PR DESCRIPTION
Start of #253 

I add a file called `providers/mocks/data.ts` with mock HDF5 objects and generation utilities, which I then used to rewrite the tests of the visualizations' `supportsEntity` functions.

In the next PR, I will use these objects and utilities to generate mock data for the `/mock` endpoint.