### PR TITLE
Fixed NeXus vis that did not use `axes` values

### DIFF
--- a/cypress/integration/app.spec.ts
+++ b/cypress/integration/app.spec.ts
@@ -98,7 +98,7 @@ describe('App', () => {
 
       cy.findByRole('heading', { name: 'nexus_entry / image' }).should('exist');
       cy.findByRole('tab', { name: 'NX Image' }).should('exist');
-      cy.wait(500);
+      cy.wait(500); // Monkey-patch: sometimes this test makes the following test hanging if the texture computation didn't end.
     });
 
     it('use signal name and units to compute title', () => {
@@ -129,6 +129,16 @@ describe('App', () => {
       cy.get('svg[data-type="ordinate"] svg').should(
         'have.text',
         'Angle (degrees)'
+      );
+    });
+
+    it('use axis values to compute axis ticks', () => {
+      cy.findByRole('treeitem', { name: 'nexus_entry' }).click();
+      cy.findByRole('treeitem', { name: 'image' }).click();
+
+      cy.get('svg[data-type="abscissa"] .vx-axis-tick').should(
+        'have.text',
+        ['−20', '−10', '0', '10', '20'].join('') // Tick text uses minus sign − (U+2212) rather than hyphen minus - (U+002D)
       );
     });
   });

--- a/src/h5web/visualizations/heatmap/HeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapVis.tsx
@@ -42,8 +42,8 @@ function HeatmapVis(props: Props): ReactElement {
   const { rows, cols } = getDims(dataArray);
   const aspectRatio = keepAspectRatio ? cols / rows : undefined; // width / height <=> cols / rows
 
-  const abscissas = getPixelEdges(abscissaParams.values, cols);
-  const ordinates = getPixelEdges(ordinateParams.values, rows);
+  const abscissas = getPixelEdges(abscissaParams.value, cols);
+  const ordinates = getPixelEdges(ordinateParams.value, rows);
 
   const abscissaToIndex = getValueToIndexScale(abscissas);
 
@@ -65,13 +65,13 @@ function HeatmapVis(props: Props): ReactElement {
         abscissaConfig={{
           domain: abscissaDomain,
           showGrid,
-          isIndexAxis: !abscissaParams.values,
+          isIndexAxis: !abscissaParams.value,
           label: abscissaParams.label,
         }}
         ordinateConfig={{
           domain: ordinateDomain,
           showGrid,
-          isIndexAxis: !ordinateParams.values,
+          isIndexAxis: !ordinateParams.value,
           label: ordinateParams.label,
         }}
         aspectRatio={aspectRatio}

--- a/src/h5web/visualizations/line/LineVis.tsx
+++ b/src/h5web/visualizations/line/LineVis.tsx
@@ -41,7 +41,7 @@ function LineVis(props: Props): ReactElement {
 
   const {
     label: abscissaLabel,
-    values: abscissas = range(dataArray.size),
+    value: abscissas = range(dataArray.size),
   } = abscissaParams;
 
   if (abscissas.length !== dataArray.size) {
@@ -79,7 +79,7 @@ function LineVis(props: Props): ReactElement {
         abscissaConfig={{
           domain: abscissaDomain,
           showGrid,
-          isIndexAxis: !abscissaParams.values,
+          isIndexAxis: !abscissaParams.value,
           label: abscissaLabel,
         }}
         ordinateConfig={{

--- a/src/h5web/visualizations/shared/models.ts
+++ b/src/h5web/visualizations/shared/models.ts
@@ -50,7 +50,7 @@ export interface AxisOffsets {
 
 export interface AxisParams {
   label?: string;
-  values?: number[];
+  value?: number[];
 }
 
 export type AxisMapping = AxisParams | undefined;

--- a/src/stories/HeatmapVis.stories.tsx
+++ b/src/stories/HeatmapVis.stories.tsx
@@ -103,12 +103,12 @@ CustomEdges.args = {
   dataArray,
   domain,
   abscissaParams: {
-    values: new Array(dataArray.shape[1] + 1)
+    value: new Array(dataArray.shape[1] + 1)
       .fill(0)
       .map((_, i) => 100 + 10 * i),
   },
   ordinateParams: {
-    values: new Array(dataArray.shape[0] + 1)
+    value: new Array(dataArray.shape[0] + 1)
       .fill(0)
       .map((_, i) => -5 + 0.5 * i),
   },
@@ -120,10 +120,10 @@ CustomEdgesWithExtension.args = {
   dataArray,
   domain,
   abscissaParams: {
-    values: new Array(dataArray.shape[1]).fill(0).map((_, i) => 100 + 10 * i),
+    value: new Array(dataArray.shape[1]).fill(0).map((_, i) => 100 + 10 * i),
   },
   ordinateParams: {
-    values: new Array(dataArray.shape[0]).fill(0).map((_, i) => -5 + 0.5 * i),
+    value: new Array(dataArray.shape[0]).fill(0).map((_, i) => -5 + 0.5 * i),
   },
 };
 

--- a/src/stories/LineVis.stories.tsx
+++ b/src/stories/LineVis.stories.tsx
@@ -86,7 +86,7 @@ CustomAbscissas.args = {
   dataArray,
   domain,
   abscissaParams: {
-    values: new Array(dataArray.size).fill(0).map((_, i) => -10 + 0.5 * i),
+    value: new Array(dataArray.size).fill(0).map((_, i) => -10 + 0.5 * i),
   },
 };
 


### PR DESCRIPTION
Fix #300 and adds the relevant Cypress test to avoid unnoticed regression.



The source was the fact that `AxisParams` uses a member `values` while in the refacto #297 I did use `value` instead. Not sure why it was not caught by TS...