### PR TITLE
Refactor `getEntityAtPath` to accept string path

### DIFF
--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@
 #####
 
 # Path to entity to select on first mount in Explorer.
-# Provide an array of indices (e.g. [0,2,1,0]) or leave blank to select root entity.
+# Provide an absolute path (e.g. `/entry_0000`) or leave blank to select root entity.
 REACT_APP_DEFAULT_PATH=
 
 # HSDS parameters

--- a/src/h5web/explorer/Explorer.tsx
+++ b/src/h5web/explorer/Explorer.tsx
@@ -8,9 +8,7 @@ import { ProviderContext } from '../providers/context';
 import { isGroup, isMyMetadata } from '../providers/utils';
 import { useSet } from 'react-use';
 
-const DEFAULT_PATH: number[] = JSON.parse(
-  process.env.REACT_APP_DEFAULT_PATH || '[]'
-);
+const DEFAULT_PATH = process.env.REACT_APP_DEFAULT_PATH || '/';
 
 interface Props {
   onSelect: (entity: MyHDF5Entity) => void;
@@ -43,7 +41,7 @@ function Explorer(props: Props): ReactElement {
 
   useEffect(() => {
     // Find and select entity at default path
-    const entityToSelect = getEntityAtPath(root, DEFAULT_PATH);
+    const entityToSelect = getEntityAtPath(root, DEFAULT_PATH) || root;
     onSelect(entityToSelect);
 
     // Expand entity if group

--- a/src/h5web/providers/mock/utils.ts
+++ b/src/h5web/providers/mock/utils.ts
@@ -3,27 +3,15 @@ import {
   assertDataset,
   assertMySimpleShape,
   assertNumericType,
-  isGroup,
 } from '../utils';
 import { assertArray, assertDefined } from '../../visualizations/shared/utils';
 import ndarray from 'ndarray';
-import { MyHDF5Entity } from '../models';
-import { getChildEntity } from '../../visualizations/nexus/utils';
+import { getEntityAtPath } from '../../explorer/utils';
 
-export function getMockDataArray(absolutePath: string): ndarray {
-  const pathSegments = absolutePath.slice(1).split('/');
-
-  const dataset = pathSegments.reduce<MyHDF5Entity | undefined>(
-    (parentEntity, currSegment) => {
-      return parentEntity && isGroup(parentEntity)
-        ? getChildEntity(parentEntity, currSegment)
-        : undefined;
-    },
-    mockMetadata
-  );
-
-  assertDefined(dataset, `Expected entity at path "${absolutePath}"`);
-  assertDataset(dataset, `Expected group at path "${absolutePath}"`);
+export function getMockDataArray(path: string): ndarray {
+  const dataset = getEntityAtPath(mockMetadata, path);
+  assertDefined(dataset, `Expected entity at path "${path}"`);
+  assertDataset(dataset, `Expected group at path "${path}"`);
   assertNumericType(dataset);
   assertMySimpleShape(dataset);
 

--- a/src/h5web/visualizations/nexus/utils.ts
+++ b/src/h5web/visualizations/nexus/utils.ts
@@ -13,7 +13,6 @@ import {
   assertDataset,
   assertNumericType,
   assertMySimpleShape,
-  isGroup,
 } from '../../providers/utils';
 import {
   NxAttribute,
@@ -27,7 +26,7 @@ import {
   assertStr,
   isScaleType,
 } from '../shared/utils';
-import { findRoot } from '../../explorer/utils';
+import { getEntityAtPath } from '../../explorer/utils';
 
 export function getAttributeValue(
   entity: HDF5Dataset | HDF5Group | MyHDF5Entity,
@@ -55,18 +54,7 @@ export function findNxDataGroup(group: MyHDF5Group): MyHDF5Group | undefined {
 
   assertStr(defaultPath, `Expected 'default' attribute to be a string`);
 
-  const isAbsolutePath = defaultPath.startsWith('/');
-  const pathSegments = defaultPath.slice(isAbsolutePath ? 1 : 0).split('/');
-
-  const defaultEntity = pathSegments.reduce<MyHDF5Entity | undefined>(
-    (parentEntity, currSegment) => {
-      return parentEntity && isGroup(parentEntity)
-        ? getChildEntity(parentEntity, currSegment)
-        : undefined;
-    },
-    (isAbsolutePath && findRoot(group)) || group
-  );
-
+  const defaultEntity = getEntityAtPath(group, defaultPath, false);
   assertDefined(defaultEntity, `Expected entity at path "${defaultPath}"`);
   assertGroup(defaultEntity, `Expected group at path "${defaultPath}"`);
 


### PR DESCRIPTION
`REACT_APP_DEFAULT_PATH` now accepts a string path, like `/entry_0000/2_buffer_subtraction`.