### PR TITLE
Add generic types to HDF5Dataset and improve assertions

### DIFF
--- a/.env
+++ b/.env
@@ -16,3 +16,7 @@ REACT_APP_HSDS_DOMAIN=
 
 # Rendering performance profiling (local development only)
 REACT_APP_PROFILING_ENABLED=false
+
+# Logging limit of React Testing Library
+# https://testing-library.com/docs/dom-testing-library/api-helpers/#debugging
+DEBUG_PRINT_LIMIT=

--- a/src/h5web/providers/mock/utils.ts
+++ b/src/h5web/providers/mock/utils.ts
@@ -1,13 +1,10 @@
 import { mockMetadata } from './data';
 import { assertSimpleShape } from '../utils';
+import { assertDefined } from 'src/h5web/visualizations/shared/utils';
 
 export function getMockDatasetDims(name: string): number[] {
   const dataset = mockMetadata.datasets?.[name];
-
-  if (!dataset) {
-    throw new Error("Dataset doesn't exist");
-  }
-
-  assertSimpleShape(dataset.shape);
+  assertDefined(dataset, "Dataset doesn't exist");
+  assertSimpleShape(dataset);
   return dataset.shape.dims;
 }

--- a/src/h5web/providers/models.ts
+++ b/src/h5web/providers/models.ts
@@ -31,18 +31,21 @@ export interface HDF5Group {
   links?: HDF5Link[];
 }
 
