### PR TITLE
Now using custom hook to parse nxData entities

### DIFF
--- a/cypress/integration/app.spec.ts
+++ b/cypress/integration/app.spec.ts
@@ -98,6 +98,7 @@ describe('App', () => {
 
       cy.findByRole('heading', { name: 'nexus_entry / image' }).should('exist');
       cy.findByRole('tab', { name: 'NX Image' }).should('exist');
+      cy.wait(500);
     });
 
     it('use signal name and units to compute title', () => {

--- a/src/h5web/visualizations/containers/NxImageContainer.tsx
+++ b/src/h5web/visualizations/containers/NxImageContainer.tsx
@@ -1,23 +1,13 @@
 import React, { ReactElement, useState, useContext } from 'react';
 import { range } from 'lodash-es';
-import { HDF5SimpleShape } from '../../providers/models';
-import { assertGroup, isDataset } from '../../providers/utils';
+import { assertGroup } from '../../providers/utils';
 import DimensionMapper from '../../dimension-mapper/DimensionMapper';
 import { DimensionMapping } from '../../dimension-mapper/models';
 import { ProviderContext } from '../../providers/context';
-import {
-  getAttributeValue,
-  getLinkedEntity,
-  getNxDataGroup,
-  getNxAxisMapping,
-  getLinkedDatasets,
-  getNxAxesParams,
-  getDatasetLabel,
-} from '../nexus/utils';
+import { getNxDataGroup } from '../nexus/utils';
 import { VisContainerProps } from './models';
 import MappedHeatmapVis from '../heatmap/MappedHeatmapVis';
-import { assertStr } from '../shared/utils';
-import { useDatasetValues } from './hooks';
+import { useNxData } from '../nexus/hooks';
 
 function NxImageContainer(props: VisContainerProps): ReactElement {
   const { entity } = props;
@@ -30,15 +20,9 @@ function NxImageContainer(props: VisContainerProps): ReactElement {
     throw new Error('NXdata group not found');
   }
 
-  const signalName = getAttributeValue(nxDataGroup, 'signal');
-  assertStr(signalName);
-  const signalDataset = getLinkedEntity(signalName, nxDataGroup, metadata);
+  const nxData = useNxData(nxDataGroup, metadata);
 
-  if (!signalDataset || !isDataset(signalDataset)) {
-    throw new Error('Signal dataset not found');
-  }
-
-  const { dims } = signalDataset.shape as HDF5SimpleShape;
+  const { dims } = nxData.signal;
   if (dims.length < 2) {
     throw new Error('Expected signal dataset with at least two dimensions');
   }
@@ -49,29 +33,9 @@ function NxImageContainer(props: VisContainerProps): ReactElement {
     'x',
   ]);
 
-  const nxAxisMapping = getNxAxisMapping(nxDataGroup);
-  const auxiliaryDatasets = getLinkedDatasets(
-    ['title', ...nxAxisMapping.filter((v): v is string => !!v)],
-    nxDataGroup,
-    metadata
-  );
+  const { signal, title, axisMapping } = nxData;
 
-  const datasetValues = useDatasetValues({
-    [signalName]: signalDataset.id,
-    ...Object.fromEntries(
-      Object.entries(auxiliaryDatasets).map(([name, dataset]) => [
-        name,
-        dataset.id,
-      ])
-    ),
-  });
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { title: _, ...axisDatasets } = auxiliaryDatasets;
-
-  const nxAxesParams = getNxAxesParams(axisDatasets, datasetValues);
-
-  if (!datasetValues || !datasetValues[signalName]) {
+  if (!signal.value) {
     return <></>;
   }
 
@@ -83,16 +47,11 @@ function NxImageContainer(props: VisContainerProps): ReactElement {
         onChange={setDimensionMapping}
       />
       <MappedHeatmapVis
-        value={datasetValues[signalName]}
-        title={
-          typeof datasetValues.title === 'string'
-            ? datasetValues.title
-            : getDatasetLabel(signalDataset, signalName)
-        }
+        value={signal.value}
+        title={title || signal.label}
         dims={dims}
         dimensionMapping={dimensionMapping}
-        axisMapping={nxAxisMapping}
-        axesParams={nxAxesParams}
+        axisMapping={axisMapping}
       />
     </>
   );

--- a/src/h5web/visualizations/containers/hooks.ts
+++ b/src/h5web/visualizations/containers/hooks.ts
@@ -1,6 +1,6 @@
 import { useAsyncResource } from 'use-async-resource';
 import { useContext } from 'react';
-import type { HDF5Id, HDF5Value } from '../../providers/models';
+import { HDF5Id, HDF5Value } from '../../providers/models';
 import { ProviderContext } from '../../providers/context';
 
 export function useDatasetValue(id: HDF5Id): HDF5Value | undefined {

--- a/src/h5web/visualizations/heatmap/MappedHeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/MappedHeatmapVis.tsx
@@ -6,26 +6,18 @@ import HeatmapVis from './HeatmapVis';
 import { assertArray } from '../shared/utils';
 import { useMappedArray, useDomain, useBaseArray } from '../shared/hooks';
 import { useHeatmapConfig } from './config';
-import { AxisParams } from '../shared/models';
+import { AxisMapping } from '../shared/models';
 
 interface Props {
   value: HDF5Value;
   dims: number[];
   dimensionMapping: DimensionMapping;
   title?: string;
-  axisMapping?: (string | undefined)[];
-  axesParams?: Record<string, AxisParams>;
+  axisMapping?: AxisMapping[];
 }
 
 function MappedHeatmapVis(props: Props): ReactElement {
-  const {
-    value,
-    axisMapping = [],
-    axesParams = {},
-    title,
-    dims,
-    dimensionMapping,
-  } = props;
+  const { value, axisMapping = [], title, dims, dimensionMapping } = props;
   assertArray<number>(value);
 
   const {
@@ -60,11 +52,6 @@ function MappedHeatmapVis(props: Props): ReactElement {
     resetDomains(dataDomain); // in config, update `dataDomain` and reset `customDomain`
   }, [dataDomain, resetDomains]);
 
-  const abscissaName =
-    dimensionMapping && axisMapping[dimensionMapping.indexOf('x')];
-  const ordinateName =
-    dimensionMapping && axisMapping[dimensionMapping.indexOf('y')];
-
   return (
     <HeatmapVis
       dataArray={dataArray}
@@ -74,8 +61,12 @@ function MappedHeatmapVis(props: Props): ReactElement {
       scaleType={scaleType}
       keepAspectRatio={keepAspectRatio}
       showGrid={showGrid}
-      abscissaParams={abscissaName ? axesParams[abscissaName] : undefined}
-      ordinateParams={ordinateName ? axesParams[ordinateName] : undefined}
+      abscissaParams={
+        dimensionMapping && axisMapping[dimensionMapping.indexOf('x')]
+      }
+      ordinateParams={
+        dimensionMapping && axisMapping[dimensionMapping.indexOf('y')]
+      }
     />
   );
 }

--- a/src/h5web/visualizations/line/MappedLineVis.tsx
+++ b/src/h5web/visualizations/line/MappedLineVis.tsx
@@ -5,15 +5,14 @@ import LineVis from './LineVis';
 import { assertArray } from '../shared/utils';
 import { useMappedArray, useDomain, useBaseArray } from '../shared/hooks';
 import { useLineConfig } from './config';
-import { AxisParams } from '../shared/models';
+import { AxisMapping } from '../shared/models';
 
 interface Props {
   value: HDF5Value;
   dims: number[];
   dimensionMapping: DimensionMapping;
   valueLabel?: string;
-  axisMapping?: (string | undefined)[];
-  axesParams?: Record<string, AxisParams>;
+  axisMapping?: AxisMapping[];
   title?: string;
 }
 
@@ -22,7 +21,6 @@ function MappedLineVis(props: Props): ReactElement {
     value,
     valueLabel,
     axisMapping = [],
-    axesParams = {},
     dims,
     dimensionMapping,
     title,
@@ -50,9 +48,6 @@ function MappedLineVis(props: Props): ReactElement {
     scaleType
   );
 
-  const abscissaName =
-    dimensionMapping && axisMapping[dimensionMapping.indexOf('x')];
-
   return (
     <LineVis
       dataArray={dataArray}
@@ -60,7 +55,9 @@ function MappedLineVis(props: Props): ReactElement {
       scaleType={scaleType}
       curveType={curveType}
       showGrid={showGrid}
-      abscissaParams={abscissaName ? axesParams[abscissaName] : undefined}
+      abscissaParams={
+        dimensionMapping && axisMapping[dimensionMapping.indexOf('x')]
+      }
       ordinateLabel={valueLabel}
       title={title}
     />

--- a/src/h5web/visualizations/nexus/hooks.ts
+++ b/src/h5web/visualizations/nexus/hooks.ts
@@ -1,0 +1,97 @@
+import {
+  HDF5Collection,
+  HDF5Group,
+  HDF5Id,
+  HDF5Metadata,
+  HDF5SimpleShape,
+} from '../../providers/models';
+import {
+  assertDataset,
+  getEntity,
+  isDataset,
+  isReachable,
+} from '../../providers/utils';
+import { useDatasetValues } from '../containers/hooks';
+import { assertStr, assertArray, assertOptionalArray } from '../shared/utils';
+import { NxData } from './models';
+import {
+  getAttributeValue,
+  getLinkedEntity,
+  getDatasetLabel,
+  getNxAxisNames,
+} from './utils';
+
+export function useLinkedDatasetValues(
+  group: HDF5Group,
+  metadata: HDF5Metadata
+) {
+  const datasetLinks =
+    group.links?.filter(
+      (link) => isReachable(link) && link.collection === HDF5Collection.Datasets
+    ) || [];
+
+  const datasetEntries = datasetLinks
+    .map((link) => {
+      const entity = getEntity(link, metadata);
+
+      return entity && isDataset(entity) ? [link.title, entity.id] : undefined;
+    })
+    .filter((entry): entry is [string, HDF5Id] => !!entry);
+
+  return useDatasetValues(Object.fromEntries(datasetEntries));
+}
+
+export function useNxData(group: HDF5Group, metadata: HDF5Metadata): NxData {
+  const datasetValues = useLinkedDatasetValues(group, metadata);
+
+  const signalName = getAttributeValue(group, 'signal');
+  assertStr(signalName);
+  const signalDataset = getLinkedEntity(signalName, group, metadata);
+
+  if (!signalDataset) {
+    throw new Error('Signal dataset not found');
+  }
+  assertDataset(signalDataset);
+
+  const signalValue = datasetValues && datasetValues[signalName];
+  if (!signalValue) {
+    return {
+      signal: {
+        dims: (signalDataset.shape as HDF5SimpleShape).dims,
+      },
+    };
+  }
+  assertArray<number>(signalValue);
+
+  const axesNames = getNxAxisNames(group);
+
+  const axisMapping = axesNames.map((name) => {
+    if (!name) {
+      return undefined;
+    }
+
+    const dataset = getLinkedEntity(name, group, metadata);
+    if (!dataset) {
+      return undefined;
+    }
+    assertDataset(dataset);
+
+    const value = datasetValues && datasetValues[name];
+    assertOptionalArray<number>(value);
+
+    return { value, label: getDatasetLabel(dataset, name) };
+  });
+
+  return {
+    signal: {
+      label: getDatasetLabel(signalDataset, signalName),
+      value: signalValue,
+      dims: (signalDataset.shape as HDF5SimpleShape).dims,
+    },
+    title:
+      datasetValues && typeof datasetValues.title === 'string'
+        ? datasetValues.title
+        : undefined,
+    axisMapping,
+  };
+}

--- a/src/h5web/visualizations/nexus/models.ts
+++ b/src/h5web/visualizations/nexus/models.ts
@@ -1,3 +1,5 @@
+import { AxisMapping } from '../shared/models';
+
 export type NxAttribute =
   | 'signal'
   | 'interpretation'
@@ -12,3 +14,9 @@ export enum NxInterpretation {
 }
 
 export const NX_INTERPRETATIONS = Object.values<string>(NxInterpretation);
+
+export interface NxData {
+  signal: { label?: string; value?: number[]; dims: number[] };
+  title?: string;
+  axisMapping?: AxisMapping[];
+}

--- a/src/h5web/visualizations/shared/models.ts
+++ b/src/h5web/visualizations/shared/models.ts
@@ -52,3 +52,5 @@ export interface AxisParams {
   label?: string;
   values?: number[];
 }
+
+export type AxisMapping = AxisParams | undefined;


### PR DESCRIPTION
Another tentative refactoring. Following our discussion, I:
- added a dedicated `NxData` type
- implemented the fetching of **all** children datasets at the beginning at it is much more easier then to build the NxData object.

Let me know what you think.