### PR TITLE
AxisSystem svg now have zero width and height to avoid svg default size

### DIFF
--- a/src/h5web/visualizations/shared/AxisSystem.module.css
+++ b/src/h5web/visualizations/shared/AxisSystem.module.css
@@ -10,6 +10,11 @@
   pointer-events: none;
 }
 
+.axisSystem > svg {
+  width: 0;
+  height: 0;
+}
+
 .grid,
 .axis {
   display: block;


### PR DESCRIPTION
Fix #258 

_Mocked dataset `fourD` with D0 in Y and D3 in X:_
![image](https://user-images.githubusercontent.com/42204205/97411547-b3abb080-1900-11eb-97a4-51b854e4d91f.png)


It was due to the default size of the parent `<svg>` of `Axis` (300 x 150). At heights lower than 150px, the height of the ordinate axis `<svg>` made the bottom axis go lower than the canvas.

<s>I fixed it by setting the dimensions of the `Grid` and `Axis` `<svg>` to `100%` so that they always have the same width/height as the canvas.</s>
https://github.com/silx-kit/h5web/pull/269#issuecomment-717955822 instead