-export interface HDF5Dataset {
+export interface HDF5Dataset<
+  S extends HDF5Shape = HDF5Shape,
+  T extends HDF5Type = HDF5Type
+> {
   id: HDF5Id;
   collection: HDF5Collection.Datasets;
   attributes?: HDF5Attribute[];
-  shape: HDF5Shape;
-  type: HDF5Type;
+  shape: S;
+  type: T;
 }
 
-export interface HDF5Datatype {
+export interface HDF5Datatype<T = HDF5Type> {
   id: HDF5Id;
   collection: HDF5Collection.Datatypes;
-  type: HDF5Type;
+  type: T;
 }
 
 /* ---------------------- */

--- a/src/h5web/providers/utils.ts
+++ b/src/h5web/providers/utils.ts
@@ -79,21 +79,25 @@ export function assertGroup(
   }
 }
 
-export function assertNumericType(
-  type: HDF5Type,
-  message = 'Expected numeric type'
-): asserts type is HDF5NumericType {
-  if (!isNumericType(type)) {
-    throw new Error(message);
+export function assertNumericType<S extends HDF5Shape>(
+  dataset: HDF5Dataset<S>
+): asserts dataset is HDF5Dataset<S, HDF5NumericType> {
+  if (!isNumericType(dataset.type)) {
+    throw new Error('Expected dataset to have numeric type');
   }
 }
 
-export function assertSimpleShape(
-  shape: HDF5Shape,
-  message = 'Expected simple shape'
-): asserts shape is HDF5SimpleShape {
+export function assertSimpleShape<T extends HDF5Type>(
+  dataset: HDF5Dataset<HDF5Shape, T>
+): asserts dataset is HDF5Dataset<HDF5SimpleShape, T> {
+  const { shape } = dataset;
+
   if (!isSimpleShape(shape)) {
-    throw new Error(message);
+    throw new Error('Expected dataset to have simple shape');
+  }
+
+  if (shape.dims.length === 0) {
+    throw new Error('Expected dataset with simple shape to have dimensions');
   }
 }
 

--- a/src/h5web/visualizations/containers/HeatmapVisContainer.tsx
+++ b/src/h5web/visualizations/containers/HeatmapVisContainer.tsx
@@ -1,8 +1,11 @@
 import React, { ReactElement, useState } from 'react';
 import { range } from 'lodash-es';
-import { HDF5SimpleShape } from '../../providers/models';
 import { useDatasetValue } from './hooks';
-import { assertDataset } from '../../providers/utils';
+import {
+  assertDataset,
+  assertNumericType,
+  assertSimpleShape,
+} from '../../providers/utils';
 import DimensionMapper from '../../dimension-mapper/DimensionMapper';
 import { DimensionMapping } from '../../dimension-mapper/models';
 import MappedHeatmapVis from '../heatmap/MappedHeatmapVis';
@@ -11,10 +14,10 @@ import { VisContainerProps } from './models';
 function HeatmapVisContainer(props: VisContainerProps): ReactElement {
   const { entity, entityName } = props;
   assertDataset(entity);
+  assertSimpleShape(entity);
+  assertNumericType(entity);
 
-  const value = useDatasetValue(entity.id);
-
-  const { dims } = entity.shape as HDF5SimpleShape;
+  const { dims } = entity.shape;
   if (dims.length < 2) {
     throw new Error('Expected dataset with at least two dimensions');
   }
@@ -25,6 +28,7 @@ function HeatmapVisContainer(props: VisContainerProps): ReactElement {
     'x',
   ]);
 
+  const value = useDatasetValue(entity.id);
   if (!value) {
     return <></>;
   }

--- a/src/h5web/visualizations/containers/LineVisContainer.tsx
+++ b/src/h5web/visualizations/containers/LineVisContainer.tsx
@@ -1,8 +1,11 @@
 import React, { ReactElement, useState } from 'react';
 import { range } from 'lodash-es';
-import { HDF5SimpleShape } from '../../providers/models';
 import { useDatasetValue } from './hooks';
-import { assertDataset } from '../../providers/utils';
+import {
+  assertDataset,
+  assertNumericType,
+  assertSimpleShape,
+} from '../../providers/utils';
 import DimensionMapper from '../../dimension-mapper/DimensionMapper';
 import { DimensionMapping } from '../../dimension-mapper/models';
 import MappedLineVis from '../line/MappedLineVis';
@@ -11,10 +14,10 @@ import { VisContainerProps } from './models';
 function LineVisContainer(props: VisContainerProps): ReactElement {
   const { entity, entityName } = props;
   assertDataset(entity);
+  assertSimpleShape(entity);
+  assertNumericType(entity);
 
-  const value = useDatasetValue(entity.id);
-
-  const { dims } = entity.shape as HDF5SimpleShape;
+  const { dims } = entity.shape;
   if (dims.length === 0) {
     throw new Error('Expected dataset with at least one dimension');
   }
@@ -24,6 +27,7 @@ function LineVisContainer(props: VisContainerProps): ReactElement {
     'x',
   ]);
 
+  const value = useDatasetValue(entity.id);
   if (!value) {
     return <></>;
   }

--- a/src/h5web/visualizations/containers/MatrixVisContainer.tsx
+++ b/src/h5web/visualizations/containers/MatrixVisContainer.tsx
@@ -1,8 +1,7 @@
 import React, { ReactElement, useState } from 'react';
 import { range } from 'lodash-es';
-import { HDF5SimpleShape } from '../../providers/models';
 import { useDatasetValue } from './hooks';
-import { assertDataset } from '../../providers/utils';
+import { assertDataset, assertSimpleShape } from '../../providers/utils';
 import MappedMatrixVis from '../matrix/MappedMatrixVis';
 import DimensionMapper from '../../dimension-mapper/DimensionMapper';
 import { DimensionMapping } from '../../dimension-mapper/models';
@@ -11,10 +10,11 @@ import { VisContainerProps } from './models';
 function MatrixVisContainer(props: VisContainerProps): ReactElement {
   const { entity } = props;
   assertDataset(entity);
+  assertSimpleShape(entity);
 
   const value = useDatasetValue(entity.id);
 
-  const { dims } = entity.shape as HDF5SimpleShape;
+  const { dims } = entity.shape;
   const [mapperState, setMapperState] = useState<DimensionMapping>(
     dims.length === 1 ? ['x'] : [...range(dims.length - 2).fill(0), 'y', 'x']
   );

--- a/src/h5web/visualizations/containers/NxImageContainer.tsx
+++ b/src/h5web/visualizations/containers/NxImageContainer.tsx
@@ -33,7 +33,6 @@ function NxImageContainer(props: VisContainerProps): ReactElement {
   ]);
 
   const { signal, title, axisMapping } = nxData;
-
   const { setScaleType } = useHeatmapConfig();
 
   useEffect(() => {

--- a/src/h5web/visualizations/containers/NxSpectrumContainer.tsx
+++ b/src/h5web/visualizations/containers/NxSpectrumContainer.tsx
@@ -22,10 +22,6 @@ function NxSpectrumContainer(props: VisContainerProps): ReactElement {
   const nxData = useNxData(nxDataGroup, metadata);
 
   const { dims } = nxData.signal;
-  if (dims.length === 0) {
-    throw new Error('Expected dataset with at least one dimension');
-  }
-
   const [dimensionMapping, setDimensionMapping] = useState<DimensionMapping>([
     ...range(dims.length - 1).fill(0),
     'x',

--- a/src/h5web/visualizations/heatmap/HeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapVis.tsx
@@ -10,7 +10,11 @@ import VisCanvas from '../shared/VisCanvas';
 import { getDims, getPixelEdges } from './utils';
 import { Domain, ScaleType, AxisParams } from '../shared/models';
 import type { ColorMap } from './models';
-import { getDomain, getValueToIndexScale } from '../shared/utils';
+import {
+  assertDefined,
+  getDomain,
+  getValueToIndexScale,
+} from '../shared/utils';
 
 interface Props {
   dataArray: ndarray;
@@ -43,21 +47,14 @@ function HeatmapVis(props: Props): ReactElement {
   const aspectRatio = keepAspectRatio ? cols / rows : undefined; // width / height <=> cols / rows
 
   const abscissas = getPixelEdges(abscissaParams.value, cols);
-  const ordinates = getPixelEdges(ordinateParams.value, rows);
-
   const abscissaToIndex = getValueToIndexScale(abscissas);
-
   const abscissaDomain = useMemo(() => getDomain(abscissas), [abscissas]);
-  if (!abscissaDomain) {
-    throw new Error(`Abscissas have undefined domain`);
-  }
+  assertDefined(abscissaDomain, 'Abscissas have undefined domain');
 
+  const ordinates = getPixelEdges(ordinateParams.value, rows);
   const ordinateToIndex = getValueToIndexScale(ordinates);
-
   const ordinateDomain = useMemo(() => getDomain(ordinates), [ordinates]);
-  if (!ordinateDomain) {
-    throw new Error(`Ordinates have undefined domain`);
-  }
+  assertDefined(ordinateDomain, 'Ordinates have undefined domain');
 
   return (
     <figure className={styles.root} aria-labelledby="vis-title">

--- a/src/h5web/visualizations/index.tsx
+++ b/src/h5web/visualizations/index.tsx
@@ -134,22 +134,8 @@ export const VIS_DEFS: Record<Vis, VisDef> = {
       const dataset = getLinkedEntity(signal, group, metadata);
       assertDefined(dataset, `Expected "${signal}" signal entity to exist`);
       assertDataset(dataset, `Expected "${signal}" signal to be a dataset`);
-
-      assertNumericType(
-        dataset.type,
-        `Expected "${signal}" dataset to have numeric type`
-      );
-      assertSimpleShape(
-        dataset.shape,
-        `Expected "${signal}" dataset to have simple shape`
-      );
-
-      const dimsCount = dataset.shape.dims.length;
-      if (dimsCount === 0) {
-        throw new Error(
-          `Expected "${signal}" dataset to have at least one dimension`
-        );
-      }
+      assertNumericType(dataset);
+      assertSimpleShape(dataset);
 
       const interpretation = getAttributeValue(dataset, 'interpretation');
       if (isNxInterpretation(interpretation)) {
@@ -182,23 +168,10 @@ export const VIS_DEFS: Record<Vis, VisDef> = {
       assertDefined(dataset, `Expected "${signal}" signal entity to exist`);
       assertDataset(dataset, `Expected "${signal}" signal to be a dataset`);
 
-      assertNumericType(
-        dataset.type,
-        `Expected "${signal}" dataset to have numeric type`
-      );
-      assertSimpleShape(
-        dataset.shape,
-        `Expected "${signal}" dataset to have simple shape`
-      );
+      assertNumericType(dataset);
+      assertSimpleShape(dataset);
 
-      const dimsCount = dataset.shape.dims.length;
-      if (dimsCount === 0) {
-        throw new Error(
-          `Expected "${signal}" dataset to have at least one dimension`
-        );
-      }
-
-      if (dimsCount < 2) {
+      if (dataset.shape.dims.length < 2) {
         return false;
       }
 

--- a/src/h5web/visualizations/line/LineVis.tsx
+++ b/src/h5web/visualizations/line/LineVis.tsx
@@ -9,7 +9,12 @@ import PanZoomMesh from '../shared/PanZoomMesh';
 import TooltipMesh from '../shared/TooltipMesh';
 import { ScaleType, Domain, AxisParams } from '../shared/models';
 import { CurveType } from './models';
-import { getValueToIndexScale, getDomain, extendDomain } from '../shared/utils';
+import {
+  getValueToIndexScale,
+  getDomain,
+  extendDomain,
+  assertDefined,
+} from '../shared/utils';
 import ErrorBarCurve from './ErrorBarCurve';
 
 const DEFAULT_DOMAIN: Domain = [0.1, 1];
@@ -69,9 +74,7 @@ function LineVis(props: Props): ReactElement {
     );
   }, [abscissas, abscissaScaleType]);
 
-  if (!abscissaDomain) {
-    throw new Error(`Abscissas have undefined domain`);
-  }
+  assertDefined(abscissaDomain, 'Abscissas have undefined domain');
 
   const dataDomain = useMemo(() => {
     return domain

--- a/src/h5web/visualizer/Visualizer.test.tsx
+++ b/src/h5web/visualizer/Visualizer.test.tsx
@@ -179,6 +179,6 @@ describe('Visualizer', () => {
     expect(await screen.findByText(/simple shape/u)).toBeVisible();
 
     await selectExplorerNode('signal_dataset_zero_dim');
-    expect(await screen.findByText(/at least one/u)).toBeVisible();
+    expect(await screen.findByText(/to have dimensions/u)).toBeVisible();
   });
 });


### PR DESCRIPTION
I just had a spark on how we can better type `HDF5Dataset` so that our assertions can accept `HDF5Dataset` objects rather than `HDF5Shape` or `HDF5Type`. This should open up some refactoring opportunities. 🎇 

Apart from that, I use single-line assertions in a few more places to make the code more readable.
