### PR TITLE
Lift `selectedPath` state up into App and use in BreadcrumbsBar

### DIFF
--- a/src/h5web/App.tsx
+++ b/src/h5web/App.tsx
@@ -1,7 +1,6 @@
 import { useState, ReactElement, useContext } from 'react';
 import { ReflexContainer, ReflexSplitter, ReflexElement } from 'react-reflex';
 import Explorer from './explorer/Explorer';
-import type { Entity } from './providers/models';
 import MetadataViewer from './metadata-viewer/MetadataViewer';
 import styles from './App.module.css';
 import BreadcrumbsBar from './BreadcrumbsBar';
@@ -9,12 +8,15 @@ import Visualizer from './visualizer/Visualizer';
 import { getEntityAtPath } from './utils';
 import { ProviderContext } from './providers/context';
 
-function App(): ReactElement {
-  const { metadata } = useContext(ProviderContext);
+const DEFAULT_PATH = process.env.REACT_APP_DEFAULT_PATH || '/';
 
-  const [selectedEntity, setSelectedEntity] = useState<Entity>();
+function App(): ReactElement {
+  const [selectedPath, setSelectedPath] = useState<string>(DEFAULT_PATH);
   const [isExplorerOpen, setExplorerOpen] = useState(true);
   const [isInspecting, setInspecting] = useState(false);
+
+  const { metadata } = useContext(ProviderContext);
+  const selectedEntity = getEntityAtPath(metadata, selectedPath);
 
   return (
     <ReflexContainer orientation="vertical">
@@ -24,11 +26,7 @@ function App(): ReactElement {
         flex={25}
         minSize={250}
       >
-        <Explorer
-          onSelect={(path: string) => {
-            setSelectedEntity(getEntityAtPath(metadata, path));
-          }}
-        />
+        <Explorer selectedPath={selectedPath} onSelect={setSelectedPath} />
       </ReflexElement>
 
       <ReflexSplitter
@@ -37,11 +35,11 @@ function App(): ReactElement {
 
       <ReflexElement className={styles.mainArea} flex={75} minSize={500}>
         <BreadcrumbsBar
+          entityPath={selectedPath}
           isExplorerOpen={isExplorerOpen}
-          onToggleExplorer={() => setExplorerOpen(!isExplorerOpen)}
           isInspecting={isInspecting}
+          onToggleExplorer={() => setExplorerOpen(!isExplorerOpen)}
           onChangeInspecting={setInspecting}
-          selectedEntity={selectedEntity}
         />
         {isInspecting ? (
           <MetadataViewer entity={selectedEntity} />

--- a/src/h5web/BreadcrumbsBar.tsx
+++ b/src/h5web/BreadcrumbsBar.tsx
@@ -1,30 +1,34 @@
-import { Fragment, ReactElement } from 'react';
-import { FiSidebar, FiChevronRight } from 'react-icons/fi';
+import { Fragment, ReactElement, useContext } from 'react';
+import { FiChevronRight, FiSidebar } from 'react-icons/fi';
 import styles from './BreadcrumbsBar.module.css';
-import type { Entity } from './providers/models';
 import ToggleGroup from './toolbar/controls/ToggleGroup';
 import ToggleBtn from './toolbar/controls/ToggleBtn';
-import { getParents } from './utils';
+import { ProviderContext } from './providers/context';
 
 interface Props {
+  entityPath: string;
   isExplorerOpen: boolean;
-  onToggleExplorer: () => void;
   isInspecting: boolean;
+  onToggleExplorer: () => void;
   onChangeInspecting: (b: boolean) => void;
-  selectedEntity?: Entity;
 }
 
 function BreadcrumbsBar(props: Props): ReactElement {
   const {
+    entityPath,
     isExplorerOpen,
-    onToggleExplorer,
     isInspecting,
+    onToggleExplorer,
     onChangeInspecting,
-    selectedEntity,
   } = props;
 
-  // Excludes the first parent (the domain) if the explorer is opened
-  const firstParentIndex = isExplorerOpen ? 1 : 0;
+  if (!entityPath.startsWith('/')) {
+    throw new Error("Expected path to start with '/'");
+  }
+
+  const { domain } = useContext(ProviderContext);
+  const crumbs = `${domain}${entityPath === '/' ? '' : entityPath}`.split('/');
+  const firstCrumbIndex = isExplorerOpen ? 1 : 0; // skip domain crumb if explorer is open
 
   return (
     <div className={styles.bar}>
@@ -35,21 +39,20 @@ function BreadcrumbsBar(props: Props): ReactElement {
         value={isExplorerOpen}
         onChange={onToggleExplorer}
       />
-      {selectedEntity && (
-        <h1 className={styles.breadCrumbs}>
-          {getParents(selectedEntity)
-            .slice(firstParentIndex)
-            .map((parent) => (
-              <Fragment key={parent.id}>
-                <span className={styles.crumb}>{parent.name}</span>
-                <FiChevronRight className={styles.separator} title="/" />
-              </Fragment>
-            ))}
-          <span className={styles.crumb} data-current>
-            {selectedEntity.name}
-          </span>
-        </h1>
-      )}
+
+      <h1 className={styles.breadCrumbs}>
+        {crumbs.slice(firstCrumbIndex, -1).map((crumb, i) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <Fragment key={i}>
+            <span className={styles.crumb}>{crumb}</span>
+            <FiChevronRight className={styles.separator} title="/" />
+          </Fragment>
+        ))}
+        <span className={styles.crumb} data-current>
+          {crumbs[crumbs.length - 1]}
+        </span>
+      </h1>
+
       <ToggleGroup
         role="tablist"
         ariaLabel="Viewer mode"

--- a/src/h5web/explorer/Explorer.tsx
+++ b/src/h5web/explorer/Explorer.tsx
@@ -1,30 +1,17 @@
-import { useContext, ReactElement, useState, Suspense } from 'react';
+import { useContext, ReactElement, Suspense } from 'react';
 import { FiFileText, FiRefreshCw } from 'react-icons/fi';
 import EntityList from './EntityList';
 import styles from './Explorer.module.css';
 import { ProviderContext } from '../providers/context';
-import { useMount } from 'react-use';
-
-const DEFAULT_PATH = process.env.REACT_APP_DEFAULT_PATH || '/';
 
 interface Props {
+  selectedPath: string;
   onSelect: (path: string) => void;
 }
 
 function Explorer(props: Props): ReactElement {
-  const { onSelect } = props;
-
+  const { selectedPath, onSelect } = props;
   const { domain } = useContext(ProviderContext);
-  const [selectedPath, setSelectedPath] = useState<string>(DEFAULT_PATH);
-
-  function handleSelect(path: string): void {
-    setSelectedPath(path);
-    onSelect(path);
-  }
-
-  useMount(() => {
-    onSelect(DEFAULT_PATH);
-  });
 
   return (
     <div className={styles.explorer} role="tree">
@@ -33,7 +20,7 @@ function Explorer(props: Props): ReactElement {
         type="button"
         role="treeitem"
         aria-selected={selectedPath === '/'}
-        onClick={() => handleSelect('/')}
+        onClick={() => onSelect('/')}
       >
         <FiFileText className={styles.domainIcon} />
         {domain}
@@ -48,7 +35,7 @@ function Explorer(props: Props): ReactElement {
           level={0}
           parentPath="/"
           selectedPath={selectedPath}
-          onSelect={handleSelect}
+          onSelect={onSelect}
         />
       </Suspense>
     </div>

--- a/src/h5web/visualizations/RawVis.module.css
+++ b/src/h5web/visualizations/RawVis.module.css
@@ -4,5 +4,5 @@
 }
 
 .fallback {
-  composes: fallback from '../visualizer/Visualizer.module.css';
+  composes: fallback from '../App.module.css';
 }


### PR DESCRIPTION
Part of #417. The `BreadcrumbsBar` is now much simpler, since it now has direct access to the path. The path is now the core state of the `App`. It will be used to retrieve the associated `Entity` metadata.