### PR TITLE
Basic working version of the Jupyter backend provider

### DIFF
--- a/.env
+++ b/.env
@@ -14,6 +14,10 @@ REACT_APP_HSDS_USERNAME=
 REACT_APP_HSDS_PASSWORD=
 REACT_APP_HSDS_FALLBACK_DOMAIN="/home/reader/water"
 
+# JupyterLab backend parameters
+REACT_APP_JLAB_URL=
+REACT_APP_JLAB_FALLBACK_DOMAIN="water_224.h5"
+
 # Rendering performance profiling (local development only)
 REACT_APP_PROFILING_ENABLED=false
 

--- a/src/demo-app/DemoApp.tsx
+++ b/src/demo-app/DemoApp.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import App from '../h5web/App';
 import SilxProvider from '../h5web/providers/silx/SilxProvider';
 import HsdsApp from './HsdsApp';
+import JupyterApp from './JupyterApp';
 
 // Split mock data generation code out of main bundle
 const MockProvider = lazy(
@@ -25,6 +26,9 @@ function DemoApp(): ReactElement {
         </Route>
         <Route path="/hsds">
           <HsdsApp />
+        </Route>
+        <Route path="/jupyter">
+          <JupyterApp />
         </Route>
         <Route exact path="/">
           <SilxProvider domain="bsa_002_000-integrate-sub">

--- a/src/demo-app/JupyterApp.tsx
+++ b/src/demo-app/JupyterApp.tsx
@@ -1,0 +1,20 @@
+import React, { ReactElement } from 'react';
+import { useLocation } from 'react-router-dom';
+import JupyterProvider from '../h5web/providers/jupyter/JupyterProvider';
+import { App } from '../packages/app';
+
+const URL = process.env.REACT_APP_JLAB_URL || '';
+const DOMAIN = process.env.REACT_APP_JLAB_FALLBACK_DOMAIN || '';
+
+function JupyterApp(): ReactElement {
+  const query = new URLSearchParams(useLocation().search);
+  const domain = query.get('domain');
+
+  return (
+    <JupyterProvider url={URL} domain={domain || DOMAIN}>
+      <App />
+    </JupyterProvider>
+  );
+}
+
+export default JupyterApp;

--- a/src/h5web/providers/hdf5-models.ts
+++ b/src/h5web/providers/hdf5-models.ts
@@ -80,7 +80,7 @@ export interface HDF5HardLink {
   id: HDF5Id;
 }
 
-interface HDF5SoftLink {
+export interface HDF5SoftLink {
   class: HDF5LinkClass.Soft;
   title: string;
   h5path: string;

--- a/src/h5web/providers/jupyter/JupyterProvider.tsx
+++ b/src/h5web/providers/jupyter/JupyterProvider.tsx
@@ -1,0 +1,19 @@
+import React, { ReactNode, ReactElement, useMemo } from 'react';
+import { JupyterApi } from './api';
+import Provider from '../Provider';
+
+interface Props {
+  url: string;
+  domain: string;
+  children: ReactNode;
+}
+
+/* Provider of metadata and values by JupyterLab backend */
+function JupyterProvider(props: Props): ReactElement {
+  const { url, domain, children } = props;
+  const api = useMemo(() => new JupyterApi(url, domain), [domain, url]);
+
+  return <Provider api={api}>{children}</Provider>;
+}
+
+export default JupyterProvider;

--- a/src/h5web/providers/jupyter/api.ts
+++ b/src/h5web/providers/jupyter/api.ts
@@ -1,0 +1,155 @@
+import axios, { AxiosInstance } from 'axios';
+import { Group, Dataset, Metadata, EntityKind, Link } from '../models';
+import type { ProviderAPI } from '../context';
+import {
+  assertGroupContent,
+  isDatasetResponse,
+  isGroupResponse,
+} from './utils';
+import type {
+  JupyterAttrsResponse,
+  JupyterContentResponse,
+  JupyterDataResponse,
+  JupyterMetaResponse,
+} from './models';
+import { nanoid } from 'nanoid';
+import { makeStrAttr, floatType } from '../mock/utils';
+import {
+  HDF5Id,
+  HDF5LinkClass,
+  HDF5ShapeClass,
+  HDF5Value,
+  HDF5SoftLink,
+} from '../hdf5-models';
+import { assertGroup } from '../../guards';
+
+export class JupyterApi implements ProviderAPI {
+  public readonly domain: string;
+  private readonly client: AxiosInstance;
+
+  private values: Record<HDF5Id, HDF5Value> = {};
+
+  public constructor(url: string, domain: string) {
+    this.domain = domain;
+    this.client = axios.create({
+      baseURL: `${url}/hdf`,
+    });
+  }
+
+  public async getMetadata(): Promise<Metadata> {
+    const rootId = '/';
+    const rootGrp = await this.processEntity(rootId);
+    assertGroup(rootGrp);
+    return rootGrp;
+  }
+
+  public async getValue(id: HDF5Id): Promise<HDF5Value | undefined> {
+    if (id in this.values) {
+      return this.values[id];
+    }
+
+    const value = await this.fetchValue(id);
+    this.values[id] = value;
+    return this.values[id];
+  }
+
+  private async fetchAttributes(path: string): Promise<JupyterAttrsResponse> {
+    const { data } = await this.client.get<JupyterAttrsResponse>(
+      `/attrs/${this.domain}?uri=${path}`
+    );
+    return data;
+  }
+
+  private async fetchMetadata(path: string): Promise<JupyterMetaResponse> {
+    const { data } = await this.client.get<JupyterMetaResponse>(
+      `/meta/${this.domain}?uri=${path}`
+    );
+    return data;
+  }
+
+  private async fetchContents(path: string): Promise<JupyterContentResponse> {
+    const { data } = await this.client.get<JupyterContentResponse>(
+      `/contents/${this.domain}?uri=${path}`
+    );
+    return data;
+  }
+
+  private async fetchValue(path: string): Promise<HDF5Value> {
+    const { data } = await this.client.get<JupyterDataResponse>(
+      `/data/${this.domain}?uri=${path}`
+    );
+    return data;
+  }
+
+  /** The main tree-building method */
+  private async processEntity(
+    path: string
+  ): Promise<Group | Dataset | Link<HDF5SoftLink>> {
+    const response = await this.fetchMetadata(path);
+    const { attributeCount } = response;
+
+    const attrReponse =
+      attributeCount > 0 ? await this.fetchAttributes(path) : {};
+    const attributes = Object.entries(attrReponse).map(([name, value]) =>
+      // TODO: fix this once I can infer the type of attributes
+      makeStrAttr(name, value)
+    );
+
+    if (isGroupResponse(response)) {
+      const { name, type, childrenCount } = response;
+      const contents = childrenCount > 0 ? await this.fetchContents(path) : [];
+      assertGroupContent(contents);
+
+      const children = await Promise.all(
+        contents.map((content) => {
+          return this.processEntity(content.uri);
+        })
+      );
+
+      const group: Group = {
+        uid: nanoid(),
+        name,
+        id: path,
+        kind: type,
+        children,
+        attributes,
+      };
+      group.children.forEach((child) => {
+        child.parent = group;
+      });
+
+      return group;
+    }
+
+    if (isDatasetResponse(response)) {
+      const { name, type, shape: dims } = response;
+      return {
+        uid: nanoid(),
+        name,
+        id: path,
+        kind: type,
+        attributes,
+        // TODO: Find the type from the dtype OR change the backend to return the true HDF5Type
+        type: floatType,
+        shape:
+          dims.length > 0
+            ? { class: HDF5ShapeClass.Simple, dims }
+            : { class: HDF5ShapeClass.Scalar },
+        // `parent` is set by the containing group
+      };
+    }
+
+    // Consider other as unresolved soft links
+    return {
+      uid: nanoid(),
+      kind: EntityKind.Link,
+      name: path,
+      attributes,
+      rawLink: {
+        class: HDF5LinkClass.Soft,
+        title: path,
+        h5path: path,
+      },
+    };
+  }
+}

--- a/src/h5web/providers/jupyter/models.ts
+++ b/src/h5web/providers/jupyter/models.ts
@@ -1,0 +1,43 @@
+import type { HDF5Value } from '../hdf5-models';
+import type { EntityKind } from '../models';
+
+export interface JupyterMetaResponse {
+  attributeCount: number;
+  id: string;
+  name: string;
+  type: EntityKind.Group | EntityKind.Dataset;
+}
+
+export interface JupyterMetaDatasetResponse extends JupyterMetaResponse {
+  dtype: string;
+  ndim: number;
+  shape: number[];
+  size: number;
+  type: EntityKind.Dataset;
+}
+
+export interface JupyterMetaGroupResponse extends JupyterMetaResponse {
+  childrenCount: number;
+  type: EntityKind.Group;
+}
+
+export interface JupyterContent {
+  type: EntityKind;
+  name: string;
+  uri: string;
+}
+
+export interface JupyterContentDatasetResponse extends JupyterContent {
+  content: JupyterMetaDatasetResponse;
+  type: EntityKind.Dataset;
+}
+
+export type JupyterContentGroupResponse = JupyterContent[];
+
+export type JupyterContentResponse =
+  | JupyterContentDatasetResponse
+  | JupyterContentGroupResponse;
+
+export type JupyterDataResponse = HDF5Value;
+
+export type JupyterAttrsResponse = Record<string, string>;

--- a/src/h5web/providers/jupyter/utils.ts
+++ b/src/h5web/providers/jupyter/utils.ts
@@ -1,0 +1,26 @@
+import { assertArray } from '../../guards';
+import { EntityKind } from '../models';
+import type {
+  JupyterContentGroupResponse,
+  JupyterContentResponse,
+  JupyterMetaDatasetResponse,
+  JupyterMetaGroupResponse,
+  JupyterMetaResponse,
+} from './models';
+
+export function isGroupResponse(
+  response: JupyterMetaResponse
+): response is JupyterMetaGroupResponse {
+  return response.type === EntityKind.Group;
+}
+export function isDatasetResponse(
+  response: JupyterMetaResponse
+): response is JupyterMetaDatasetResponse {
+  return response.type === EntityKind.Dataset;
+}
+
+export function assertGroupContent(
+  contents: JupyterContentResponse
+): asserts contents is JupyterContentGroupResponse {
+  assertArray(contents);
+}

--- a/src/packages/app.ts
+++ b/src/packages/app.ts
@@ -9,3 +9,4 @@ export { default as App } from '../h5web/App';
 export { default as MockProvider } from '../h5web/providers/mock/MockProvider';
 export { default as SilxProvider } from '../h5web/providers/silx/SilxProvider';
 export { default as HsdsProvider } from '../h5web/providers/hsds/HsdsProvider';
+export { default as JupyterProvider } from '../h5web/providers/jupyter/JupyterProvider';


### PR DESCRIPTION
A few loose ends left to tie:

## What we can fix:
- [x] The root response is cast to `Group`/`Metadata`

## What needs to be fixed in the backend:
- [ ] The type and shape of attributes cannot be inferred yet as the backend does not provide the necessary info. **Left unresolved for now. See  #406**
- [ ] The type of datasets is also tough to find as the `dtype` field is the NumPy type and not the HDF5 type that we use. We could infer the HDF5 type from the `dtype` on the front but I would prefer that the backend provides directly the HDF5 type. **Left unresolved for now. See  #406**
- [x] Similarly, `shape` is the NumPy shape that are what we call `dims`. <s>Complex shapes are therefore not supported yet.</s>. 
**EDIT**: I think it is fine for now: shapes can be either scalar, simple or null. Inferring from the dims seems sufficient. 
- [x] The signature of the attribute response is not the one described in the API. It necessitates an unpacking step (`attrs`).

## Other points:
- [x] The path in the file is used as `id`. The backend could return this information but it is not critical for now.
- [x] As discussed earlier, having an `attributeCount` and a `childrenCount` field in the metadata could help in avoiding unnecessary requests.
