### PR TITLE
Nx Axis labels are now determined from long_name and units attributes

### DIFF
--- a/src/h5web/providers/mock/data.ts
+++ b/src/h5web/providers/mock/data.ts
@@ -308,15 +308,30 @@ export const mockMetadata = makeMetadata({
     ),
   ],
   datasets: [
-    makeSimpleDataset('oneD', intType, [41]),
+    makeSimpleDataset(
+      'oneD',
+      intType,
+      [41],
+      [makeStrAttr('units', 'arb. units')]
+    ),
     makeSimpleDataset('twoD', intType, [20, 41]),
     makeSimpleDataset('threeD', intType, [9, 20, 41]),
-    makeSimpleDataset('fourD', intType, [3, 9, 20, 41]),
+    makeSimpleDataset(
+      'fourD',
+      intType,
+      [3, 9, 20, 41],
+      [makeStrAttr('long_name', 'Interference fringes')]
+    ),
     makeDataset('raw', compoundType, scalarShape),
     makeDataset('scalar_int', intType, scalarShape),
     makeDataset('scalar_str', stringType, scalarShape),
-    makeSimpleDataset('X', intType, [41]),
-    makeSimpleDataset('Y', intType, [20]),
+    makeSimpleDataset('X', intType, [41], [makeStrAttr('units', 'nm')]),
+    makeSimpleDataset(
+      'Y',
+      intType,
+      [20],
+      [makeStrAttr('units', 'deg'), makeStrAttr('long_name', 'Angle (degrees)')]
+    ),
   ],
   datatypes: [makeDatatype('datatype', compoundType)],
 });

--- a/src/h5web/visualizations/containers/HeatmapVisContainer.tsx
+++ b/src/h5web/visualizations/containers/HeatmapVisContainer.tsx
@@ -36,7 +36,11 @@ function HeatmapVisContainer(props: VisContainerProps): ReactElement {
         mapperState={mapperState}
         onChange={setMapperState}
       />
-      <MappedHeatmapVis value={value} dims={dims} mapperState={mapperState} />
+      <MappedHeatmapVis
+        value={value}
+        dims={dims}
+        dimensionMapping={mapperState}
+      />
     </>
   );
 }

--- a/src/h5web/visualizations/containers/LineVisContainer.tsx
+++ b/src/h5web/visualizations/containers/LineVisContainer.tsx
@@ -35,7 +35,7 @@ function LineVisContainer(props: VisContainerProps): ReactElement {
         mapperState={mapperState}
         onChange={setMapperState}
       />
-      <MappedLineVis value={value} dims={dims} mapperState={mapperState} />
+      <MappedLineVis value={value} dims={dims} dimensionMapping={mapperState} />
     </>
   );
 }

--- a/src/h5web/visualizations/containers/NxImageContainer.tsx
+++ b/src/h5web/visualizations/containers/NxImageContainer.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement, useState, useContext } from 'react';
 import { range } from 'lodash-es';
 import { HDF5SimpleShape } from '../../providers/models';
-import { useDatasetValues } from './hooks';
 import { assertGroup, isDataset } from '../../providers/utils';
 import DimensionMapper from '../../dimension-mapper/DimensionMapper';
 import { DimensionMapping } from '../../dimension-mapper/models';
@@ -9,12 +8,16 @@ import { ProviderContext } from '../../providers/context';
 import {
   getAttributeValue,
   getLinkedEntity,
-  getNxAxes,
   getNxDataGroup,
+  getNxAxisMapping,
+  getLinkedDatasets,
+  getNxAxesParams,
+  getDatasetLabel,
 } from '../nexus/utils';
 import { VisContainerProps } from './models';
 import MappedHeatmapVis from '../heatmap/MappedHeatmapVis';
 import { assertStr } from '../shared/utils';
