### PR TITLE
Different HSDS domains can now be queried by URL

### DIFF
--- a/.env
+++ b/.env
@@ -8,11 +8,11 @@
 REACT_APP_DEFAULT_PATH=
 
 # HSDS parameters
-# URL, username, password and filepath as strings
+# URL, username, password and domain as strings
 REACT_APP_HSDS_URL=
 REACT_APP_HSDS_USERNAME=
 REACT_APP_HSDS_PASSWORD=
-REACT_APP_HSDS_FILEPATH=
+REACT_APP_HSDS_DOMAIN=
 
 # Rendering performance profiling (local development only)
 REACT_APP_PROFILING_ENABLED=false

--- a/src/demo-app/DemoApp.tsx
+++ b/src/demo-app/DemoApp.tsx
@@ -2,7 +2,7 @@ import React, { lazy, ReactElement, Suspense } from 'react';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import App from '../h5web/App';
 import SilxProvider from '../h5web/providers/silx/SilxProvider';
-import HsdsProvider from '../h5web/providers/hsds/HsdsProvider';
+import HsdsApp from './HsdsApp';
 
 // Split mock data generation code out of main bundle
 const MockProvider = lazy(
@@ -11,11 +11,6 @@ const MockProvider = lazy(
       /* webpackChunkName: "mock" */ '../h5web/providers/mock/MockProvider'
     )
 );
-
-const HSDS_URL = process.env.REACT_APP_HSDS_URL || '';
-const HSDS_USERNAME = process.env.REACT_APP_HSDS_USERNAME || '';
-const HSDS_PASSWORD = process.env.REACT_APP_HSDS_PASSWORD || '';
-const HSDS_FILEPATH = process.env.REACT_APP_HSDS_FILEPATH || '';
 
 function DemoApp(): ReactElement {
   return (
@@ -29,14 +24,7 @@ function DemoApp(): ReactElement {
           </Suspense>
         </Route>
         <Route path="/hsds">
-          <HsdsProvider
-            url={HSDS_URL}
-            username={HSDS_USERNAME}
-            password={HSDS_PASSWORD}
-            filepath={HSDS_FILEPATH}
-          >
-            <App />
-          </HsdsProvider>
+          <HsdsApp />
         </Route>
         <Route exact path="/">
           <SilxProvider domain="bsa_002_000-integrate-sub">

--- a/src/demo-app/HsdsApp.tsx
+++ b/src/demo-app/HsdsApp.tsx
@@ -1,0 +1,26 @@
+import React, { ReactElement } from 'react';
+import { useLocation } from 'react-router-dom';
+import { App, HsdsProvider } from '../packages/app';
+
+const URL = process.env.REACT_APP_HSDS_URL || '';
+const USERNAME = process.env.REACT_APP_HSDS_USERNAME || '';
+const PASSWORD = process.env.REACT_APP_HSDS_PASSWORD || '';
+const DOMAIN = process.env.REACT_APP_HSDS_DOMAIN || '';
+
+function HsdsApp(): ReactElement {
+  const query = new URLSearchParams(useLocation().search);
+  const domain = query.get('domain');
+
+  return (
+    <HsdsProvider
+      url={URL}
+      username={USERNAME}
+      password={PASSWORD}
+      domain={domain || DOMAIN}
+    >
+      <App />
+    </HsdsProvider>
+  );
+}
+
+export default HsdsApp;

--- a/src/h5web/providers/Provider.tsx
+++ b/src/h5web/providers/Provider.tsx
@@ -1,9 +1,10 @@
 import React, { ReactElement, ReactNode } from 'react';
 import { useAsync } from 'react-use';
 import { ProviderAPI, ProviderContext } from './context';
+import styles from '../visualizer/Visualizer.module.css';
 
 interface Props {
-  api?: ProviderAPI;
+  api: ProviderAPI;
   children: ReactNode;
 }
 
@@ -11,10 +12,16 @@ function Provider(props: Props): ReactElement {
   const { api, children } = props;
 
   // Wait until metadata is fetched before rendering app
-  const { value: metadata } = useAsync(async () => api?.getMetadata(), [api]);
+  const { value: metadata, error } = useAsync(async () => api.getMetadata(), [
+    api,
+  ]);
 
-  if (!api || !metadata) {
-    return <></>;
+  if (error) {
+    return <p className={styles.error}>Error: {error.message}</p>;
+  }
+
+  if (!metadata) {
+    return <p className={styles.fallback}>Loading...</p>;
   }
 
   const getValue = api.getValue.bind(api);

--- a/src/h5web/providers/hsds/HsdsProvider.tsx
+++ b/src/h5web/providers/hsds/HsdsProvider.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState, useEffect, ReactElement } from 'react';
+import React, { ReactNode, ReactElement, useMemo } from 'react';
 import { HsdsApi } from './api';
 import Provider from '../Provider';
 
@@ -6,18 +6,19 @@ interface Props {
   url: string;
   username: string;
   password: string;
-  filepath: string;
+  domain: string;
   children: ReactNode;
 }
 
 /* Provider of metadata and values by HSDS */
 function HsdsProvider(props: Props): ReactElement {
-  const { url, username, password, filepath, children } = props;
-  const [api, setApi] = useState<HsdsApi>();
-
-  useEffect(() => {
-    setApi(new HsdsApi(url, username, password, filepath));
-  }, [filepath, password, url, username]);
+  const { url, username, password, domain, children } = props;
+  const api = useMemo(() => new HsdsApi(url, username, password, domain), [
+    domain,
+    password,
+    url,
+    username,
+  ]);
 
   return <Provider api={api}>{children}</Provider>;
 }

--- a/src/h5web/providers/hsds/api.ts
+++ b/src/h5web/providers/hsds/api.ts
@@ -38,12 +38,12 @@ export class HsdsApi implements ProviderAPI {
     url: string,
     username: string,
     password: string,
-    filepath: string
+    domain: string
   ) {
-    this.domain = `/home/${username}/${filepath}`;
+    this.domain = domain;
     this.client = axios.create({
       baseURL: url,
-      params: { domain: this.domain },
+      params: { domain },
       auth: { username, password },
     });
   }

--- a/src/h5web/providers/silx/SilxProvider.tsx
+++ b/src/h5web/providers/silx/SilxProvider.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState, useEffect, ReactElement } from 'react';
+import React, { ReactNode, ReactElement, useMemo } from 'react';
 import { SilxApi } from './api';
 import Provider from '../Provider';
 
@@ -9,11 +9,8 @@ interface Props {
 
 function SilxProvider(props: Props): ReactElement {
   const { domain, children } = props;
-  const [api, setApi] = useState<SilxApi>();
 
-  useEffect(() => {
-    setApi(new SilxApi(domain));
-  }, [domain]);
+  const api = useMemo(() => new SilxApi(domain), [domain]);
 
   return <Provider api={api}>{children}</Provider>;
 }


### PR DESCRIPTION
Fix #280 

Available domains so far on `bosquet`:
- `/home/reader/water`
- `/home/reader/tall`