### PR TITLE
Implement async loading of groups metadata in Explorer

### DIFF
--- a/src/h5web/App.module.css
+++ b/src/h5web/App.module.css
@@ -8,3 +8,8 @@
   display: flex;
   flex-direction: column;
 }
+
+.fallback {
+  padding: 1em;
+  color: var(--secondary-dark);
+}

--- a/src/h5web/App.tsx
+++ b/src/h5web/App.tsx
@@ -1,4 +1,4 @@
-import { useState, ReactElement, useContext, Suspense } from 'react';
+import { useState, ReactElement, useContext } from 'react';
 import { ReflexContainer, ReflexSplitter, ReflexElement } from 'react-reflex';
 import Explorer from './explorer/Explorer';
 import type { Entity } from './providers/models';
@@ -24,13 +24,11 @@ function App(): ReactElement {
         flex={25}
         minSize={250}
       >
-        <Suspense fallback={<p className={styles.fallback}>Loading...</p>}>
-          <Explorer
-            onSelect={(path: string) => {
-              setSelectedEntity(getEntityAtPath(metadata, path));
-            }}
-          />
-        </Suspense>
+        <Explorer
+          onSelect={(path: string) => {
+            setSelectedEntity(getEntityAtPath(metadata, path));
+          }}
+        />
       </ReflexElement>
 
       <ReflexSplitter

--- a/src/h5web/App.tsx
+++ b/src/h5web/App.tsx
@@ -1,4 +1,4 @@
-import { useState, ReactElement } from 'react';
+import { useState, ReactElement, useContext, Suspense } from 'react';
 import { ReflexContainer, ReflexSplitter, ReflexElement } from 'react-reflex';
 import Explorer from './explorer/Explorer';
 import type { Entity } from './providers/models';
@@ -6,8 +6,12 @@ import MetadataViewer from './metadata-viewer/MetadataViewer';
 import styles from './App.module.css';
 import BreadcrumbsBar from './BreadcrumbsBar';
 import Visualizer from './visualizer/Visualizer';
+import { getEntityAtPath } from './utils';
+import { ProviderContext } from './providers/context';
 
 function App(): ReactElement {
+  const { metadata } = useContext(ProviderContext);
+
   const [selectedEntity, setSelectedEntity] = useState<Entity>();
   const [isExplorerOpen, setExplorerOpen] = useState(true);
   const [isInspecting, setInspecting] = useState(false);
@@ -20,10 +24,13 @@ function App(): ReactElement {
         flex={25}
         minSize={250}
       >
-        <Explorer
-          selectedEntity={selectedEntity}
-          onSelect={setSelectedEntity}
-        />
+        <Suspense fallback={<p className={styles.fallback}>Loading...</p>}>
+          <Explorer
+            onSelect={(path: string) => {
+              setSelectedEntity(getEntityAtPath(metadata, path));
+            }}
+          />
+        </Suspense>
       </ReflexElement>
 
       <ReflexSplitter

--- a/src/h5web/explorer/EntityItem.tsx
+++ b/src/h5web/explorer/EntityItem.tsx
@@ -1,0 +1,69 @@
+import { CSSProperties, ReactElement, Suspense } from 'react';
+import { FiRefreshCw } from 'react-icons/fi';
+import styles from './Explorer.module.css';
+import Icon from './Icon';
+import { isGroup } from '../guards';
+import type { Entity } from '../providers/models';
+import EntityList from './EntityList';
+import { useToggle } from 'react-use';
+
+interface Props {
+  path: string;
+  entity: Entity;
+  level: number;
+  selectedPath: string;
+  onSelect: (path: string) => void;
+}
+
+function EntityItem(props: Props): ReactElement {
+  const { path, entity, level, selectedPath, onSelect } = props;
+  const isSelected = path === selectedPath;
+
+  const [isExpanded, toggleExpanded] = useToggle(
+    isGroup(entity) && selectedPath.startsWith(path)
+  );
+
+  return (
+    <li
+      className={styles.entity}
+      style={{ '--level': level } as CSSProperties}
+      role="none"
+    >
+      <button
+        className={styles.btn}
+        type="button"
+        role="treeitem"
+        aria-expanded={isGroup(entity) ? isExpanded : undefined}
+        aria-selected={isSelected}
+        onClick={() => {
+          // Expand if collapsed; collapse is expanded and selected
+          if (isGroup(entity) && (!isExpanded || isSelected)) {
+            toggleExpanded();
+          }
+
+          onSelect(path);
+        }}
+      >
+        <Icon entity={entity} isExpanded={isExpanded} />
+        {entity.name}
+      </button>
+
+      {isGroup(entity) && isExpanded && (
+        <Suspense
+          fallback={
+            <FiRefreshCw className={styles.spinner}>Loading...</FiRefreshCw>
+          }
+        >
+          <EntityList
+            level={level + 1}
+            parentPath={path}
+            selectedPath={selectedPath}
+            onSelect={onSelect}
+          />
+        </Suspense>
+      )}
+    </li>
+  );
+}
+
+export default EntityItem;

--- a/src/h5web/explorer/EntityList.tsx
+++ b/src/h5web/explorer/EntityList.tsx
@@ -1,27 +1,17 @@
-import {
-  CSSProperties,
-  ReactElement,
-  Suspense,
-  useContext,
-  useEffect,
-} from 'react';
+import { ReactElement, useContext } from 'react';
 import styles from './Explorer.module.css';
-import type { Entity } from '../providers/models';
-import Icon from './Icon';
-import { isGroup } from '../guards';
 import { ProviderContext } from '../providers/context';
-import { FiRefreshCw } from 'react-icons/fi';
+import EntityItem from './EntityItem';
 
 interface Props {
   level: number;
   parentPath: string;
   selectedPath: string;
-  expandedGroups: Set<string>;
-  onSelect: (entity: Entity, path: string) => void;
+  onSelect: (path: string) => void;
 }
 
 function EntityList(props: Props): ReactElement {
-  const { level, parentPath, selectedPath, expandedGroups, onSelect } = props;
+  const { level, parentPath, selectedPath, onSelect } = props;
 
   const { groupsStore } = useContext(ProviderContext);
   const entities = groupsStore.get(parentPath).children;
@@ -35,45 +25,16 @@ function EntityList(props: Props): ReactElement {
       {entities.map((entity) => {
         const { uid, name } = entity;
         const path = `${parentPath === '/' ? '' : parentPath}/${name}`;
-        const isExpanded = expandedGroups.has(entity.uid);
 
         return (
-          <li
+          <EntityItem
             key={uid}
-            className={styles.entity}
-            style={{ '--level': level } as CSSProperties}
-            role="none"
-          >
-            <button
-              className={styles.btn}
-              type="button"
-              role="treeitem"
-              aria-expanded={isGroup(entity) ? isExpanded : undefined}
-              aria-selected={path === selectedPath}
-              onClick={() => onSelect(entity, path)}
-            >
-              <Icon entity={entity} isExpanded={isExpanded} />
-              {name}
-            </button>
-
-            {isGroup(entity) && isExpanded && (
-              <Suspense
-                fallback={
-                  <FiRefreshCw className={styles.spinner}>
-                    Loading...
-                  </FiRefreshCw>
-                }
-              >
-                <EntityList
-                  level={level + 1}
-                  parentPath={path}
-                  selectedPath={selectedPath}
-                  expandedGroups={expandedGroups}
-                  onSelect={onSelect}
-                />
-              </Suspense>
-            )}
-          </li>
+            path={path}
+            entity={entity}
+            level={level}
+            selectedPath={selectedPath}
+            onSelect={onSelect}
+          />
         );
       })}
     </ul>

--- a/src/h5web/explorer/Explorer.module.css
+++ b/src/h5web/explorer/Explorer.module.css
@@ -1,4 +1,5 @@
 .explorer {
+  position: relative;
   flex: 1 1 0%;
 }
 
@@ -6,6 +7,10 @@
   list-style: none;
   margin: 0;
   padding: 0;
+}
+
+.entity {
+  position: relative;
 }
 
 .btn {
@@ -44,4 +49,24 @@
   font-size: 1.25em;
   margin-left: -0.375rem;
   margin-right: 0.125rem;
+}
+
+.spinner {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.75rem;
+  font-size: 0.75em;
+  animation: spin 1.5s ease-in-out infinite, fade 0.1s 0.1s backwards;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes fade {
+  from {
+    opacity: 0;
+  }
 }

--- a/src/h5web/explorer/Explorer.test.tsx
+++ b/src/h5web/explorer/Explorer.test.tsx
@@ -49,7 +49,9 @@ describe('Explorer', () => {
     expect(groupBtn).toHaveAttribute('aria-selected', 'true');
     expect(groupBtn).toHaveAttribute('aria-expanded', 'true');
 
-    const childGroupBtn = screen.getByRole('treeitem', { name: 'empty_group' });
+    const childGroupBtn = await screen.findByRole('treeitem', {
+      name: 'empty_group',
+    });
     expect(childGroupBtn).toHaveAttribute('aria-selected', 'false');
     expect(childGroupBtn).toHaveAttribute('aria-expanded', 'false');
 

--- a/src/h5web/providers/Provider.tsx
+++ b/src/h5web/providers/Provider.tsx
@@ -15,13 +15,18 @@ function Provider(props: Props): ReactElement {
 
   // Wait until metadata is fetched before rendering app
   const { value: metadata, error } = useAsync(async () => {
-    return api.fetchMetadata();
+    return api.getMetadata();
   }, [api]);
 
-  const valuesStore = useMemo(
-    () => createFetchStore(api.fetchValue.bind(api)),
-    [api]
-  );
+  const groupsStore = useMemo(() => {
+    const store = createFetchStore(api.getGroup.bind(api));
+    store.prefetch('/'); // pre-fetch root group
+    return store;
+  }, [api]);
+
+  const valuesStore = useMemo(() => {
+    return createFetchStore(api.getValue.bind(api));
+  }, [api]);
 
   if (error) {
     return <ErrorMessage error={error} />;
@@ -36,6 +41,7 @@ function Provider(props: Props): ReactElement {
       value={{
         domain: api.domain,
         metadata,
+        groupsStore,
         valuesStore,
       }}
     >

--- a/src/h5web/providers/context.ts
+++ b/src/h5web/providers/context.ts
@@ -1,16 +1,18 @@
 import { createContext } from 'react';
-import type { Metadata } from './models';
+import type { Group, Metadata } from './models';
 import type { HDF5Id, HDF5Value } from './hdf5-models';
 import type { FetchStore } from 'react-suspense-fetch';
 
 export abstract class ProviderAPI {
   abstract domain: string;
-  abstract fetchMetadata(): Promise<Metadata>;
-  abstract fetchValue(id: HDF5Id): Promise<HDF5Value>;
+  abstract getMetadata(): Promise<Metadata>;
+  abstract getGroup(path: string): Promise<Group>;
+  abstract getValue(id: HDF5Id): Promise<HDF5Value>;
 }
 
 export const ProviderContext = createContext<{
   domain: string;
   metadata: Metadata;
+  groupsStore: FetchStore<Group, HDF5Id>;
   valuesStore: FetchStore<HDF5Value, HDF5Id>;
 }>({} as any); // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/src/h5web/providers/hsds/api.ts
+++ b/src/h5web/providers/hsds/api.ts
@@ -10,7 +10,7 @@ import type {
   HsdsAttributeWithValueResponse,
   HsdsLink,
 } from './models';
-import type { Metadata } from '../models';
+import type { Group, Metadata } from '../models';
 import {
   HDF5Collection,
   HDF5Dataset,
@@ -50,7 +50,7 @@ export class HsdsApi implements ProviderAPI {
     });
   }
 
-  public async fetchMetadata(): Promise<Metadata> {
+  public async getMetadata(): Promise<Metadata> {
     const rootId = await this.fetchRoot();
     await this.processGroup(rootId);
 
@@ -65,7 +65,11 @@ export class HsdsApi implements ProviderAPI {
     );
   }
 
-  public async fetchValue(id: HDF5Id): Promise<HDF5Value> {
+  public async getGroup(): Promise<Group> {
+    throw new Error('not supported');
+  }
+
+  public async getValue(id: HDF5Id): Promise<HDF5Value> {
     const { data } = await this.client.get<HsdsValueResponse>(
       `/datasets/${id}/value`
     );

--- a/src/h5web/providers/hsds/api.ts
+++ b/src/h5web/providers/hsds/api.ts
@@ -10,7 +10,7 @@ import type {
   HsdsAttributeWithValueResponse,
   HsdsLink,
 } from './models';
-import type { Group, Metadata } from '../models';
+import { Entity, EntityKind, Group, Metadata } from '../models';
 import {
   HDF5Collection,
   HDF5Dataset,
@@ -23,14 +23,18 @@ import {
   HDF5Attribute,
   HDF5Link,
 } from '../hdf5-models';
-import { isReachable } from '../../guards';
+import { assertDefined, assertGroup, isReachable } from '../../guards';
 import type { ProviderAPI } from '../context';
 import { buildTree } from '../utils';
-import { isHsdsExternalLink } from './utils';
+import { COLLECTION_TO_KIND, isHsdsExternalLink } from './utils';
+import { nanoid } from 'nanoid';
 
 export class HsdsApi implements ProviderAPI {
   public readonly domain: string;
   private readonly client: AxiosInstance;
+
+  private rootId?: string;
+  private readonly groupsByPath: Map<string, Group> = new Map();
 
   private groups: Record<HDF5Id, HDF5Group> = {};
   private datasets: Record<HDF5Id, HDF5Dataset> = {};
@@ -51,7 +55,7 @@ export class HsdsApi implements ProviderAPI {
   }
 
   public async getMetadata(): Promise<Metadata> {
-    const rootId = await this.fetchRoot();
+    const rootId = await this.getRootId();
     await this.processGroup(rootId);
 
     return buildTree(
@@ -65,8 +69,41 @@ export class HsdsApi implements ProviderAPI {
     );
   }
 
-  public async getGroup(): Promise<Group> {
-    throw new Error('not supported');
+  public async getGroup(path: string): Promise<Group> {
+    if (this.groupsByPath.has(path)) {
+      return this.groupsByPath.get(path) as Group;
+    }
+
+    if (path === '/') {
+      const rootId = await this.getRootId();
+      const rootGroup: Group = {
+        uid: nanoid(),
+        name: this.domain,
+        id: rootId,
+        kind: EntityKind.Group,
+        attributes: [],
+        children: await this.getGroupChildren(rootId),
+      };
+
+      this.groupsByPath.set('/', rootGroup);
+      return rootGroup;
+    }
+
+    const parentPath = path.slice(0, path.lastIndexOf('/')) || '/';
+    const parentGroup = await this.getGroup(parentPath);
+
+    const childName = path.slice(path.lastIndexOf('/') + 1);
+    const child = parentGroup.children.find(({ name }) => name === childName);
+    assertDefined(child);
+    assertGroup(child);
+
+    const group: Group = {
+      ...child,
+      children: await this.getGroupChildren(child.id),
+    };
+
+    this.groupsByPath.set(path, group);
+    return group;
   }
 
   public async getValue(id: HDF5Id): Promise<HDF5Value> {
@@ -76,7 +113,42 @@ export class HsdsApi implements ProviderAPI {
     return data.value;
   }
 
-  private async fetchRoot(): Promise<HDF5Id> {
+  private async getRootId(): Promise<HDF5Id> {
+    if (!this.rootId) {
+      this.rootId = await this.fetchRootId();
+    }
+
+    return this.rootId;
+  }
+
+  private async getGroupChildren(id: HDF5Id): Promise<Entity[]> {
+    const linksResponse = await this.fetchLinks(id);
+
+    return linksResponse.map<Entity>((hsdsLink: HsdsLink) => {
+      const link = isHsdsExternalLink(hsdsLink)
+        ? { ...hsdsLink, file: hsdsLink.h5domain }
+        : hsdsLink;
+
+      const baseEntity = {
+        uid: nanoid(),
+        name: hsdsLink.title,
+        attributes: [],
+      };
+
+      if (!isReachable(link)) {
+        return { ...baseEntity, kind: EntityKind.Link, rawLink: link };
+      }
+
+      return {
+        ...baseEntity,
+        id: link.id,
+        kind: COLLECTION_TO_KIND[link.collection],
+        rawLink: link,
+      };
+    });
+  }
+
+  private async fetchRootId(): Promise<HDF5Id> {
     const { data } = await this.client.get<HsdsRootResponse>('/');
     return data.root;
   }

--- a/src/h5web/providers/hsds/utils.ts
+++ b/src/h5web/providers/hsds/utils.ts
@@ -1,5 +1,13 @@
+import { HDF5Collection } from '../hdf5-models';
+import { EntityKind } from '../models';
 import type { HsdsLink, HsdsExternalLink } from './models';
 
 export function isHsdsExternalLink(link: HsdsLink): link is HsdsExternalLink {
   return 'h5domain' in link;
 }
+
+export const COLLECTION_TO_KIND: Record<HDF5Collection, EntityKind> = {
+  [HDF5Collection.Groups]: EntityKind.Group,
+  [HDF5Collection.Datasets]: EntityKind.Dataset,
+  [HDF5Collection.Datatypes]: EntityKind.Datatype,
+};

--- a/src/h5web/providers/jupyter/api.ts
+++ b/src/h5web/providers/jupyter/api.ts
@@ -33,14 +33,18 @@ export class JupyterApi implements ProviderAPI {
     });
   }
 
-  public async fetchMetadata(): Promise<Metadata> {
+  public async getMetadata(): Promise<Metadata> {
     const rootId = '/';
     const rootGrp = await this.processEntity(rootId);
     assertGroup(rootGrp);
     return rootGrp;
   }
 
-  public async fetchValue(path: string): Promise<HDF5Value> {
+  public async getGroup(): Promise<Group> {
+    throw new Error('not supported');
+  }
+
+  public async getValue(path: string): Promise<HDF5Value> {
     const { data } = await this.client.get<JupyterDataResponse>(
       `/data/${this.domain}?uri=${path}`
     );

--- a/src/h5web/providers/jupyter/api.ts
+++ b/src/h5web/providers/jupyter/api.ts
@@ -3,6 +3,7 @@ import { Group, Dataset, Metadata, EntityKind, Link } from '../models';
 import type { ProviderAPI } from '../context';
 import {
   assertGroupContent,
+  assertGroupResponse,
   isDatasetResponse,
   isGroupResponse,
 } from './utils';
@@ -40,8 +41,28 @@ export class JupyterApi implements ProviderAPI {
     return rootGrp;
   }
 
-  public async getGroup(): Promise<Group> {
-    throw new Error('not supported');
+  public async getGroup(path: string): Promise<Group> {
+    const [metadata, children] = await Promise.all([
+      this.fetchMetadata(path),
+      this.fetchContents(path),
+    ]);
+
+    assertGroupResponse(metadata);
+    assertGroupContent(children);
+
+    return {
+      uid: nanoid(),
+      name: metadata.name,
+      id: path,
+      kind: EntityKind.Group,
+      attributes: [],
+      children: children.map((c) => ({
+        uid: nanoid(),
+        name: c.name,
+        kind: c.type,
+        attributes: [],
+      })),
+    };
   }
 
   public async getValue(path: string): Promise<HDF5Value> {
@@ -58,7 +79,7 @@ export class JupyterApi implements ProviderAPI {
     return data;
   }
 
-  private async _fetchMetadata(path: string): Promise<JupyterMetaResponse> {
+  private async fetchMetadata(path: string): Promise<JupyterMetaResponse> {
     const { data } = await this.client.get<JupyterMetaResponse>(
       `/meta/${this.domain}?uri=${path}`
     );
@@ -76,7 +97,7 @@ export class JupyterApi implements ProviderAPI {
   private async processEntity(
     path: string
   ): Promise<Group | Dataset | Link<HDF5SoftLink>> {
-    const response = await this._fetchMetadata(path);
+    const response = await this.fetchMetadata(path);
     const { attributeCount } = response;
 
     const attrReponse =

--- a/src/h5web/providers/jupyter/utils.ts
+++ b/src/h5web/providers/jupyter/utils.ts
@@ -19,6 +19,14 @@ export function isDatasetResponse(
   return response.type === EntityKind.Dataset;
 }
 
+export function assertGroupResponse(
+  response: JupyterMetaResponse
+): asserts response is JupyterMetaGroupResponse {
+  if (!isGroupResponse(response)) {
+    throw new Error('Expected group response');
+  }
+}
+
 export function assertGroupContent(
   contents: JupyterContentResponse
 ): asserts contents is JupyterContentGroupResponse {

--- a/src/h5web/providers/mock/MockProvider.tsx
+++ b/src/h5web/providers/mock/MockProvider.tsx
@@ -1,22 +1,38 @@
 import type { ReactElement, ReactNode } from 'react';
+import { assertDefined, assertGroup } from '../../guards';
+import { getEntityAtPath } from '../../utils';
 import Provider from '../Provider';
 import { mockMetadata, mockValues, mockDomain } from './data';
 
 interface Props {
   domain?: string;
+  slowOnPath?: string;
   errorOnId?: string;
   children: ReactNode;
 }
 
 function MockProvider(props: Props): ReactElement {
-  const { domain = mockDomain, errorOnId, children } = props;
+  const { domain = mockDomain, errorOnId, slowOnPath, children } = props;
 
   return (
     <Provider
       api={{
         domain,
-        fetchMetadata: async () => mockMetadata,
-        fetchValue: async (id: keyof typeof mockValues) => {
+        getMetadata: async () => mockMetadata,
+        getGroup: async (path: string) => {
+          if (path === slowOnPath) {
+            await new Promise((resolve) => {
+              setTimeout(resolve, 3000);
+            });
+          }
+
+          const group = getEntityAtPath(mockMetadata, path, true);
+          assertDefined(group);
+          assertGroup(group);
+
+          return group;
+        },
+        getValue: async (id: keyof typeof mockValues) => {
           if (id === errorOnId) {
             // Throw error when fetching value with specific ID
             throw new Error('error');

--- a/src/h5web/providers/silx/api.ts
+++ b/src/h5web/providers/silx/api.ts
@@ -7,7 +7,7 @@ import type {
   HDF5Metadata,
   HDF5Values,
 } from '../hdf5-models';
-import type { Metadata } from '../models';
+import type { Group, Metadata } from '../models';
 
 export class SilxApi implements ProviderAPI {
   public readonly domain: string;
@@ -21,12 +21,16 @@ export class SilxApi implements ProviderAPI {
     });
   }
 
-  public async fetchMetadata(): Promise<Metadata> {
+  public async getMetadata(): Promise<Metadata> {
     const { data } = await this.client.get<HDF5Metadata>('/metadata.json');
     return buildTree(data, this.domain);
   }
 
-  public async fetchValue(id: HDF5Id): Promise<HDF5Value> {
+  public async getGroup(): Promise<Group> {
+    throw new Error('not supported');
+  }
+
+  public async getValue(id: HDF5Id): Promise<HDF5Value> {
     if (this.values) {
       return this.values[id];
     }

--- a/src/h5web/visualizer/ErrorMessage.tsx
+++ b/src/h5web/visualizer/ErrorMessage.tsx
@@ -7,7 +7,7 @@ interface Props {
 
 function ErrorMessage(props: Props): ReactElement {
   const { error } = props;
-  return <p className={styles.error}>Error: {error.message}</p>;
+  return <p className={styles.error}>{error.message}</p>;
 }
 
 export default ErrorMessage;

--- a/src/h5web/visualizer/Visualizer.module.css
+++ b/src/h5web/visualizer/Visualizer.module.css
@@ -22,8 +22,7 @@
 }
 
 .fallback {
-  padding: 1em;
-  color: var(--secondary-dark);
+  composes: fallback from '../App.module.css';
 }
 
 .error {

--- a/src/h5web/visualizer/Visualizer.test.tsx
+++ b/src/h5web/visualizer/Visualizer.test.tsx
@@ -135,7 +135,7 @@ describe('Visualizer', () => {
     const { consoleMock, resetConsole } = mockConsoleMethod('error');
     await selectExplorerNode('entities/raw');
 
-    expect(await screen.findByText('Error: error')).toBeVisible();
+    expect(await screen.findByText('error')).toBeVisible();
     expect(consoleMock).toHaveBeenCalledTimes(2); // React logs two stack traces
     resetConsole();
 


### PR DESCRIPTION
After much staring into space trying to figure out the best approach, here is what I came up with:

- The `ProviderAPI` contract that providers must implement now includes a `getGroup` method, which will eventually replace `getMetadata`. `getGroup` accepts a string `path` and must return a `Group` entity. As an example, `getGroup('/')` must return the root `Group`. 
- `Provider` now includes a second suspense store called `groupsStore` that wraps the new `getGroup` method. In other words, **we now have a cache that stores groups against their paths**. `groupsStore` is available through context, which means that we can call `groupsStore.get('/some/path')` to either get the metadata of the group at `/some/path` from the cache, or suspend rendering while the group's metadata is being fetched for the first time.

As a first refactoring increment, I chose to use the new `groupsStore` in the `Explorer` only. The `Provider` still fetches the entire `metadata` tree on initial load, but the `Explorer` no longer relies on this object.

---

Here is how the Explorer UI behaves now:

- On page load, ignoring the "legacy" loading of the whole metadata tree, the first thing we see is the Explorer sidebar with the domain button (since the domain is known, this is instantaneous). Then, the root group's `EntityList` renders for the first time, triggering a call to get the group's metadata (i.e. `groupsStore.get('/')`). Since the root group hasn't been fetched yet, this call suspends the rendering of `EntityList`, falling back to a spinner positioned on top of the domain button. Once the root group is fetched, `EntityList` renders again, this time to completion, and the root group's direct children appear.
    
    | | |
    |---|---|
    | ![image](https://user-images.githubusercontent.com/2936402/103916486-c87c9f80-510c-11eb-8cc2-1916ead4273f.png) | ![image](https://user-images.githubusercontent.com/2936402/103915128-155f7680-510b-11eb-94d9-8caa33a01b2e.png) |

- When expanding a nested group, the group's `EntityList` renders, triggering a call to fetch the group's metadata using its path (i.e. constructed by prefixing the group's name with the parent group's path). Again, the rendering suspends, revealing a spinner, until the group is fetched and its children are finally rendered.

    | | |
    |---|---|
    | ![image](https://user-images.githubusercontent.com/2936402/103916561-ddf1c980-510c-11eb-8e12-d5a2d28b7a57.png) | ![image](https://user-images.githubusercontent.com/2936402/103916298-8ce1d580-510c-11eb-9596-489add68c363.png) |

- If a group is collapsed and then expanded again, `groupsStore('/group/path')` is called again, but this time, since the group's metadata is already in the cache, its children are rendered right away and the spinner doesn't appear at all.

---

In the Explorer's code, the big change is that the core state is no longer a `selectedEntity` object, but a `selectedPath` string. This is really convenient, because it makes selecting the `DEFAULT_PATH` trivial: `useState(DEFAULT_PATH)`. When an entity is selected, we notify the `App`, which turns the path into an `Entity` object with `getEntityAtPath`. This works fine for now because we still fetch the entire `metadata` tree, but it will need to be refactored.

Since we now consider paths to be unique, we can also simplify the management of expanded groups. Instead of managing a complex state in `Explorer`, and resorting to a `useEffect` to expand the correct groups when a `DEFAULT_PATH` is present, we can now switch to a simple boolean state in a new component called `EntityItem`. If the default path begins with the entity's path, the group can be expanded simply by initialising the boolean state to `true`.