### PR TITLE
Refactor `buildTree` to use new entity creation utilities

### DIFF
--- a/src/h5web/explorer/utils.test.ts
+++ b/src/h5web/explorer/utils.test.ts
@@ -16,7 +16,7 @@ import {
   makeMetadata,
   makeStrAttr,
   scalarShape,
-} from '../providers/mock/data';
+} from '../providers/raw-utils';
 import { makeMyDataset, makeMyGroup } from '../providers/my-utils';
 
 const domain = 'domain';

--- a/src/h5web/explorer/utils.ts
+++ b/src/h5web/explorer/utils.ts
@@ -1,4 +1,3 @@
-import { nanoid } from 'nanoid';
 import {
   HDF5Collection,
   HDF5LinkClass,
@@ -9,108 +8,83 @@ import {
   MyHDF5Dataset,
   MyHDF5Datatype,
   HDF5HardLink,
-  MyHDF5EntityKind,
   MyHDF5Metadata,
 } from '../providers/models';
+import {
+  makeMyDataset,
+  makeMyDatatype,
+  makeMyGroup,
+  makeMyLink,
+} from '../providers/my-utils';
 import { isGroup, isReachable } from '../providers/utils';
-
-function prepareEntity(
-  link: HDF5HardLink | HDF5RootLink,
-  parent?: MyHDF5Group
-): Omit<MyHDF5Group | MyHDF5Dataset | MyHDF5Datatype, 'kind'> {
-  return {
-    uid: nanoid(),
-    id: link.id,
-    name: link.title,
-    parent,
-    attributes: [],
-    rawLink: link,
-  };
-}
 
 function buildDataset(
   metadata: HDF5Metadata,
-  link: HDF5HardLink | HDF5RootLink,
-  parent?: MyHDF5Group
+  link: HDF5HardLink
 ): MyHDF5Dataset {
-  const rawDataset = metadata.datasets![link.id]; // eslint-disable-line @typescript-eslint/no-non-null-assertion
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const { shape, type, attributes } = metadata.datasets![link.id];
 
-  return {
-    ...prepareEntity(link, parent),
-    kind: MyHDF5EntityKind.Dataset,
-    attributes: rawDataset.attributes || [],
-    shape: rawDataset.shape,
-    type: rawDataset.type,
-  };
+  return makeMyDataset(link.title, shape, type, {
+    id: link.id,
+    attributes,
+    rawLink: link,
+  });
 }
 
 function buildDatatype(
   metadata: HDF5Metadata,
-  link: HDF5HardLink | HDF5RootLink,
-  parent?: MyHDF5Group
+  link: HDF5HardLink
 ): MyHDF5Datatype {
-  const rawDatatype = metadata.datatypes![link.id]; // eslint-disable-line @typescript-eslint/no-non-null-assertion
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const { type } = metadata.datatypes![link.id];
 
-  return {
-    ...prepareEntity(link, parent),
-    kind: MyHDF5EntityKind.Datatype,
-    type: rawDatatype.type,
-  };
+  return makeMyDatatype(link.title, type, {
+    id: link.id,
+    rawLink: link,
+  });
 }
 
 function buildGroup(
   metadata: HDF5Metadata,
-  link: HDF5HardLink | HDF5RootLink,
-  parent?: MyHDF5Group
+  link: HDF5HardLink | HDF5RootLink
 ): MyHDF5Group {
   const rawGroup = metadata.groups[link.id];
 
-  const group: MyHDF5Group = {
-    ...prepareEntity(link, parent),
-    kind: MyHDF5EntityKind.Group,
-    attributes: rawGroup.attributes || [],
-    children: [],
-  };
-
-  group.children = (rawGroup.links || []).map((link) => {
+  const children = (rawGroup.links || []).map((link) => {
     if (!isReachable(link)) {
-      return {
-        uid: nanoid(),
-        name: link.title,
-        kind: MyHDF5EntityKind.Link,
-        parent: group,
-        attributes: [],
-        rawLink: link,
-      };
+      return makeMyLink(link);
     }
 
     switch (link.collection) {
       case HDF5Collection.Groups:
-        return buildGroup(metadata, link, group);
+        return buildGroup(metadata, link);
       case HDF5Collection.Datasets:
-        return buildDataset(metadata, link, group);
+        return buildDataset(metadata, link);
       case HDF5Collection.Datatypes:
-        return buildDatatype(metadata, link, group);
+        return buildDatatype(metadata, link);
       default:
-        throw new Error('Expected known HDF5 collection');
+        throw new Error('Expected link with known HDF5 collection');
     }
   });
 
-  return group;
+  return makeMyGroup(link.title, children, {
+    id: link.id,
+    attributes: rawGroup.attributes,
+    rawLink: link,
+  });
 }
 
 export function buildTree(
   metadata: HDF5Metadata,
   domain: string
 ): MyHDF5Metadata {
-  const rootLink: HDF5RootLink = {
+  return buildGroup(metadata, {
     class: HDF5LinkClass.Root,
     collection: HDF5Collection.Groups,
     title: domain,
     id: metadata.root,
-  };
-
-  return buildGroup(metadata, rootLink);
+  });
 }
 
 export function getEntityAtPath(

--- a/src/h5web/providers/mock/data.ts
+++ b/src/h5web/providers/mock/data.ts
@@ -1,31 +1,6 @@
 import { range } from 'lodash-es';
 import { ScaleType } from '../../visualizations/shared/models';
 import {
-  HDF5Id,
-  HDF5LinkClass,
-  HDF5ExternalLink,
-  HDF5Collection,
-  HDF5Attribute,
-  HDF5Dataset,
-  HDF5Metadata,
-  HDF5TypeClass,
-  HDF5IntegerType,
-  HDF5FloatType,
-  HDF5StringType,
-  HDF5CompoundType,
-  HDF5SimpleShape,
-  HDF5Dims,
-  HDF5ShapeClass,
-  HDF5ScalarShape,
-  HDF5Type,
-  HDF5Shape,
-  HDF5Group,
-  HDF5Link,
-  HDF5Datatype,
-  HDF5Value,
-  HDF5HardLink,
-} from '../models';
-import {
   makeMyDataset,
   makeMyDatatype,
   makeMyExternalLink,
@@ -35,144 +10,18 @@ import {
   makeMyNxEntityGroup,
   makeMySimpleDataset,
 } from '../my-utils';
-
-/* ----------------- */
-/* ----- TYPES ----- */
-
-export const intType: HDF5IntegerType = {
-  class: HDF5TypeClass.Integer,
-  base: 'H5T_STD_I32LE',
-};
-
-export const floatType: HDF5FloatType = {
-  class: HDF5TypeClass.Float,
-  base: 'H5T_IEEE_F64LE',
-};
-
-export const stringType: HDF5StringType = {
-  class: HDF5TypeClass.String,
-  charSet: 'H5T_CSET_ASCII',
-  strPad: 'H5T_STR_NULLPAD',
-  length: 1,
-};
-
-export const compoundType: HDF5CompoundType = {
-  class: HDF5TypeClass.Compound,
-  fields: [{ name: 'int', type: intType }],
-};
-
-/* ------------------ */
-/* ----- SHAPES ----- */
-
-export const scalarShape: HDF5ScalarShape = { class: HDF5ShapeClass.Scalar };
-
-export function makeSimpleShape(dims: HDF5Dims): HDF5SimpleShape {
-  return { class: HDF5ShapeClass.Simple, dims };
-}
-
-/* ---------------------- */
-/* ----- ATTRIBUTES ----- */
-
-export function makeAttr(
-  name: string,
-  shape: HDF5Shape,
-  type: HDF5Type,
-  value: HDF5Value
-): HDF5Attribute {
-  return { name, type, shape, value };
-}
-
-export function makeStrAttr(name: string, value: HDF5Value): HDF5Attribute {
-  return makeAttr(name, scalarShape, stringType, value);
-}
-
-/* -------------------- */
-/* ----- ENTITIES ----- */
-
-export function makeDataset(
-  id: HDF5Id,
-  type: HDF5Type,
-  shape: HDF5Shape,
-  attributes?: HDF5Attribute[]
-): HDF5Dataset {
-  return { id, collection: HDF5Collection.Datasets, type, shape, attributes };
-}
-
-export function makeSimpleDataset(
-  id: HDF5Id,
-  type: HDF5Type,
-  dims: HDF5Dims,
-  attributes?: HDF5Attribute[]
-): HDF5Dataset {
-  return makeDataset(id, type, makeSimpleShape(dims), attributes);
-}
-
-export function makeGroup(
-  id: HDF5Id,
-  attributes?: HDF5Attribute[],
-  links?: HDF5Link[]
-): HDF5Group {
-  return { id, collection: HDF5Collection.Groups, attributes, links };
-}
-
-export function makeDatatype(id: HDF5Id, type: HDF5Type): HDF5Datatype {
-  return { id, collection: HDF5Collection.Datatypes, type };
-}
-
-/* ----------------- */
-/* ----- LINKS ----- */
-
-export function makeHardLink(
-  collection: HDF5Collection,
-  title: string,
-  id = title
-): HDF5HardLink {
-  return { class: HDF5LinkClass.Hard, title, collection, id };
-}
-
-export function makeDatasetHardLink(title: string, id = title): HDF5HardLink {
-  return makeHardLink(HDF5Collection.Datasets, title, id);
-}
-
-export function makeGroupHardLink(title: string, id = title): HDF5HardLink {
-  return makeHardLink(HDF5Collection.Groups, title, id);
-}
-
-export function makeExternalLink(
-  title: string,
-  file: string,
-  h5path: string
-): HDF5ExternalLink {
-  return { class: HDF5LinkClass.External, title, file, h5path };
-}
-
-/* ----------------- */
-/* ----- NEXUS ----- */
-
-export function makeNxAxesAttr(axes: string[]): HDF5Attribute {
-  return makeAttr('axes', makeSimpleShape([axes.length]), stringType, axes);
-}
+import {
+  compoundType,
+  floatType,
+  intType,
+  makeAttr,
+  makeStrAttr,
+  scalarShape,
+  stringType,
+} from '../raw-utils';
 
 /* -------------------- */
 /* ----- METADATA ----- */
-
-export function makeMetadata(
-  opts: {
-    root?: HDF5Id;
-    datasets?: HDF5Dataset[];
-    groups?: HDF5Group[];
-    datatypes?: HDF5Datatype[];
-  } = {}
-): HDF5Metadata {
-  const { root = '', datasets = [], groups = [], datatypes = [] } = opts;
-
-  return {
-    root,
-    datasets: Object.fromEntries(datasets.map((ds) => [ds.id, ds])),
-    groups: Object.fromEntries(groups.map((gr) => [gr.id, gr])),
-    datatypes: Object.fromEntries(datatypes.map((dt) => [dt.id, dt])),
-  };
-}
 
 export const mockDomain = 'source.h5';
 

--- a/src/h5web/providers/raw-utils.ts
+++ b/src/h5web/providers/raw-utils.ts
@@ -1,0 +1,163 @@
+import {
+  HDF5Id,
+  HDF5LinkClass,
+  HDF5ExternalLink,
+  HDF5Collection,
+  HDF5Attribute,
+  HDF5Dataset,
+  HDF5Metadata,
+  HDF5TypeClass,
+  HDF5IntegerType,
+  HDF5FloatType,
+  HDF5StringType,
+  HDF5CompoundType,
+  HDF5SimpleShape,
+  HDF5Dims,
+  HDF5ShapeClass,
+  HDF5ScalarShape,
+  HDF5Type,
+  HDF5Shape,
+  HDF5Group,
+  HDF5Link,
+  HDF5Datatype,
+  HDF5Value,
+  HDF5HardLink,
+} from './models';
+
+/* ----------------- */
+/* ----- TYPES ----- */
+
+export const intType: HDF5IntegerType = {
+  class: HDF5TypeClass.Integer,
+  base: 'H5T_STD_I32LE',
+};
+
+export const floatType: HDF5FloatType = {
+  class: HDF5TypeClass.Float,
+  base: 'H5T_IEEE_F64LE',
+};
+
+export const stringType: HDF5StringType = {
+  class: HDF5TypeClass.String,
+  charSet: 'H5T_CSET_ASCII',
+  strPad: 'H5T_STR_NULLPAD',
+  length: 'H5T_VARIABLE',
+};
+
+export const compoundType: HDF5CompoundType = {
+  class: HDF5TypeClass.Compound,
+  fields: [{ name: 'int', type: intType }],
+};
+
+/* ------------------ */
+/* ----- SHAPES ----- */
+
+export const scalarShape: HDF5ScalarShape = { class: HDF5ShapeClass.Scalar };
+
+export function makeSimpleShape(dims: HDF5Dims): HDF5SimpleShape {
+  return { class: HDF5ShapeClass.Simple, dims };
+}
+
+/* ---------------------- */
+/* ----- ATTRIBUTES ----- */
+
+export function makeAttr(
+  name: string,
+  shape: HDF5Shape,
+  type: HDF5Type,
+  value: HDF5Value
+): HDF5Attribute {
+  return { name, type, shape, value };
+}
+
+export function makeStrAttr(name: string, value: HDF5Value): HDF5Attribute {
+  return makeAttr(name, scalarShape, stringType, value);
+}
+
+/* -------------------- */
+/* ----- ENTITIES ----- */
+
+export function makeDataset(
+  id: HDF5Id,
+  type: HDF5Type,
+  shape: HDF5Shape,
+  attributes?: HDF5Attribute[]
+): HDF5Dataset {
+  return { id, collection: HDF5Collection.Datasets, type, shape, attributes };
+}
+
+export function makeSimpleDataset(
+  id: HDF5Id,
+  type: HDF5Type,
+  dims: HDF5Dims,
+  attributes?: HDF5Attribute[]
+): HDF5Dataset {
+  return makeDataset(id, type, makeSimpleShape(dims), attributes);
+}
+
+export function makeGroup(
+  id: HDF5Id,
+  attributes?: HDF5Attribute[],
+  links?: HDF5Link[]
+): HDF5Group {
+  return { id, collection: HDF5Collection.Groups, attributes, links };
+}
+
+export function makeDatatype(id: HDF5Id, type: HDF5Type): HDF5Datatype {
+  return { id, collection: HDF5Collection.Datatypes, type };
+}
+
+/* ----------------- */
+/* ----- LINKS ----- */
+
+export function makeHardLink(
+  collection: HDF5Collection,
+  title: string,
+  id = title
+): HDF5HardLink {
+  return { class: HDF5LinkClass.Hard, title, collection, id };
+}
+
+export function makeDatasetHardLink(title: string, id = title): HDF5HardLink {
+  return makeHardLink(HDF5Collection.Datasets, title, id);
+}
+
+export function makeGroupHardLink(title: string, id = title): HDF5HardLink {
+  return makeHardLink(HDF5Collection.Groups, title, id);
+}
+
+export function makeExternalLink(
+  title: string,
+  file: string,
+  h5path: string
+): HDF5ExternalLink {
+  return { class: HDF5LinkClass.External, title, file, h5path };
+}
+
+/* ----------------- */
+/* ----- NEXUS ----- */
+
+export function makeNxAxesAttr(axes: string[]): HDF5Attribute {
+  return makeAttr('axes', makeSimpleShape([axes.length]), stringType, axes);
+}
+
+/* -------------------- */
+/* ----- METADATA ----- */
+
+export function makeMetadata(
+  opts: {
+    root?: HDF5Id;
+    datasets?: HDF5Dataset[];
+    groups?: HDF5Group[];
+    datatypes?: HDF5Datatype[];
+  } = {}
+): HDF5Metadata {
+  const { root = '', datasets = [], groups = [], datatypes = [] } = opts;
+
+  return {
+    root,
+    datasets: Object.fromEntries(datasets.map((ds) => [ds.id, ds])),
+    groups: Object.fromEntries(groups.map((gr) => [gr.id, gr])),
+    datatypes: Object.fromEntries(datatypes.map((dt) => [dt.id, dt])),
+  };
+}

--- a/src/h5web/visualizations/index.test.ts
+++ b/src/h5web/visualizations/index.test.ts
@@ -9,7 +9,7 @@ import {
   stringType,
   makeStrAttr,
   floatType,
-} from '../providers/mock/data';
+} from '../providers/raw-utils';
 import {
   makeMyDataset,
   makeMyDatatype,

--- a/src/h5web/visualizer/utils.test.ts
+++ b/src/h5web/visualizer/utils.test.ts
@@ -6,7 +6,7 @@ import {
   makeAttr,
   makeStrAttr,
   scalarShape,
-} from '../providers/mock/data';
+} from '../providers/raw-utils';
 import {
   makeMyDataset,
   makeMyGroup,


### PR DESCRIPTION
I also move all the old utilities into a file called `raw-utils.ts` to avoid circular imports, as some of these "raw" utilities are used by the new utilities (like `makeStrAttr`). I'm not a huge fan of this; we'll have to talk about it over Zoom later on.