### PR TITLE
Improve accessibility of Matrix vis table

### DIFF
--- a/src/h5web/visualizations/matrix/Cell.tsx
+++ b/src/h5web/visualizations/matrix/Cell.tsx
@@ -20,6 +20,9 @@ function Cell(props: GridChildComponentProps): ReactElement {
     <div
       className={styles.cell}
       style={style}
+      role="cell"
+      aria-rowindex={rowIndex}
+      aria-colindex={columnIndex}
       data-bg={(rowIndex + columnIndex) % 2 === 1 ? '' : undefined}
     >
       {typeof dataValue === 'number' ? format('.3e')(dataValue) : dataValue}

--- a/src/h5web/visualizations/matrix/StickyGrid.tsx
+++ b/src/h5web/visualizations/matrix/StickyGrid.tsx
@@ -26,6 +26,7 @@ function StickyGrid(props: Props, ref: Ref<HTMLDivElement>): ReactElement {
       className={styles.stickyGrid}
       ref={ref}
       style={style}
+      role="table"
       data-sticky={sticky || undefined}
     >
       <IndexTrack className={styles.indexRow} cellCount={columnCount - 1}>


### PR DESCRIPTION
The Matrix vis table was just made of `div`s with no semantic whatsoever. I noticed it when trying to feature test the Matrix vis (which I ended up giving up on, because of `useMeasure` not working in JSDOM).