### PR TITLE
Get dataset values by path rather than ID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20048,7 +20048,8 @@
     "nanoid": {
       "version": "3.1.20",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
-      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw=="
+      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "d3-scale": "^3.2.3",
     "d3-scale-chromatic": "^2.0.0",
     "lodash-es": "^4.17.20",
-    "nanoid": "^3.1.20",
     "ndarray": "^1.0.19",
     "ndarray-ops": "^1.2.2",
     "ndarray-unpack": "^1.0.0",

--- a/src/h5web/explorer/EntityList.tsx
+++ b/src/h5web/explorer/EntityList.tsx
@@ -26,11 +26,11 @@ function EntityList(props: Props): ReactElement {
   return (
     <ul className={styles.group} role="group">
       {group.children.map((entity) => {
-        const { uid, name } = entity;
+        const { name } = entity;
 
         return (
           <EntityItem
-            key={uid}
+            key={name}
             path={buildEntityPath(parentPath, name)}
             entity={entity}
             level={level}

--- a/src/h5web/explorer/Explorer.test.tsx
+++ b/src/h5web/explorer/Explorer.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, screen } from '@testing-library/react';
-import { mockDomain } from '../providers/mock/data';
+import { mockDomain } from '../providers/mock/metadata';
 import { renderApp } from '../test-utils';
 
 describe('Explorer', () => {

--- a/src/h5web/guards.ts
+++ b/src/h5web/guards.ts
@@ -5,7 +5,6 @@ import {
   Datatype,
   Dataset,
   Link,
-  ResolvedEntity,
 } from './providers/models';
 import {
   HDF5HardLink,
@@ -65,10 +64,6 @@ export function assertOptionalArray<T>(
   if (val !== undefined) {
     assertArray<T>(val);
   }
-}
-
-export function isResolved(entity: Entity): entity is ResolvedEntity {
-  return 'id' in entity;
 }
 
 export function isGroup(entity: Entity): entity is Group {

--- a/src/h5web/metadata-viewer/EntityTable.tsx
+++ b/src/h5web/metadata-viewer/EntityTable.tsx
@@ -1,13 +1,7 @@
 import { ReactElement, useContext } from 'react';
 import type { Entity } from '../providers/models';
 import styles from './MetadataViewer.module.css';
-import {
-  hasSimpleShape,
-  isDataset,
-  isDatatype,
-  isLink,
-  isResolved,
-} from '../guards';
+import { hasSimpleShape, isDataset, isDatatype, isLink } from '../guards';
 import { renderShapeDims } from './utils';
 import RawInspector from './RawInspector';
 import LinkInfo from './LinkInfo';
@@ -33,12 +27,6 @@ function EntityTable(props: Props): ReactElement {
         </tr>
       </thead>
       <tbody>
-        {isResolved(entity) && (
-          <tr>
-            <th scope="row">ID</th>
-            <td>{entity.id}</td>
-          </tr>
-        )}
         <tr>
           <th scope="row">Path</th>
           <td>{path}</td>

--- a/src/h5web/metadata-viewer/MetadataViewer.test.tsx
+++ b/src/h5web/metadata-viewer/MetadataViewer.test.tsx
@@ -17,13 +17,15 @@ describe('MetadataViewer', () => {
     fireEvent.click(inspectBtn);
 
     expect(queryVisSelector()).not.toBeInTheDocument();
-    expect(screen.getByRole('row', { name: /^ID/u })).toBeVisible();
+    expect(screen.getByRole('row', { name: /^Path/u })).toBeVisible();
 
     // Switch back to "display" mode
     fireEvent.click(displayBtn);
 
     expect(await findVisSelector()).toBeVisible();
-    expect(screen.queryByRole('row', { name: /^ID/u })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('row', { name: /^Path/u })
+    ).not.toBeInTheDocument();
   });
 
   test('inspect group', async () => {
@@ -32,12 +34,10 @@ describe('MetadataViewer', () => {
     await selectExplorerNode('entities');
 
     const column = await screen.findByRole('columnheader', { name: /^Group/u });
-    const idRow = screen.getByRole('row', { name: /^ID/u });
     const nameRow = screen.getByRole('row', { name: /^Name/u });
     const pathRow = screen.getByRole('row', { name: /^Path/u });
 
     expect(column).toBeVisible();
-    expect(idRow).toHaveTextContent(/entities/u);
     expect(nameRow).toHaveTextContent(/entities/u);
     expect(pathRow).toHaveTextContent(/\/entities/u);
   });
@@ -50,14 +50,12 @@ describe('MetadataViewer', () => {
     const column = await screen.findByRole('columnheader', {
       name: /Dataset/u,
     });
-    const idRow = screen.getByRole('row', { name: /^ID/u });
     const nameRow = screen.getByRole('row', { name: /^Name/u });
     const pathRow = screen.getByRole('row', { name: /^Path/u });
     const shapeRow = screen.getByRole('row', { name: /^Shape/u });
     const typeRow = screen.getByRole('row', { name: /^Type/u });
 
     expect(column).toBeVisible();
-    expect(idRow).toHaveTextContent(/scalar_int/u);
     expect(nameRow).toHaveTextContent(/scalar_int/u);
     expect(pathRow).toHaveTextContent(/\/entities\/scalar_int/u);
     expect(shapeRow).toHaveTextContent(/H5S_SCALAR/u);
@@ -81,13 +79,11 @@ describe('MetadataViewer', () => {
     const column = await screen.findByRole('columnheader', {
       name: /Datatype/u,
     });
-    const idRow = screen.getByRole('row', { name: /^ID/u });
     const nameRow = screen.getByRole('row', { name: /^Name/u });
     const pathRow = screen.getByRole('row', { name: /^Path/u });
     const typeRow = screen.getByRole('row', { name: /^Type/u });
 
     expect(column).toBeVisible();
-    expect(idRow).toHaveTextContent(/datatype/u);
     expect(nameRow).toHaveTextContent(/datatype/u);
     expect(pathRow).toHaveTextContent(/\/entities\/datatype/u);
     expect(typeRow).toHaveTextContent(/H5T_COMPOUND/u);

--- a/src/h5web/providers/context.ts
+++ b/src/h5web/providers/context.ts
@@ -1,16 +1,16 @@
 import { createContext } from 'react';
 import type { Entity } from './models';
-import type { HDF5Id, HDF5Value } from './hdf5-models';
+import type { HDF5Value } from './hdf5-models';
 import type { FetchStore } from 'react-suspense-fetch';
 
 export abstract class ProviderAPI {
   abstract domain: string;
   abstract getEntity(path: string): Promise<Entity>;
-  abstract getValue(id: HDF5Id): Promise<HDF5Value>;
+  abstract getValue(path: string): Promise<HDF5Value>;
 }
 
 export const ProviderContext = createContext<{
   domain: string;
   entitiesStore: FetchStore<Entity, string>;
-  valuesStore: FetchStore<HDF5Value, HDF5Id>;
+  valuesStore: FetchStore<HDF5Value, string>;
 }>({} as any); // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/src/h5web/providers/hdf5-models.ts
+++ b/src/h5web/providers/hdf5-models.ts
@@ -3,7 +3,6 @@
 
 export type HDF5Id = string;
 export type HDF5Value = unknown;
-export type HDF5Values = Record<HDF5Id, HDF5Value>;
 export type HDF5Dims = number[];
 
 export enum HDF5Collection {

--- a/src/h5web/providers/hsds/api.ts
+++ b/src/h5web/providers/hsds/api.ts
@@ -23,7 +23,6 @@ import {
 import { assertDefined, assertGroup, isHardLink } from '../../guards';
 import type { ProviderAPI } from '../context';
 import { assertHsdsDataset, isHsdsExternalLink, isHsdsGroup } from './utils';
-import { nanoid } from 'nanoid';
 import { buildEntityPath, getChildEntity } from '../../utils';
 
 export class HsdsApi implements ProviderAPI {
@@ -165,7 +164,6 @@ export class HsdsApi implements ProviderAPI {
     );
 
     return {
-      uid: nanoid(),
       id,
       path,
       name,
@@ -189,7 +187,6 @@ export class HsdsApi implements ProviderAPI {
         : [];
 
     return {
-      uid: nanoid(),
       id,
       path,
       name,
@@ -208,7 +205,6 @@ export class HsdsApi implements ProviderAPI {
     const { type } = await this.fetchDatatype(id);
 
     return {
-      uid: nanoid(),
       path,
       name,
       kind: EntityKind.Datatype,
@@ -224,7 +220,6 @@ export class HsdsApi implements ProviderAPI {
   ): Promise<Entity> {
     if (!isHardLink(link)) {
       return {
-        uid: nanoid(),
         name: link.title,
         path,
         kind: EntityKind.Link,

--- a/src/h5web/providers/hsds/models.ts
+++ b/src/h5web/providers/hsds/models.ts
@@ -8,6 +8,7 @@ import type {
   HDF5HardLink,
   HDF5SoftLink,
 } from '../hdf5-models';
+import type { Dataset, Group } from '../models';
 
 export interface HsdsRootResponse {
   root: HDF5Id;
@@ -45,6 +46,14 @@ export type HsdsLink = HDF5HardLink | HDF5SoftLink | HsdsExternalLink;
 
 export interface HsdsExternalLink extends Omit<HDF5ExternalLink, 'file'> {
   h5domain: string;
+}
+
+export interface HsdsGroup extends Group {
+  id: HDF5Id;
+}
+
+export interface HsdsDataset extends Dataset {
+  id: HDF5Id;
 }
 
 export interface HsdsValueResponse {

--- a/src/h5web/providers/hsds/utils.ts
+++ b/src/h5web/providers/hsds/utils.ts
@@ -1,5 +1,28 @@
-import type { HsdsLink, HsdsExternalLink } from './models';
+import { isDataset, isGroup } from '../../guards';
+import type { Entity } from '../models';
+import type {
+  HsdsLink,
+  HsdsExternalLink,
+  HsdsDataset,
+  HsdsGroup,
+} from './models';
 
 export function isHsdsExternalLink(link: HsdsLink): link is HsdsExternalLink {
   return 'h5domain' in link;
+}
+
+export function isHsdsGroup(entity: Entity): entity is HsdsGroup {
+  return isGroup(entity) && 'id' in entity;
+}
+
+export function isHsdsDataset(entity: Entity): entity is HsdsDataset {
+  return isDataset(entity) && 'id' in entity;
+}
+
+export function assertHsdsDataset(
+  entity: Entity
+): asserts entity is HsdsDataset {
+  if (!isHsdsDataset(entity)) {
+    throw new Error('Expected entity to be HSDS dataset');
+  }
 }

--- a/src/h5web/providers/jupyter/api.ts
+++ b/src/h5web/providers/jupyter/api.ts
@@ -13,7 +13,7 @@ import type {
   JupyterMetaResponse,
 } from './models';
 import { nanoid } from 'nanoid';
-import { makeStrAttr, floatType } from '../mock/data-utils';
+import { makeStrAttr, floatType } from '../mock/metadata-utils';
 import {
   HDF5LinkClass,
   HDF5ShapeClass,
@@ -81,7 +81,6 @@ export class JupyterApi implements ProviderAPI {
 
     const baseEntity = {
       uid: nanoid(),
-      id: path,
       name: response.name,
       path,
       attributes,

--- a/src/h5web/providers/jupyter/api.ts
+++ b/src/h5web/providers/jupyter/api.ts
@@ -12,7 +12,6 @@ import type {
   JupyterDataResponse,
   JupyterMetaResponse,
 } from './models';
-import { nanoid } from 'nanoid';
 import { makeStrAttr, floatType } from '../mock/metadata-utils';
 import {
   HDF5LinkClass,
@@ -80,7 +79,6 @@ export class JupyterApi implements ProviderAPI {
     );
 
     const baseEntity = {
-      uid: nanoid(),
       name: response.name,
       path,
       attributes,

--- a/src/h5web/providers/mock/MockProvider.tsx
+++ b/src/h5web/providers/mock/MockProvider.tsx
@@ -1,17 +1,17 @@
 import type { ReactElement, ReactNode } from 'react';
 import Provider from '../Provider';
-import { mockMetadata, mockValues, mockDomain } from './data';
-import { findMockEntity } from './utils';
+import { mockMetadata, mockDomain } from './metadata';
+import { assertMockDataset, findMockEntity } from './utils';
 
 interface Props {
   domain?: string;
   slowOnPath?: string;
-  errorOnId?: string;
+  errorOnPath?: string;
   children: ReactNode;
 }
 
 function MockProvider(props: Props): ReactElement {
-  const { domain = mockDomain, errorOnId, slowOnPath, children } = props;
+  const { domain = mockDomain, errorOnPath, slowOnPath, children } = props;
 
   return (
     <Provider
@@ -26,13 +26,16 @@ function MockProvider(props: Props): ReactElement {
 
           return findMockEntity(mockMetadata, path);
         },
-        getValue: async (id: keyof typeof mockValues) => {
-          if (id === errorOnId) {
+        getValue: async (path: string) => {
+          if (path === errorOnPath) {
             // Throw error when fetching value with specific ID
             throw new Error('error');
           }
 
-          return mockValues[id];
+          const dataset = findMockEntity(mockMetadata, path);
+          assertMockDataset(dataset);
+
+          return dataset.value;
         },
       }}
     >

--- a/src/h5web/providers/mock/metadata-utils.ts
+++ b/src/h5web/providers/mock/metadata-utils.ts
@@ -1,13 +1,5 @@
 import { nanoid } from 'nanoid';
-import {
-  Dataset,
-  Datatype,
-  Entity,
-  EntityKind,
-  Group,
-  Link,
-  ResolvedEntity,
-} from '../models';
+import { Datatype, Entity, EntityKind, Group, Link } from '../models';
 import {
   HDF5Attribute,
   HDF5CompoundType,
@@ -30,6 +22,8 @@ import {
 import type { NxInterpretation, SilxStyle } from '../../vis-packs/nexus/models';
 import { isGroup } from '../../guards';
 import { buildEntityPath } from '../../utils';
+import type { MockDataset, MockValueId } from './models';
+import { mockValues } from './values';
 
 /* -------------------------- */
 /* ----- TYPES & SHAPES ----- */
@@ -95,11 +89,9 @@ export function withAttributes<T extends Entity>(
 /* -------------------- */
 /* ----- ENTITIES ----- */
 
-type EntityOpts = Partial<
-  Pick<ResolvedEntity, 'id' | 'attributes' | 'rawLink'>
->;
-
+type EntityOpts = Partial<Pick<Entity, 'attributes' | 'rawLink'>>;
 type GroupOpts = EntityOpts & { isRoot?: boolean; children?: Entity[] };
+type DatasetOpts = EntityOpts & { valueId?: MockValueId };
 
 function prefixChildrenPaths(group: Group, parentPath: string): void {
   group.children.forEach((c) => {
@@ -116,12 +108,11 @@ export function makeGroup(
   children: Entity[] = [],
   opts: Omit<GroupOpts, 'children'> = {}
 ): Group {
-  const { id = name, attributes = [], rawLink, isRoot = false } = opts;
+  const { attributes = [], rawLink, isRoot = false } = opts;
   const path = isRoot ? '/' : `/${name}`;
 
   const group: Group = {
     uid: nanoid(),
-    id,
     name,
     path,
     kind: EntityKind.Group,
@@ -138,19 +129,19 @@ export function makeDataset<S extends HDF5Shape, T extends HDF5Type>(
   name: string,
   shape: S,
   type: T,
-  opts: EntityOpts = {}
-): Dataset<S, T> {
-  const { id = name, attributes = [], rawLink } = opts;
+  opts: DatasetOpts = {}
+): MockDataset<S, T> {
+  const { attributes = [], valueId = name, rawLink } = opts;
 
   return {
     uid: nanoid(),
-    id,
     name,
     path: `/${name}`,
     kind: EntityKind.Dataset,
     attributes,
     shape,
     type,
+    value: mockValues[valueId as MockValueId],
     rawLink,
   };
 }
@@ -159,8 +150,8 @@ export function makeSimpleDataset<T extends HDF5Type>(
   name: string,
   type: T,
   dims: HDF5Dims,
-  opts: EntityOpts = {}
-): Dataset<HDF5SimpleShape, T> {
+  opts: DatasetOpts = {}
+): MockDataset<HDF5SimpleShape, T> {
   return makeDataset(name, makeSimpleShape(dims), type, opts);
 }
 
@@ -169,11 +160,10 @@ export function makeDatatype<T extends HDF5Type>(
   type: T,
   opts: EntityOpts = {}
 ): Datatype<T> {
-  const { id = name, attributes = [], rawLink } = opts;
+  const { attributes = [], rawLink } = opts;
 
   return {
     uid: nanoid(),
-    id,
     name,
     path: `/${name}`,
     kind: EntityKind.Datatype,
@@ -244,13 +234,13 @@ export function makeNxGroup(
 }
 
 export function makeNxDataGroup<
-  T extends Record<string, Dataset<HDF5SimpleShape, HDF5NumericType>>
+  T extends Record<string, MockDataset<HDF5SimpleShape, HDF5NumericType>>
 >(
   name: string,
   opts: {
-    signal: Dataset<HDF5SimpleShape, HDF5NumericType>;
-    errors?: Dataset<HDF5SimpleShape, HDF5NumericType>;
-    title?: Dataset<HDF5ScalarShape, HDF5StringType>;
+    signal: MockDataset<HDF5SimpleShape, HDF5NumericType>;
+    errors?: MockDataset<HDF5SimpleShape, HDF5NumericType>;
+    title?: MockDataset<HDF5ScalarShape, HDF5StringType>;
     silxStyle?: SilxStyle;
   } & (
     | { axes: T; axesAttr: (Extract<keyof T, string> | '.')[] }
@@ -280,7 +270,7 @@ export function makeNxDataGroup<
       signal,
       ...(title ? [title] : []),
       ...(errors ? [errors] : []),
-      ...Object.values<Dataset>(axes),
+      ...Object.values<MockDataset>(axes),
     ],
   });
 }
@@ -293,14 +283,14 @@ export function makeNxDataset(
     interpretation?: string;
     longName?: string;
     units?: string;
-  } & EntityOpts = {}
-): Dataset<HDF5SimpleShape, HDF5NumericType> {
-  const { interpretation, longName, units } = opts;
+  } & DatasetOpts = {}
+): MockDataset<HDF5SimpleShape, HDF5NumericType> {
+  const { interpretation, longName, units, ...datasetOpts } = opts;
 
   return makeSimpleDataset(name, type, dims, {
-    ...opts,
+    ...datasetOpts,
     attributes: [
-      ...(opts.attributes || []),
+      ...(datasetOpts.attributes || []),
       ...(interpretation
         ? [makeStrAttr('interpretation', interpretation)]
         : []),
@@ -311,7 +301,7 @@ export function makeNxDataset(
 }
 
 export function withNxInterpretation<
-  T extends Dataset<HDF5SimpleShape, HDF5NumericType>
+  T extends MockDataset<HDF5SimpleShape, HDF5NumericType>
 >(dataset: T, interpretation: NxInterpretation): T {
   return withAttributes(dataset, [
     makeStrAttr('interpretation', interpretation),

--- a/src/h5web/providers/mock/metadata-utils.ts
+++ b/src/h5web/providers/mock/metadata-utils.ts
@@ -1,4 +1,3 @@
-import { nanoid } from 'nanoid';
 import { Datatype, Entity, EntityKind, Group, Link } from '../models';
 import {
   HDF5Attribute,
@@ -112,7 +111,6 @@ export function makeGroup(
   const path = isRoot ? '/' : `/${name}`;
 
   const group: Group = {
-    uid: nanoid(),
     name,
     path,
     kind: EntityKind.Group,
@@ -134,7 +132,6 @@ export function makeDataset<S extends HDF5Shape, T extends HDF5Type>(
   const { attributes = [], valueId = name, rawLink } = opts;
 
   return {
-    uid: nanoid(),
     name,
     path: `/${name}`,
     kind: EntityKind.Dataset,
@@ -163,7 +160,6 @@ export function makeDatatype<T extends HDF5Type>(
   const { attributes = [], rawLink } = opts;
 
   return {
-    uid: nanoid(),
     name,
     path: `/${name}`,
     kind: EntityKind.Datatype,
@@ -175,7 +171,6 @@ export function makeDatatype<T extends HDF5Type>(
 
 function makeLink<T extends HDF5Link>(rawLink: T): Link<T> {
   return {
-    uid: nanoid(),
     name: rawLink.title,
     path: `/${rawLink.title}`,
     kind: EntityKind.Link,

--- a/src/h5web/providers/mock/metadata.ts
+++ b/src/h5web/providers/mock/metadata.ts
@@ -1,4 +1,3 @@
-import { range } from 'lodash-es';
 import { ScaleType } from '../../vis-packs/core/models';
 import {
   compoundType,
@@ -16,10 +15,7 @@ import {
   makeNxGroup,
   makeSimpleDataset,
   makeAttr,
-} from './data-utils';
-
-/* -------------------- */
-/* ----- METADATA ----- */
+} from './metadata-utils';
 
 export const mockDomain = 'source.h5';
 
@@ -52,7 +48,7 @@ export const mockMetadata = makeNxGroup(mockDomain, 'NXroot', {
               signal: makeNxDataset('twoD', intType, [20, 41]),
               silxStyle: { signalScaleType: ScaleType.SymLog },
               title: makeDataset('title', scalarShape, stringType, {
-                id: 'title_twoD',
+                valueId: 'title_twoD',
               }),
             }),
             makeNxGroup('absolute_default_path', 'NXentry', {
@@ -66,7 +62,7 @@ export const mockMetadata = makeNxGroup(mockDomain, 'NXroot', {
             units: 'arb. units',
           }),
           errors: makeNxDataset('errors', floatType, [20, 41], {
-            id: 'errors_twoD',
+            valueId: 'errors_twoD',
           }),
           axes: { X: makeNxDataset('X', intType, [41], { units: 'nm' }) },
           axesAttr: ['.', 'X'],
@@ -117,44 +113,3 @@ export const mockMetadata = makeNxGroup(mockDomain, 'NXroot', {
     ]),
   ],
 });
-
-/* ------------------ */
-/* ----- VALUES ----- */
-
-const arr1 = range(-20, 21);
-const arr2 = range(0, 100, 5);
-const arr3 = range(-1, 1.25, 0.25);
-const arr4 = range(10, 40, 10);
-
-const oneD = arr1.map((val) => val ** 2);
-const twoD = arr2.map((offset) => oneD.map((val) => val - offset));
-const threeD = arr3.map((multiplier) =>
-  twoD.map((arrOneD) => arrOneD.map((val) => val * multiplier))
-);
-const fourD = arr4.map((divider) =>
-  threeD.map((arrTwoD) =>
-    arrTwoD.map((arrOneD) => arrOneD.map((val) => Math.sin(val / divider)))
-  )
-);
-
-export const mockValues = {
-  null: null,
-  raw: { int: 42 },
-  raw_large: { str: '.'.repeat(1000) },
-  scalar_int: 0,
-  scalar_str: 'foo',
-  oneD_linear: arr1,
-  oneD,
-  twoD,
-  twoD_spectrum: twoD,
-  threeD,
-  fourD,
-  X: arr1,
-  Y: arr2,
-  X_log: arr1.map((_, i) => (i + 1) * 0.1),
-  title_twoD: 'NeXus 2D',
-  oneD_str: ['foo', 'bar'],
-  errors_twoD: arr2.map((offset) => arr1.map((val) => Math.abs(val - offset))),
-  fourD_image: fourD,
-  oneD_errors: oneD.map((x) => Math.abs(x) / 10),
-};

--- a/src/h5web/providers/mock/models.ts
+++ b/src/h5web/providers/mock/models.ts
@@ -1,0 +1,12 @@
+import type { HDF5Shape, HDF5Type, HDF5Value } from '../hdf5-models';
+import type { Dataset } from '../models';
+import type { mockValues } from './values';
+
+export interface MockDataset<
+  S extends HDF5Shape = HDF5Shape,
+  T extends HDF5Type = HDF5Type
+> extends Dataset<S, T> {
+  value: HDF5Value;
+}
+
+export type MockValueId = keyof typeof mockValues;

--- a/src/h5web/providers/mock/utils.test.ts
+++ b/src/h5web/providers/mock/utils.test.ts
@@ -1,4 +1,4 @@
-import { intType, makeDataset, makeGroup, scalarShape } from './data-utils';
+import { intType, makeDataset, makeGroup, scalarShape } from './metadata-utils';
 import { findMockEntity } from './utils';
 
 describe('MockProvider utilities', () => {

--- a/src/h5web/providers/mock/utils.ts
+++ b/src/h5web/providers/mock/utils.ts
@@ -2,15 +2,28 @@ import ndarray from 'ndarray';
 import {
   assertAbsolutePath,
   assertArray,
-  assertDataset,
   assertDefined,
   assertNumericType,
   assertSimpleShape,
+  isDataset,
   isGroup,
 } from '../../guards';
 import { getChildEntity } from '../../utils';
 import type { Entity, Metadata } from '../models';
-import { mockMetadata, mockValues } from './data';
+import { mockMetadata } from './metadata';
+import type { MockDataset } from './models';
+
+function isMockDataset(entity: Entity): entity is MockDataset {
+  return isDataset(entity) && 'value' in entity;
+}
+
+export function assertMockDataset(
+  entity: Entity
+): asserts entity is MockDataset {
+  if (!isMockDataset(entity)) {
+    throw new Error('Expected mock dataset');
+  }
+}
 
 export function findMockEntity(root: Metadata, path: string): Entity {
   assertAbsolutePath(path);
@@ -34,15 +47,14 @@ export function findMockEntity(root: Metadata, path: string): Entity {
 }
 
 export function getMockDataArray(path: string): ndarray {
-  assertAbsolutePath(path);
-
   const dataset = findMockEntity(mockMetadata, path);
-  assertDataset(dataset);
+  assertMockDataset(dataset);
+
+  const { value } = dataset;
+  assertArray<number>(value);
+
   assertNumericType(dataset);
   assertSimpleShape(dataset);
-
-  const value = mockValues[dataset.id as keyof typeof mockValues];
-  assertArray<number>(value);
 
   return ndarray(value.flat(Infinity), dataset.shape.dims);
 }

--- a/src/h5web/providers/mock/values.ts
+++ b/src/h5web/providers/mock/values.ts
@@ -1,0 +1,39 @@
+import { range } from 'lodash-es';
+
+const arr1 = range(-20, 21);
+const arr2 = range(0, 100, 5);
+const arr3 = range(-1, 1.25, 0.25);
+const arr4 = range(10, 40, 10);
+
+const oneD = arr1.map((val) => val ** 2);
+const twoD = arr2.map((offset) => oneD.map((val) => val - offset));
+const threeD = arr3.map((multiplier) =>
+  twoD.map((arrOneD) => arrOneD.map((val) => val * multiplier))
+);
+const fourD = arr4.map((divider) =>
+  threeD.map((arrTwoD) =>
+    arrTwoD.map((arrOneD) => arrOneD.map((val) => Math.sin(val / divider)))
+  )
+);
+
+export const mockValues = {
+  null: null,
+  raw: { int: 42 },
+  raw_large: { str: '.'.repeat(1000) },
+  scalar_int: 0,
+  scalar_str: 'foo',
+  oneD_linear: arr1,
+  oneD,
+  twoD,
+  twoD_spectrum: twoD,
+  threeD,
+  fourD,
+  X: arr1,
+  Y: arr2,
+  X_log: arr1.map((_, i) => (i + 1) * 0.1),
+  title_twoD: 'NeXus 2D',
+  oneD_str: ['foo', 'bar'],
+  errors_twoD: arr2.map((offset) => arr1.map((val) => Math.abs(val - offset))),
+  fourD_image: fourD,
+  oneD_errors: oneD.map((x) => Math.abs(x) / 10),
+};

--- a/src/h5web/providers/models.ts
+++ b/src/h5web/providers/models.ts
@@ -1,6 +1,5 @@
 import type {
   HDF5Attribute,
-  HDF5Id,
   HDF5Link,
   HDF5Shape,
   HDF5Type,
@@ -22,11 +21,7 @@ export interface Entity {
   rawLink?: HDF5Link;
 }
 
-export interface ResolvedEntity extends Entity {
-  id: HDF5Id;
-}
-
-export interface Group extends ResolvedEntity {
+export interface Group extends Entity {
   kind: EntityKind.Group;
   children: Entity[];
 }
@@ -34,13 +29,13 @@ export interface Group extends ResolvedEntity {
 export interface Dataset<
   S extends HDF5Shape = HDF5Shape,
   T extends HDF5Type = HDF5Type
-> extends ResolvedEntity {
+> extends Entity {
   kind: EntityKind.Dataset;
   shape: S;
   type: T;
 }
 
-export interface Datatype<T = HDF5Type> extends ResolvedEntity {
+export interface Datatype<T = HDF5Type> extends Entity {
   kind: EntityKind.Datatype;
   type: T;
 }

--- a/src/h5web/providers/models.ts
+++ b/src/h5web/providers/models.ts
@@ -13,7 +13,6 @@ export enum EntityKind {
 }
 
 export interface Entity {
-  uid: string;
   name: string;
   path: string;
   kind: EntityKind;

--- a/src/h5web/utils.test.ts
+++ b/src/h5web/utils.test.ts
@@ -3,7 +3,7 @@ import {
   scalarShape,
   makeDataset,
   makeGroup,
-} from './providers/mock/data-utils';
+} from './providers/mock/metadata-utils';
 import { buildEntityPath, getChildEntity } from './utils';
 
 describe('Global utilities', () => {

--- a/src/h5web/vis-packs/core/CorePack.test.tsx
+++ b/src/h5web/vis-packs/core/CorePack.test.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react';
-import { mockValues } from '../../../packages/lib';
+import { mockValues } from '../../providers/mock/values';
 import {
   findVisSelectorTabs,
   mockConsoleMethod,

--- a/src/h5web/vis-packs/core/containers/HeatmapVisContainer.tsx
+++ b/src/h5web/vis-packs/core/containers/HeatmapVisContainer.tsx
@@ -14,13 +14,15 @@ function HeatmapVisContainer(props: VisContainerProps): ReactElement {
   assertSimpleShape(entity);
   assertNumericType(entity);
 
-  const { dims } = entity.shape;
+  const { name, path, shape } = entity;
+  const { dims } = shape;
+
   if (dims.length < 2) {
     throw new Error('Expected dataset with at least two dimensions');
   }
 
-  const value = useDatasetValue(entity.id);
-  return <MappedHeatmapVis value={value} dims={dims} title={entity.name} />;
+  const value = useDatasetValue(path);
+  return <MappedHeatmapVis value={value} dims={dims} title={name} />;
 }
 
 export default HeatmapVisContainer;

--- a/src/h5web/vis-packs/core/containers/LineVisContainer.tsx
+++ b/src/h5web/vis-packs/core/containers/LineVisContainer.tsx
@@ -14,11 +14,10 @@ function LineVisContainer(props: VisContainerProps): ReactElement {
   assertSimpleShape(entity);
   assertNumericType(entity);
 
-  const value = useDatasetValue(entity.id);
+  const { name, path, shape } = entity;
+  const value = useDatasetValue(path);
 
-  return (
-    <MappedLineVis value={value} dims={entity.shape.dims} title={entity.name} />
-  );
+  return <MappedLineVis value={value} dims={shape.dims} title={name} />;
 }
 
 export default LineVisContainer;

--- a/src/h5web/vis-packs/core/containers/MatrixVisContainer.tsx
+++ b/src/h5web/vis-packs/core/containers/MatrixVisContainer.tsx
@@ -9,8 +9,10 @@ function MatrixVisContainer(props: VisContainerProps): ReactElement {
   assertDataset(entity);
   assertSimpleShape(entity);
 
-  const value = useDatasetValue(entity.id);
-  return <MappedMatrixVis value={value} dims={entity.shape.dims} />;
+  const { path, shape } = entity;
+  const value = useDatasetValue(path);
+
+  return <MappedMatrixVis value={value} dims={shape.dims} />;
 }
 
 export default MatrixVisContainer;

--- a/src/h5web/vis-packs/core/containers/RawVisContainer.tsx
+++ b/src/h5web/vis-packs/core/containers/RawVisContainer.tsx
@@ -8,7 +8,7 @@ function RawVisContainer(props: VisContainerProps): ReactElement {
   const { entity } = props;
   assertDataset(entity);
 
-  const value = useDatasetValue(entity.id);
+  const value = useDatasetValue(entity.path);
   return <RawVis value={value} />;
 }
 

--- a/src/h5web/vis-packs/core/containers/ScalarVisContainer.tsx
+++ b/src/h5web/vis-packs/core/containers/ScalarVisContainer.tsx
@@ -8,7 +8,7 @@ function ScalarVisContainer(props: VisContainerProps): ReactElement {
   const { entity } = props;
   assertDataset(entity);
 
-  const value = useDatasetValue(entity.id);
+  const value = useDatasetValue(entity.path);
   return <ScalarVis value={value} />;
 }
 

--- a/src/h5web/vis-packs/core/hooks.ts
+++ b/src/h5web/vis-packs/core/hooks.ts
@@ -8,13 +8,13 @@ import type { DimensionMapping } from '../../dimension-mapper/models';
 import { getCanvasScale, getDomain } from './utils';
 import AxisSystemContext from './shared/AxisSystemContext';
 import type { AxisScale } from './models';
-import type { HDF5Id, HDF5Value } from '../../providers/hdf5-models';
+import type { HDF5Value } from '../../providers/hdf5-models';
 import { ProviderContext } from '../../providers/context';
 import type { Dataset } from '../../providers/models';
 
-export function useDatasetValue(id: HDF5Id): HDF5Value {
+export function useDatasetValue(path: string): HDF5Value {
   const { valuesStore } = useContext(ProviderContext);
-  return valuesStore.get(id);
+  return valuesStore.get(path);
 }
 
 export function useDatasetValues(
@@ -23,11 +23,11 @@ export function useDatasetValues(
   const { valuesStore } = useContext(ProviderContext);
 
   // Start fetching values (but only those that are not already fetched or being fetched)
-  datasets.forEach(({ id }) => valuesStore.prefetch(id));
+  datasets.forEach(({ path }) => valuesStore.prefetch(path));
 
   // Read values from store (but suspend if at least one of the values is still being fetched)
   return Object.fromEntries(
-    datasets.map(({ id, name }) => [name, valuesStore.get(id)])
+    datasets.map(({ name, path }) => [name, valuesStore.get(path)])
   );
 }
 

--- a/src/h5web/vis-packs/core/pack-utils.test.ts
+++ b/src/h5web/vis-packs/core/pack-utils.test.ts
@@ -6,7 +6,7 @@ import {
   makeDataset,
   makeGroup,
   makeSimpleDataset,
-} from '../../providers/mock/data-utils';
+} from '../../providers/mock/metadata-utils';
 import { CORE_VIS } from './visualizations';
 
 describe('Core pack utilities', () => {

--- a/src/h5web/vis-packs/core/visualizations.test.ts
+++ b/src/h5web/vis-packs/core/visualizations.test.ts
@@ -8,7 +8,7 @@ import {
   makeSimpleShape,
   makeDataset,
   makeSimpleDataset,
-} from '../../providers/mock/data-utils';
+} from '../../providers/mock/metadata-utils';
 
 const datasetIntScalar = makeDataset('dataset_int', scalarShape, intType);
 const datasetFltScalar = makeDataset('dataset_flt', scalarShape, floatType);

--- a/src/h5web/vis-packs/nexus/pack-utils.test.ts
+++ b/src/h5web/vis-packs/nexus/pack-utils.test.ts
@@ -1,6 +1,7 @@
 import { getSupportedVis } from './pack-utils';
 import {
   intType,
+  floatType,
   makeStrAttr,
   makeGroup,
   makeNxDataGroup,
@@ -8,13 +9,13 @@ import {
   withNxInterpretation,
   makeNxGroup,
   withAttributes,
-} from '../../providers/mock/data-utils';
+} from '../../providers/mock/metadata-utils';
 import { NEXUS_VIS } from './visualizations';
 import { NxInterpretation } from './models';
 
 const datasetInt1D = makeSimpleDataset('dataset_int_1d', intType, [5]);
 const datasetInt2D = makeSimpleDataset('dataset_int_2d', intType, [5, 3]);
-const datasetFlt3D = makeSimpleDataset('dataset_flt_3d', intType, [5, 3, 1]);
+const datasetFlt3D = makeSimpleDataset('dataset_flt_3d', floatType, [5, 3, 1]);
 
 describe('Nexus pack utilities', () => {
   describe('getSupportedVis', () => {

--- a/src/h5web/vis-packs/nexus/utils.test.ts
+++ b/src/h5web/vis-packs/nexus/utils.test.ts
@@ -10,7 +10,7 @@ import {
   makeNxAxesAttr,
   makeIntAttr,
   makeSilxStyleAttr,
-} from '../../providers/mock/data-utils';
+} from '../../providers/mock/metadata-utils';
 import { mockConsoleMethod } from '../../test-utils';
 import { ScaleType } from '../core/models';
 import {

--- a/src/h5web/visualizer/Visualizer.test.tsx
+++ b/src/h5web/visualizer/Visualizer.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import App from '../App';
 import MockProvider from '../providers/mock/MockProvider';
-import { mockValues } from '../providers/mock/data';
+import { mockValues } from '../providers/mock/values';
 import {
   mockConsoleMethod,
   queryVisSelector,
@@ -38,7 +38,7 @@ describe('Visualizer', () => {
 
   test("show error when dataset value can't be fetched and reset when selecting another dataset", async () => {
     render(
-      <MockProvider errorOnId="raw">
+      <MockProvider errorOnPath="/entities/raw">
         <App />
       </MockProvider>
     );

--- a/src/h5web/visualizer/Visualizer.tsx
+++ b/src/h5web/visualizer/Visualizer.tsx
@@ -37,12 +37,12 @@ function Visualizer<T extends VisDef>(props: Props<T>): ReactElement {
 
       <div className={styles.displayArea}>
         <ErrorBoundary
-          resetKeys={[entity.uid]}
+          resetKeys={[entity.path]}
           FallbackComponent={ErrorMessage}
         >
           <Suspense fallback={<ValueLoader />}>
             <Profiler id={activeVis.name}>
-              <Container key={entity.uid} entity={entity} />
+              <Container key={entity.path} entity={entity} />
             </Profiler>
           </Suspense>
         </ErrorBoundary>

--- a/src/packages/lib.ts
+++ b/src/packages/lib.ts
@@ -43,7 +43,8 @@ export type {
 } from '../h5web/vis-packs/core/heatmap/models';
 
 // Mock data
-export { mockMetadata, mockValues } from '../h5web/providers/mock/data';
+export { mockMetadata } from '../h5web/providers/mock/metadata';
+export { mockValues } from '../h5web/providers/mock/values';
 
 export {
   findMockEntity,


### PR DESCRIPTION
The signature is now `getValue(path: string): HDF5Value`. This allows us to remove `id` from the `Entity` model. Since this ID is still needed by HSDS, I had to compensate by creating a couple of models specific to HSDS.