### PR TITLE
Simplify signature of `useDatasetValues` hook

### DIFF
--- a/src/h5web/providers/Provider.tsx
+++ b/src/h5web/providers/Provider.tsx
@@ -32,14 +32,9 @@ function Provider(props: Props): ReactElement {
         domain: api.domain,
         metadata,
         getValue,
-        getValues: async (idsRecord) =>
+        getValues: async (ids) =>
           Object.fromEntries(
-            await Promise.all(
-              Object.entries(idsRecord).map(async ([name, id]) => {
-                const val = await getValue(id);
-                return [name, val];
-              })
-            )
+            await Promise.all(ids.map(async (id) => [id, await getValue(id)]))
           ),
       }}
     >

--- a/src/h5web/providers/context.ts
+++ b/src/h5web/providers/context.ts
@@ -11,7 +11,5 @@ export const ProviderContext = createContext<{
   domain: string;
   metadata: HDF5Metadata;
   getValue: ProviderAPI['getValue'];
-  getValues: (
-    idsRecord: Record<string, HDF5Id>
-  ) => Promise<Record<string, HDF5Value>>;
+  getValues: (ids: HDF5Id[]) => Promise<Record<HDF5Id, HDF5Value | undefined>>;
 }>({} as any); // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/src/h5web/providers/utils.ts
+++ b/src/h5web/providers/utils.ts
@@ -112,6 +112,10 @@ export function assertSimpleShape<T extends HDF5Type>(
   }
 }
 
+export function getLink(name: string, group: HDF5Group): HDF5Link | undefined {
+  return group.links?.find((l) => l.title === name);
+}
+
 export function getEntity(
   link: HDF5Link | undefined,
   metadata: HDF5Metadata
@@ -130,6 +134,6 @@ export function getLinkedEntity(
   group: HDF5Group,
   metadata: HDF5Metadata
 ): HDF5Entity | undefined {
-  const childLink = group.links?.find((l) => l.title === entityName);
-  return getEntity(childLink, metadata);
+  const link = getLink(entityName, group);
+  return getEntity(link, metadata);
 }

--- a/src/h5web/visualizations/containers/hooks.ts
+++ b/src/h5web/visualizations/containers/hooks.ts
@@ -10,10 +10,10 @@ export function useDatasetValue(id: HDF5Id): HDF5Value | undefined {
 }
 
 export function useDatasetValues(
-  datasetsRecord: Record<string, HDF5Id>
-): Record<string, HDF5Value> | undefined {
+  ids: HDF5Id[]
+): Record<HDF5Id, HDF5Value | undefined> {
   const { getValues } = useContext(ProviderContext);
-  const [valuesReader] = useAsyncResource(getValues, datasetsRecord);
+  const [valuesReader] = useAsyncResource(getValues, ids);
 
-  return valuesReader();
+  return valuesReader() || {};
 }


### PR DESCRIPTION
I'm going step by step to keep things clear. I'll refactor `findSignalDataset` next.