### PR TITLE
Test vis selector

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,8 +52,9 @@ module.exports = createConfig({
     {
       files: jestFiles,
       rules: {
-        'jest-formatting/padding-around-all': 'off', // allow writing concise two-line tests
+        'jest/no-focused-tests': 'warn', // warning instead of error
         'jest/prefer-strict-equal': 'off', // `toEqual` is shorter and sufficient in most cases
+        'jest-formatting/padding-around-all': 'off', // allow writing concise two-line tests
         'testing-library/await-fire-event': 'off', // not supported by React Testing Library
 
         // Tests in different `describe` blocks may have the same names and identical functions

--- a/src/h5web/visualizations/Visualizations.test.tsx
+++ b/src/h5web/visualizations/Visualizations.test.tsx
@@ -1,0 +1,24 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { renderApp } from '../test-utils';
+
+describe('Visualizer', () => {
+  test('visualise scalar dataset', async () => {
+    renderApp();
+
+    fireEvent.click(await screen.findByRole('treeitem', { name: 'entities' }));
+    const datasetBtn = screen.getByRole('treeitem', { name: 'scalar_int' });
+    expect(datasetBtn).toBeVisible();
+
+    fireEvent.click(datasetBtn);
+    expect(datasetBtn).toHaveAttribute('aria-selected', 'true');
+    expect(datasetBtn).not.toHaveAttribute('aria-expanded'); // a dataset cannot be expanded
+
+    const scalarTab = await screen.findByRole('tab', { name: 'Scalar' });
+    expect(scalarTab).toBeVisible();
+    expect(scalarTab).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByText('0')).toBeVisible();
+
+    fireEvent.click(screen.getByRole('treeitem', { name: 'scalar_str' }));
+    expect(await screen.findByText('foo')).toBeVisible();
+  });
+});


### PR DESCRIPTION
Some higher-level feature tests for `supportsEntity` and the vis selector. I only test ideal scenarios with existing mock data. I think the tests in `visualizations/index.test.ts` are worth keeping, though.