### PR TITLE
Use `ScaleType` enum in `createAxisScale` function

### DIFF
--- a/src/h5web/visualizations/shared/utils.ts
+++ b/src/h5web/visualizations/shared/utils.ts
@@ -32,23 +32,20 @@ const adaptedLogTicksThreshold = scaleLinear({
 });
 
 export function createAxisScale(
-  config: PickScaleConfig<'linear' | 'log' | 'symlog', number>
+  config: PickScaleConfig<ScaleType, number>
 ): AxisScale {
   const { type } = config;
 
-  if (type === 'linear') {
-    return scaleLinear<number>(config);
+  switch (type) {
+    case ScaleType.Linear:
+      return scaleLinear<number>(config);
+    case ScaleType.Log:
+      return scaleLog<number>(config);
+    case ScaleType.SymLog:
+      return scaleSymlog<number>(config);
+    default:
+      throw new Error('Unknown type');
   }
-
-  if (type === 'log') {
-    return scaleLog<number>(config);
-  }
-
-  if (type === 'symlog') {
-    return scaleSymlog<number>(config);
-  }
-
-  throw new Error('Unknown type');
 }
 
 export function computeVisSize(


### PR DESCRIPTION
I had a crack at #346 but I can't find a solution that infers the subset of the `ScaleType` union automatically. Best I can do is `createScale<'linear' | 'log' | 'symlog'>(config)`, so telling Typescript which types of config to expect, which isn't bad but isn't particularly amazing either...

So I think our current solution of having our own `createScale` implementation is fine. I just rewrote it with a `switch` and by referring to the `ScaleType` enum instead of repeating the strings `linear`, `log` and `symlog`.