+import { useDatasetValues } from './hooks';
 
 function NxImageContainer(props: VisContainerProps): ReactElement {
   const { entity } = props;
@@ -27,9 +30,9 @@ function NxImageContainer(props: VisContainerProps): ReactElement {
     throw new Error('NXdata group not found');
   }
 
-  const signal = getAttributeValue(nxDataGroup, 'signal');
-  assertStr(signal);
-  const signalDataset = getLinkedEntity(nxDataGroup, metadata, signal);
+  const signalName = getAttributeValue(nxDataGroup, 'signal');
+  assertStr(signalName);
+  const signalDataset = getLinkedEntity(signalName, nxDataGroup, metadata);
 
   if (!signalDataset || !isDataset(signalDataset)) {
     throw new Error('Signal dataset not found');
@@ -40,17 +43,27 @@ function NxImageContainer(props: VisContainerProps): ReactElement {
     throw new Error('Expected signal dataset with at least two dimensions');
   }
 
-  const [mapperState, setMapperState] = useState<DimensionMapping>([
+  const [dimensionMapping, setDimensionMapping] = useState<DimensionMapping>([
     ...range(dims.length - 2).fill(0),
     'y',
     'x',
   ]);
 
-  const axes = getNxAxes(nxDataGroup, metadata);
+  const nxAxisMapping = getNxAxisMapping(nxDataGroup);
+  const axisDatasets = getLinkedDatasets(
+    nxAxisMapping.filter((v): v is string => !!v),
+    nxDataGroup,
+    metadata
+  );
+  const datasetValues = useDatasetValues({
+    [signalName]: signalDataset.id,
+    ...Object.fromEntries(
+      Object.entries(axisDatasets).map(([axis, dataset]) => [axis, dataset.id])
+    ),
+  });
+  const nxAxesParams = getNxAxesParams(axisDatasets, datasetValues);
 
-  const values = useDatasetValues({ signal: signalDataset.id, ...axes.ids });
-
-  if (!values || !values.signal) {
+  if (!datasetValues || !datasetValues[signalName]) {
     return <></>;
   }
 
@@ -58,16 +71,16 @@ function NxImageContainer(props: VisContainerProps): ReactElement {
     <>
       <DimensionMapper
         rawDims={dims}
-        mapperState={mapperState}
-        onChange={setMapperState}
+        mapperState={dimensionMapping}
+        onChange={setDimensionMapping}
       />
       <MappedHeatmapVis
-        value={values.signal}
-        valueLabel={signal}
+        value={datasetValues[signalName]}
+        title={getDatasetLabel(signalDataset, signalName)}
         dims={dims}
-        mapperState={mapperState}
-        axesLabels={axes.labels}
-        axesValues={values}
+        dimensionMapping={dimensionMapping}
+        axisMapping={nxAxisMapping}
+        axesParams={nxAxesParams}
       />
     </>
   );

--- a/src/h5web/visualizations/heatmap/HeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapVis.tsx
@@ -20,7 +20,7 @@ interface Props {
   keepAspectRatio?: boolean;
   showGrid?: boolean;
   showLoader?: boolean;
-  dataLabel?: string;
+  title?: string;
   abscissaParams?: AxisParams;
   ordinateParams?: AxisParams;
 }
@@ -34,7 +34,7 @@ function HeatmapVis(props: Props): ReactElement {
     keepAspectRatio = true,
     showGrid = false,
     showLoader = true,
-    dataLabel,
+    title,
     abscissaParams = {},
     ordinateParams = {},
   } = props;
@@ -75,7 +75,7 @@ function HeatmapVis(props: Props): ReactElement {
           label: ordinateParams.label,
         }}
         aspectRatio={aspectRatio}
-        canvasTitle={dataLabel}
+        canvasTitle={title}
       >
         <TooltipMesh
           formatIndex={([x, y]) => {

--- a/src/h5web/visualizations/heatmap/MappedHeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/MappedHeatmapVis.tsx
@@ -3,27 +3,28 @@ import { usePrevious } from 'react-use';
 import type { HDF5Value } from '../../providers/models';
 import type { DimensionMapping } from '../../dimension-mapper/models';
 import HeatmapVis from './HeatmapVis';
-import { assertArray, assertOptionalArray } from '../shared/utils';
+import { assertArray } from '../shared/utils';
 import { useMappedArray, useDomain, useBaseArray } from '../shared/hooks';
 import { useHeatmapConfig } from './config';
+import { AxisParams } from '../shared/models';
 
 interface Props {
   value: HDF5Value;
   dims: number[];
-  mapperState: DimensionMapping;
-  valueLabel?: string;
-  axesLabels?: (string | undefined)[];
-  axesValues?: Record<string, HDF5Value>;
+  dimensionMapping: DimensionMapping;
+  title?: string;
+  axisMapping?: (string | undefined)[];
+  axesParams?: Record<string, AxisParams>;
 }
 
 function MappedHeatmapVis(props: Props): ReactElement {
   const {
     value,
-    axesLabels = [],
-    axesValues = {},
-    valueLabel,
+    axisMapping = [],
+    axesParams = {},
+    title,
     dims,
-    mapperState,
+    dimensionMapping,
   } = props;
   assertArray<number>(value);
 
@@ -39,7 +40,7 @@ function MappedHeatmapVis(props: Props): ReactElement {
   } = useHeatmapConfig();
 
   const baseArray = useBaseArray(value, dims);
-  const dataArray = useMappedArray(baseArray, mapperState);
+  const dataArray = useMappedArray(baseArray, dimensionMapping);
   const dataDomain = useDomain(
     (autoScale ? dataArray.data : baseArray.data) as number[],
     scaleType
@@ -59,25 +60,22 @@ function MappedHeatmapVis(props: Props): ReactElement {
     resetDomains(dataDomain); // in config, update `dataDomain` and reset `customDomain`
   }, [dataDomain, resetDomains]);
 
-  const abscissaLabel = mapperState && axesLabels[mapperState.indexOf('x')];
-  const abscissas = abscissaLabel && axesValues[abscissaLabel];
-  assertOptionalArray<number>(abscissas);
-
-  const ordinateLabel = mapperState && axesLabels[mapperState.indexOf('y')];
-  const ordinates = ordinateLabel && axesValues[ordinateLabel];
-  assertOptionalArray<number>(ordinates);
+  const abscissaName =
+    dimensionMapping && axisMapping[dimensionMapping.indexOf('x')];
+  const ordinateName =
+    dimensionMapping && axisMapping[dimensionMapping.indexOf('y')];
 
   return (
     <HeatmapVis
       dataArray={dataArray}
-      dataLabel={valueLabel}
+      title={title}
       domain={domain}
       colorMap={colorMap}
       scaleType={scaleType}
       keepAspectRatio={keepAspectRatio}
       showGrid={showGrid}
-      abscissaParams={{ label: abscissaLabel, values: abscissas }}
-      ordinateParams={{ label: ordinateLabel, values: ordinates }}
+      abscissaParams={abscissaName ? axesParams[abscissaName] : undefined}
+      ordinateParams={ordinateName ? axesParams[ordinateName] : undefined}
     />
   );
 }

--- a/src/h5web/visualizations/index.tsx
+++ b/src/h5web/visualizations/index.tsx
@@ -122,7 +122,7 @@ export const VIS_DEFS: Record<Vis, VisDef> = {
         return false;
       }
 
-      const dataset = getLinkedEntity(group, metadata, signal);
+      const dataset = getLinkedEntity(signal, group, metadata);
       if (
         !dataset ||
         !isDataset(dataset) ||
@@ -161,7 +161,7 @@ export const VIS_DEFS: Record<Vis, VisDef> = {
         return false;
       }
 
-      const dataset = getLinkedEntity(group, metadata, signal);
+      const dataset = getLinkedEntity(signal, group, metadata);
       if (
         !dataset ||
         !isDataset(dataset) ||

--- a/src/h5web/visualizations/line/MappedLineVis.tsx
+++ b/src/h5web/visualizations/line/MappedLineVis.tsx
@@ -2,27 +2,28 @@ import React, { ReactElement, useEffect } from 'react';
 import type { HDF5Value } from '../../providers/models';
 import type { DimensionMapping } from '../../dimension-mapper/models';
 import LineVis from './LineVis';
-import { assertArray, assertOptionalArray } from '../shared/utils';
+import { assertArray } from '../shared/utils';
 import { useMappedArray, useDomain, useBaseArray } from '../shared/hooks';
 import { useLineConfig } from './config';
+import { AxisParams } from '../shared/models';
 
 interface Props {
   value: HDF5Value;
   dims: number[];
-  mapperState: DimensionMapping;
+  dimensionMapping: DimensionMapping;
   valueLabel?: string;
-  axesLabels?: (string | undefined)[];
-  axesValues?: Record<string, HDF5Value>;
+  axisMapping?: (string | undefined)[];
+  axesParams?: Record<string, AxisParams>;
 }
 
 function MappedLineVis(props: Props): ReactElement {
   const {
     value,
     valueLabel,
-    axesLabels = [],
-    axesValues = {},
+    axisMapping = [],
+    axesParams = {},
     dims,
-    mapperState,
+    dimensionMapping,
   } = props;
   assertArray<number>(value);
 
@@ -35,7 +36,7 @@ function MappedLineVis(props: Props): ReactElement {
   } = useLineConfig();
 
   const baseArray = useBaseArray(value, dims);
-  const dataArray = useMappedArray(baseArray, mapperState);
+  const dataArray = useMappedArray(baseArray, dimensionMapping);
 
   // Disable `autoScale` for 1D datasets (baseArray and dataArray are the same)
   useEffect(() => {
@@ -47,9 +48,8 @@ function MappedLineVis(props: Props): ReactElement {
     scaleType
   );
 
-  const abscissaLabel = mapperState && axesLabels[mapperState.indexOf('x')];
-  const abscissas = abscissaLabel && axesValues[abscissaLabel];
-  assertOptionalArray<number>(abscissas);
+  const abscissaName =
+    dimensionMapping && axisMapping[dimensionMapping.indexOf('x')];
 
   return (
     <LineVis
@@ -58,10 +58,7 @@ function MappedLineVis(props: Props): ReactElement {
       scaleType={scaleType}
       curveType={curveType}
       showGrid={showGrid}
-      abscissaParams={{
-        label: abscissaLabel,
-        values: abscissas,
-      }}
+      abscissaParams={abscissaName ? axesParams[abscissaName] : undefined}
       ordinateLabel={valueLabel}
     />
   );

--- a/src/h5web/visualizations/nexus/models.ts
+++ b/src/h5web/visualizations/nexus/models.ts
@@ -1,4 +1,10 @@
-export type NxAttribute = 'signal' | 'interpretation' | 'axes' | 'default';
+export type NxAttribute =
+  | 'signal'
+  | 'interpretation'
+  | 'axes'
+  | 'default'
+  | 'long_name'
+  | 'units';
 
 export enum NxInterpretation {
   Spectrum = 'spectrum',

--- a/src/h5web/visualizations/shared/AxisSystem.module.css
+++ b/src/h5web/visualizations/shared/AxisSystem.module.css
@@ -48,6 +48,7 @@
   font-family: inherit;
   font-size: inherit;
   font-weight: 600;
+  text-anchor: middle;
 }
 
 .title {

--- a/src/stories/HeatmapVis.stories.tsx
+++ b/src/stories/HeatmapVis.stories.tsx
@@ -141,7 +141,7 @@ export const WithTitle = Template.bind({});
 WithTitle.args = {
   dataArray,
   domain,
-  dataLabel: 'Pretty colors',
+  title: 'Pretty colors',
 };
 
 export default {


### PR DESCRIPTION
Fix #265 

![image](https://user-images.githubusercontent.com/42204205/97571690-23e13180-19e8-11eb-87c7-9489d7339bd5.png)


I added the support of `long_name` as well as it was the same logic.

Also updated the mock data with some `long_name` and `units` attributes.