### PR TITLE
Refactor `getGroup` in HSDS and Jupyter provider APIs

### DIFF
--- a/src/h5web/guards.ts
+++ b/src/h5web/guards.ts
@@ -145,6 +145,14 @@ export function assertGroup(
   }
 }
 
+export function assertReachable(
+  link: HDF5Link
+): asserts link is HDF5HardLink | HDF5RootLink {
+  if (!isReachable(link)) {
+    throw new Error('Expected link to be reachable');
+  }
+}
+
 export function assertNumericType<S extends HDF5Shape>(
   dataset: Dataset<S>
 ): asserts dataset is Dataset<S, HDF5NumericType> {

--- a/src/h5web/providers/hsds/utils.ts
+++ b/src/h5web/providers/hsds/utils.ts
@@ -1,13 +1,5 @@
-import { HDF5Collection } from '../hdf5-models';
-import { EntityKind } from '../models';
 import type { HsdsLink, HsdsExternalLink } from './models';
 
 export function isHsdsExternalLink(link: HsdsLink): link is HsdsExternalLink {
   return 'h5domain' in link;
 }
-
-export const COLLECTION_TO_KIND: Record<HDF5Collection, EntityKind> = {
-  [HDF5Collection.Groups]: EntityKind.Group,
-  [HDF5Collection.Datasets]: EntityKind.Dataset,
-  [HDF5Collection.Datatypes]: EntityKind.Datatype,
-};

--- a/src/h5web/providers/utils.ts
+++ b/src/h5web/providers/utils.ts
@@ -40,7 +40,7 @@ function buildDatatype(datatype: HDF5Datatype, link: HDF5HardLink): Datatype {
   };
 }
 
-function buildGroup(
+export function buildGroup(
   metadata: Required<HDF5Metadata>,
   link: HDF5HardLink | HDF5RootLink
 ): Group {


### PR DESCRIPTION
Part of #417.

The `getGroup` methods now return fuller `Group` objects (with attributes, type/shape of child datasets, etc.) They also make mroe use of the existing methods and utilities.