### PR TITLE
Introduce new nested HDF5 models to replace Explorer's `TreeNode`

### DIFF
--- a/.env
+++ b/.env
@@ -3,8 +3,8 @@
 # Copy and configure the variables below in your own `.env.local` file
 #####
 
-# Path of Explorer node to select on first mount.
-# Provide an array of indices (e.g. [0,2,1,0]) or leave blank to select root node.
+# Path to entity to select on first mount in Explorer.
+# Provide an array of indices (e.g. [0,2,1,0]) or leave blank to select root entity.
 REACT_APP_DEFAULT_PATH=
 
 # HSDS parameters

--- a/src/h5web/App.tsx
+++ b/src/h5web/App.tsx
@@ -1,24 +1,16 @@
-import React, { useState, useContext, ReactElement } from 'react';
+import React, { useState, ReactElement } from 'react';
 import { ReflexContainer, ReflexSplitter, ReflexElement } from 'react-reflex';
 import Explorer from './explorer/Explorer';
-import type { HDF5Link } from './providers/models';
+import type { MyHDF5Entity } from './providers/models';
 import MetadataViewer from './metadata-viewer/MetadataViewer';
 import styles from './App.module.css';
-import type { TreeNode } from './explorer/models';
 import BreadcrumbsBar from './BreadcrumbsBar';
 import Visualizer from './visualizer/Visualizer';
