### PR TITLE
First round of clean up

### DIFF
--- a/src/h5web/explorer/EntityList.tsx
+++ b/src/h5web/explorer/EntityList.tsx
@@ -2,7 +2,7 @@ import React, { CSSProperties, ReactElement } from 'react';
 import styles from './Explorer.module.css';
 import { MyHDF5Entity } from '../providers/models';
 import Icon from './Icon';
-import { isGroup } from '../providers/utils';
+import { isGroup } from '../guards';
 
 interface Props {
   level: number;

--- a/src/h5web/explorer/Explorer.tsx
+++ b/src/h5web/explorer/Explorer.tsx
@@ -5,7 +5,7 @@ import EntityList from './EntityList';
 import styles from './Explorer.module.css';
 import { getEntityAtPath, getParents } from './utils';
 import { ProviderContext } from '../providers/context';
-import { isGroup } from '../providers/utils';
+import { isGroup } from '../guards';
 import { useSet } from 'react-use';
 
 const DEFAULT_PATH = process.env.REACT_APP_DEFAULT_PATH || '/';

--- a/src/h5web/explorer/Icon.tsx
+++ b/src/h5web/explorer/Icon.tsx
@@ -10,7 +10,7 @@ import {
 import type { IconType } from 'react-icons';
 import { MyHDF5Entity, MyHDF5EntityKind } from '../providers/models';
 import styles from './Explorer.module.css';
-import { isGroup } from '../providers/utils';
+import { isGroup } from '../guards';
 
 const LEAF_ICONS: Record<MyHDF5EntityKind, IconType> = {
   [MyHDF5EntityKind.Group]: FiFolder,

--- a/src/h5web/explorer/utils.ts
+++ b/src/h5web/explorer/utils.ts
@@ -9,83 +9,110 @@ import {
   MyHDF5Datatype,
   HDF5HardLink,
   MyHDF5Metadata,
+  MyHDF5EntityKind,
+  HDF5Datatype,
+  HDF5Dataset,
 } from '../providers/models';
-import {
-  makeMyDataset,
-  makeMyDatatype,
-  makeMyGroup,
-  makeMyLink,
-} from '../providers/my-utils';
 import { isGroup, isReachable } from '../guards';
 import { getChildEntity } from '../visualizations/nexus/utils';
+import { nanoid } from 'nanoid';
 
-function buildDataset(
-  metadata: HDF5Metadata,
-  link: HDF5HardLink
-): MyHDF5Dataset {
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const { shape, type, attributes } = metadata.datasets![link.id];
+function buildDataset(dataset: HDF5Dataset, link: HDF5HardLink): MyHDF5Dataset {
+  const { shape, type, attributes = [] } = dataset;
 
-  return makeMyDataset(link.title, shape, type, {
+  return {
+    uid: nanoid(),
     id: link.id,
+    name: link.title,
+    kind: MyHDF5EntityKind.Dataset,
     attributes,
+    shape,
+    type,
     rawLink: link,
-  });
+  };
 }
 
 function buildDatatype(
-  metadata: HDF5Metadata,
+  datatype: HDF5Datatype,
   link: HDF5HardLink
 ): MyHDF5Datatype {
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const { type } = metadata.datatypes![link.id];
+  const { type } = datatype;
 
-  return makeMyDatatype(link.title, type, {
+  return {
+    uid: nanoid(),
     id: link.id,
+    name: link.title,
+    kind: MyHDF5EntityKind.Datatype,
+    attributes: [],
+    type,
     rawLink: link,
-  });
+  };
 }
 
 function buildGroup(
-  metadata: HDF5Metadata,
+  metadata: Required<HDF5Metadata>,
   link: HDF5HardLink | HDF5RootLink
 ): MyHDF5Group {
   const rawGroup = metadata.groups[link.id];
 
   const children = (rawGroup.links || []).map((link) => {
     if (!isReachable(link)) {
-      return makeMyLink(link);
+      return {
+        uid: nanoid(),
+        name: link.title,
+        kind: MyHDF5EntityKind.Link,
+        attributes: [],
+        rawLink: link,
+      };
     }
 
     switch (link.collection) {
       case HDF5Collection.Groups:
         return buildGroup(metadata, link);
       case HDF5Collection.Datasets:
-        return buildDataset(metadata, link);
+        return buildDataset(metadata.datasets[link.id], link);
       case HDF5Collection.Datatypes:
-        return buildDatatype(metadata, link);
+        return buildDatatype(metadata.datatypes[link.id], link);
       default:
         throw new Error('Expected link with known HDF5 collection');
     }
   });
 
-  return makeMyGroup(link.title, children, {
+  const group: MyHDF5Group = {
+    uid: nanoid(),
     id: link.id,
-    attributes: rawGroup.attributes,
+    name: link.title,
+    kind: MyHDF5EntityKind.Group,
+    attributes: rawGroup.attributes || [],
+    children,
     rawLink: link,
+  };
+
+  group.children.forEach((child) => {
+    child.parent = group;
   });
+
+  return group;
 }
 
 export function buildTree(
-  metadata: HDF5Metadata,
+  rawMetadata: HDF5Metadata,
   domain: string
 ): MyHDF5Metadata {
-  return buildGroup(metadata, {
-    class: HDF5LinkClass.Root,
-    collection: HDF5Collection.Groups,
+  const metadata = {
+    ...rawMetadata,
+    datasets: rawMetadata.datasets || {},
+    datatypes: rawMetadata.datatypes || {},
+  };
+
+  const rootGroup = {
+    class: HDF5LinkClass.Root as const,
+    collection: HDF5Collection.Groups as const,
     title: domain,
     id: metadata.root,
-  });
+  };
+
+  return buildGroup(metadata, rootGroup);
 }
 
 function findRoot(entity: MyHDF5Entity): MyHDF5Entity {

--- a/src/h5web/explorer/utils.ts
+++ b/src/h5web/explorer/utils.ts
@@ -16,7 +16,7 @@ import {
   makeMyGroup,
   makeMyLink,
 } from '../providers/my-utils';
-import { isGroup, isReachable } from '../providers/utils';
+import { isGroup, isReachable } from '../guards';
 import { getChildEntity } from '../visualizations/nexus/utils';
 
 function buildDataset(

--- a/src/h5web/guards.ts
+++ b/src/h5web/guards.ts
@@ -18,13 +18,44 @@ import {
   MyHDF5Dataset,
   MyHDF5Link,
   MyHDF5ResolvedEntity,
-} from './models';
+} from './providers/models';
 
-export function isReachable(
-  link: HDF5Link
-): link is HDF5HardLink | HDF5RootLink {
-  // Only hard and root links are considered as reachable for now
-  return link.class === HDF5LinkClass.Hard || link.class === HDF5LinkClass.Root;
+export function assertDefined<T>(
+  val: T,
+  message = 'Expected some value'
+): asserts val is NonNullable<T> {
+  if (val === undefined) {
+    throw new TypeError(message);
+  }
+}
+
+export function assertStr(
+  val: unknown,
+  message = 'Expected string'
+): asserts val is string {
+  if (typeof val !== 'string') {
+    throw new TypeError(message);
+  }
+}
+
+export function assertNumOrStr(val: unknown): asserts val is number | string {
+  if (typeof val !== 'number' && typeof val !== 'string') {
+    throw new TypeError('Expected number or string');
+  }
+}
+
+export function assertArray<T>(val: unknown): asserts val is T[] {
+  if (!Array.isArray(val)) {
+    throw new TypeError('Expected array');
+  }
+}
+
+export function assertOptionalArray<T>(
+  val: unknown
+): asserts val is T[] | undefined {
+  if (val !== undefined) {
+    assertArray<T>(val);
+  }
 }
 
 export function isResolved(
@@ -47,6 +78,13 @@ export function isDatatype(entity: MyHDF5Entity): entity is MyHDF5Datatype {
 
 export function isLink(entity: MyHDF5Entity): entity is MyHDF5Link {
   return entity.kind === MyHDF5EntityKind.Link;
+}
+
+export function isReachable(
+  link: HDF5Link
+): link is HDF5HardLink | HDF5RootLink {
+  // Only hard and root links are considered as reachable for now
+  return link.class === HDF5LinkClass.Hard || link.class === HDF5LinkClass.Root;
 }
 
 export function hasSimpleShape<T extends HDF5Type>(

--- a/src/h5web/metadata-viewer/EntityTable.tsx
+++ b/src/h5web/metadata-viewer/EntityTable.tsx
@@ -7,7 +7,7 @@ import {
   isDatatype,
   isLink,
   isResolved,
-} from '../providers/utils';
+} from '../guards';
 import { renderShapeDims } from './utils';
 import RawInspector from './RawInspector';
 import LinkInfo from './LinkInfo';

--- a/src/h5web/providers/hsds/api.ts
+++ b/src/h5web/providers/hsds/api.ts
@@ -22,7 +22,7 @@ import {
   HDF5Link,
   MyHDF5Metadata,
 } from '../models';
-import { isReachable } from '../utils';
+import { isReachable } from '../../guards';
 import type { ProviderAPI } from '../context';
 import { buildTree } from '../../explorer/utils';
 

--- a/src/h5web/providers/mock/data.ts
+++ b/src/h5web/providers/mock/data.ts
@@ -50,7 +50,7 @@ export const mockMetadata = makeMyNxEntityGroup(mockDomain, 'NXroot', {
           children: [
             makeMyNxDataGroup('nx_data', {
               signal: makeMyNxDataset('twoD', intType, [20, 41]),
-              silxStyle: { signal_scale_type: ScaleType.SymLog },
+              silxStyle: { signalScaleType: ScaleType.SymLog },
               title: makeMyDataset('title', scalarShape, stringType, {
                 id: 'title_twoD',
               }),
@@ -81,7 +81,7 @@ export const mockMetadata = makeMyNxEntityGroup(mockDomain, 'NXroot', {
             }),
           },
           axesAttr: ['.', '.', 'Y', 'X'],
-          silxStyle: { signal_scale_type: ScaleType.Log },
+          silxStyle: { signalScaleType: ScaleType.Log },
         }),
         makeMyNxDataGroup('log_spectrum', {
           signal: makeMyNxDataset('oneD', intType, [41]),
@@ -89,8 +89,8 @@ export const mockMetadata = makeMyNxEntityGroup(mockDomain, 'NXroot', {
           axes: { X_log: makeMyNxDataset('X_log', floatType, [41]) },
           axesAttr: ['X_log'],
           silxStyle: {
-            signal_scale_type: ScaleType.Log,
-            axes_scale_type: [ScaleType.Log],
+            signalScaleType: ScaleType.Log,
+            axesScaleType: [ScaleType.Log],
           },
         }),
       ],

--- a/src/h5web/providers/mock/utils.ts
+++ b/src/h5web/providers/mock/utils.ts
@@ -1,6 +1,11 @@
 import { mockValues, mockMetadata } from './data';
-import { assertDataset, assertSimpleShape, assertNumericType } from '../utils';
-import { assertArray, assertDefined } from '../../visualizations/shared/utils';
+import {
+  assertDefined,
+  assertArray,
+  assertDataset,
+  assertSimpleShape,
+  assertNumericType,
+} from '../../guards';
 import ndarray from 'ndarray';
 import { getEntityAtPath } from '../../explorer/utils';
 

--- a/src/h5web/providers/my-utils.ts
+++ b/src/h5web/providers/my-utils.ts
@@ -20,7 +20,12 @@ import {
   MyHDF5ResolvedEntity,
 } from '../providers/models';
 import { NxInterpretation, SilxStyle } from '../visualizations/nexus/models';
-import { makeNxAxesAttr, makeSimpleShape, makeStrAttr } from './raw-utils';
+import {
+  makeNxAxesAttr,
+  makeSilxStyleAttr,
+  makeSimpleShape,
+  makeStrAttr,
+} from './raw-utils';
 
 type EntityOpts = Partial<
   Pick<MyHDF5ResolvedEntity, 'id' | 'attributes' | 'rawLink'>
@@ -179,9 +184,7 @@ export function makeMyNxDataGroup<
         makeStrAttr('NX_class', 'NXdata'),
         makeStrAttr('signal', signal.name),
         ...(axesAttr ? [makeNxAxesAttr(axesAttr)] : []),
-        ...(silxStyle
-          ? [makeStrAttr('SILX_style', JSON.stringify(silxStyle))]
-          : []),
+        ...(silxStyle ? [makeSilxStyleAttr(silxStyle)] : []),
       ],
     }
   );

--- a/src/h5web/providers/raw-utils.ts
+++ b/src/h5web/providers/raw-utils.ts
@@ -1,3 +1,4 @@
+import { SilxStyle } from '../visualizations/nexus/models';
 import {
   HDF5Id,
   HDF5LinkClass,
@@ -136,6 +137,18 @@ export function makeExternalLink(
 
 export function makeNxAxesAttr(axes: string[]): HDF5Attribute {
   return makeAttr('axes', makeSimpleShape([axes.length]), stringType, axes);
+}
+
+export function makeSilxStyleAttr(style: SilxStyle): HDF5Attribute {
+  const { signalScaleType, axesScaleType } = style;
+
+  return makeStrAttr(
+    'SILX_style',
+    JSON.stringify({
+      signal_scale_type: signalScaleType,
+      axes_scale_type: axesScaleType,
+    })
+  );
 }
 
 /* -------------------- */

--- a/src/h5web/visualizations/ScalarVis.tsx
+++ b/src/h5web/visualizations/ScalarVis.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import styles from './ScalarVis.module.css';
 import type { HDF5Value } from '../providers/models';
-import { assertNumOrStr } from './shared/utils';
+import { assertNumOrStr } from '../guards';
 
 interface Props {
   value: HDF5Value;

--- a/src/h5web/visualizations/containers/HeatmapVisContainer.tsx
+++ b/src/h5web/visualizations/containers/HeatmapVisContainer.tsx
@@ -4,7 +4,7 @@ import {
   assertDataset,
   assertNumericType,
   assertSimpleShape,
-} from '../../providers/utils';
+} from '../../guards';
 import MappedHeatmapVis from '../heatmap/MappedHeatmapVis';
 import type { VisContainerProps } from './models';
 

--- a/src/h5web/visualizations/containers/LineVisContainer.tsx
+++ b/src/h5web/visualizations/containers/LineVisContainer.tsx
@@ -4,7 +4,7 @@ import {
   assertDataset,
   assertNumericType,
   assertSimpleShape,
-} from '../../providers/utils';
+} from '../../guards';
 import MappedLineVis from '../line/MappedLineVis';
 import type { VisContainerProps } from './models';
 

--- a/src/h5web/visualizations/containers/MatrixVisContainer.tsx
+++ b/src/h5web/visualizations/containers/MatrixVisContainer.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import { useDatasetValue } from './hooks';
-import { assertDataset, assertSimpleShape } from '../../providers/utils';
+import { assertDataset, assertSimpleShape } from '../../guards';
 import MappedMatrixVis from '../matrix/MappedMatrixVis';
 import type { VisContainerProps } from './models';
 

--- a/src/h5web/visualizations/containers/NxImageContainer.tsx
+++ b/src/h5web/visualizations/containers/NxImageContainer.tsx
@@ -1,11 +1,10 @@
 import React, { ReactElement, useEffect } from 'react';
-import { assertGroup } from '../../providers/utils';
+import { assertDefined, assertGroup } from '../../guards';
 import { findNxDataGroup } from '../nexus/utils';
 import type { VisContainerProps } from './models';
 import MappedHeatmapVis from '../heatmap/MappedHeatmapVis';
 import { useNxData } from '../nexus/hooks';
 import { useHeatmapConfig } from '../heatmap/config';
-import { assertDefined } from '../shared/utils';
 
 function NxImageContainer(props: VisContainerProps): ReactElement {
   const { entity } = props;

--- a/src/h5web/visualizations/containers/NxSpectrumContainer.tsx
+++ b/src/h5web/visualizations/containers/NxSpectrumContainer.tsx
@@ -1,10 +1,9 @@
 import React, { ReactElement, useEffect } from 'react';
-import { assertGroup } from '../../providers/utils';
+import { assertDefined, assertGroup } from '../../guards';
 import MappedLineVis from '../line/MappedLineVis';
 import { findNxDataGroup } from '../nexus/utils';
 import type { VisContainerProps } from './models';
 import { useNxData } from '../nexus/hooks';
-import { assertDefined } from '../shared/utils';
 import { useNxSpectrumConfig } from '../nexus/config';
 
 function NxSpectrumContainer(props: VisContainerProps): ReactElement {

--- a/src/h5web/visualizations/containers/RawVisContainer.tsx
+++ b/src/h5web/visualizations/containers/RawVisContainer.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react';
 import RawVis from '../RawVis';
 import type { VisContainerProps } from './models';
 import { useDatasetValue } from './hooks';
-import { assertDataset } from '../../providers/utils';
+import { assertDataset } from '../../guards';
 
 function RawVisContainer(props: VisContainerProps): ReactElement {
   const { entity } = props;

--- a/src/h5web/visualizations/containers/ScalarVisContainer.tsx
+++ b/src/h5web/visualizations/containers/ScalarVisContainer.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import ScalarVis from '../ScalarVis';
 import { useDatasetValue } from './hooks';
-import { assertDataset } from '../../providers/utils';
+import { assertDataset } from '../../guards';
 import type { VisContainerProps } from './models';
 
 function ScalarVisContainer(props: VisContainerProps): ReactElement {

--- a/src/h5web/visualizations/heatmap/HeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/HeatmapVis.tsx
@@ -10,11 +10,8 @@ import VisCanvas from '../shared/VisCanvas';
 import { getDims, getPixelEdges } from './utils';
 import { Domain, ScaleType, AxisParams } from '../shared/models';
 import type { ColorMap } from './models';
-import {
-  assertDefined,
-  getDomain,
-  getValueToIndexScale,
-} from '../shared/utils';
+import { getDomain, getValueToIndexScale } from '../shared/utils';
+import { assertDefined } from '../../guards';
 
 interface Props {
   dataArray: ndarray;

--- a/src/h5web/visualizations/heatmap/MappedHeatmapVis.tsx
+++ b/src/h5web/visualizations/heatmap/MappedHeatmapVis.tsx
@@ -3,7 +3,7 @@ import { usePrevious } from 'react-use';
 import type { HDF5Value } from '../../providers/models';
 import type { DimensionMapping } from '../../dimension-mapper/models';
 import HeatmapVis from './HeatmapVis';
-import { assertArray } from '../shared/utils';
+import { assertArray } from '../../guards';
 import { useDomain, useBaseArray, useMappedArray } from '../shared/hooks';
 import { useHeatmapConfig } from './config';
 import type { AxisMapping } from '../shared/models';

--- a/src/h5web/visualizations/index.tsx
+++ b/src/h5web/visualizations/index.tsx
@@ -11,7 +11,7 @@ import {
   hasNumericType,
   isDataset,
   isGroup,
-} from '../providers/utils';
+} from '../guards';
 import type { VisContainerProps } from './containers/models';
 import {
   getAttributeValue,

--- a/src/h5web/visualizations/line/LineVis.tsx
+++ b/src/h5web/visualizations/line/LineVis.tsx
@@ -9,12 +9,8 @@ import PanZoomMesh from '../shared/PanZoomMesh';
 import TooltipMesh from '../shared/TooltipMesh';
 import { ScaleType, Domain, AxisParams } from '../shared/models';
 import { CurveType } from './models';
-import {
-  getValueToIndexScale,
-  getDomain,
-  extendDomain,
-  assertDefined,
-} from '../shared/utils';
+import { getValueToIndexScale, getDomain, extendDomain } from '../shared/utils';
+import { assertDefined } from '../../guards';
 
 const DEFAULT_DOMAIN: Domain = [0.1, 1];
 

--- a/src/h5web/visualizations/line/MappedLineVis.tsx
+++ b/src/h5web/visualizations/line/MappedLineVis.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, useEffect, useState } from 'react';
 import type { HDF5Value } from '../../providers/models';
 import type { DimensionMapping } from '../../dimension-mapper/models';
 import LineVis from './LineVis';
-import { assertArray } from '../shared/utils';
+import { assertArray } from '../../guards';
 import { useMappedArray, useDomain, useBaseArray } from '../shared/hooks';
 import { useLineConfig } from './config';
 import type { AxisMapping, ScaleType } from '../shared/models';

--- a/src/h5web/visualizations/matrix/MappedMatrixVis.tsx
+++ b/src/h5web/visualizations/matrix/MappedMatrixVis.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, useState } from 'react';
 import type { HDF5Value } from '../../providers/models';
 import type { DimensionMapping } from '../../dimension-mapper/models';
 import MatrixVis from './MatrixVis';
-import { assertArray } from '../shared/utils';
+import { assertArray } from '../../guards';
 import { useBaseArray, useMappedArray } from '../shared/hooks';
 import DimensionMapper from '../../dimension-mapper/DimensionMapper';
 

--- a/src/h5web/visualizations/nexus/hooks.ts
+++ b/src/h5web/visualizations/nexus/hooks.ts
@@ -33,7 +33,7 @@ export function useNxData(group: MyHDF5Group): NxData {
   const axesNames = getNxAxisNames(group);
 
   const silxStyle = parseSilxStyleAttribute(group);
-  const { axes_scale_type, signal_scale_type } = silxStyle;
+  const { axesScaleType, signalScaleType } = silxStyle;
 
   const axisMapping = axesNames.map((axisName, i) => {
     if (!axisName) {
@@ -50,7 +50,7 @@ export function useNxData(group: MyHDF5Group): NxData {
     return {
       value: axisValue,
       label: getDatasetLabel(axisDataset, axisName),
-      scaleType: axes_scale_type && axes_scale_type[i],
+      scaleType: axesScaleType && axesScaleType[i],
     };
   });
 
@@ -70,7 +70,7 @@ export function useNxData(group: MyHDF5Group): NxData {
       label: getDatasetLabel(signalDataset, signalName),
       value: signalValue,
       dims: signalDataset.shape.dims,
-      scaleType: signal_scale_type,
+      scaleType: signalScaleType,
     },
     errors: errorsValue,
     title: typeof titleValue === 'string' ? titleValue : undefined,

--- a/src/h5web/visualizations/nexus/hooks.ts
+++ b/src/h5web/visualizations/nexus/hooks.ts
@@ -1,11 +1,12 @@
 import { MyHDF5Group } from '../../providers/models';
-import { assertDataset, isDataset } from '../../providers/utils';
 import { useDatasetValues } from '../containers/hooks';
 import {
   assertArray,
   assertDefined,
   assertOptionalArray,
-} from '../shared/utils';
+  assertDataset,
+  isDataset,
+} from '../../guards';
 import type { NxData } from './models';
 import {
   findSignalDataset,

--- a/src/h5web/visualizations/nexus/models.ts
+++ b/src/h5web/visualizations/nexus/models.ts
@@ -26,12 +26,7 @@ export interface NxData {
   axisMapping?: AxisMapping[];
 }
 
-export interface RawSilxStyle {
-  signal_scale_type?: unknown;
-  axes_scale_type?: unknown;
-}
-
 export interface SilxStyle {
-  signal_scale_type?: ScaleType;
-  axes_scale_type?: ScaleType[];
+  signalScaleType?: ScaleType;
+  axesScaleType?: ScaleType[];
 }

--- a/src/h5web/visualizations/nexus/utils.ts
+++ b/src/h5web/visualizations/nexus/utils.ts
@@ -130,16 +130,21 @@ export function parseSilxStyleAttribute(group: MyHDF5Group): SilxStyle {
     return {};
   }
 
-  const rawSilxStyle = JSON.parse(silxStyle);
-  const { axes_scale_type, signal_scale_type } = rawSilxStyle;
+  try {
+    const rawSilxStyle = JSON.parse(silxStyle);
+    const { axes_scale_type, signal_scale_type } = rawSilxStyle;
 
-  return {
-    signalScaleType: isScaleType(signal_scale_type)
-      ? signal_scale_type
-      : undefined,
-    axesScaleType:
-      Array.isArray(axes_scale_type) && axes_scale_type.every(isScaleType)
-        ? axes_scale_type
+    return {
+      signalScaleType: isScaleType(signal_scale_type)
+        ? signal_scale_type
         : undefined,
-  };
+      axesScaleType:
+        Array.isArray(axes_scale_type) && axes_scale_type.every(isScaleType)
+          ? axes_scale_type
+          : undefined,
+    };
+  } catch {
+    console.warn(`Malformed 'SILX_style' attribute: ${silxStyle}`); // eslint-disable-line no-console
+    return {};
+  }
 }

--- a/src/h5web/visualizations/nexus/utils.ts
+++ b/src/h5web/visualizations/nexus/utils.ts
@@ -14,12 +14,7 @@ import {
   assertNumericType,
   assertSimpleShape,
 } from '../../providers/utils';
-import {
-  NxAttribute,
-  NxInterpretation,
-  RawSilxStyle,
-  SilxStyle,
-} from './models';
+import { NxAttribute, NxInterpretation, SilxStyle } from './models';
 import {
   assertArray,
   assertDefined,
@@ -135,14 +130,14 @@ export function parseSilxStyleAttribute(group: MyHDF5Group): SilxStyle {
     return {};
   }
 
-  const rawSilxStyle: RawSilxStyle = JSON.parse(silxStyle);
+  const rawSilxStyle = JSON.parse(silxStyle);
   const { axes_scale_type, signal_scale_type } = rawSilxStyle;
 
   return {
-    signal_scale_type: isScaleType(signal_scale_type)
+    signalScaleType: isScaleType(signal_scale_type)
       ? signal_scale_type
       : undefined,
-    axes_scale_type:
+    axesScaleType:
       Array.isArray(axes_scale_type) && axes_scale_type.every(isScaleType)
         ? axes_scale_type
         : undefined,

--- a/src/h5web/visualizations/nexus/utils.ts
+++ b/src/h5web/visualizations/nexus/utils.ts
@@ -9,18 +9,16 @@ import type {
   MyHDF5Dataset,
 } from '../../providers/models';
 import {
+  assertArray,
+  assertDefined,
+  assertStr,
   assertGroup,
   assertDataset,
   assertNumericType,
   assertSimpleShape,
-} from '../../providers/utils';
+} from '../../guards';
 import { NxAttribute, NxInterpretation, SilxStyle } from './models';
-import {
-  assertArray,
-  assertDefined,
-  assertStr,
-  isScaleType,
-} from '../shared/utils';
+import { isScaleType } from '../shared/utils';
 import { getEntityAtPath } from '../../explorer/utils';
 
 export function getAttributeValue(

--- a/src/h5web/visualizations/shared/utils.ts
+++ b/src/h5web/visualizations/shared/utils.ts
@@ -220,44 +220,6 @@ export function getTickFormatter(
   };
 }
 
-export function assertDefined<T>(
-  val: T,
-  message = 'Expected some value'
-): asserts val is NonNullable<T> {
-  if (val === undefined) {
-    throw new TypeError(message);
-  }
-}
-
-export function assertStr(
-  val: unknown,
-  message = 'Expected string'
-): asserts val is string {
-  if (typeof val !== 'string') {
-    throw new TypeError(message);
-  }
-}
-
-export function assertNumOrStr(val: unknown): asserts val is number | string {
-  if (typeof val !== 'number' && typeof val !== 'string') {
-    throw new TypeError('Expected number or string');
-  }
-}
-
-export function assertArray<T>(val: unknown): asserts val is T[] {
-  if (!Array.isArray(val)) {
-    throw new TypeError('Expected array');
-  }
-}
-
-export function assertOptionalArray<T>(
-  val: unknown
-): asserts val is T[] | undefined {
-  if (val !== undefined) {
-    assertArray<T>(val);
-  }
-}
-
 export function isScaleType(val: unknown): val is ScaleType {
   return (
     typeof val === 'string' && Object.values<string>(ScaleType).includes(val)


### PR DESCRIPTION
- Move shared guards to `h5web/guards.ts`.
- Don't use `make*` mock data utilities in `buildTree` to avoid confusion.
- Remove `RawSilxStyle` model and rename properties of `SilxStyle` to camel case.
- Silently protect against malformed `SILX_style `attribute.