### PR TITLE
Line and Heatmap now show the entity name as title

### DIFF
--- a/src/h5web/App.tsx
+++ b/src/h5web/App.tsx
@@ -47,7 +47,10 @@ function App(): ReactElement {
           {isInspecting ? (
             <MetadataViewer link={selectedLink} entity={selectedEntity} />
           ) : (
-            <Visualizer entity={selectedEntity} />
+            <Visualizer
+              entity={selectedEntity}
+              entityName={selectedLink && selectedLink.title}
+            />
           )}
         </ReflexElement>
       </ReflexContainer>

--- a/src/h5web/providers/mock/data.ts
+++ b/src/h5web/providers/mock/data.ts
@@ -252,6 +252,7 @@ export const mockMetadata = makeMetadata({
       makeDatasetHardLink('scalar_str'),
     ]),
     makeGroup('nD_datasets', undefined, [
+      makeDatasetHardLink('oneD_linear'),
       makeDatasetHardLink('oneD'),
       makeDatasetHardLink('twoD'),
       makeDatasetHardLink('threeD'),
@@ -308,6 +309,7 @@ export const mockMetadata = makeMetadata({
     ),
   ],
   datasets: [
+    makeSimpleDataset('oneD_linear', intType, [41]),
     makeSimpleDataset(
       'oneD',
       intType,
@@ -359,6 +361,7 @@ export const mockValues = {
   raw: { int: 42 },
   scalar_int: 0,
   scalar_str: 'foo',
+  oneD_linear: arr1,
   oneD,
   twoD,
   threeD,

--- a/src/h5web/visualizations/containers/HeatmapVisContainer.tsx
+++ b/src/h5web/visualizations/containers/HeatmapVisContainer.tsx
@@ -9,7 +9,7 @@ import MappedHeatmapVis from '../heatmap/MappedHeatmapVis';
 import { VisContainerProps } from './models';
 
 function HeatmapVisContainer(props: VisContainerProps): ReactElement {
-  const { entity } = props;
+  const { entity, entityName } = props;
   assertDataset(entity);
 
   const value = useDatasetValue(entity.id);
@@ -40,6 +40,7 @@ function HeatmapVisContainer(props: VisContainerProps): ReactElement {
         value={value}
         dims={dims}
         dimensionMapping={mapperState}
+        title={entityName}
       />
     </>
   );

--- a/src/h5web/visualizations/containers/LineVisContainer.tsx
+++ b/src/h5web/visualizations/containers/LineVisContainer.tsx
@@ -9,7 +9,7 @@ import MappedLineVis from '../line/MappedLineVis';
 import { VisContainerProps } from './models';
 
 function LineVisContainer(props: VisContainerProps): ReactElement {
-  const { entity } = props;
+  const { entity, entityName } = props;
   assertDataset(entity);
 
   const value = useDatasetValue(entity.id);
@@ -35,7 +35,12 @@ function LineVisContainer(props: VisContainerProps): ReactElement {
         mapperState={mapperState}
         onChange={setMapperState}
       />
-      <MappedLineVis value={value} dims={dims} dimensionMapping={mapperState} />
+      <MappedLineVis
+        value={value}
+        dims={dims}
+        dimensionMapping={mapperState}
+        title={entityName}
+      />
     </>
   );
 }

--- a/src/h5web/visualizations/containers/models.ts
+++ b/src/h5web/visualizations/containers/models.ts
@@ -2,4 +2,5 @@ import type { HDF5Entity } from '../../providers/models';
 
 export interface VisContainerProps {
   entity: HDF5Entity;
+  entityName?: string;
 }

--- a/src/h5web/visualizations/line/LineVis.tsx
+++ b/src/h5web/visualizations/line/LineVis.tsx
@@ -21,6 +21,7 @@ interface Props {
   showGrid?: boolean;
   abscissaParams?: AxisParams;
   ordinateLabel?: string;
+  title?: string;
 }
 
 function LineVis(props: Props): ReactElement {
@@ -32,6 +33,7 @@ function LineVis(props: Props): ReactElement {
     scaleType = ScaleType.Linear,
     abscissaParams = {},
     ordinateLabel,
+    title,
   } = props;
 
   const {
@@ -77,6 +79,7 @@ function LineVis(props: Props): ReactElement {
           scaleType,
           label: ordinateLabel,
         }}
+        canvasTitle={title}
       >
         <TooltipMesh
           formatIndex={([x]) =>

--- a/src/h5web/visualizations/line/MappedLineVis.tsx
+++ b/src/h5web/visualizations/line/MappedLineVis.tsx
@@ -14,6 +14,7 @@ interface Props {
   valueLabel?: string;
   axisMapping?: (string | undefined)[];
   axesParams?: Record<string, AxisParams>;
+  title?: string;
 }
 
 function MappedLineVis(props: Props): ReactElement {
@@ -24,6 +25,7 @@ function MappedLineVis(props: Props): ReactElement {
     axesParams = {},
     dims,
     dimensionMapping,
+    title,
   } = props;
   assertArray<number>(value);
 
@@ -60,6 +62,7 @@ function MappedLineVis(props: Props): ReactElement {
       showGrid={showGrid}
       abscissaParams={abscissaName ? axesParams[abscissaName] : undefined}
       ordinateLabel={valueLabel}
+      title={title}
     />
   );
 }

--- a/src/h5web/visualizer/Visualizer.tsx
+++ b/src/h5web/visualizer/Visualizer.tsx
@@ -11,10 +11,11 @@ import Profiler from '../Profiler';
 
 interface Props {
   entity?: HDF5Entity;
+  entityName?: string;
 }
 
 function Visualizer(props: Props): ReactElement {
-  const { entity } = props;
+  const { entity, entityName } = props;
   const { metadata } = useContext(ProviderContext);
 
   const supportedVis = entity ? getSupportedVis(entity, metadata) : [];
@@ -55,7 +56,7 @@ function Visualizer(props: Props): ReactElement {
           )}
         >
           <Profiler id={activeVis}>
-            <Container entity={entity} />
+            <Container entity={entity} entityName={entityName} />
           </Profiler>
         </AsyncResourceContent>
       </div>

--- a/src/stories/LineVis.stories.tsx
+++ b/src/stories/LineVis.stories.tsx
@@ -9,8 +9,8 @@ import { getDomain, mockValues } from '../packages/lib';
 import { getMockDatasetDims } from '../h5web/providers/mock/utils';
 
 // Prepare 1D data array
-const values = mockValues.oneD;
-const dataArray = ndarray(values, getMockDatasetDims('oneD'));
+const values = mockValues.oneD_linear;
+const dataArray = ndarray(values, getMockDatasetDims('oneD_linear'));
 const domain = getDomain(values);
 const logSafeDomain = getDomain(values, ScaleType.Log);
 
@@ -97,6 +97,14 @@ WithAxesLabels.args = {
   domain,
   abscissaParams: { label: 'Time' },
   ordinateLabel: 'Position',
+};
+
+export const WithTitle = Template.bind({});
+
+WithTitle.args = {
+  dataArray,
+  domain,
+  title: 'A simple curve',
 };
 
 export default {


### PR DESCRIPTION
Fix #278 

<s>I had to make a few changes to have access to the entity name. Indeed, Vis containers only recieve `entity` in props which did not contain the name of the entity.

I therefore changed the `HDF5Entity` names and the API creating them so that the name is now included in `entity`.</s> 

See https://github.com/silx-kit/h5web/pull/286#issuecomment-721728077