### PR TITLE
Build nest metadata in HSDS and Silx providers directly

### DIFF
--- a/src/h5web/explorer/Explorer.tsx
+++ b/src/h5web/explorer/Explorer.tsx
@@ -1,11 +1,11 @@
-import React, { useEffect, useMemo, useContext, ReactElement } from 'react';
+import React, { useEffect, useContext, ReactElement } from 'react';
 import { FiFileText } from 'react-icons/fi';
 import type { MyHDF5Entity } from '../providers/models';
 import EntityList from './EntityList';
 import styles from './Explorer.module.css';
-import { buildTree, getEntityAtPath, getParents } from './utils';
+import { getEntityAtPath, getParents } from './utils';
 import { ProviderContext } from '../providers/context';
-import { isGroup, isMyMetadata } from '../providers/utils';
+import { isGroup } from '../providers/utils';
 import { useSet } from 'react-use';
 
 const DEFAULT_PATH = process.env.REACT_APP_DEFAULT_PATH || '/';
@@ -17,11 +17,7 @@ interface Props {
 
 function Explorer(props: Props): ReactElement {
   const { onSelect, selectedEntity } = props;
-  const { domain, metadata } = useContext(ProviderContext);
-
-  const root = useMemo(() => {
-    return isMyMetadata(metadata) ? metadata : buildTree(metadata, domain);
-  }, [domain, metadata]);
+  const { domain, metadata: root } = useContext(ProviderContext);
 
   const [
     expandedGroups,

--- a/src/h5web/providers/context.ts
+++ b/src/h5web/providers/context.ts
@@ -1,15 +1,15 @@
 import { createContext } from 'react';
-import type { HDF5Id, HDF5Value, HDF5Metadata, MyHDF5Metadata } from './models';
+import type { HDF5Id, HDF5Value, MyHDF5Metadata } from './models';
 
 export abstract class ProviderAPI {
   abstract domain: string;
-  abstract getMetadata(): Promise<HDF5Metadata | MyHDF5Metadata>;
+  abstract getMetadata(): Promise<MyHDF5Metadata>;
   abstract getValue(id: HDF5Id): Promise<HDF5Value | undefined>;
 }
 
 export const ProviderContext = createContext<{
   domain: string;
-  metadata: HDF5Metadata | MyHDF5Metadata;
+  metadata: MyHDF5Metadata;
   getValue: ProviderAPI['getValue'];
   getValues: (ids: HDF5Id[]) => Promise<Record<HDF5Id, HDF5Value | undefined>>;
 }>({} as any); // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/src/h5web/providers/hsds/HsdsProvider.tsx
+++ b/src/h5web/providers/hsds/HsdsProvider.tsx
@@ -10,9 +10,9 @@ interface Props {
   children: ReactNode;
 }
 
-/* Provider of metadata and values by HSDS */
 function HsdsProvider(props: Props): ReactElement {
   const { url, username, password, domain, children } = props;
+
   const api = useMemo(() => new HsdsApi(url, username, password, domain), [
     domain,
     password,

--- a/src/h5web/providers/hsds/api.ts
+++ b/src/h5web/providers/hsds/api.ts
@@ -18,12 +18,13 @@ import {
   HDF5Id,
   HDF5RootLink,
   HDF5Value,
-  HDF5Metadata,
   HDF5Attribute,
   HDF5Link,
+  MyHDF5Metadata,
 } from '../models';
 import { isReachable } from '../utils';
 import type { ProviderAPI } from '../context';
+import { buildTree } from '../../explorer/utils';
 
 export class HsdsApi implements ProviderAPI {
   public readonly domain: string;
@@ -48,16 +49,19 @@ export class HsdsApi implements ProviderAPI {
     });
   }
 
-  public async getMetadata(): Promise<HDF5Metadata> {
+  public async getMetadata(): Promise<MyHDF5Metadata> {
     const rootId = await this.fetchRoot();
     await this.processGroup(rootId);
 
-    return {
-      root: rootId,
-      groups: this.groups,
-      datasets: this.datasets,
-      datatypes: this.datatypes,
-    };
+    return buildTree(
+      {
+        root: rootId,
+        groups: this.groups,
+        datasets: this.datasets,
+        datatypes: this.datatypes,
+      },
+      this.domain
+    );
   }
 
   public async getValue(id: HDF5Id): Promise<HDF5Value | undefined> {

--- a/src/h5web/providers/silx/api.ts
+++ b/src/h5web/providers/silx/api.ts
@@ -1,6 +1,13 @@
 import axios, { AxiosInstance } from 'axios';
+import { buildTree } from '../../explorer/utils';
 import type { ProviderAPI } from '../context';
-import { HDF5Id, HDF5Value, HDF5Metadata, HDF5Values } from '../models';
+import {
+  HDF5Id,
+  HDF5Value,
+  HDF5Metadata,
+  HDF5Values,
+  MyHDF5Metadata,
+} from '../models';
 
 export class SilxApi implements ProviderAPI {
   public readonly domain: string;
@@ -14,9 +21,9 @@ export class SilxApi implements ProviderAPI {
     });
   }
 
-  public async getMetadata(): Promise<HDF5Metadata> {
+  public async getMetadata(): Promise<MyHDF5Metadata> {
     const { data } = await this.client.get<HDF5Metadata>('/metadata.json');
-    return data;
+    return buildTree(data, this.domain);
   }
 
   public async getValue(id: HDF5Id): Promise<HDF5Value | undefined> {

--- a/src/h5web/providers/utils.ts
+++ b/src/h5web/providers/utils.ts
@@ -18,15 +18,7 @@ import {
   MyHDF5Dataset,
   MyHDF5Link,
   MyHDF5ResolvedEntity,
-  HDF5Metadata,
-  MyHDF5Metadata,
 } from './models';
-
-export function isMyMetadata(
-  metadata: HDF5Metadata | MyHDF5Metadata
-): metadata is MyHDF5Metadata {
-  return 'kind' in metadata;
-}
 
 export function isReachable(
   link: HDF5Link


### PR DESCRIPTION
And ... done! All providers now provide the new nested metadata structure to the app!

Well, one step remains: cleaning things up -- i.e. moving and renaming things. But we should maybe do this together via LiveShare.