### PR TITLE
NxImage and NxSpectrum now supports NX groups with default attribute

### DIFF
--- a/src/h5web/App.test.tsx
+++ b/src/h5web/App.test.tsx
@@ -35,22 +35,15 @@ test('renders with root group selected', async () => {
 });
 
 test('switch between "display" and "inspect" modes', async () => {
-  const {
-    findByRole,
-    findByText,
-    getByRole,
-    queryByRole,
-    queryByText,
-  } = renderApp();
+  const { findByRole, getByRole, queryByRole } = renderApp();
 
   const inspectBtn = await findByRole('tab', { name: 'Inspect' });
   const displayBtn = getByRole('tab', { name: 'Display' });
 
   // Switch to "inspect" mode
   fireEvent.click(inspectBtn);
-
-  const noVisText1 = queryByText('Nothing to visualize');
-  expect(noVisText1).not.toBeInTheDocument();
+  const visSelector1 = queryByRole('tablist', { name: 'Visualization' });
+  expect(visSelector1).not.toBeInTheDocument();
 
   const groupIdRow1 = await findByRole('row', { name: /Entity ID/ });
   expect(groupIdRow1).toBeVisible();
@@ -61,8 +54,8 @@ test('switch between "display" and "inspect" modes', async () => {
   const groupIdRow2 = queryByRole('row', { name: /Entity ID/ });
   expect(groupIdRow2).not.toBeInTheDocument();
 
-  const noVisText2 = await findByText('Nothing to visualize');
-  expect(noVisText2).toBeVisible();
+  const visSelector2 = await findByRole('tablist', { name: 'Visualization' });
+  expect(visSelector2).toBeVisible();
 });
 
 test('toggle explorer sidebar', async () => {

--- a/src/h5web/providers/mock/data.ts
+++ b/src/h5web/providers/mock/data.ts
@@ -132,7 +132,7 @@ export function makeGroupHardLink(title: string, id: string): HDF5HardLink {
 /* ----------------- */
 /* ----- NEXUS ----- */
 
-export function makeNxDataGroup(
+export function makeNxData(
   id: string,
   opts: {
     signal: string;
@@ -150,6 +150,38 @@ export function makeNxDataGroup(
       ...(axes ? [makeStrAttr('axes', axes)] : []),
     ],
     Object.entries(ids).map(([...args]) => makeDatasetHardLink(...args))
+  );
+}
+
+export function makeNxEntry(
+  id: string,
+  opts: {
+    defaultPath?: string;
+    ids?: Record<string, HDF5Id>;
+  }
+): HDF5Group {
+  const { ids = {}, defaultPath } = opts;
+
+  return makeGroup(
+    id,
+    [makeStrAttr('NX_class', 'NXentry'), makeStrAttr('default', defaultPath)],
+    Object.entries(ids).map(([...args]) => makeGroupHardLink(...args))
+  );
+}
+
+export function makeNxRoot(
+  id: string,
+  opts: {
+    defaultPath?: string;
+    ids?: Record<string, HDF5Id>;
+  }
+): HDF5Group {
+  const { ids = {}, defaultPath } = opts;
+
+  return makeGroup(
+    id,
+    [makeStrAttr('NX_class', 'NXroot'), makeStrAttr('default', defaultPath)],
+    Object.entries(ids).map(([...args]) => makeGroupHardLink(...args))
   );
 }
 

--- a/src/h5web/visualizations/containers/NxImageContainer.tsx
+++ b/src/h5web/visualizations/containers/NxImageContainer.tsx
@@ -6,7 +6,12 @@ import { assertGroup, isDataset } from '../../providers/utils';
 import DimensionMapper from '../../dimension-mapper/DimensionMapper';
 import { DimensionMapping } from '../../dimension-mapper/models';
 import { ProviderContext } from '../../providers/context';
-import { getAttributeValue, getLinkedEntity, getNxAxes } from '../nexus/utils';
+import {
+  getAttributeValue,
+  getLinkedEntity,
+  getNxAxes,
+  getNxDataGroup,
+} from '../nexus/utils';
 import { VisContainerProps } from './models';
 import MappedHeatmapVis from '../heatmap/MappedHeatmapVis';
 import { assertStr } from '../shared/utils';
@@ -16,9 +21,15 @@ function NxImageContainer(props: VisContainerProps): ReactElement {
   assertGroup(entity);
 
   const { metadata } = useContext(ProviderContext);
-  const signal = getAttributeValue(entity, 'signal');
+
+  const nxDataGroup = getNxDataGroup(entity, metadata);
+  if (!nxDataGroup) {
+    throw new Error('NXdata group not found');
+  }
+
+  const signal = getAttributeValue(nxDataGroup, 'signal');
   assertStr(signal);
-  const signalDataset = getLinkedEntity(entity, metadata, signal);
+  const signalDataset = getLinkedEntity(nxDataGroup, metadata, signal);
 
   if (!signalDataset || !isDataset(signalDataset)) {
     throw new Error('Signal dataset not found');
@@ -35,7 +46,7 @@ function NxImageContainer(props: VisContainerProps): ReactElement {
     'x',
   ]);
 
-  const axes = getNxAxes(entity, metadata);
+  const axes = getNxAxes(nxDataGroup, metadata);
 
   const values = useDatasetValues({ signal: signalDataset.id, ...axes.ids });
 

--- a/src/h5web/visualizations/containers/NxSpectrumContainer.tsx
+++ b/src/h5web/visualizations/containers/NxSpectrumContainer.tsx
@@ -7,7 +7,12 @@ import DimensionMapper from '../../dimension-mapper/DimensionMapper';
 import { DimensionMapping } from '../../dimension-mapper/models';
 import MappedLineVis from '../line/MappedLineVis';
 import { ProviderContext } from '../../providers/context';
-import { getAttributeValue, getLinkedEntity, getNxAxes } from '../nexus/utils';
+import {
+  getAttributeValue,
+  getLinkedEntity,
+  getNxAxes,
+  getNxDataGroup,
+} from '../nexus/utils';
 import { VisContainerProps } from './models';
 import { assertStr } from '../shared/utils';
 
@@ -16,9 +21,15 @@ function NxSpectrumContainer(props: VisContainerProps): ReactElement {
   assertGroup(entity);
 
   const { metadata } = useContext(ProviderContext);
-  const signal = getAttributeValue(entity, 'signal');
+
+  const nxDataGroup = getNxDataGroup(entity, metadata);
+  if (!nxDataGroup) {
+    throw new Error('NXdata group not found');
+  }
+
+  const signal = getAttributeValue(nxDataGroup, 'signal');
   assertStr(signal);
-  const signalDataset = getLinkedEntity(entity, metadata, signal);
+  const signalDataset = getLinkedEntity(nxDataGroup, metadata, signal);
 
   if (!signalDataset || !isDataset(signalDataset)) {
     throw new Error('Signal dataset not found');
@@ -29,7 +40,7 @@ function NxSpectrumContainer(props: VisContainerProps): ReactElement {
     throw new Error('Expected dataset with at least one dimension');
   }
 
-  const axes = getNxAxes(entity, metadata);
+  const axes = getNxAxes(nxDataGroup, metadata);
 
   const [mapperState, setMapperState] = useState<DimensionMapping>([
     ...range(dims.length - 1).fill(0),

--- a/src/h5web/visualizations/index.tsx
+++ b/src/h5web/visualizations/index.tsx
@@ -10,14 +10,13 @@ import {
   isSimpleShape,
   isNumericType,
   isDataset,
-  isGroup,
 } from '../providers/utils';
 import type { VisContainerProps } from './containers/models';
 import {
-  isNxDataGroup,
   getAttributeValue,
   isNxInterpretation,
   getLinkedEntity,
+  getNxDataGroup,
 } from './nexus/utils';
 import { NxInterpretation } from './nexus/models';
 import {
@@ -112,16 +111,18 @@ export const VIS_DEFS: Record<Vis, VisDef> = {
     Toolbar: LineToolbar,
     Container: NxSpectrumContainer,
     supportsEntity: (entity, metadata) => {
-      if (!isGroup(entity) || !isNxDataGroup(entity)) {
+      const group = getNxDataGroup(entity, metadata);
+
+      if (!group) {
         return false;
       }
 
-      const signal = getAttributeValue(entity, 'signal');
+      const signal = getAttributeValue(group, 'signal');
       if (typeof signal !== 'string') {
         return false;
       }
 
-      const dataset = getLinkedEntity(entity, metadata, signal);
+      const dataset = getLinkedEntity(group, metadata, signal);
       if (
         !dataset ||
         !isDataset(dataset) ||
@@ -138,7 +139,7 @@ export const VIS_DEFS: Record<Vis, VisDef> = {
 
       const interpretation = getAttributeValue(dataset, 'interpretation');
       return (
-        (!isNxInterpretation(interpretation) && dimsCount === 1) || // NxImage already suports datasets with 2+ dimensions
+        (!isNxInterpretation(interpretation) && dimsCount === 1) || // NxImage already supports datasets with 2+ dimensions
         interpretation === NxInterpretation.Spectrum
       );
     },
@@ -149,16 +150,18 @@ export const VIS_DEFS: Record<Vis, VisDef> = {
     Toolbar: HeatmapToolbar,
     Container: NxImageContainer,
     supportsEntity: (entity, metadata) => {
-      if (!isGroup(entity) || !isNxDataGroup(entity)) {
+      const group = getNxDataGroup(entity, metadata);
+
+      if (!group) {
         return false;
       }
 
-      const signal = getAttributeValue(entity, 'signal');
+      const signal = getAttributeValue(group, 'signal');
       if (typeof signal !== 'string') {
         return false;
       }
 
-      const dataset = getLinkedEntity(entity, metadata, signal);
+      const dataset = getLinkedEntity(group, metadata, signal);
       if (
         !dataset ||
         !isDataset(dataset) ||

--- a/src/h5web/visualizations/nexus/models.ts
+++ b/src/h5web/visualizations/nexus/models.ts
@@ -1,4 +1,4 @@
-export type NxAttribute = 'signal' | 'interpretation' | 'axes';
+export type NxAttribute = 'signal' | 'interpretation' | 'axes' | 'default';
 
 export enum NxInterpretation {
   Spectrum = 'spectrum',


### PR DESCRIPTION
Fix #233 

![image](https://user-images.githubusercontent.com/42204205/97167094-876c2480-1786-11eb-84dc-89bad4d72978.png)

The default attribute can:
- be a relative path in the file
- be an absolute path in the file
- points to another entity with a default attribute