### PR TITLE
Replace `useDataArray` hook with overrides and more

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,6 @@
   },
 
   "typescript.tsdk": "node_modules/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "typescript.preferences.importModuleSpecifier": "relative"
 }

--- a/src/h5web/dimension-mapper/AxisMapper.tsx
+++ b/src/h5web/dimension-mapper/AxisMapper.tsx
@@ -7,7 +7,7 @@ import type { Axis, DimensionMapping } from './models';
 interface Props {
   axis: Axis;
   rawDims: number[];
-  mapperState: NonNullable<DimensionMapping>;
+  mapperState: DimensionMapping;
   onChange: (mapperState: DimensionMapping) => void;
 }
 

--- a/src/h5web/dimension-mapper/SlicingSlider.tsx
+++ b/src/h5web/dimension-mapper/SlicingSlider.tsx
@@ -7,7 +7,7 @@ interface Props {
   dimension: number;
   slicingIndex: number;
   rawDims: number[];
-  mapperState: NonNullable<DimensionMapping>;
+  mapperState: DimensionMapping;
   onChange: (mapperState: DimensionMapping) => void;
 }
 

--- a/src/h5web/dimension-mapper/models.ts
+++ b/src/h5web/dimension-mapper/models.ts
@@ -1,3 +1,2 @@
 export type Axis = 'x' | 'y';
-export type MappingType = number | Axis;
-export type DimensionMapping = MappingType[] | undefined;
+export type DimensionMapping = (number | Axis)[];

--- a/src/h5web/visualizations/containers/MatrixVisContainer.tsx
+++ b/src/h5web/visualizations/containers/MatrixVisContainer.tsx
@@ -1,10 +1,7 @@
-import React, { ReactElement, useState } from 'react';
-import { range } from 'lodash-es';
+import React, { ReactElement } from 'react';
 import { useDatasetValue } from './hooks';
 import { assertDataset, assertSimpleShape } from '../../providers/utils';
 import MappedMatrixVis from '../matrix/MappedMatrixVis';
-import DimensionMapper from '../../dimension-mapper/DimensionMapper';
-import { DimensionMapping } from '../../dimension-mapper/models';
 import { VisContainerProps } from './models';
 
 function MatrixVisContainer(props: VisContainerProps): ReactElement {
@@ -13,26 +10,11 @@ function MatrixVisContainer(props: VisContainerProps): ReactElement {
   assertSimpleShape(entity);
 
   const value = useDatasetValue(entity.id);
-
-  const { dims } = entity.shape;
-  const [mapperState, setMapperState] = useState<DimensionMapping>(
-    dims.length === 1 ? ['x'] : [...range(dims.length - 2).fill(0), 'y', 'x']
-  );
-
   if (!value) {
     return <></>;
   }
 
-  return (
-    <>
-      <DimensionMapper
-        rawDims={dims}
-        mapperState={mapperState}
-        onChange={setMapperState}
-      />
-      <MappedMatrixVis value={value} dims={dims} mapperState={mapperState} />
-    </>
-  );
+  return <MappedMatrixVis value={value} dims={entity.shape.dims} />;
 }
 
 export default MatrixVisContainer;

--- a/src/h5web/visualizations/heatmap/MappedHeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/MappedHeatmapVis.tsx
@@ -4,7 +4,7 @@ import type { HDF5Value } from '../../providers/models';
 import type { DimensionMapping } from '../../dimension-mapper/models';
 import HeatmapVis from './HeatmapVis';
 import { assertArray } from '../shared/utils';
-import { useDomain, useDataArrays } from '../shared/hooks';
+import { useDomain, useBaseArray, useMappedArray } from '../shared/hooks';
 import { useHeatmapConfig } from './config';
 import { AxisMapping } from '../shared/models';
 import DimensionMapper from '../../dimension-mapper/DimensionMapper';
@@ -37,11 +37,9 @@ function MappedHeatmapVis(props: Props): ReactElement {
     'x',
   ]);
 
