### PR TITLE
Show link class in metadata viewer

### DIFF
--- a/src/h5web/metadata-viewer/LinkInfo.tsx
+++ b/src/h5web/metadata-viewer/LinkInfo.tsx
@@ -10,6 +10,10 @@ function LinkInfo(props: Props): ReactElement {
 
   return (
     <>
+      <tr>
+        <th scope="row">Class</th>
+        <td>{link.class}</td>
+      </tr>
       {'collection' in link && (
         <tr>
           <th scope="row">Collection</th>


### PR DESCRIPTION
Fix #354 

![image](https://user-images.githubusercontent.com/2936402/101175277-400a6b00-3645-11eb-8317-a28bf41b1064.png)
