### PR TITLE
Generate nested mock metadata

### DIFF
--- a/src/h5web/explorer/Explorer.test.tsx
+++ b/src/h5web/explorer/Explorer.test.tsx
@@ -1,15 +1,15 @@
 import { fireEvent, screen } from '@testing-library/react';
-import { MOCK_DOMAIN } from '../providers/mock/MockProvider';
+import { mockDomain } from '../providers/mock/data';
 import { renderApp } from '../test-utils';
 
 describe('Explorer', () => {
   test('select root group by default', async () => {
     renderApp();
 
-    const title = await screen.findByRole('heading', { name: MOCK_DOMAIN });
+    const title = await screen.findByRole('heading', { name: mockDomain });
     expect(title).toBeVisible();
 
-    const domainBtn = screen.getByRole('treeitem', { name: MOCK_DOMAIN });
+    const domainBtn = screen.getByRole('treeitem', { name: mockDomain });
     expect(domainBtn).toBeVisible();
     expect(domainBtn).toHaveAttribute('aria-selected', 'true');
   });
@@ -18,7 +18,7 @@ describe('Explorer', () => {
     renderApp();
 
     const domainBtn = await screen.findByRole('treeitem', {
-      name: MOCK_DOMAIN,
+      name: mockDomain,
     });
     const sidebarBtn = screen.getByRole('button', {
       name: 'Toggle explorer sidebar',

--- a/src/h5web/explorer/Explorer.tsx
+++ b/src/h5web/explorer/Explorer.tsx
@@ -5,7 +5,7 @@ import EntityList from './EntityList';
 import styles from './Explorer.module.css';
 import { buildTree, getEntityAtPath, getParents } from './utils';
 import { ProviderContext } from '../providers/context';
-import { isGroup } from '../providers/utils';
+import { isGroup, isMetadataMyGroup } from '../providers/utils';
 import { useSet } from 'react-use';
 
 const DEFAULT_PATH: number[] = JSON.parse(
@@ -19,9 +19,11 @@ interface Props {
 
 function Explorer(props: Props): ReactElement {
   const { onSelect, selectedEntity } = props;
-
   const { domain, metadata } = useContext(ProviderContext);
-  const root = useMemo(() => buildTree(metadata, domain), [domain, metadata]);
+
+  const root = useMemo(() => {
+    return isMetadataMyGroup(metadata) ? metadata : buildTree(metadata, domain);
+  }, [domain, metadata]);
 
   const [
     expandedGroups,

--- a/src/h5web/explorer/Explorer.tsx
+++ b/src/h5web/explorer/Explorer.tsx
@@ -5,7 +5,7 @@ import EntityList from './EntityList';
 import styles from './Explorer.module.css';
 import { buildTree, getEntityAtPath, getParents } from './utils';
 import { ProviderContext } from '../providers/context';
-import { isGroup, isMetadataMyGroup } from '../providers/utils';
+import { isGroup, isMyMetadata } from '../providers/utils';
 import { useSet } from 'react-use';
 
 const DEFAULT_PATH: number[] = JSON.parse(
@@ -22,7 +22,7 @@ function Explorer(props: Props): ReactElement {
   const { domain, metadata } = useContext(ProviderContext);
 
   const root = useMemo(() => {
-    return isMetadataMyGroup(metadata) ? metadata : buildTree(metadata, domain);
+    return isMyMetadata(metadata) ? metadata : buildTree(metadata, domain);
   }, [domain, metadata]);
 
   const [

--- a/src/h5web/explorer/utils.test.ts
+++ b/src/h5web/explorer/utils.test.ts
@@ -6,6 +6,7 @@ import {
   MyHDF5EntityKind,
   MyHDF5Dataset,
   MyHDF5Group,
+  MyHDF5Metadata,
 } from '../providers/models';
 import {
   intType,
@@ -35,7 +36,7 @@ describe('Explorer utilities', () => {
         groups: [rootGroup],
       });
 
-      const expectedTree: MyHDF5Group = {
+      const expectedTree: MyHDF5Metadata = {
         uid: expect.any(String),
         id: '913d8791',
         name: domain,
@@ -59,7 +60,7 @@ describe('Explorer utilities', () => {
         datasets: [dataset],
       });
 
-      const expectedTree: MyHDF5Group = {
+      const expectedTree: MyHDF5Metadata = {
         uid: expect.any(String),
         id: '913d8791',
         name: domain,
@@ -108,7 +109,7 @@ describe('Explorer utilities', () => {
         datasets: [dataset],
       });
 
-      const expectedTree: MyHDF5Group = {
+      const expectedTree: MyHDF5Metadata = {
         uid: expect.any(String),
         id: '913d8791',
         name: domain,

--- a/src/h5web/explorer/utils.ts
+++ b/src/h5web/explorer/utils.ts
@@ -10,6 +10,7 @@ import {
   MyHDF5Datatype,
   HDF5HardLink,
   MyHDF5EntityKind,
+  MyHDF5Metadata,
 } from '../providers/models';
 import { isGroup, isReachable } from '../providers/utils';
 
@@ -98,7 +99,10 @@ function buildGroup(
   return group;
 }
 
-export function buildTree(metadata: HDF5Metadata, domain: string): MyHDF5Group {
+export function buildTree(
+  metadata: HDF5Metadata,
+  domain: string
+): MyHDF5Metadata {
   const rootLink: HDF5RootLink = {
     class: HDF5LinkClass.Root,
     collection: HDF5Collection.Groups,
@@ -130,7 +134,7 @@ export function getParents(
   return parent ? getParents(parent, [parent, ...prevParents]) : prevParents;
 }
 
-export function findRoot(entity: MyHDF5Entity): MyHDF5Group | undefined {
+export function findRoot(entity: MyHDF5Entity): MyHDF5Metadata | undefined {
   if (!entity.parent) {
     return isGroup(entity) ? entity : undefined;
   }

--- a/src/h5web/providers/context.ts
+++ b/src/h5web/providers/context.ts
@@ -1,15 +1,15 @@
 import { createContext } from 'react';
-import type { HDF5Id, HDF5Value, HDF5Metadata } from './models';
+import type { HDF5Id, HDF5Value, HDF5Metadata, MyHDF5Group } from './models';
 
 export abstract class ProviderAPI {
   abstract domain: string;
-  abstract getMetadata(): Promise<HDF5Metadata>;
+  abstract getMetadata(): Promise<HDF5Metadata | MyHDF5Group>;
   abstract getValue(id: HDF5Id): Promise<HDF5Value | undefined>;
 }
 
 export const ProviderContext = createContext<{
   domain: string;
-  metadata: HDF5Metadata;
+  metadata: HDF5Metadata | MyHDF5Group;
   getValue: ProviderAPI['getValue'];
   getValues: (ids: HDF5Id[]) => Promise<Record<HDF5Id, HDF5Value | undefined>>;
 }>({} as any); // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/src/h5web/providers/context.ts
+++ b/src/h5web/providers/context.ts
@@ -1,15 +1,15 @@
 import { createContext } from 'react';
-import type { HDF5Id, HDF5Value, HDF5Metadata, MyHDF5Group } from './models';
+import type { HDF5Id, HDF5Value, HDF5Metadata, MyHDF5Metadata } from './models';
 
 export abstract class ProviderAPI {
   abstract domain: string;
-  abstract getMetadata(): Promise<HDF5Metadata | MyHDF5Group>;
+  abstract getMetadata(): Promise<HDF5Metadata | MyHDF5Metadata>;
   abstract getValue(id: HDF5Id): Promise<HDF5Value | undefined>;
 }
 
 export const ProviderContext = createContext<{
   domain: string;
-  metadata: HDF5Metadata | MyHDF5Group;
+  metadata: HDF5Metadata | MyHDF5Metadata;
   getValue: ProviderAPI['getValue'];
   getValues: (ids: HDF5Id[]) => Promise<Record<HDF5Id, HDF5Value | undefined>>;
 }>({} as any); // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/src/h5web/providers/mock/MockProvider.tsx
+++ b/src/h5web/providers/mock/MockProvider.tsx
@@ -1,9 +1,6 @@
 import React, { ReactElement, ReactNode } from 'react';
 import Provider from '../Provider';
-import { mockMetadata, mockValues } from './data';
-import type { HDF5Id, HDF5Values } from '../models';
-
-export const MOCK_DOMAIN = 'source.h5';
+import { myMockMetadata, mockValues, mockDomain } from './data';
 
 interface Props {
   domain?: string;
@@ -12,20 +9,20 @@ interface Props {
 }
 
 function MockProvider(props: Props): ReactElement {
-  const { domain = MOCK_DOMAIN, errorOnId, children } = props;
+  const { domain = mockDomain, errorOnId, children } = props;
 
   return (
     <Provider
       api={{
         domain,
-        getMetadata: async () => mockMetadata,
-        getValue: async (id: HDF5Id) => {
+        getMetadata: async () => myMockMetadata,
+        getValue: async (id: keyof typeof mockValues) => {
           if (id === errorOnId) {
-            // Throw error when trying to fetch value of dataset with ID `raw`
+            // Throw error when fetching value with specific ID
             throw new Error('error');
           }
 
-          return (mockValues as HDF5Values)[id];
+          return mockValues[id];
         },
       }}
     >

--- a/src/h5web/providers/mock/MockProvider.tsx
+++ b/src/h5web/providers/mock/MockProvider.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, ReactNode } from 'react';
 import Provider from '../Provider';
-import { myMockMetadata, mockValues, mockDomain } from './data';
+import { mockMetadata, mockValues, mockDomain } from './data';
 
 interface Props {
   domain?: string;
@@ -15,7 +15,7 @@ function MockProvider(props: Props): ReactElement {
     <Provider
       api={{
         domain,
-        getMetadata: async () => myMockMetadata,
+        getMetadata: async () => mockMetadata,
         getValue: async (id: keyof typeof mockValues) => {
           if (id === errorOnId) {
             // Throw error when fetching value with specific ID

--- a/src/h5web/providers/mock/data.ts
+++ b/src/h5web/providers/mock/data.ts
@@ -1,4 +1,5 @@
 import { range } from 'lodash-es';
+import { ScaleType } from '../../visualizations/shared/models';
 import {
   HDF5Id,
   HDF5LinkClass,
@@ -24,6 +25,16 @@ import {
   HDF5Value,
   HDF5HardLink,
 } from '../models';
+import {
+  makeMyDataset,
+  makeMyDatatype,
+  makeMyExternalLink,
+  makeMyGroup,
+  makeMyNxDataGroup,
+  makeMyNxDataset,
+  makeMyNxEntityGroup,
+  makeMySimpleDataset,
+} from '../my-utils';
 
 /* ----------------- */
 /* ----- TYPES ----- */
@@ -162,6 +173,147 @@ export function makeMetadata(
     datatypes: Object.fromEntries(datatypes.map((dt) => [dt.id, dt])),
   };
 }
+
+export const mockDomain = 'source.h5';
+
+export const myMockMetadata = makeMyNxEntityGroup(mockDomain, 'NXroot', {
+  defaultPath: 'nexus_entry',
+  children: [
+    makeMyGroup('entities', [
+      makeMyGroup('empty_group'),
+      makeMyExternalLink('external_link', 'my_file', 'entry_000/dataset'),
+      makeMyDatatype('datatype', compoundType),
+      makeMyDataset('raw', scalarShape, compoundType),
+      makeMyDataset('scalar_int', scalarShape, intType),
+      makeMyDataset('scalar_str', scalarShape, stringType),
+    ]),
+    makeMyGroup('nD_datasets', [
+      makeMySimpleDataset('oneD_linear', intType, [41]),
+      makeMySimpleDataset('oneD', intType, [41]),
+      makeMySimpleDataset('twoD', intType, [20, 41]),
+      makeMySimpleDataset('threeD', intType, [9, 20, 41]),
+      makeMySimpleDataset('fourD', intType, [3, 9, 20, 41]),
+    ]),
+    makeMyNxEntityGroup('nexus_entry', 'NXentry', {
+      defaultPath: 'nx_process/nx_data',
+      children: [
+        makeMyNxEntityGroup('nx_process', 'NXprocess', {
+          children: [
+            makeMyNxDataGroup('nx_data', {
+              signal: makeMyNxDataset('twoD', intType, [20, 41]),
+              silxStyle: { signal_scale_type: ScaleType.SymLog },
+              title: makeMyDataset('title', scalarShape, stringType, {
+                id: 'title_twoD',
+              }),
+            }),
+          ],
+        }),
+        makeMyNxDataGroup('spectrum', {
+          signal: makeMyNxDataset('twoD_spectrum', intType, [20, 41], {
+            interpretation: 'spectrum',
+            units: 'arb. units',
+          }),
+          errors: makeMyNxDataset('errors', floatType, [20, 41], {
+            id: 'errors_twoD',
+          }),
+          axes: { X: makeMyNxDataset('X', intType, [41], { units: 'nm' }) },
+          axesAttr: ['.', 'X'],
+        }),
+        makeMyNxDataGroup('image', {
+          signal: makeMyNxDataset('fourD_image', intType, [3, 9, 20, 41], {
+            longName: 'Interference fringes',
+            interpretation: 'image',
+          }),
+          axes: {
+            X: makeMyNxDataset('X', intType, [41], { units: 'nm' }),
+            Y: makeMyNxDataset('Y', intType, [20], {
+              units: 'deg',
+              longName: 'Angle (degrees)',
+            }),
+          },
+          axesAttr: ['.', '.', 'Y', 'X'],
+          silxStyle: { signal_scale_type: ScaleType.Log },
+        }),
+        makeMyNxDataGroup('log_spectrum', {
+          signal: makeMyNxDataset('oneD', intType, [41]),
+          errors: makeMyNxDataset('oneD_errors', intType, [41]),
+          axes: { X_log: makeMyNxDataset('X_log', floatType, [41]) },
+          axesAttr: ['X_log'],
+          silxStyle: {
+            signal_scale_type: ScaleType.Log,
+            axes_scale_type: [ScaleType.Log],
+          },
+        }),
+      ],
+    }),
+    makeMyGroup('nexus_malformed', [
+      makeMyGroup('default_not_string', [], {
+        attributes: [makeAttr('default', scalarShape, intType, 42)],
+      }),
+      makeMyGroup('default_empty', [], {
+        attributes: [makeStrAttr('default', '')],
+      }),
+      makeMyGroup('default_not_found', [], {
+        attributes: [makeStrAttr('default', '/test')],
+      }),
+      makeMyNxEntityGroup('default_not_group', 'NXentry', {
+        defaultPath: 'scalar_int',
+        children: [makeMyDataset('scalar_int', scalarShape, intType)],
+      }),
+      makeMyGroup('no_signal', [], {
+        attributes: [makeStrAttr('NX_class', 'NXdata')],
+      }),
+      makeMyGroup('signal_not_string', [], {
+        attributes: [
+          makeStrAttr('NX_class', 'NXdata'),
+          makeAttr('signal', scalarShape, intType, 42),
+        ],
+      }),
+      makeMyGroup('signal_not_found', [], {
+        attributes: [
+          makeStrAttr('NX_class', 'NXdata'),
+          makeStrAttr('signal', 'unknown'),
+        ],
+      }),
+      makeMyGroup('signal_not_dataset', [makeMyGroup('empty_group')], {
+        attributes: [
+          makeStrAttr('NX_class', 'NXdata'),
+          makeStrAttr('signal', 'empty_group'),
+        ],
+      }),
+      makeMyGroup(
+        'signal_dataset_not_numeric',
+        [makeMySimpleDataset('oneD_str', stringType, [2])],
+        {
+          attributes: [
+            makeStrAttr('NX_class', 'NXdata'),
+            makeStrAttr('signal', 'oneD_str'),
+          ],
+        }
+      ),
+      makeMyGroup(
+        'signal_dataset_not_simple',
+        [makeMyDataset('scalar_int', scalarShape, intType)],
+        {
+          attributes: [
+            makeStrAttr('NX_class', 'NXdata'),
+            makeStrAttr('signal', 'scalar_int'),
+          ],
+        }
+      ),
+      makeMyGroup(
+        'signal_dataset_zero_dim',
+        [makeMySimpleDataset('zeroD', intType, [], { id: 'null' })],
+        {
+          attributes: [
+            makeStrAttr('NX_class', 'NXdata'),
+            makeStrAttr('signal', 'zeroD'),
+          ],
+        }
+      ),
+    ]),
+  ],
+});
 
 export const mockMetadata = makeMetadata({
   root: 'root',

--- a/src/h5web/providers/mock/data.ts
+++ b/src/h5web/providers/mock/data.ts
@@ -98,7 +98,7 @@ export function makeDataset(
   return { id, collection: HDF5Collection.Datasets, type, shape, attributes };
 }
 
-function makeSimpleDataset(
+export function makeSimpleDataset(
   id: HDF5Id,
   type: HDF5Type,
   dims: HDF5Dims,
@@ -115,7 +115,7 @@ export function makeGroup(
   return { id, collection: HDF5Collection.Groups, attributes, links };
 }
 
-function makeDatatype(id: HDF5Id, type: HDF5Type): HDF5Datatype {
+export function makeDatatype(id: HDF5Id, type: HDF5Type): HDF5Datatype {
   return { id, collection: HDF5Collection.Datatypes, type };
 }
 
@@ -130,15 +130,15 @@ export function makeHardLink(
   return { class: HDF5LinkClass.Hard, title, collection, id };
 }
 
-function makeDatasetHardLink(title: string, id = title): HDF5HardLink {
+export function makeDatasetHardLink(title: string, id = title): HDF5HardLink {
   return makeHardLink(HDF5Collection.Datasets, title, id);
 }
 
-function makeGroupHardLink(title: string, id = title): HDF5HardLink {
+export function makeGroupHardLink(title: string, id = title): HDF5HardLink {
   return makeHardLink(HDF5Collection.Groups, title, id);
 }
 
-function makeExternalLink(
+export function makeExternalLink(
   title: string,
   file: string,
   h5path: string
@@ -149,7 +149,7 @@ function makeExternalLink(
 /* ----------------- */
 /* ----- NEXUS ----- */
 
-function makeNxAxesAttr(axes: string[]): HDF5Attribute {
+export function makeNxAxesAttr(axes: string[]): HDF5Attribute {
   return makeAttr('axes', makeSimpleShape([axes.length]), stringType, axes);
 }
 
@@ -176,7 +176,7 @@ export function makeMetadata(
 
 export const mockDomain = 'source.h5';
 
-export const myMockMetadata = makeMyNxEntityGroup(mockDomain, 'NXroot', {
+export const mockMetadata = makeMyNxEntityGroup(mockDomain, 'NXroot', {
   defaultPath: 'nexus_entry',
   children: [
     makeMyGroup('entities', [
@@ -313,213 +313,6 @@ export const myMockMetadata = makeMyNxEntityGroup(mockDomain, 'NXroot', {
       ),
     ]),
   ],
-});
-
-export const mockMetadata = makeMetadata({
-  root: 'root',
-  groups: [
-    makeGroup(
-      'root',
-      [
-        makeStrAttr('NX_class', 'NXroot'),
-        makeStrAttr('default', 'nexus_entry'),
-      ],
-      [
-        makeGroupHardLink('entities'),
-        makeGroupHardLink('nD_datasets'),
-        makeGroupHardLink('nexus_entry'),
-        makeGroupHardLink('nexus_malformed'),
-      ]
-    ),
-
-    // ==> Top-level groups
-    makeGroup('entities', undefined, [
-      makeGroupHardLink('empty_group'),
-      makeExternalLink('external_link', 'my_file', 'entry_000/dataset'),
-      makeHardLink(HDF5Collection.Datatypes, 'datatype'),
-      makeDatasetHardLink('raw'),
-      makeDatasetHardLink('scalar_int'),
-      makeDatasetHardLink('scalar_str'),
-    ]),
-    makeGroup('nD_datasets', undefined, [
-      makeDatasetHardLink('oneD_linear'),
-      makeDatasetHardLink('oneD'),
-      makeDatasetHardLink('twoD'),
-      makeDatasetHardLink('threeD'),
-      makeDatasetHardLink('fourD'),
-    ]),
-    makeGroup(
-      'nexus_entry',
-      [
-        makeStrAttr('NX_class', 'NXentry'),
-        makeStrAttr('default', 'nx_process/nx_data'),
-      ],
-      [
-        makeGroupHardLink('nx_process'),
-        makeGroupHardLink('spectrum'),
-        makeGroupHardLink('image'),
-        makeGroupHardLink('log_spectrum'),
-      ]
-    ),
-    makeGroup('nexus_malformed', undefined, [
-      makeGroupHardLink('default_not_string'),
-      makeGroupHardLink('default_empty'),
-      makeGroupHardLink('default_not_found'),
-      makeGroupHardLink('default_not_group'),
-      makeGroupHardLink('no_signal'),
-      makeGroupHardLink('signal_not_string'),
-      makeGroupHardLink('signal_not_found'),
-      makeGroupHardLink('signal_not_dataset'),
-      makeGroupHardLink('signal_dataset_not_numeric'),
-      makeGroupHardLink('signal_dataset_not_simple'),
-      makeGroupHardLink('signal_dataset_zero_dim'),
-    ]),
-
-    // ==> Inner groups
-    makeGroup('empty_group'),
-    makeGroup(
-      'nx_process',
-      [makeStrAttr('NX_class', 'NXprocess')], // intentionally has no `default` attribute
-      [makeGroupHardLink('nx_data')]
-    ),
-    makeGroup(
-      'nx_data',
-      [
-        makeStrAttr('NX_class', 'NXdata'),
-        makeStrAttr('signal', 'twoD'),
-        makeStrAttr(
-          'SILX_style',
-          JSON.stringify({ signal_scale_type: 'symlog' })
-        ),
-      ],
-      [makeDatasetHardLink('twoD'), makeDatasetHardLink('title', 'title_twoD')]
-    ),
-    makeGroup(
-      'spectrum',
-      [
-        makeStrAttr('NX_class', 'NXdata'),
-        makeStrAttr('signal', 'twoD_spectrum'),
-        makeNxAxesAttr(['.', 'X']),
-      ],
-      [
-        makeDatasetHardLink('twoD_spectrum'),
-        makeDatasetHardLink('X'),
-        makeDatasetHardLink('errors', 'errors_twoD'),
-      ]
-    ),
-    makeGroup(
-      'image',
-      [
-        makeStrAttr('NX_class', 'NXdata'),
-        makeStrAttr('signal', 'fourD_image'),
-        makeStrAttr('SILX_style', JSON.stringify({ signal_scale_type: 'log' })),
-        makeNxAxesAttr(['.', '.', 'Y', 'X']),
-      ],
-      [
-        makeDatasetHardLink('fourD_image'),
-        makeDatasetHardLink('X'),
-        makeDatasetHardLink('Y'),
-      ]
-    ),
-    makeGroup(
-      'log_spectrum',
-      [
-        makeStrAttr('NX_class', 'NXdata'),
-        makeStrAttr('signal', 'oneD'),
-        makeStrAttr(
-          'SILX_style',
-          JSON.stringify({ axes_scale_type: ['log'], signal_scale_type: 'log' })
-        ),
-        makeNxAxesAttr(['X_log']),
-      ],
-      [
-        makeDatasetHardLink('oneD', 'oneD'),
-        makeDatasetHardLink('X_log'),
-        makeDatasetHardLink('oneD_errors'),
-      ]
-    ),
-    makeGroup('default_not_string', [
-      makeAttr('default', scalarShape, intType, 42),
-    ]),
-    makeGroup('default_empty', [makeStrAttr('default', '')]),
-    makeGroup('default_not_found', [makeStrAttr('default', '/test')]),
-    makeGroup(
-      'default_not_group',
-      [makeStrAttr('default', 'scalar_int')],
-      [makeDatasetHardLink('scalar_int')]
-    ),
-    makeGroup('no_signal', [makeStrAttr('NX_class', 'NXdata')]),
-    makeGroup('signal_not_string', [
-      makeStrAttr('NX_class', 'NXdata'),
-      makeAttr('signal', scalarShape, intType, 42),
-    ]),
-    makeGroup('signal_not_found', [
-      makeStrAttr('NX_class', 'NXdata'),
-      makeStrAttr('signal', 'unknown'),
-    ]),
-    makeGroup(
-      'signal_not_dataset',
-      [makeStrAttr('NX_class', 'NXdata'), makeStrAttr('signal', 'empty_group')],
-      [makeGroupHardLink('empty_group')]
-    ),
-    makeGroup(
-      'signal_dataset_not_numeric',
-      [makeStrAttr('NX_class', 'NXdata'), makeStrAttr('signal', 'oneD_str')],
-      [makeDatasetHardLink('oneD_str')]
-    ),
-    makeGroup(
-      'signal_dataset_not_simple',
-      [makeStrAttr('NX_class', 'NXdata'), makeStrAttr('signal', 'scalar_int')],
-      [makeDatasetHardLink('scalar_int')]
-    ),
-    makeGroup(
-      'signal_dataset_zero_dim',
-      [makeStrAttr('NX_class', 'NXdata'), makeStrAttr('signal', 'zeroD')],
-      [makeDatasetHardLink('zeroD', 'null')]
-    ),
-  ],
-  datasets: [
-    makeSimpleDataset('oneD_linear', intType, [41]),
-    makeSimpleDataset('oneD', intType, [41]),
-    makeSimpleDataset('twoD', intType, [20, 41]),
-    makeSimpleDataset('threeD', intType, [9, 20, 41]),
-    makeSimpleDataset('fourD', intType, [3, 9, 20, 41]),
-    makeDataset('raw', compoundType, scalarShape),
-    makeDataset('scalar_int', intType, scalarShape),
-    makeDataset('scalar_str', stringType, scalarShape),
-    makeSimpleDataset('X', intType, [41], [makeStrAttr('units', 'nm')]),
-    makeSimpleDataset(
-      'Y',
-      intType,
-      [20],
-      [makeStrAttr('units', 'deg'), makeStrAttr('long_name', 'Angle (degrees)')]
-    ),
-    makeDataset('title_twoD', stringType, scalarShape),
-    makeSimpleDataset('X_log', floatType, [41]),
-    makeSimpleDataset('oneD_str', stringType, [2]),
-    makeSimpleDataset('null', intType, []),
-    makeSimpleDataset(
-      'twoD_spectrum',
-      intType,
-      [20, 41],
-      [
-        makeStrAttr('interpretation', 'spectrum'),
-        makeStrAttr('units', 'arb. units'),
-      ]
-    ),
-    makeSimpleDataset('errors_twoD', floatType, [20, 41]),
-    makeSimpleDataset(
-      'fourD_image',
-      intType,
-      [3, 9, 20, 41],
-      [
-        makeStrAttr('long_name', 'Interference fringes'),
-        makeStrAttr('interpretation', 'image'),
-      ]
-    ),
-    makeSimpleDataset('oneD_errors', intType, [41]),
-  ],
-  datatypes: [makeDatatype('datatype', compoundType)],
 });
 
 /* ------------------ */

--- a/src/h5web/providers/mock/utils.ts
+++ b/src/h5web/providers/mock/utils.ts
@@ -1,4 +1,4 @@
-import { mockValues, myMockMetadata } from './data';
+import { mockValues, mockMetadata } from './data';
 import {
   assertDataset,
   assertMySimpleShape,
@@ -19,7 +19,7 @@ export function getMockDataArray(path: string): ndarray {
         ? getChildEntity(parentEntity, currSegment)
         : undefined;
     },
-    myMockMetadata
+    mockMetadata
   );
 
   assertDefined(dataset, `Expected entity at path "${path}"`);

--- a/src/h5web/providers/mock/utils.ts
+++ b/src/h5web/providers/mock/utils.ts
@@ -10,8 +10,8 @@ import ndarray from 'ndarray';
 import { MyHDF5Entity } from '../models';
 import { getChildEntity } from '../../visualizations/nexus/utils';
 
-export function getMockDataArray(path: string): ndarray {
-  const pathSegments = path.slice(1).split('/');
+export function getMockDataArray(absolutePath: string): ndarray {
+  const pathSegments = absolutePath.slice(1).split('/');
 
   const dataset = pathSegments.reduce<MyHDF5Entity | undefined>(
     (parentEntity, currSegment) => {
@@ -22,8 +22,8 @@ export function getMockDataArray(path: string): ndarray {
     mockMetadata
   );
 
-  assertDefined(dataset, `Expected entity at path "${path}"`);
-  assertDataset(dataset, `Expected group at path "${path}"`);
+  assertDefined(dataset, `Expected entity at path "${absolutePath}"`);
+  assertDataset(dataset, `Expected group at path "${absolutePath}"`);
   assertNumericType(dataset);
   assertMySimpleShape(dataset);
 

--- a/src/h5web/providers/mock/utils.ts
+++ b/src/h5web/providers/mock/utils.ts
@@ -1,10 +1,34 @@
-import { mockMetadata } from './data';
-import { assertSimpleShape } from '../utils';
-import { assertDefined } from '../../visualizations/shared/utils';
+import { mockValues, myMockMetadata } from './data';
+import {
+  assertDataset,
+  assertMySimpleShape,
+  assertNumericType,
+  isGroup,
+} from '../utils';
+import { assertArray, assertDefined } from '../../visualizations/shared/utils';
+import ndarray from 'ndarray';
+import { MyHDF5Entity } from '../models';
+import { getChildEntity } from '../../visualizations/nexus/utils';
 
-export function getMockDatasetDims(name: string): number[] {
-  const dataset = mockMetadata.datasets?.[name];
-  assertDefined(dataset, "Dataset doesn't exist");
-  assertSimpleShape(dataset);
-  return dataset.shape.dims;
+export function getMockDataArray(path: string): ndarray {
+  const pathSegments = path.slice(1).split('/');
+
+  const dataset = pathSegments.reduce<MyHDF5Entity | undefined>(
+    (parentEntity, currSegment) => {
+      return parentEntity && isGroup(parentEntity)
+        ? getChildEntity(parentEntity, currSegment)
+        : undefined;
+    },
+    myMockMetadata
+  );
+
+  assertDefined(dataset, `Expected entity at path "${path}"`);
+  assertDataset(dataset, `Expected group at path "${path}"`);
+  assertNumericType(dataset);
+  assertMySimpleShape(dataset);
+
+  const value = mockValues[dataset.id as keyof typeof mockValues];
+  assertArray<number>(value);
+
+  return ndarray(value, dataset.shape.dims);
 }

--- a/src/h5web/providers/models.ts
+++ b/src/h5web/providers/models.ts
@@ -55,6 +55,8 @@ export enum MyHDF5EntityKind {
   Link = 'link',
 }
 
+export type MyHDF5Metadata = MyHDF5Group;
+
 export interface MyHDF5Entity {
   uid: string;
   name: string;

--- a/src/h5web/providers/models.ts
+++ b/src/h5web/providers/models.ts
@@ -87,8 +87,10 @@ export interface MyHDF5Datatype<T = HDF5Type> extends MyHDF5ResolvedEntity {
   type: T;
 }
 
-export interface MyHDF5Link extends MyHDF5Entity {
+export interface MyHDF5Link<T extends HDF5Link = HDF5Link>
+  extends MyHDF5Entity {
   kind: MyHDF5EntityKind.Link;
+  rawLink: T;
 }
 
 /* ---------------------- */

--- a/src/h5web/providers/my-utils.ts
+++ b/src/h5web/providers/my-utils.ts
@@ -2,25 +2,32 @@ import { nanoid } from 'nanoid';
 import {
   HDF5Attribute,
   HDF5Dims,
+  HDF5ExternalLink,
+  HDF5LinkClass,
   HDF5NumericType,
+  HDF5ScalarShape,
   HDF5Shape,
   HDF5SimpleShape,
+  HDF5StringType,
   HDF5Type,
   MyHDF5Dataset,
   MyHDF5Datatype,
   MyHDF5Entity,
   MyHDF5EntityKind,
   MyHDF5Group,
+  MyHDF5Link,
 } from '../providers/models';
 import { makeSimpleShape, makeStrAttr } from '../providers/mock/data';
-import { NxInterpretation } from '../visualizations/nexus/models';
+import { NxInterpretation, SilxStyle } from '../visualizations/nexus/models';
 
-type Opts = Partial<Pick<MyHDF5Dataset, 'id' | 'attributes'>>;
+type EntityOpts = Partial<Pick<MyHDF5Dataset, 'id' | 'attributes'>>;
+type GroupOpts = EntityOpts & { children?: MyHDF5Entity[] };
+type AllOrNone<T> = T | { [K in keyof T]?: never };
 
 export function makeMyGroup(
   name: string,
   children: MyHDF5Entity[] = [],
-  opts: Opts = {}
+  opts: EntityOpts = {}
 ): MyHDF5Group {
   const { id = name, attributes = [] } = opts;
 
@@ -33,10 +40,9 @@ export function makeMyGroup(
     attributes,
   };
 
-  group.children = group.children.map((child) => ({
-    ...child,
-    parent: group,
-  }));
+  group.children.forEach((child) => {
+    child.parent = group;
+  });
 
   return group;
 }
@@ -45,7 +51,7 @@ export function makeMyDataset<S extends HDF5Shape, T extends HDF5Type>(
   name: string,
   shape: S,
   type: T,
-  opts: Opts = {}
+  opts: EntityOpts = {}
 ): MyHDF5Dataset<S, T> {
   const { id = name, attributes = [] } = opts;
 
@@ -64,7 +70,7 @@ export function makeMySimpleDataset<T extends HDF5Type>(
   name: string,
   type: T,
   dims: HDF5Dims,
-  opts: Opts = {}
+  opts: EntityOpts = {}
 ): MyHDF5Dataset<HDF5SimpleShape, T> {
   return makeMyDataset(name, makeSimpleShape(dims), type, opts);
 }
@@ -72,7 +78,7 @@ export function makeMySimpleDataset<T extends HDF5Type>(
 export function makeMyDatatype<T extends HDF5Type>(
   name: string,
   type: T,
-  opts: Opts = {}
+  opts: EntityOpts = {}
 ): MyHDF5Datatype<T> {
   const { id = name, attributes = [] } = opts;
 
@@ -83,6 +89,28 @@ export function makeMyDatatype<T extends HDF5Type>(
     kind: MyHDF5EntityKind.Datatype,
     attributes,
     type,
+  };
+}
+
+export function makeMyExternalLink(
+  name: string,
+  file: string,
+  h5path: string,
+  opts: Omit<EntityOpts, 'id'> = {}
+): MyHDF5Link<HDF5ExternalLink> {
+  const { attributes = [] } = opts;
+
+  return {
+    uid: nanoid(),
+    name,
+    kind: MyHDF5EntityKind.Link,
+    attributes,
+    rawLink: {
+      class: HDF5LinkClass.External,
+      title: name,
+      file,
+      h5path,
+    },
   };
 }
 
@@ -104,46 +132,55 @@ export function withMyInterpretation<
   ]);
 }
 
-export function makeMyNxDataGroup(
-  name: string,
-  signal: MyHDF5Dataset,
-  opts: Opts = {}
-): MyHDF5Group {
-  return makeMyGroup(name, [signal], {
-    ...opts,
-    attributes: [
-      ...(opts.attributes || []),
-      makeStrAttr('NX_class', 'NXdata'),
-      makeStrAttr('signal', signal.name),
-    ],
-  });
-}
-
-export function makeMyNxDataGroupWithAxes(
+export function makeMyNxDataGroup<
+  U extends Record<string, MyHDF5Dataset<HDF5SimpleShape, HDF5NumericType>>
+>(
   name: string,
   opts: {
     signal: MyHDF5Dataset<HDF5SimpleShape, HDF5NumericType>;
-    axes: Record<string, MyHDF5Dataset<HDF5SimpleShape, HDF5NumericType>>;
-    axesAttr: (keyof typeof opts.axes | '.')[];
-  } & Opts
+    errors?: MyHDF5Dataset<HDF5SimpleShape, HDF5NumericType>;
+    title?: MyHDF5Dataset<HDF5ScalarShape, HDF5StringType>;
+    silxStyle?: SilxStyle;
+  } & AllOrNone<{ axes: U; axesAttr: (keyof U | '.')[] }> &
+    GroupOpts
 ): MyHDF5Group {
-  const { signal, axes, axesAttr, ...groupOpts } = opts;
+  const {
+    signal,
+    title,
+    errors,
+    silxStyle,
+    axes = {},
+    axesAttr,
+    ...groupOpts
+  } = opts;
 
-  return makeMyGroup(name, [signal, ...Object.values(axes)], {
-    ...groupOpts,
-    attributes: [
-      ...(groupOpts.attributes || []),
-      makeStrAttr('NX_class', 'NXdata'),
-      makeStrAttr('signal', signal.name),
-      makeStrAttr('axes', axesAttr),
+  return makeMyGroup(
+    name,
+    [
+      signal,
+      ...(title ? [title] : []),
+      ...(errors ? [errors] : []),
+      ...Object.values<MyHDF5Dataset>(axes),
     ],
-  });
+    {
+      ...groupOpts,
+      attributes: [
+        ...(groupOpts.attributes || []),
+        makeStrAttr('NX_class', 'NXdata'),
+        makeStrAttr('signal', signal.name),
+        makeStrAttr('axes', axesAttr),
+        ...(silxStyle
+          ? [makeStrAttr('SILX_style', JSON.stringify(silxStyle))]
+          : []),
+      ],
+    }
+  );
 }
 
 export function makeMyNxEntityGroup(
   name: string,
   type: 'NXroot' | 'NXentry' | 'NXprocess',
-  opts: { defaultPath?: string; children?: MyHDF5Entity[] } & Opts = {}
+  opts: { defaultPath?: string } & GroupOpts = {}
 ): MyHDF5Group {
   const { defaultPath, children, ...groupOpts } = opts;
 
@@ -153,6 +190,31 @@ export function makeMyNxEntityGroup(
       ...(groupOpts.attributes || []),
       makeStrAttr('NX_class', type),
       ...(defaultPath ? [makeStrAttr('default', defaultPath)] : []),
+    ],
+  });
+}
+
+export function makeMyNxDataset(
+  name: string,
+  type: HDF5NumericType,
+  dims: HDF5Dims,
+  opts: {
+    interpretation?: string;
+    longName?: string;
+    units?: string;
+  } & EntityOpts = {}
+): MyHDF5Dataset<HDF5SimpleShape, HDF5NumericType> {
+  const { interpretation, longName, units } = opts;
+
+  return makeMySimpleDataset(name, type, dims, {
+    ...opts,
+    attributes: [
+      ...(opts.attributes || []),
+      ...(interpretation
+        ? [makeStrAttr('interpretation', interpretation)]
+        : []),
+      ...(longName ? [makeStrAttr('long_name', longName)] : []),
+      ...(units ? [makeStrAttr('units', units)] : []),
     ],
   });
 }

--- a/src/h5web/providers/my-utils.ts
+++ b/src/h5web/providers/my-utils.ts
@@ -27,7 +27,7 @@ type AllOrNone<T> = T | { [K in keyof T]?: never };
 export function makeMyGroup(
   name: string,
   children: MyHDF5Entity[] = [],
-  opts: EntityOpts = {}
+  opts: Omit<GroupOpts, 'children'> = {}
 ): MyHDF5Group {
   const { id = name, attributes = [] } = opts;
 
@@ -133,7 +133,7 @@ export function withMyInterpretation<
 }
 
 export function makeMyNxDataGroup<
-  U extends Record<string, MyHDF5Dataset<HDF5SimpleShape, HDF5NumericType>>
+  T extends Record<string, MyHDF5Dataset<HDF5SimpleShape, HDF5NumericType>>
 >(
   name: string,
   opts: {
@@ -141,7 +141,7 @@ export function makeMyNxDataGroup<
     errors?: MyHDF5Dataset<HDF5SimpleShape, HDF5NumericType>;
     title?: MyHDF5Dataset<HDF5ScalarShape, HDF5StringType>;
     silxStyle?: SilxStyle;
-  } & AllOrNone<{ axes: U; axesAttr: (keyof U | '.')[] }> &
+  } & AllOrNone<{ axes: T; axesAttr: (keyof T | '.')[] }> &
     GroupOpts
 ): MyHDF5Group {
   const {

--- a/src/h5web/providers/utils.ts
+++ b/src/h5web/providers/utils.ts
@@ -20,11 +20,12 @@ import {
   MyHDF5Link,
   MyHDF5ResolvedEntity,
   HDF5Metadata,
+  MyHDF5Metadata,
 } from './models';
 
-export function isMetadataMyGroup(
-  metadata: HDF5Metadata | MyHDF5Group
-): metadata is MyHDF5Group {
+export function isMyMetadata(
+  metadata: HDF5Metadata | MyHDF5Metadata
+): metadata is MyHDF5Metadata {
   return 'kind' in metadata;
 }
 

--- a/src/h5web/providers/utils.ts
+++ b/src/h5web/providers/utils.ts
@@ -19,7 +19,14 @@ import {
   MyHDF5Dataset,
   MyHDF5Link,
   MyHDF5ResolvedEntity,
+  HDF5Metadata,
 } from './models';
+
+export function isMetadataMyGroup(
+  metadata: HDF5Metadata | MyHDF5Group
+): metadata is MyHDF5Group {
+  return 'kind' in metadata;
+}
 
 export function isReachable(
   link: HDF5Link

--- a/src/h5web/visualizations/index.test.ts
+++ b/src/h5web/visualizations/index.test.ts
@@ -176,35 +176,34 @@ describe('Visualization definitions', () => {
     const supportsEntity = makeSupportFn(Vis.NxSpectrum);
 
     it('should support NXdata group referencing signal with spectrum interpretation', () => {
-      const group = makeMyNxDataGroup('foo', spectrumDatasetInt1D);
+      const group = makeMyNxDataGroup('foo', { signal: spectrumDatasetInt1D });
       expect(supportsEntity(group)).toBe(true);
     });
 
     it('should support NXdata group referencing signal with numeric type, simple shape, one dimension and no interpretation', () => {
-      const group = makeMyNxDataGroup('foo', datasetInt1D);
+      const group = makeMyNxDataGroup('foo', { signal: datasetInt1D });
       expect(supportsEntity(group)).toBe(true);
     });
 
     it('should support NXdata group referencing signal with numeric type, simple shape, one dimension and unknown interpretation', () => {
-      const group = makeMyNxDataGroup(
-        'foo',
-        withMyAttributes(datasetInt1D, [
+      const group = makeMyNxDataGroup('foo', {
+        signal: withMyAttributes(datasetInt1D, [
           makeStrAttr('interpretation', 'unknown'),
-        ])
-      );
+        ]),
+      });
 
       expect(supportsEntity(group)).toBe(true);
     });
 
     it('should not support NXdata group referencing signal with non-spectrum interpretation', () => {
-      const group = makeMyNxDataGroup('foo', imageDatasetInt1D);
+      const group = makeMyNxDataGroup('foo', { signal: imageDatasetInt1D });
       expect(supportsEntity(group)).toBe(false);
     });
 
     it('should support group with relative `default` path to supported NXdata group', () => {
       const group = makeMyNxEntityGroup('foo', 'NXentry', {
         defaultPath: 'bar',
-        children: [makeMyNxDataGroup('bar', spectrumDatasetInt1D)],
+        children: [makeMyNxDataGroup('bar', { signal: spectrumDatasetInt1D })],
       });
 
       expect(supportsEntity(group)).toBe(true);
@@ -215,7 +214,9 @@ describe('Visualization definitions', () => {
         children: [
           makeMyNxEntityGroup('foo', 'NXentry', {
             defaultPath: '/foo/bar',
-            children: [makeMyNxDataGroup('bar', spectrumDatasetInt1D)],
+            children: [
+              makeMyNxDataGroup('bar', { signal: spectrumDatasetInt1D }),
+            ],
           }),
         ],
       });
@@ -230,7 +231,9 @@ describe('Visualization definitions', () => {
         children: [
           makeMyNxEntityGroup('foo', 'NXentry', {
             defaultPath: 'bar',
-            children: [makeMyNxDataGroup('bar', spectrumDatasetInt1D)],
+            children: [
+              makeMyNxDataGroup('bar', { signal: spectrumDatasetInt1D }),
+            ],
           }),
         ],
       });
@@ -256,40 +259,39 @@ describe('Visualization definitions', () => {
     const supportsEntity = makeSupportFn(Vis.NxImage);
 
     it('should support NXdata group referencing signal with image interpretation', () => {
-      const group = makeMyNxDataGroup('foo', imageDatasetInt2D);
+      const group = makeMyNxDataGroup('foo', { signal: imageDatasetInt2D });
       expect(supportsEntity(group)).toBe(true);
     });
 
     it('should support NXdata group referencing signal with numeric type, simple shape, two dimensions and no interpretation', () => {
-      const group = makeMyNxDataGroup('foo', datasetInt2D);
+      const group = makeMyNxDataGroup('foo', { signal: datasetInt2D });
       expect(supportsEntity(group)).toBe(true);
     });
 
     it('should support NXdata group referencing signal with numeric type, simple shape, more than two dimensions and unknown interpretation', () => {
-      const group = makeMyNxDataGroup(
-        'foo',
-        withMyAttributes(datasetFlt3D, [
+      const group = makeMyNxDataGroup('foo', {
+        signal: withMyAttributes(datasetFlt3D, [
           makeStrAttr('interpretation', 'unknown'),
-        ])
-      );
+        ]),
+      });
 
       expect(supportsEntity(group)).toBe(true);
     });
 
     it('should not support NXdata group referencing signal with less than two dimensions', () => {
-      const group = makeMyNxDataGroup('foo', datasetInt1D);
+      const group = makeMyNxDataGroup('foo', { signal: datasetInt1D });
       expect(supportsEntity(group)).toBe(false);
     });
 
     it('should not support NXdata group referencing signal with non-image interpretation', () => {
-      const group = makeMyNxDataGroup('foo', spectrumDatasetInt2D);
+      const group = makeMyNxDataGroup('foo', { signal: spectrumDatasetInt2D });
       expect(supportsEntity(group)).toBe(false);
     });
 
     it('should support group with relative `default` path to supported NXdata group', () => {
       const group = makeMyNxEntityGroup('foo', 'NXentry', {
         defaultPath: 'bar',
-        children: [makeMyNxDataGroup('bar', imageDatasetInt2D)],
+        children: [makeMyNxDataGroup('bar', { signal: imageDatasetInt2D })],
       });
 
       expect(supportsEntity(group)).toBe(true);
@@ -300,7 +302,7 @@ describe('Visualization definitions', () => {
         children: [
           makeMyNxEntityGroup('foo', 'NXentry', {
             defaultPath: '/foo/bar',
-            children: [makeMyNxDataGroup('bar', imageDatasetInt2D)],
+            children: [makeMyNxDataGroup('bar', { signal: imageDatasetInt2D })],
           }),
         ],
       });
@@ -315,7 +317,7 @@ describe('Visualization definitions', () => {
         children: [
           makeMyNxEntityGroup('foo', 'NXentry', {
             defaultPath: 'bar',
-            children: [makeMyNxDataGroup('bar', imageDatasetInt2D)],
+            children: [makeMyNxDataGroup('bar', { signal: imageDatasetInt2D })],
           }),
         ],
       });

--- a/src/h5web/visualizer/Visualizer.test.tsx
+++ b/src/h5web/visualizer/Visualizer.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { mockValues } from '../../packages/lib';
+import { mockValues } from '../providers/mock/data';
 import App from '../App';
 import {
   findVisSelectorTabs,

--- a/src/h5web/visualizer/utils.test.ts
+++ b/src/h5web/visualizer/utils.test.ts
@@ -32,7 +32,7 @@ describe('Visualizer utilities', () => {
 
     it('should not include NxSpectrum vis if any other visualization is supported', () => {
       const datasetInt2D = makeMySimpleDataset('dataset', intType, [5, 3]);
-      const nxDataSignal2D = makeMyNxDataGroup('foo', datasetInt2D);
+      const nxDataSignal2D = makeMyNxDataGroup('foo', { signal: datasetInt2D });
       const supportedVis = getSupportedVis(nxDataSignal2D);
 
       expect(supportedVis).toEqual({ supportedVis: [Vis.NxImage] });

--- a/src/packages/lib.ts
+++ b/src/packages/lib.ts
@@ -42,5 +42,5 @@ export type {
 } from '../h5web/visualizations/heatmap/models';
 
 // Mock data
-export { myMockMetadata, mockValues } from '../h5web/providers/mock/data';
+export { mockMetadata, mockValues } from '../h5web/providers/mock/data';
 export { getMockDataArray } from '../h5web/providers/mock/utils';

--- a/src/packages/lib.ts
+++ b/src/packages/lib.ts
@@ -42,5 +42,5 @@ export type {
 } from '../h5web/visualizations/heatmap/models';
 
 // Mock data
-export { mockMetadata, mockValues } from '../h5web/providers/mock/data';
-export { getMockDatasetDims } from '../h5web/providers/mock/utils';
+export { myMockMetadata, mockValues } from '../h5web/providers/mock/data';
+export { getMockDataArray } from '../h5web/providers/mock/utils';

--- a/src/stories/HeatmapVis.stories.tsx
+++ b/src/stories/HeatmapVis.stories.tsx
@@ -8,14 +8,12 @@ import HeatmapVis, {
 } from '../h5web/visualizations/heatmap/HeatmapVis';
 import { ScaleType } from '../h5web/visualizations/shared/models';
 import { INTERPOLATORS } from '../h5web/visualizations/heatmap/interpolators';
-import { getDomain, mockValues } from '../packages/lib';
-import { getMockDatasetDims } from '../h5web/providers/mock/utils';
+import { getDomain } from '../packages/lib';
+import { getMockDataArray } from '../h5web/providers/mock/utils';
 
-// Prepare 2D data array
-const values = mockValues.twoD.flat(Infinity) as number[];
-const dataArray = ndarray(values, getMockDatasetDims('twoD'));
-const domain = getDomain(values);
-const logSafeDomain = getDomain(values, ScaleType.Log);
+const dataArray = getMockDataArray('/nD_datasets/twoD');
+const domain = getDomain(dataArray.data as number[]);
+const logSafeDomain = getDomain(dataArray.data as number[], ScaleType.Log);
 
 const Template: Story<HeatmapVisProps> = (args): ReactElement => (
   <HeatmapVis {...args} />

--- a/src/stories/Home.stories.mdx
+++ b/src/stories/Home.stories.mdx
@@ -85,19 +85,19 @@ The components are organised in two categories:
 
 ## Mock data
 
-The library exposes mock metadata, values and utilities for testing purposes:
+The library exposes a utility function to retrieve a mock ndarray for testing purposes.
+You can browse through the available mock data at https://h5web.panosc.eu/mock.
 
 ```ts
-import { mockMetadata, mockValues, getMockDatasetDims } from '@h5web/lib';
+import { getMockDataArray } from '@h5web/lib';
 
-const values = mockValues.twoD.flat(Infinity) as number[];
-const dataArray = ndarray<number>(values, getMockDatasetDims('twoD'));
+const dataArray = getMockDataArray('/nD_datasets/twoD');
 ```
 
 ## Utilities
 
 The library exposes a number of utility functions, which are documented below, as well as all the enums and types used by these utility functions.
-If you use only the top-level visualization components, the only utilities you need are `findDomain` and/or `useDomain`.
+If you use only the top-level visualization components, the only utilities you need are `getDomain` and/or `useDomain`.
 
 - **`getDomain(values: number[], scaleType: ScaleType = ScaleType.Linear): Domain | undefined`** - Find the min and max values contained in a flat array of numbers. If `scaleType` is `ScaleType.Log` and the domain crosses zero, clamp the min to the first positive value or return `undefined` if the domain is not supported (i.e. `[-x, 0]`).
 - **`useDomain(...args): Domain | undefined`** - Memoised React hook wrapper of `getDomain`.

--- a/src/stories/LineVis.stories.tsx
+++ b/src/stories/LineVis.stories.tsx
@@ -5,13 +5,11 @@ import FillHeight from '../../.storybook/decorators/FillHeight';
 import { ScaleType } from '../h5web/visualizations/shared/models';
 import LineVis, { LineVisProps } from '../h5web/visualizations/line/LineVis';
 import { CurveType } from '../h5web/visualizations/line/models';
-import { getDomain, mockValues } from '../packages/lib';
-import { getMockDatasetDims } from '../h5web/providers/mock/utils';
+import { getDomain } from '../packages/lib';
+import { getMockDataArray } from '../h5web/providers/mock/utils';
 
-// Prepare 1D data array
-const values = mockValues.oneD_linear;
-const dataArray = ndarray(values, getMockDatasetDims('oneD_linear'));
-const domain = getDomain(values);
+const dataArray = getMockDataArray('/nD_datasets/oneD_linear');
+const domain = getDomain(dataArray.data as number[]);
 
 const errorsArray = ndarray(
   new Array(dataArray.size).fill(0).map((_, i) => Math.abs(10 - 0.5 * i)),

--- a/src/stories/LineVisDisplay.stories.tsx
+++ b/src/stories/LineVisDisplay.stories.tsx
@@ -1,16 +1,13 @@
 import React, { ReactElement } from 'react';
 import type { Story } from '@storybook/react/types-6-0';
-import ndarray from 'ndarray';
 import LineVis, { LineVisProps } from '../h5web/visualizations/line/LineVis';
 import { CurveType } from '../h5web/visualizations/line/models';
-import { getDomain, mockValues } from '../packages/lib';
-import { getMockDatasetDims } from '../h5web/providers/mock/utils';
+import { getDomain } from '../packages/lib';
+import { getMockDataArray } from '../h5web/providers/mock/utils';
 import LineVisStoriesConfig from './LineVis.stories';
 
-// Prepare 1D data array
-const values = mockValues.oneD_linear;
-const dataArray = ndarray(values, getMockDatasetDims('oneD_linear'));
-const domain = getDomain(values);
+const dataArray = getMockDataArray('/nD_datasets/oneD_linear');
+const domain = getDomain(dataArray.data as number[]);
 
 const Template: Story<LineVisProps> = (args): ReactElement => (
   <LineVis {...args} />

--- a/src/stories/LineVisScales.stories.tsx
+++ b/src/stories/LineVisScales.stories.tsx
@@ -1,21 +1,17 @@
 import React, { ReactElement } from 'react';
 import type { Story } from '@storybook/react/types-6-0';
-import ndarray from 'ndarray';
 import { ScaleType } from '../h5web/visualizations/shared/models';
 import LineVis, { LineVisProps } from '../h5web/visualizations/line/LineVis';
-import { getDomain, mockValues } from '../packages/lib';
-import { getMockDatasetDims } from '../h5web/providers/mock/utils';
+import { getDomain } from '../packages/lib';
+import { getMockDataArray } from '../h5web/providers/mock/utils';
 import LineVisStoriesConfig from './LineVis.stories';
 
-// Prepare 1D data array
-const values = mockValues.oneD_linear;
-const dataArray = ndarray(values, getMockDatasetDims('oneD_linear'));
-const domain = getDomain(values);
-const logSafeDomain = getDomain(values, ScaleType.Log);
+const dataArray = getMockDataArray('/nD_datasets/oneD_linear');
+const domain = getDomain(dataArray.data as number[]);
+const logSafeDomain = getDomain(dataArray.data as number[], ScaleType.Log);
 
-const valuesForXLog = mockValues.X_log;
-const dataArrayForXLog = ndarray(valuesForXLog, getMockDatasetDims('X_log'));
-const domainForXLog = getDomain(valuesForXLog);
+const dataArrayForXLog = getMockDataArray('/nexus_entry/log_spectrum/X_log');
+const domainForXLog = getDomain(dataArrayForXLog.data as number[]);
 
 const Template: Story<LineVisProps> = (args): ReactElement => (
   <LineVis {...args} />


### PR DESCRIPTION
I use the new metadata in `MockProvider` with a temporary change to the types of the providers' context. This will allow us to migrate the providers one at a time.