### PR TITLE
Fix non-integer ticks when abscissa/ordinate values were not supplied

### DIFF
--- a/src/h5web/visualizations/heatmap/HeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapVis.tsx
@@ -69,13 +69,13 @@ function HeatmapVis(props: Props): JSX.Element {
         abscissaConfig={{
           domain: abscissaDomain,
           showGrid,
-          isIndexAxis: !abscissas,
+          isIndexAxis: !abscissaParams.values,
           label: abscissaParams.label,
         }}
         ordinateConfig={{
           domain: ordinateDomain,
           showGrid,
-          isIndexAxis: !ordinates,
+          isIndexAxis: !ordinateParams.values,
           label: ordinateParams.label,
         }}
         aspectRatio={aspectRatio}

--- a/src/h5web/visualizations/line/LineVis.tsx
+++ b/src/h5web/visualizations/line/LineVis.tsx
@@ -68,7 +68,7 @@ function LineVis(props: Props): ReactElement {
         abscissaConfig={{
           domain: abscissaDomain,
           showGrid,
-          isIndexAxis: !abscissas,
+          isIndexAxis: !abscissaParams.values,
           label: abscissaLabel,
         }}
         ordinateConfig={{


### PR DESCRIPTION
I thought a refactoring would be needed to fix this but I found a workaround.

That being said, I am not extremely happy about the current state of things. To be discussed together when we have time.