### PR TITLE
Store only direct parents in nested entities

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 /build/
 /storybook-static/
 /packages/**/dist/
+/package-lock.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -27630,9 +27630,9 @@
       }
     },
     "nanoid": {
-      "version": "3.1.18",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.18.tgz",
-      "integrity": "sha512-rndlDjbbHbcV3xi+R2fpJ+PbGMdfBxz5v1fATIQFq0DP64FsicQdwnKLy47K4kZHdRpmQXtz24eGsxQqamzYTA=="
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
+      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw=="
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "d3-scale": "^3.2.3",
     "d3-scale-chromatic": "^2.0.0",
     "lodash-es": "^4.17.15",
-    "nanoid": "^3.1.18",
+    "nanoid": "^3.1.20",
     "ndarray": "^1.0.19",
     "ndarray-ops": "^1.2.2",
     "ndarray-unpack": "^1.0.0",

--- a/src/h5web/BreadcrumbsBar.tsx
+++ b/src/h5web/BreadcrumbsBar.tsx
@@ -4,6 +4,7 @@ import styles from './BreadcrumbsBar.module.css';
 import type { MyHDF5Entity } from './providers/models';
 import ToggleGroup from './toolbar/controls/ToggleGroup';
 import ToggleBtn from './toolbar/controls/ToggleBtn';
+import { getParents } from './explorer/utils';
 
 interface Props {
   isExplorerOpen: boolean;
@@ -36,12 +37,14 @@ function BreadcrumbsBar(props: Props): ReactElement {
       />
       {selectedEntity && (
         <h1 className={styles.breadCrumbs}>
-          {selectedEntity?.parents.slice(firstParentIndex).map((parent) => (
-            <Fragment key={parent.id}>
-              <span className={styles.crumb}>{parent.name}</span>
-              <FiChevronRight className={styles.separator} title="/" />
-            </Fragment>
-          ))}
+          {getParents(selectedEntity)
+            .slice(firstParentIndex)
+            .map((parent) => (
+              <Fragment key={parent.id}>
+                <span className={styles.crumb}>{parent.name}</span>
+                <FiChevronRight className={styles.separator} title="/" />
+              </Fragment>
+            ))}
           <span className={styles.crumb} data-current>
             {selectedEntity.name}
           </span>

--- a/src/h5web/explorer/Explorer.tsx
+++ b/src/h5web/explorer/Explorer.tsx
@@ -3,7 +3,7 @@ import { FiFileText } from 'react-icons/fi';
 import type { MyHDF5Entity } from '../providers/models';
 import EntityList from './EntityList';
 import styles from './Explorer.module.css';
-import { buildTree, getEntityAtPath } from './utils';
+import { buildTree, getEntityAtPath, getParents } from './utils';
 import { ProviderContext } from '../providers/context';
 import { isGroup } from '../providers/utils';
 import { useSet } from 'react-use';
@@ -50,7 +50,7 @@ function Explorer(props: Props): ReactElement {
     }
 
     // Expand parent groups
-    entityToSelect.parents.forEach((group) => expandGroup(group.uid));
+    getParents(entityToSelect).forEach((group) => expandGroup(group.uid));
   }, [expandGroup, onSelect, root]);
 
   return (

--- a/src/h5web/explorer/utils.test.ts
+++ b/src/h5web/explorer/utils.test.ts
@@ -35,16 +35,17 @@ describe('Explorer utilities', () => {
         groups: [rootGroup],
       });
 
-      expect(buildTree(emptyMetadata, domain)).toEqual({
+      const expectedTree: MyHDF5Group = {
         uid: expect.any(String),
         id: '913d8791',
         name: domain,
         kind: MyHDF5EntityKind.Group,
-        parents: [],
         children: [],
         attributes: [],
         rawLink: rootLink,
-      });
+      };
+
+      expect(buildTree(emptyMetadata, domain)).toEqual(expectedTree);
     });
 
     it('should process metadata with single dataset in root group', () => {
@@ -63,7 +64,6 @@ describe('Explorer utilities', () => {
         id: '913d8791',
         name: domain,
         kind: MyHDF5EntityKind.Group,
-        parents: [],
         children: [],
         attributes: [],
         rawLink: rootLink,
@@ -74,7 +74,7 @@ describe('Explorer utilities', () => {
         id: '1203fee7',
         name: link.title,
         kind: MyHDF5EntityKind.Dataset,
-        parents: [expectedTree],
+        parent: expectedTree,
         attributes: [],
         shape: scalarShape,
         type: intType,
@@ -113,7 +113,6 @@ describe('Explorer utilities', () => {
         id: '913d8791',
         name: domain,
         kind: MyHDF5EntityKind.Group,
-        parents: [],
         children: [],
         attributes: [],
         rawLink: rootLink,
@@ -124,7 +123,7 @@ describe('Explorer utilities', () => {
         id: '0a68caca',
         name: 'group',
         kind: MyHDF5EntityKind.Group,
-        parents: [expectedTree],
+        parent: expectedTree,
         children: [],
         attributes: [groupAttr],
         rawLink: groupLink,
@@ -135,7 +134,7 @@ describe('Explorer utilities', () => {
         id: '1203fee7',
         name: 'foo',
         kind: MyHDF5EntityKind.Dataset,
-        parents: [expectedTree, expectedChildGroup],
+        parent: expectedChildGroup,
         attributes: [],
         shape: scalarShape,
         type: intType,

--- a/src/h5web/metadata-viewer/EntityTable.tsx
+++ b/src/h5web/metadata-viewer/EntityTable.tsx
@@ -12,6 +12,7 @@ import { renderShapeDims } from './utils';
 import RawInspector from './RawInspector';
 import LinkInfo from './LinkInfo';
 import { capitalize } from 'lodash-es';
+import { getParents } from '../explorer/utils';
 
 interface Props {
   entity: MyHDF5Entity;
@@ -19,7 +20,7 @@ interface Props {
 
 function EntityTable(props: Props): ReactElement {
   const { entity } = props;
-  const { name, kind, parents } = entity;
+  const { name, kind } = entity;
 
   return (
     <table className={styles.table}>
@@ -43,7 +44,7 @@ function EntityTable(props: Props): ReactElement {
           <th scope="row">Path</th>
           <td>
             /
-            {[...parents, entity]
+            {[...getParents(entity), entity]
               .slice(1)
               .map(({ name }) => name)
               .join('/')}

--- a/src/h5web/providers/models.ts
+++ b/src/h5web/providers/models.ts
@@ -59,7 +59,7 @@ export interface MyHDF5Entity {
   uid: string;
   name: string;
   kind: MyHDF5EntityKind;
-  parents: MyHDF5Group[];
+  parent?: MyHDF5Group;
   attributes: HDF5Attribute[];
   rawLink?: HDF5Link;
 }

--- a/src/h5web/test-utils.tsx
+++ b/src/h5web/test-utils.tsx
@@ -94,9 +94,10 @@ export function makeMyGroup(
     attributes,
   };
 
-  group.children.forEach((child) => {
-    child.parent = group;
-  });
+  group.children = group.children.map((child) => ({
+    ...child,
+    parent: group,
+  }));
 
   return group;
 }

--- a/src/h5web/test-utils.tsx
+++ b/src/h5web/test-utils.tsx
@@ -76,31 +76,26 @@ export function prepareForConsoleError() {
 }
 /* eslint-enable no-console */
 
-type Opts = Partial<Pick<MyHDF5Dataset, 'id' | 'parents' | 'attributes'>>;
+type Opts = Partial<Pick<MyHDF5Dataset, 'id' | 'attributes'>>;
 
 export function makeMyGroup(
   name: string,
   children: MyHDF5Entity[] = [],
   opts: Opts = {}
 ): MyHDF5Group {
-  const { id = name, parents = [], attributes = [] } = opts;
+  const { id = name, attributes = [] } = opts;
 
   const group: MyHDF5Group = {
     uid: nanoid(),
     id,
     name,
     kind: MyHDF5EntityKind.Group,
-    parents,
     children,
     attributes,
   };
 
-  group.parents.forEach((parent) => {
-    parent.children = [...parent.children, group];
-  });
-
   group.children.forEach((child) => {
-    child.parents = [group, ...child.parents];
+    child.parent = group;
   });
 
   return group;
@@ -112,24 +107,17 @@ export function makeMyDataset<S extends HDF5Shape, T extends HDF5Type>(
   type: T,
   opts: Opts = {}
 ): MyHDF5Dataset<S, T> {
-  const { id = name, parents = [], attributes = [] } = opts;
+  const { id = name, attributes = [] } = opts;
 
-  const dataset: MyHDF5Dataset<S, T> = {
+  return {
     uid: nanoid(),
     id,
     name,
     kind: MyHDF5EntityKind.Dataset,
-    parents,
     attributes,
     shape,
     type,
   };
-
-  dataset.parents.forEach((parent) => {
-    parent.children = [...parent.children, dataset];
-  });
-
-  return dataset;
 }
 
 export function makeMySimpleDataset<T extends HDF5Type>(
@@ -146,23 +134,16 @@ export function makeMyDatatype<T extends HDF5Type>(
   type: T,
   opts: Opts = {}
 ): MyHDF5Datatype<T> {
-  const { id = name, parents = [], attributes = [] } = opts;
+  const { id = name, attributes = [] } = opts;
 
-  const datatype: MyHDF5Datatype<T> = {
+  return {
     uid: nanoid(),
     id,
     name,
     kind: MyHDF5EntityKind.Datatype,
-    parents,
     attributes,
     type,
   };
-
-  datatype.parents.forEach((parent) => {
-    parent.children = [...parent.children, datatype];
-  });
-
-  return datatype;
 }
 
 export function withMyAttributes<T extends MyHDF5Entity>(

--- a/src/h5web/visualizations/index.test.ts
+++ b/src/h5web/visualizations/index.test.ts
@@ -211,13 +211,17 @@ describe('Visualization definitions', () => {
     });
 
     it('should support group with absolute `default` path to supported NXdata group', () => {
-      const group = makeMyNxEntityGroup('foo', 'NXentry', {
-        defaultPath: '/foo/bar',
-        children: [makeMyNxDataGroup('bar', spectrumDatasetInt1D)],
-        parents: [makeMyNxEntityGroup('root', 'NXroot')],
+      const rootGroup = makeMyNxEntityGroup('root', 'NXroot', {
+        children: [
+          makeMyNxEntityGroup('foo', 'NXentry', {
+            defaultPath: '/foo/bar',
+            children: [makeMyNxDataGroup('bar', spectrumDatasetInt1D)],
+          }),
+        ],
       });
 
-      expect(supportsEntity(group)).toBe(true);
+      const [groupWithDefault] = rootGroup.children;
+      expect(supportsEntity(groupWithDefault)).toBe(true);
     });
 
     it('should support group with multi-step `default` path to supported NXdata group', () => {
@@ -292,13 +296,17 @@ describe('Visualization definitions', () => {
     });
 
     it('should support group with absolute `default` path to supported NXdata group', () => {
-      const group = makeMyNxEntityGroup('foo', 'NXentry', {
-        defaultPath: '/foo/bar',
-        children: [makeMyNxDataGroup('bar', imageDatasetInt2D)],
-        parents: [makeMyNxEntityGroup('root', 'NXroot')],
+      const rootGroup = makeMyNxEntityGroup('root', 'NXroot', {
+        children: [
+          makeMyNxEntityGroup('foo', 'NXentry', {
+            defaultPath: '/foo/bar',
+            children: [makeMyNxDataGroup('bar', imageDatasetInt2D)],
+          }),
+        ],
       });
 
-      expect(supportsEntity(group)).toBe(true);
+      const [groupWithDefault] = rootGroup.children;
+      expect(supportsEntity(groupWithDefault)).toBe(true);
     });
 
     it('should support group with multi-step `default` path to supported NXdata group', () => {

--- a/src/h5web/visualizations/nexus/utils.ts
+++ b/src/h5web/visualizations/nexus/utils.ts
@@ -27,6 +27,7 @@ import {
   assertStr,
   isScaleType,
 } from '../shared/utils';
+import { findRoot } from '../../explorer/utils';
 
 export function getAttributeValue(
   entity: HDF5Dataset | HDF5Group | MyHDF5Entity,
@@ -63,7 +64,7 @@ export function findNxDataGroup(group: MyHDF5Group): MyHDF5Group | undefined {
         ? getChildEntity(parentEntity, currSegment)
         : undefined;
     },
-    isAbsolutePath && group.parents.length > 0 ? group.parents[0] : group
+    (isAbsolutePath && findRoot(group)) || group
   );
 
   assertDefined(defaultEntity, `Expected entity at path "${defaultPath}"`);


### PR DESCRIPTION
Some isolated preparatory work for #365.

When creating mock data, it feels too complex and unnecessary to recursively add a parent to its nested children. A classic tree structure in which entities reference only their direct parent is perfectly suited to our use case. It is indeed very easy to recursively find every ancestor of an entity when needed.