-import { getEntity } from './providers/utils';
-import { ProviderContext } from './providers/context';
 
 function App(): ReactElement {
-  const { metadata } = useContext(ProviderContext);
-
-  const [selectedNode, setSelectedNode] = useState<TreeNode<HDF5Link>>();
+  const [selectedEntity, setSelectedEntity] = useState<MyHDF5Entity>();
   const [isExplorerOpen, setExplorerOpen] = useState(true);
   const [isInspecting, setInspecting] = useState(false);
-
-  const selectedLink = selectedNode?.data;
-  const selectedEntity = getEntity(selectedLink, metadata);
 
   return (
     <div className={styles.app}>
@@ -29,7 +21,10 @@ function App(): ReactElement {
           flex={25}
           minSize={250}
         >
-          <Explorer selectedNode={selectedNode} onSelect={setSelectedNode} />
+          <Explorer
+            selectedEntity={selectedEntity}
+            onSelect={setSelectedEntity}
+          />
         </ReflexElement>
 
         <ReflexSplitter
@@ -42,14 +37,17 @@ function App(): ReactElement {
             onToggleExplorer={() => setExplorerOpen(!isExplorerOpen)}
             isInspecting={isInspecting}
             onChangeInspecting={setInspecting}
-            selectedNode={selectedNode}
+            selectedEntity={selectedEntity}
           />
           {isInspecting ? (
-            <MetadataViewer link={selectedLink} entity={selectedEntity} />
+            <MetadataViewer
+              link={selectedEntity?.rawLink}
+              entity={selectedEntity?.rawEntity}
+            />
           ) : (
             <Visualizer
-              entity={selectedEntity}
-              entityName={selectedLink && selectedLink.title}
+              entity={selectedEntity?.rawEntity}
+              entityName={selectedEntity?.name}
             />
           )}
         </ReflexElement>

--- a/src/h5web/BreadcrumbsBar.tsx
+++ b/src/h5web/BreadcrumbsBar.tsx
@@ -1,8 +1,7 @@
 import React, { Fragment, ReactElement } from 'react';
 import { FiSidebar, FiChevronRight } from 'react-icons/fi';
 import styles from './BreadcrumbsBar.module.css';
-import type { TreeNode } from './explorer/models';
-import type { HDF5Link, HDF5HardLink } from './providers/models';
+import type { MyHDF5Entity } from './providers/models';
 import ToggleGroup from './toolbar/controls/ToggleGroup';
 import ToggleBtn from './toolbar/controls/ToggleBtn';
 
@@ -11,7 +10,7 @@ interface Props {
   onToggleExplorer: () => void;
   isInspecting: boolean;
   onChangeInspecting: (b: boolean) => void;
-  selectedNode?: TreeNode<HDF5Link>;
+  selectedEntity?: MyHDF5Entity;
 }
 
 function BreadcrumbsBar(props: Props): ReactElement {
@@ -20,7 +19,7 @@ function BreadcrumbsBar(props: Props): ReactElement {
     onToggleExplorer,
     isInspecting,
     onChangeInspecting,
-    selectedNode,
+    selectedEntity,
   } = props;
 
   // Excludes the first parent (the domain) if the explorer is opened
@@ -35,16 +34,16 @@ function BreadcrumbsBar(props: Props): ReactElement {
         value={isExplorerOpen}
         onChange={onToggleExplorer}
       />
-      {selectedNode && (
+      {selectedEntity && (
         <h1 className={styles.breadCrumbs}>
-          {selectedNode?.parents.slice(firstParentIndex).map((member) => (
-            <Fragment key={(member as HDF5HardLink).id}>
-              <span className={styles.crumb}>{member.title}</span>
+          {selectedEntity?.parents.slice(firstParentIndex).map((parent) => (
+            <Fragment key={parent.id}>
+              <span className={styles.crumb}>{parent.name}</span>
               <FiChevronRight className={styles.separator} title="/" />
             </Fragment>
           ))}
           <span className={styles.crumb} data-current>
-            {selectedNode.data.title}
+            {selectedEntity.name}
           </span>
         </h1>
       )}

--- a/src/h5web/explorer/Explorer.module.css
+++ b/src/h5web/explorer/Explorer.module.css
@@ -26,14 +26,11 @@
   font-weight: bold;
 }
 
-.domain {
+.domainBtn {
+  composes: btn;
   margin: 0;
   padding: 1rem;
   font-weight: 600;
-}
-
-.domainBtn {
-  composes: btn domain;
 }
 
 .icon {
@@ -47,8 +44,4 @@
   font-size: 1.25em;
   margin-left: -0.375rem;
   margin-right: 0.125rem;
-}
-
-.loading {
-  padding: 0.25rem 1rem;
 }

--- a/src/h5web/explorer/Explorer.tsx
+++ b/src/h5web/explorer/Explorer.tsx
@@ -47,10 +47,6 @@ function Explorer(props: Props): ReactElement {
   }
 
   useEffect(() => {
-    if (!tree) {
-      return;
-    }
-
     // Get nodes on default path
     const nodes = getNodesOnPath(tree, DEFAULT_PATH);
 
@@ -64,18 +60,6 @@ function Explorer(props: Props): ReactElement {
       nodesToExpand.reduce((acc, node) => ({ ...acc, [node.uid]: true }), {})
     );
   }, [onSelect, tree]);
-
-  if (!tree) {
-    return (
-      <div className={styles.explorer}>
-        <p className={styles.domain}>
-          <FiFileText className={styles.domainIcon} />
-          {domain}
-        </p>
-        <p className={styles.loading}>Loading...</p>
-      </div>
-    );
-  }
 
   return (
     <div className={styles.explorer} role="tree">

--- a/src/h5web/explorer/Icon.tsx
+++ b/src/h5web/explorer/Icon.tsx
@@ -8,28 +8,26 @@ import {
   FiLink,
 } from 'react-icons/fi';
 import type { IconType } from 'react-icons';
-
-import { HDF5Link, HDF5Collection } from '../providers/models';
-
+import { MyHDF5Entity, MyHDF5EntityKind } from '../providers/models';
 import styles from './Explorer.module.css';
-import { isHardLink } from '../providers/utils';
+import { isMyGroup } from '../providers/utils';
 
-const LEAF_ICONS: Record<HDF5Collection, IconType> = {
-  [HDF5Collection.Groups]: FiFolder,
-  [HDF5Collection.Datasets]: FiLayers,
-  [HDF5Collection.Datatypes]: FiHash,
+const LEAF_ICONS: Record<MyHDF5EntityKind, IconType> = {
+  [MyHDF5EntityKind.Group]: FiFolder,
+  [MyHDF5EntityKind.Dataset]: FiLayers,
+  [MyHDF5EntityKind.Datatype]: FiHash,
+  [MyHDF5EntityKind.Link]: FiLink,
 };
 
 interface Props {
-  data: HDF5Link;
-  isBranch: boolean;
+  entity: MyHDF5Entity;
   isExpanded: boolean;
 }
 
 function Icon(props: Props): ReactElement {
-  const { data, isBranch, isExpanded } = props;
+  const { entity, isExpanded } = props;
 
-  if (isBranch) {
+  if (isMyGroup(entity)) {
     return isExpanded ? (
       <FiChevronDown className={styles.icon} />
     ) : (
@@ -37,12 +35,8 @@ function Icon(props: Props): ReactElement {
     );
   }
 
-  if (isHardLink(data)) {
-    const LeafIcon = LEAF_ICONS[data.collection];
-    return <LeafIcon className={styles.icon} />;
-  }
-
-  return <FiLink className={styles.icon} />;
+  const LeafIcon = LEAF_ICONS[entity.kind];
+  return <LeafIcon className={styles.icon} />;
 }
 
 export default Icon;

--- a/src/h5web/explorer/TreeView.tsx
+++ b/src/h5web/explorer/TreeView.tsx
@@ -1,33 +1,31 @@
 import React, { CSSProperties, ReactElement } from 'react';
-import type { TreeNode, ExpandedNodes } from './models';
-
 import styles from './Explorer.module.css';
+import { MyHDF5Entity } from '../providers/models';
+import Icon from './Icon';
+import { isMyGroup } from '../providers/utils';
 
-interface Props<T> {
+export type ExpandedGroups = Record<string, boolean>;
+
+interface Props {
   level: number;
-  nodes: TreeNode<T>[];
-  selectedNode?: TreeNode<T>;
-  expandedNodes: ExpandedNodes;
-  onSelect: (node: TreeNode<T>) => void;
-  renderIcon: (data: T, isBranch: boolean, isExpanded: boolean) => JSX.Element;
+  entities: MyHDF5Entity[];
+  selectedEntity?: MyHDF5Entity;
+  expandedGroups: ExpandedGroups;
+  onSelect: (entity: MyHDF5Entity) => void;
 }
 
-function TreeView<T>(props: Props<T>): ReactElement {
-  const {
-    level,
-    nodes,
-    selectedNode,
-    expandedNodes,
-    onSelect,
-    renderIcon,
-  } = props;
+function TreeView(props: Props): ReactElement {
+  const { level, entities, selectedEntity, expandedGroups, onSelect } = props;
+
+  if (entities.length === 0) {
+    return <></>;
+  }
 
   return (
     <ul className={styles.group} role="group">
-      {nodes.map((node) => {
-        const { uid, label, data, children } = node;
-        const isBranch = !!children;
-        const isExpanded = !!expandedNodes[node.uid];
+      {entities.map((entity) => {
+        const { uid, name } = entity;
+        const isExpanded = !!expandedGroups[entity.uid];
 
         return (
           <li
@@ -39,24 +37,23 @@ function TreeView<T>(props: Props<T>): ReactElement {
               className={styles.btn}
               type="button"
               role="treeitem"
-              aria-expanded={isBranch ? isExpanded : undefined} // Leaves cannot be expanded
-              aria-selected={node === selectedNode}
+              aria-expanded={isMyGroup(entity) ? isExpanded : undefined} // Leaves cannot be expanded
+              aria-selected={entity === selectedEntity}
               onClick={() => {
-                onSelect(node);
+                onSelect(entity);
               }}
             >
-              {renderIcon(data, isBranch, isExpanded)}
-              {label}
+              <Icon entity={entity} isExpanded={isExpanded} />
+              {name}
             </button>
 
-            {children && isExpanded && (
+            {isMyGroup(entity) && isExpanded && (
               <TreeView
                 level={level + 1}
-                nodes={children}
-                selectedNode={selectedNode}
-                expandedNodes={expandedNodes}
+                entities={entity.children}
+                selectedEntity={selectedEntity}
+                expandedGroups={expandedGroups}
                 onSelect={onSelect}
-                renderIcon={renderIcon}
               />
             )}
           </li>

--- a/src/h5web/explorer/models.ts
+++ b/src/h5web/explorer/models.ts
@@ -1,9 +1,0 @@
-export interface TreeNode<T> {
-  uid: string;
-  label: string;
-  data: T;
-  children?: TreeNode<T>[];
-  parents: T[];
-}
-
-export type ExpandedNodes = Record<string, boolean>;

--- a/src/h5web/providers/models.ts
+++ b/src/h5web/providers/models.ts
@@ -48,6 +48,47 @@ export interface HDF5Datatype<T = HDF5Type> {
   type: T;
 }
 
+export enum MyHDF5EntityKind {
+  Group = 'group',
+  Dataset = 'dataset',
+  Datatype = 'datatype',
+  Link = 'link',
+}
+
+export interface MyHDF5Entity {
+  uid: string;
+  id?: HDF5Id;
+  name: string;
+  kind: MyHDF5EntityKind;
+  parents: MyHDF5Group[];
+  attributes: HDF5Attribute[];
+  rawLink: HDF5Link;
+  rawEntity?: HDF5Entity;
+}
+
+export interface MyHDF5Group extends MyHDF5Entity {
+  kind: MyHDF5EntityKind.Group;
+  children: MyHDF5Entity[];
+}
+
+export interface MyHDF5Dataset<
+  S extends HDF5Shape = HDF5Shape,
+  T extends HDF5Type = HDF5Type
+> extends MyHDF5Entity {
+  kind: MyHDF5EntityKind.Dataset;
+  shape: S;
+  type: T;
+}
+
+export interface MyHDF5Datatype<T = HDF5Type> extends MyHDF5Entity {
+  kind: MyHDF5EntityKind.Datatype;
+  type: T;
+}
+
+export interface MyHDF5Link extends MyHDF5Entity {
+  kind: MyHDF5EntityKind.Link;
+}
+
 /* ---------------------- */
 /* ----- ATTRIBUTES ----- */
 

--- a/src/h5web/providers/utils.ts
+++ b/src/h5web/providers/utils.ts
@@ -17,11 +17,10 @@ import {
   HDF5NumericType,
   HDF5Group,
   HDF5Datatype,
+  MyHDF5Entity,
+  MyHDF5EntityKind,
+  MyHDF5Group,
 } from './models';
-
-export function isHardLink(link: HDF5Link): link is HDF5HardLink {
-  return link.class === HDF5LinkClass.Hard;
-}
 
 export function isReachable(
   link: HDF5Link
@@ -40,6 +39,10 @@ export function isDatatype(entity: HDF5Entity): entity is HDF5Datatype {
 
 export function isGroup(entity: HDF5Entity): entity is HDF5Group {
   return entity.collection === HDF5Collection.Groups;
+}
+
+export function isMyGroup(entity: MyHDF5Entity): entity is MyHDF5Group {
+  return entity.kind === MyHDF5EntityKind.Group;
 }
 
 export function hasSimpleShape<T extends HDF5Type>(
@@ -116,7 +119,7 @@ export function getLink(name: string, group: HDF5Group): HDF5Link | undefined {
   return group.links?.find((l) => l.title === name);
 }
 
-export function getEntity(
+function getEntity(
   link: HDF5Link | undefined,
   metadata: HDF5Metadata
 ): HDF5Entity | undefined {


### PR DESCRIPTION
**Part 1 of The Big Refactoring** ™️  that aims to remove the complexity of having to follow links to find entities by providing a nested HDF5 structure to the entire app.

Since the Explorer already uses a nested structure (`TreeNode`), I thought it would be a good place to start. So this first refactoring consists of replacing the generic `TreeNode<T>` model with a specific, nested HDF5 structure, and to refactor the `buildTree` function to return an object with this new structure.

To keep things manageable and limit the scope of the refactoring, I decided:

- to keep all the existing HDF5 models for now;
- to temporarily prefix the new models with `My`;
- to keep references to the raw links and entities in the new HDF5 structure, so I can pass them to `Visualizer` and `MetadataViewer`;
- to keep injecting a `metadata` object of type `HDF5Metadata` through the `ProviderContext`.