-  const { baseArray, mappedArray: dataArray } = useDataArrays(
-    value,
-    dims,
-    dimensionMapping
-  );
+  const baseArray = useBaseArray(value, dims);
+  const dataArray = useMappedArray(baseArray, dimensionMapping);
+
   const dataDomain = useDomain(
     (autoScale ? dataArray.data : baseArray.data) as number[],
     scaleType

--- a/src/h5web/visualizations/heatmap/MappedHeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/MappedHeatmapVis.tsx
@@ -7,7 +7,7 @@ import { assertArray } from '../shared/utils';
 import { useDomain, useDataArrays } from '../shared/hooks';
 import { useHeatmapConfig } from './config';
 import { AxisMapping } from '../shared/models';
-import DimensionMapper from 'src/h5web/dimension-mapper/DimensionMapper';
+import DimensionMapper from '../../dimension-mapper/DimensionMapper';
 
 interface Props {
   value: HDF5Value;
@@ -76,12 +76,8 @@ function MappedHeatmapVis(props: Props): ReactElement {
         scaleType={scaleType}
         keepAspectRatio={keepAspectRatio}
         showGrid={showGrid}
-        abscissaParams={
-          dimensionMapping && axisMapping[dimensionMapping.indexOf('x')]
-        }
-        ordinateParams={
-          dimensionMapping && axisMapping[dimensionMapping.indexOf('y')]
-        }
+        abscissaParams={axisMapping[dimensionMapping.indexOf('x')]}
+        ordinateParams={axisMapping[dimensionMapping.indexOf('y')]}
       />
     </>
   );

--- a/src/h5web/visualizations/line/LineVis.tsx
+++ b/src/h5web/visualizations/line/LineVis.tsx
@@ -28,7 +28,7 @@ interface Props {
   abscissaParams?: AxisParams;
   ordinateLabel?: string;
   title?: string;
-  errors?: number[];
+  errorsArray?: ndarray;
   showErrors?: boolean;
 }
 
@@ -42,7 +42,7 @@ function LineVis(props: Props): ReactElement {
     abscissaParams = {},
     ordinateLabel,
     title,
-    errors,
+    errorsArray,
     showErrors,
   } = props;
 
@@ -58,9 +58,9 @@ function LineVis(props: Props): ReactElement {
     );
   }
 
-  if (errors && errors.length !== dataArray.size) {
+  if (errorsArray && errorsArray.size !== dataArray.size) {
     throw new Error(
-      `Error size (${errors.length}) does not match data length (${dataArray.size})`
+      `Error size (${errorsArray.size}) does not match data length (${dataArray.size})`
     );
   }
 
@@ -114,7 +114,7 @@ function LineVis(props: Props): ReactElement {
               return undefined;
             }
 
-            const error = errors && errors[index];
+            const error = errorsArray && errorsArray.get(index);
             return error
               ? `${format('.3f')(value)} ±${format('.3f')(error)}`
               : `${format('.3f')(value)}`;
@@ -127,11 +127,11 @@ function LineVis(props: Props): ReactElement {
           abscissas={abscissas}
           ordinates={dataArray.data as number[]}
         />
-        {errors && (
+        {errorsArray && (
           <ErrorBarCurve
             abscissas={abscissas}
             ordinates={dataArray.data as number[]}
-            errors={errors}
+            errors={errorsArray.data as number[]}
             visible={showErrors}
           />
         )}

--- a/src/h5web/visualizations/line/MappedLineVis.tsx
+++ b/src/h5web/visualizations/line/MappedLineVis.tsx
@@ -3,12 +3,7 @@ import type { HDF5Value } from '../../providers/models';
 import type { DimensionMapping } from '../../dimension-mapper/models';
 import LineVis from './LineVis';
 import { assertArray } from '../shared/utils';
-import {
-  useMappedArray,
-  useDomain,
-  useBaseArray,
-  useDataArrays,
-} from '../shared/hooks';
+import { useMappedArray, useDomain, useBaseArray } from '../shared/hooks';
 import { useLineConfig } from './config';
 import { AxisMapping, ScaleType } from '../shared/models';
 import DimensionMapper from '../../dimension-mapper/DimensionMapper';
@@ -53,11 +48,8 @@ function MappedLineVis(props: Props): ReactElement {
     'x',
   ]);
 
-  const { baseArray: baseDataArray, mappedArray: dataArray } = useDataArrays(
-    value,
-    dims,
-    dimensionMapping
-  );
+  const baseDataArray = useBaseArray(value, dims);
+  const dataArray = useMappedArray(baseDataArray, dimensionMapping);
 
   const baseErrorsArray = useBaseArray(errors, dims);
   const errorArray = useMappedArray(baseErrorsArray, dimensionMapping);

--- a/src/h5web/visualizations/line/MappedLineVis.tsx
+++ b/src/h5web/visualizations/line/MappedLineVis.tsx
@@ -11,7 +11,7 @@ import {
 } from '../shared/hooks';
 import { useLineConfig } from './config';
 import { AxisMapping, ScaleType } from '../shared/models';
-import DimensionMapper from 'src/h5web/dimension-mapper/DimensionMapper';
+import DimensionMapper from '../../dimension-mapper/DimensionMapper';
 
 interface Props {
   value: HDF5Value;
@@ -73,9 +73,7 @@ function MappedLineVis(props: Props): ReactElement {
     : baseErrorsArray && (baseErrorsArray.data as number[]);
   const dataDomain = useDomain(dataValues, yScaleType, errorValues);
 
-  const mappedAbscissaParams =
-    dimensionMapping && axisMapping[dimensionMapping.indexOf('x')];
-
+  const mappedAbscissaParams = axisMapping[dimensionMapping.indexOf('x')];
   useEffect(() => {
     if (mappedAbscissaParams?.scaleType) {
       setXScaleType(mappedAbscissaParams?.scaleType);

--- a/src/h5web/visualizations/line/MappedLineVis.tsx
+++ b/src/h5web/visualizations/line/MappedLineVis.tsx
@@ -108,7 +108,7 @@ function MappedLineVis(props: Props): ReactElement {
         }}
         ordinateLabel={valueLabel}
         title={title}
-        errors={errorArray && (errorArray.data as number[])}
+        errorsArray={errorArray}
         showErrors={showErrors}
       />
     </>

--- a/src/h5web/visualizations/matrix/MappedMatrixVis.tsx
+++ b/src/h5web/visualizations/matrix/MappedMatrixVis.tsx
@@ -1,22 +1,38 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useState } from 'react';
 import type { HDF5Value } from '../../providers/models';
 import type { DimensionMapping } from '../../dimension-mapper/models';
 import MatrixVis from './MatrixVis';
 import { assertArray } from '../shared/utils';
 import { useDataArrays } from '../shared/hooks';
+import DimensionMapper from '../../dimension-mapper/DimensionMapper';
 
 interface Props {
   value: HDF5Value;
   dims: number[];
-  mapperState: DimensionMapping;
 }
 
 function MappedMatrixVis(props: Props): ReactElement {
-  const { value, dims, mapperState } = props;
+  const { value, dims } = props;
   assertArray<number | string>(value);
 
+  const [dimensionMapping, setDimensionMapping] = useState<DimensionMapping>(
+    dims.length === 1
+      ? ['x']
+      : [...new Array(dims.length - 2).fill(0), 'y', 'x']
+  );
+
   const { mappedArray } = useDataArrays(value, dims, mapperState);
-  return <MatrixVis dataArray={mappedArray} />;
+
+  return (
+    <>
+      <DimensionMapper
+        rawDims={dims}
+        mapperState={dimensionMapping}
+        onChange={setDimensionMapping}
+      />
+      <MatrixVis dataArray={mappedArray} />
+    </>
+  );
 }
 
 export default MappedMatrixVis;

--- a/src/h5web/visualizations/matrix/MappedMatrixVis.tsx
+++ b/src/h5web/visualizations/matrix/MappedMatrixVis.tsx
@@ -3,7 +3,7 @@ import type { HDF5Value } from '../../providers/models';
 import type { DimensionMapping } from '../../dimension-mapper/models';
 import MatrixVis from './MatrixVis';
 import { assertArray } from '../shared/utils';
-import { useDataArrays } from '../shared/hooks';
+import { useBaseArray, useMappedArray } from '../shared/hooks';
 import DimensionMapper from '../../dimension-mapper/DimensionMapper';
 
 interface Props {
@@ -21,7 +21,8 @@ function MappedMatrixVis(props: Props): ReactElement {
       : [...new Array(dims.length - 2).fill(0), 'y', 'x']
   );
 
-  const { mappedArray } = useDataArrays(value, dims, mapperState);
+  const baseArray = useBaseArray(value, dims);
+  const mappedArray = useMappedArray(baseArray, dimensionMapping);
 
   return (
     <>

--- a/src/stories/LineVis.stories.tsx
+++ b/src/stories/LineVis.stories.tsx
@@ -13,6 +13,11 @@ const values = mockValues.oneD_linear;
 const dataArray = ndarray(values, getMockDatasetDims('oneD_linear'));
 const domain = getDomain(values);
 
+const errorsArray = ndarray(
+  new Array(dataArray.size).fill(0).map((_, i) => Math.abs(10 - 0.5 * i)),
+  dataArray.shape
+);
+
 const Template: Story<LineVisProps> = (args): ReactElement => (
   <LineVis {...args} />
 );
@@ -36,9 +41,7 @@ export const ErrorBars = Template.bind({});
 ErrorBars.args = {
   dataArray,
   domain: [-31, 31], // Extend domain to fit error bars
-  errors: new Array(dataArray.size)
-    .fill(0)
-    .map((_, i) => Math.abs(10 - 0.5 * i)),
+  errorsArray,
 };
 
 const LineVisStoriesConfig = {


### PR DESCRIPTION
Four commits:

- **Pass errors as `ndarray` to Line vis** instead of as `number[]` for consistency with data array and with errors in Heatmap vis.
- **Make `DimensionMapping` type non-nullable**. Ever since the big refactoring of `Visualizer`, we only use the `DimensionMapper` on visualizations that need it, so we never have a `dimensionMapper` state of `undefined`.
- **Move Matrix vis mapper state from container to mapped vis**. I forgot about the Matrix vis in #342...
- **Replace `useDataArray` hook with overrides**. The overrides add a bit of bloat, but as discussed, they're a little bit cleaner than alternative solutions.