### PR TITLE
Replace `getGroup` with `getEntity` in provider API

### DIFF
--- a/cypress/specs/app.spec.ts
+++ b/cypress/specs/app.spec.ts
@@ -1,4 +1,4 @@
-const SNAPSHOT_DELAY = 500;
+const SNAPSHOT_DELAY = 700;
 
 describe('App', () => {
   beforeEach(() => {

--- a/src/h5web/explorer/EntityList.tsx
+++ b/src/h5web/explorer/EntityList.tsx
@@ -2,6 +2,7 @@ import { ReactElement, useContext } from 'react';
 import styles from './Explorer.module.css';
 import { ProviderContext } from '../providers/context';
 import EntityItem from './EntityItem';
+import { assertGroup } from '../guards';
 
 interface Props {
   level: number;
@@ -13,16 +14,17 @@ interface Props {
 function EntityList(props: Props): ReactElement {
   const { level, parentPath, selectedPath, onSelect } = props;
 
-  const { groupsStore } = useContext(ProviderContext);
-  const entities = groupsStore.get(parentPath).children;
+  const { entitiesStore } = useContext(ProviderContext);
+  const group = entitiesStore.get(parentPath);
+  assertGroup(group);
 
-  if (entities.length === 0) {
+  if (group.children.length === 0) {
     return <></>;
   }
 
   return (
     <ul className={styles.group} role="group">
-      {entities.map((entity) => {
+      {group.children.map((entity) => {
         const { uid, name } = entity;
         const path = `${parentPath === '/' ? '' : parentPath}/${name}`;
 

--- a/src/h5web/providers/context.ts
+++ b/src/h5web/providers/context.ts
@@ -1,18 +1,18 @@
 import { createContext } from 'react';
-import type { Group, Metadata } from './models';
+import type { Entity, Metadata } from './models';
 import type { HDF5Id, HDF5Value } from './hdf5-models';
 import type { FetchStore } from 'react-suspense-fetch';
 
 export abstract class ProviderAPI {
   abstract domain: string;
   abstract getMetadata(): Promise<Metadata>;
-  abstract getGroup(path: string): Promise<Group>;
+  abstract getEntity(path: string): Promise<Entity>;
   abstract getValue(id: HDF5Id): Promise<HDF5Value>;
 }
 
 export const ProviderContext = createContext<{
   domain: string;
   metadata: Metadata;
-  groupsStore: FetchStore<Group, HDF5Id>;
+  entitiesStore: FetchStore<Entity, HDF5Id>;
   valuesStore: FetchStore<HDF5Value, HDF5Id>;
 }>({} as any); // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/src/h5web/providers/jupyter/api.ts
+++ b/src/h5web/providers/jupyter/api.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosInstance } from 'axios';
-import { Group, Dataset, Metadata, EntityKind, Link } from '../models';
+import { Group, Dataset, Metadata, EntityKind, Link, Entity } from '../models';
 import type { ProviderAPI } from '../context';
 import {
   assertGroupContent,
@@ -34,16 +34,13 @@ export class JupyterApi implements ProviderAPI {
   }
 
   public async getMetadata(): Promise<Metadata> {
-    const rootId = '/';
-    const rootGrp = await this.processEntity(rootId);
+    const rootGrp = await this.processEntity('/');
     assertGroup(rootGrp);
     return rootGrp;
   }
 
-  public async getGroup(path: string): Promise<Group> {
-    const group = await this.processEntity(path, 1);
-    assertGroup(group);
-    return group;
+  public async getEntity(path: string): Promise<Entity> {
+    return this.processEntity(path, 1);
   }
 
   public async getValue(path: string): Promise<HDF5Value> {

--- a/src/h5web/providers/mock/MockProvider.tsx
+++ b/src/h5web/providers/mock/MockProvider.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement, ReactNode } from 'react';
-import { assertDefined, assertGroup } from '../../guards';
+import { assertDefined } from '../../guards';
 import { getEntityAtPath } from '../../utils';
 import Provider from '../Provider';
 import { mockMetadata, mockValues, mockDomain } from './data';
@@ -19,18 +19,17 @@ function MockProvider(props: Props): ReactElement {
       api={{
         domain,
         getMetadata: async () => mockMetadata,
-        getGroup: async (path: string) => {
+        getEntity: async (path: string) => {
           if (path === slowOnPath) {
             await new Promise((resolve) => {
               setTimeout(resolve, 3000);
             });
           }
 
-          const group = getEntityAtPath(mockMetadata, path, true);
-          assertDefined(group);
-          assertGroup(group);
+          const entity = getEntityAtPath(mockMetadata, path, true);
+          assertDefined(entity);
 
-          return group;
+          return entity;
         },
         getValue: async (id: keyof typeof mockValues) => {
           if (id === errorOnId) {

--- a/src/h5web/providers/silx/api.ts
+++ b/src/h5web/providers/silx/api.ts
@@ -7,9 +7,9 @@ import type {
   HDF5Metadata,
   HDF5Values,
 } from '../hdf5-models';
-import type { Group, Metadata } from '../models';
+import type { Entity, Metadata } from '../models';
 import { getEntityAtPath } from '../../utils';
-import { assertDefined, assertGroup } from '../../guards';
+import { assertDefined } from '../../guards';
 
 export class SilxApi implements ProviderAPI {
   public readonly domain: string;
@@ -33,14 +33,13 @@ export class SilxApi implements ProviderAPI {
     return this.metadata;
   }
 
-  public async getGroup(path: string): Promise<Group> {
+  public async getEntity(path: string): Promise<Entity> {
     const metadata = this.metadata || (await this.getMetadata());
 
-    const group = getEntityAtPath(metadata, path);
-    assertDefined(group);
-    assertGroup(group);
+    const entity = getEntityAtPath(metadata, path);
+    assertDefined(entity);
 
-    return group;
+    return entity;
   }
 
   public async getValue(id: HDF5Id): Promise<HDF5Value> {

--- a/src/h5web/providers/utils.ts
+++ b/src/h5web/providers/utils.ts
@@ -47,26 +47,17 @@ export function buildGroup(
   const rawGroup = metadata.groups[link.id];
 
   const children = (rawGroup.links || []).map((link) => {
-    if (!isReachable(link)) {
-      return {
-        uid: nanoid(),
-        name: link.title,
-        kind: EntityKind.Link,
-        attributes: [],
-        rawLink: link,
-      };
+    if (isReachable(link)) {
+      return buildEntity(metadata, link);
     }
 
-    switch (link.collection) {
-      case HDF5Collection.Groups:
-        return buildGroup(metadata, link);
-      case HDF5Collection.Datasets:
-        return buildDataset(metadata.datasets[link.id], link);
-      case HDF5Collection.Datatypes:
-        return buildDatatype(metadata.datatypes[link.id], link);
-      default:
-        throw new Error('Expected link with known HDF5 collection');
-    }
+    return {
+      uid: nanoid(),
+      name: link.title,
+      kind: EntityKind.Link,
+      attributes: [],
+      rawLink: link,
+    };
   });
 
   const group: Group = {
@@ -84,6 +75,22 @@ export function buildGroup(
   });
 
   return group;
+}
+
+export function buildEntity(
+  metadata: Required<HDF5Metadata>,
+  link: HDF5HardLink | HDF5RootLink
+): Group | Dataset | Datatype {
+  switch (link.collection) {
+    case HDF5Collection.Groups:
+      return buildGroup(metadata, link);
+    case HDF5Collection.Datasets:
+      return buildDataset(metadata.datasets[link.id], link);
+    case HDF5Collection.Datatypes:
+      return buildDatatype(metadata.datatypes[link.id], link);
+    default:
+      throw new Error('Expected link with known HDF5 collection');
+  }
 }
 
 export function buildTree(rawMetadata: HDF5Metadata, domain: string): Metadata {


### PR DESCRIPTION
Part of #417. Now that the `selectedPath` is the core local state of `App`, sub-components will need a way to retrieve the metadata object of any selected entity from its path, not only selected groups. Therefore, I had to reconsider my approach with the `getGroup` API method and `groupsStore` suspense store, and switch to a more generic `getEntity` method and `entitiesStore` suspense store.

From a back-end point of view, `getEntity` still returns the same thing when passed the path of a group (i.e. the metadata of the group and its direct children). However, it now also accepts paths to datasets and datatypes and should return their metadata.

To avoid fetching the same dataset/datatype twice (once when selecting its parent group in the Explorer, and a second time when actually using the entity in the app), I manage a sort of "proxy cache" inside the `entitiesStore`. When a group is fetched, I store its children datasets/datatypes in the cache so that, if a component tries to retrieve them from the store directly, they are returned instantly instead of being re-fetched with `getEntity`.

Most likely, the `Visualizer` will eventually include a call such as `entitiesStore.get(selectedPath)`. If `selectedPath` refers to a dataset, this dataset's metadata will only be fetched from the back-end if:

- the `Visualizer` is used in an app on its own, without the `Explorer` (otherwise, the `Explorer` would have already fetched the dataset's parent group ... and therefore the dataset itself);
- the `Visualizer` is rendered with a `selectedPath` refering to a dataset before the `Explorer` had a chance to fetch the dataset's parent group (for instance, when providing a `DEFAULT_PATH` to a dataset).