### PR TITLE
Remove coupling between `supportsEntity` functions of NeXus vis

### DIFF
--- a/src/h5web/visualizations/index.tsx
+++ b/src/h5web/visualizations/index.tsx
@@ -149,7 +149,7 @@ export const VIS_DEFS: Record<Vis, VisDef> = {
         return interpretation === NxInterpretation.Spectrum;
       }
 
-      return dimsCount === 1; // NxImage already supports datasets with 2+ dimensions
+      return true;
     },
   },
 
@@ -181,6 +181,12 @@ export const VIS_DEFS: Record<Vis, VisDef> = {
       );
 
       const dimsCount = dataset.shape.dims.length;
+      if (dimsCount === 0) {
+        throw new Error(
+          `Expected "${signal}" dataset to have at least one dimension`
+        );
+      }
+
       if (dimsCount < 2) {
         return false;
       }

--- a/src/h5web/visualizer/utils.test.ts
+++ b/src/h5web/visualizer/utils.test.ts
@@ -1,46 +1,50 @@
 import { getSupportedVis } from './utils';
 import { Vis } from '../visualizations';
-import {
-  makeDataset,
-  makeSimpleDataset,
-  makeAttr,
-  makeStrAttr,
-  intType,
-  compoundType,
-  scalarShape,
-  makeGroup,
-  makeMetadata,
-} from '../providers/mock/data';
-
-const metadata = makeMetadata();
+import { mockMetadata } from '../providers/mock/data';
 
 describe('Visualizer utilities', () => {
   describe('getSupportedVis', () => {
-    it('should identify dataset as supporting raw vis', () => {
-      const dataset = makeDataset('foo', compoundType, scalarShape);
-      const supportedVis = getSupportedVis(dataset, metadata);
+    it('should return supported visualizations', () => {
+      const supportedVis = getSupportedVis(
+        mockMetadata.datasets?.raw,
+        mockMetadata
+      );
+
       expect(supportedVis).toEqual({ supportedVis: [Vis.Raw] });
     });
 
-    it('should not include raw vis if any other visualization is supported', () => {
-      const dataset = makeSimpleDataset('foo', intType, [4]);
-      const supportedVis = getSupportedVis(dataset, metadata);
+    it('should not include Raw vis if any other visualization is supported', () => {
+      const supportedVis = getSupportedVis(
+        mockMetadata.datasets?.oneD,
+        mockMetadata
+      );
+
       expect(supportedVis).toEqual({ supportedVis: [Vis.Matrix, Vis.Line] });
     });
 
-    it('should return empty array if no visualization supports entity', () => {
-      const group = makeGroup('foo');
-      const supportedVis = getSupportedVis(group, metadata);
+    it('should not include NxSpectrum vis if any other visualization is supported', () => {
+      const supportedVis = getSupportedVis(
+        mockMetadata.groups?.nx_data,
+        mockMetadata
+      );
+
+      expect(supportedVis).toEqual({ supportedVis: [Vis.NxImage] });
+    });
+
+    it('should return empty array if no visualization is supported', () => {
+      const supportedVis = getSupportedVis(
+        mockMetadata.groups?.empty_group,
+        mockMetadata
+      );
+
       expect(supportedVis).toEqual({ supportedVis: [] });
     });
 
     it('should return error if entity has malformed NeXus metadata', () => {
-      const group = makeGroup('foo', [
-        makeStrAttr('NX_class', 'NXdata'),
-        makeAttr('signal', scalarShape, intType, 42),
-      ]);
-
-      const supportedVis = getSupportedVis(group, metadata);
+      const supportedVis = getSupportedVis(
+        mockMetadata.groups?.signal_not_string,
+        mockMetadata
+      );
 
       expect(supportedVis).toEqual({
         supportedVis: [],

--- a/src/h5web/visualizer/utils.ts
+++ b/src/h5web/visualizer/utils.ts
@@ -1,6 +1,16 @@
 import type { HDF5Entity, HDF5Metadata } from '../providers/models';
 import { VIS_DEFS, Vis } from '../visualizations';
 
+const REDUNDANT_VIS = new Set([Vis.Raw, Vis.NxSpectrum]);
+
+function removeRedundantVis(visArr: Vis[]): Vis[] {
+  if (REDUNDANT_VIS.has(visArr[0]) && visArr.length > 1) {
+    return visArr.slice(1);
+  }
+
+  return visArr;
+}
+
 export function getSupportedVis(
   entity: HDF5Entity | undefined,
   metadata: HDF5Metadata
@@ -10,7 +20,7 @@ export function getSupportedVis(
   }
 
   try {
-    const supported = Object.entries(VIS_DEFS).reduce<Vis[]>(
+    const supportedVis = Object.entries(VIS_DEFS).reduce<Vis[]>(
       (arr, visDefEntry) => {
         const [vis, { supportsEntity }] = visDefEntry;
         return supportsEntity(entity, metadata) ? [...arr, vis as Vis] : arr;
@@ -18,13 +28,7 @@ export function getSupportedVis(
       []
     );
 
-    // Remove Raw vis if any other vis is supported
-    const supportedVis =
-      supported.length > 1
-        ? supported.filter((vis) => vis !== Vis.Raw)
-        : supported;
-
-    return { supportedVis };
+    return { supportedVis: removeRedundantVis(supportedVis) };
   } catch (error) {
     return { supportedVis: [], error };
   }


### PR DESCRIPTION
The `supportsEntity` function of `NxSpectrum` no longer worries about the behaviour of `NxImage`. The spectrum vis supports nD datasets, not just 1D datasets, so that's what it checks for. The `NxSpectrum` is removed from the `supportedVis` array later, if `NxImage` is also supported. This matches the behaviour of the `Raw` vis.