### PR TITLE
Don't store reference to parent in entities and remove `findRoot`

### DIFF
--- a/src/h5web/providers/hsds/api.ts
+++ b/src/h5web/providers/hsds/api.ts
@@ -171,7 +171,7 @@ export class HsdsApi implements ProviderAPI {
         )
     );
 
-    const group: Group = {
+    return {
       uid: nanoid(),
       id,
       path,
@@ -180,12 +180,6 @@ export class HsdsApi implements ProviderAPI {
       attributes,
       children,
     };
-
-    children.forEach((c) => {
-      c.parent = group;
-    });
-
-    return group;
   }
 
   private async processDataset(

--- a/src/h5web/providers/jupyter/api.ts
+++ b/src/h5web/providers/jupyter/api.ts
@@ -100,7 +100,7 @@ export class JupyterApi implements ProviderAPI {
             )
           : [];
 
-      const group: Group = {
+      return {
         uid: nanoid(),
         id: path,
         name,
@@ -109,12 +109,6 @@ export class JupyterApi implements ProviderAPI {
         children,
         attributes,
       };
-
-      group.children.forEach((child) => {
-        child.parent = group;
-      });
-
-      return group;
     }
 
     if (isDatasetResponse(response)) {
@@ -132,7 +126,6 @@ export class JupyterApi implements ProviderAPI {
           dims.length > 0
             ? { class: HDF5ShapeClass.Simple, dims }
             : { class: HDF5ShapeClass.Scalar },
-        // `parent` is set by the containing group
       };
     }
 

--- a/src/h5web/providers/mock/utils.ts
+++ b/src/h5web/providers/mock/utils.ts
@@ -133,10 +133,6 @@ export function makeGroup(
     rawLink,
   };
 
-  group.children.forEach((child) => {
-    child.parent = group;
-  });
-
   prefixChildrenPaths(group, path);
   return group;
 }

--- a/src/h5web/providers/models.ts
+++ b/src/h5web/providers/models.ts
@@ -18,7 +18,6 @@ export interface Entity {
   name: string;
   path: string;
   kind: EntityKind;
-  parent?: Group;
   attributes: HDF5Attribute[];
   rawLink?: HDF5Link;
 }

--- a/src/h5web/utils.ts
+++ b/src/h5web/utils.ts
@@ -1,10 +1,5 @@
-import type { Entity, Group } from './providers/models';
-import { isGroup } from './guards';
-
-function findRoot(entity: Entity): Entity {
-  const { parent } = entity;
-  return parent ? findRoot(parent) : entity;
-}
+import type { Entity, Group, Metadata } from './providers/models';
+import { assertAbsolutePath, isGroup } from './guards';
 
 export function getChildEntity(
   group: Group,
@@ -14,25 +9,23 @@ export function getChildEntity(
 }
 
 export function getEntityAtPath(
-  baseGroup: Group,
+  root: Metadata,
   path: string,
   allowSelf = true
 ): Entity | undefined {
-  const isAbsolutePath = path.startsWith('/');
-  const startingGroup = isAbsolutePath ? findRoot(baseGroup) : baseGroup;
+  assertAbsolutePath(path);
 
-  if (path === '/' || path === '') {
-    return allowSelf || startingGroup !== baseGroup ? startingGroup : undefined;
+  if (path === '/') {
+    return allowSelf ? root : undefined;
   }
 
-  const pathSegments = path.slice(isAbsolutePath ? 1 : 0).split('/');
+  const pathSegments = path.slice(1).split('/');
   return pathSegments.reduce<Entity | undefined>(
-    (parentEntity, currSegment) => {
-      return parentEntity && isGroup(parentEntity)
+    (parentEntity, currSegment) =>
+      parentEntity && isGroup(parentEntity)
         ? getChildEntity(parentEntity, currSegment)
-        : undefined;
-    },
-    startingGroup
+        : undefined,
+    root
   );
 }
 

--- a/src/h5web/visualizations/containers/NxImageContainer.tsx
+++ b/src/h5web/visualizations/containers/NxImageContainer.tsx
@@ -1,16 +1,18 @@
-import { ReactElement, useEffect } from 'react';
+import { ReactElement, useContext, useEffect } from 'react';
 import { assertDefined, assertGroup } from '../../guards';
 import { findNxDataGroup } from '../nexus/utils';
 import type { VisContainerProps } from './models';
 import MappedHeatmapVis from '../heatmap/MappedHeatmapVis';
 import { useNxData } from '../nexus/hooks';
 import { useHeatmapConfig } from '../heatmap/config';
+import { ProviderContext } from '../../providers/context';
 
 function NxImageContainer(props: VisContainerProps): ReactElement {
   const { entity } = props;
   assertGroup(entity);
 
-  const nxDataGroup = findNxDataGroup(entity);
+  const { metadata } = useContext(ProviderContext);
+  const nxDataGroup = findNxDataGroup(entity, metadata);
   assertDefined(nxDataGroup, 'Expected to find NXdata group');
 
   const nxData = useNxData(nxDataGroup);

--- a/src/h5web/visualizations/containers/NxSpectrumContainer.tsx
+++ b/src/h5web/visualizations/containers/NxSpectrumContainer.tsx
@@ -1,16 +1,18 @@
-import { ReactElement, useEffect } from 'react';
+import { ReactElement, useContext, useEffect } from 'react';
 import { assertDefined, assertGroup } from '../../guards';
 import MappedLineVis from '../line/MappedLineVis';
 import { findNxDataGroup } from '../nexus/utils';
 import type { VisContainerProps } from './models';
 import { useNxData } from '../nexus/hooks';
 import { useNxSpectrumConfig } from '../nexus/config';
+import { ProviderContext } from '../../providers/context';
 
 function NxSpectrumContainer(props: VisContainerProps): ReactElement {
   const { entity } = props;
   assertGroup(entity);
 
-  const nxDataGroup = findNxDataGroup(entity);
+  const { metadata } = useContext(ProviderContext);
+  const nxDataGroup = findNxDataGroup(entity, metadata);
   assertDefined(nxDataGroup, 'Expected to find NXdata group');
 
   const nxData = useNxData(nxDataGroup);

--- a/src/h5web/visualizations/index.tsx
+++ b/src/h5web/visualizations/index.tsx
@@ -3,7 +3,7 @@ import { FiCode, FiGrid, FiActivity, FiMap, FiCpu } from 'react-icons/fi';
 import type { IconType } from 'react-icons';
 import LineToolbar from '../toolbar/LineToolbar';
 import HeatmapToolbar from '../toolbar/HeatmapToolbar';
-import type { Entity } from '../providers/models';
+import type { Entity, Metadata } from '../providers/models';
 import {
   hasScalarShape,
   hasBaseType,
@@ -46,7 +46,7 @@ interface VisDef {
   Icon: IconType;
   Toolbar?: ElementType<ToolbarProps>;
   Container: ElementType<VisContainerProps>;
-  supportsEntity: (entity: Entity) => boolean;
+  supportsEntity: (entity: Entity, metadata: Metadata) => boolean;
 }
 
 export const VIS_DEFS: Record<Vis, VisDef> = {
@@ -109,12 +109,12 @@ export const VIS_DEFS: Record<Vis, VisDef> = {
     Icon: FiActivity,
     Toolbar: NxSpectrumToolbar,
     Container: NxSpectrumContainer,
-    supportsEntity: (entity) => {
+    supportsEntity: (entity, metadata) => {
       if (!isGroup(entity)) {
         return false;
       }
 
-      const group = findNxDataGroup(entity);
+      const group = findNxDataGroup(entity, metadata);
       if (!group) {
         return false; // group is not NXdata and doesn't have `default` attribute
       }
@@ -133,12 +133,12 @@ export const VIS_DEFS: Record<Vis, VisDef> = {
     Icon: FiMap,
     Toolbar: HeatmapToolbar,
     Container: NxImageContainer,
-    supportsEntity: (entity) => {
+    supportsEntity: (entity, metadata) => {
       if (!isGroup(entity)) {
         return false;
       }
 
-      const group = findNxDataGroup(entity);
+      const group = findNxDataGroup(entity, metadata);
       if (!group) {
         return false; // group is not NXdata and doesn't have `default` attribute
       }

--- a/src/h5web/visualizer/Visualizer.tsx
+++ b/src/h5web/visualizer/Visualizer.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, Suspense, useState } from 'react';
+import { ReactElement, Suspense, useContext, useState } from 'react';
 import type { Entity } from '../providers/models';
 import styles from './Visualizer.module.css';
 import { getSupportedVis } from './utils';
@@ -8,6 +8,7 @@ import Loader from './Loader';
 import Profiler from '../Profiler';
 import ErrorMessage from './ErrorMessage';
 import { ErrorBoundary } from 'react-error-boundary';
+import { ProviderContext } from '../providers/context';
 
 interface Props {
   entity?: Entity;
@@ -16,7 +17,8 @@ interface Props {
 function Visualizer(props: Props): ReactElement {
   const { entity } = props;
 
-  const { supportedVis, error } = getSupportedVis(entity);
+  const { metadata } = useContext(ProviderContext);
+  const { supportedVis, error } = getSupportedVis(entity, metadata);
   const [activeVis, setActiveVis] = useState<Vis>();
 
   // Update `activeVis` state as needed

--- a/src/h5web/visualizer/utils.ts
+++ b/src/h5web/visualizer/utils.ts
@@ -1,4 +1,4 @@
-import type { Entity } from '../providers/models';
+import type { Entity, Metadata } from '../providers/models';
 import { VIS_DEFS, Vis } from '../visualizations';
 
 const REDUNDANT_VIS = new Set([Vis.Raw, Vis.NxSpectrum]);
@@ -12,7 +12,8 @@ function removeRedundantVis(visArr: Vis[]): Vis[] {
 }
 
 export function getSupportedVis(
-  entity: Entity | undefined
+  entity: Entity | undefined,
+  metadata: Metadata
 ): { supportedVis: Vis[]; error?: Error } {
   if (!entity) {
     return { supportedVis: [] };
@@ -22,7 +23,7 @@ export function getSupportedVis(
     const supportedVis = Object.entries(VIS_DEFS).reduce<Vis[]>(
       (arr, visDefEntry) => {
         const [vis, { supportsEntity }] = visDefEntry;
-        return supportsEntity(entity) ? [...arr, vis as Vis] : arr;
+        return supportsEntity(entity, metadata) ? [...arr, vis as Vis] : arr;
       },
       []
     );


### PR DESCRIPTION
Part of #417.

The goal of this PR is to remove `parent` from `Entity`. This key is only used for one thing: to find the root group from any entity, which in turn is used for only one reason: to follow an absolute default path. Moving forward, we won't be able to rely on this feature, so as a first step:

1. I remove the `parent` property from the `Entity` model.
2. I remove the `findRoot` utility.
3. I refactor `getEntityAtPath` to accept only the root group and an absolute path.
4. I refactor `findNxDataGroup` to forward the root group to `getEntityPath` and pass it an absolute default path. If the default path is relative, I simply prefix it with the current group's path (via the `buildAbsolutePath` utility introduced in the previous PR).

So for now, I still retrieve the whole `metadata` tree and pass it all the way down to `getEntityAtPath`, but the next step will be to pass the `entitiesStore` instead. I expect some challenges, notably with our current unit tests, which is why I'm going through this extra step.