### PR TITLE
Refactor `useNxData` so datasets values are fetched separately

### DIFF
--- a/src/h5web/guards.ts
+++ b/src/h5web/guards.ts
@@ -18,13 +18,18 @@ import {
   HDF5TypeClass,
   HDF5ScalarShape,
   HDF5NumericType,
+  HDF5StringType,
 } from './providers/hdf5-models';
+
+export function isDefined<T>(val: T): val is NonNullable<T> {
+  return val !== undefined;
+}
 
 export function assertDefined<T>(
   val: T,
   message = 'Expected some value'
 ): asserts val is NonNullable<T> {
-  if (val === undefined) {
+  if (!isDefined(val)) {
     throw new TypeError(message);
   }
 }
@@ -109,6 +114,15 @@ export function hasBaseType<S extends HDF5Shape>(
   );
 }
 
+export function hasStringType<S extends HDF5Shape>(
+  dataset: Dataset<S>
+): dataset is Dataset<S, HDF5StringType> {
+  return (
+    typeof dataset.type !== 'string' &&
+    dataset.type.class === HDF5TypeClass.String
+  );
+}
+
 export function hasNumericType<S extends HDF5Shape>(
   dataset: Dataset<S>
 ): dataset is Dataset<S, HDF5NumericType> {
@@ -140,11 +154,11 @@ export function assertGroup(
   }
 }
 
-export function assertNumericType<S extends HDF5Shape>(
-  dataset: Dataset<S>
-): asserts dataset is Dataset<S, HDF5NumericType> {
-  if (!hasNumericType(dataset)) {
-    throw new Error('Expected dataset to have numeric type');
+export function assertScalarShape<T extends HDF5Type>(
+  dataset: Dataset<HDF5Shape, T>
+): asserts dataset is Dataset<HDF5ScalarShape, T> {
+  if (!hasScalarShape(dataset)) {
+    throw new Error('Expected dataset to have scalar shape');
   }
 }
 
@@ -157,6 +171,22 @@ export function assertSimpleShape<T extends HDF5Type>(
 
   if (dataset.shape.dims.length === 0) {
     throw new Error('Expected dataset with simple shape to have dimensions');
+  }
+}
+
+export function assertStringType<S extends HDF5Shape>(
+  dataset: Dataset<S>
+): asserts dataset is Dataset<S, HDF5StringType> {
+  if (!hasStringType(dataset)) {
+    throw new Error('Expected dataset to have string type');
+  }
+}
+
+export function assertNumericType<S extends HDF5Shape>(
+  dataset: Dataset<S>
+): asserts dataset is Dataset<S, HDF5NumericType> {
+  if (!hasNumericType(dataset)) {
+    throw new Error('Expected dataset to have numeric type');
   }
 }
 

--- a/src/h5web/vis-packs/core/hooks.ts
+++ b/src/h5web/vis-packs/core/hooks.ts
@@ -12,9 +12,11 @@ import type { HDF5Value } from '../../providers/hdf5-models';
 import { ProviderContext } from '../../providers/context';
 import type { Dataset } from '../../providers/models';
 
-export function useDatasetValue(path: string): HDF5Value {
+export function useDatasetValue(
+  path: string | undefined
+): HDF5Value | undefined {
   const { valuesStore } = useContext(ProviderContext);
-  return valuesStore.get(path);
+  return path !== undefined ? valuesStore.get(path) : undefined;
 }
 
 export function useDatasetValues(
@@ -22,10 +24,6 @@ export function useDatasetValues(
 ): Record<string, HDF5Value> {
   const { valuesStore } = useContext(ProviderContext);
 
-  // Start fetching values (but only those that are not already fetched or being fetched)
-  datasets.forEach(({ path }) => valuesStore.prefetch(path));
-
-  // Read values from store (but suspend if at least one of the values is still being fetched)
   return Object.fromEntries(
     datasets.map(({ name, path }) => [name, valuesStore.get(path)])
   );

--- a/src/h5web/vis-packs/nexus/containers/NxSpectrumContainer.tsx
+++ b/src/h5web/vis-packs/nexus/containers/NxSpectrumContainer.tsx
@@ -1,36 +1,60 @@
 import { ReactElement, useEffect } from 'react';
-import { assertGroup } from '../../../guards';
+import { isEqual } from 'lodash-es';
+import { assertArray, assertGroup, assertOptionalStr } from '../../../guards';
+import { useDatasetValue } from '../../core/hooks';
 import MappedLineVis from '../../core/line/MappedLineVis';
 import type { VisContainerProps } from '../../models';
-import { useNxData } from '../hooks';
+import { useAxisMapping, useNxData } from '../hooks';
 import { useNxSpectrumConfig } from '../spectrum/config';
+import { getDatasetLabel } from '../utils';
 
 function NxSpectrumContainer(props: VisContainerProps): ReactElement {
   const { entity } = props;
   assertGroup(entity);
 
   const nxData = useNxData(entity);
-  const { signal, title, errors, axisMapping } = nxData;
+  const {
+    signalDataset,
+    titleDataset,
+    errorsDataset,
+    axisDatasetMapping,
+    silxStyle,
+  } = nxData;
+
+  const signalLabel = getDatasetLabel(signalDataset);
+  const { axesScaleType, signalScaleType } = silxStyle;
+  const signalDims = signalDataset.shape.dims;
+  const errorsDims = errorsDataset?.shape.dims;
+
+  if (errorsDims && !isEqual(signalDims, errorsDims)) {
+    const dimsStr = JSON.stringify({ signalDims, errorsDims });
+    throw new Error(`Signal and errors dimensions don't match: ${dimsStr}`);
+  }
+
+  const value = useDatasetValue(signalDataset.path);
+  assertArray<number>(value);
+
+  const errors = useDatasetValue(errorsDataset?.path);
+  assertArray<number>(errors);
+
+  const title = useDatasetValue(titleDataset?.path);
+  assertOptionalStr(title);
+
+  const axisMapping = useAxisMapping(axisDatasetMapping, axesScaleType);
 
   const { showErrors, disableErrors } = useNxSpectrumConfig();
   useEffect(() => {
     disableErrors(!errors);
   }, [disableErrors, errors]);
 
-  if (errors && signal.value.length !== errors.length) {
-    throw new Error(
-      `Error dataset has size ${errors.length} which is different from signal dataset size ${signal.value.length}`
-    );
-  }
-
   return (
     <MappedLineVis
-      value={signal.value}
-      valueLabel={signal.label}
-      valueScaleType={signal.scaleType}
+      value={value}
+      valueLabel={signalLabel}
+      valueScaleType={signalScaleType}
       axisMapping={axisMapping}
-      dims={nxData.signal.dims}
-      title={title || signal.label}
+      dims={signalDims}
+      title={title || signalLabel}
       errors={errors}
       showErrors={showErrors}
     />

--- a/src/h5web/vis-packs/nexus/models.ts
+++ b/src/h5web/vis-packs/nexus/models.ts
@@ -1,4 +1,11 @@
-import type { AxisMapping, ScaleType, AxisParams } from '../core/models';
+import type {
+  HDF5NumericType,
+  HDF5ScalarShape,
+  HDF5SimpleShape,
+  HDF5StringType,
+} from '../../providers/hdf5-models';
+import type { Dataset } from '../../providers/models';
+import type { ScaleType } from '../core/models';
 
 export type NxAttribute =
   | 'NX_class'
@@ -15,17 +22,18 @@ export enum NxInterpretation {
   Image = 'image',
 }
 
-interface SignalParams extends AxisParams {
-  dims: number[];
-  value: number[];
+export interface NxData {
+  signalDataset: Dataset<HDF5SimpleShape, HDF5NumericType>;
+  errorsDataset?: Dataset<HDF5SimpleShape, HDF5NumericType>;
+  titleDataset?: Dataset<HDF5ScalarShape, HDF5StringType>;
+  axisDatasetMapping: AxisDatasetMapping;
+  silxStyle: SilxStyle;
 }
 
-export interface NxData {
-  signal: SignalParams;
-  errors?: number[];
-  title?: string;
-  axisMapping: AxisMapping;
-}
+export type AxisDatasetMapping = (
+  | Dataset<HDF5SimpleShape, HDF5NumericType>
+  | undefined
+)[];
 
 export interface SilxStyle {
   signalScaleType?: ScaleType;

--- a/src/h5web/vis-packs/nexus/utils.test.ts
+++ b/src/h5web/vis-packs/nexus/utils.test.ts
@@ -7,7 +7,6 @@ import {
   makeStrAttr,
   scalarShape,
   stringType,
-  makeNxAxesAttr,
   makeIntAttr,
   makeSilxStyleAttr,
 } from '../../providers/mock/metadata-utils';
@@ -17,7 +16,6 @@ import {
   findSignalDataset,
   getAttributeValue,
   getDatasetLabel,
-  getNxAxes,
   getSilxStyle,
 } from './utils';
 
@@ -104,34 +102,6 @@ describe('NeXus utilities', () => {
       });
 
       expect(() => findSignalDataset(group)).toThrow(/to have numeric type/u);
-    });
-  });
-
-  describe('getNxAxes', () => {
-    it('should return array of axes', () => {
-      const axesAttr = makeNxAxesAttr(['X', 'Y']);
-      const group = makeGroup('foo', [], { attributes: [axesAttr] });
-
-      expect(getNxAxes(group)).toEqual(['X', 'Y']);
-    });
-
-    it('should wrap single axis string in array', () => {
-      const axesAttr = makeStrAttr('axes', 'X');
-      const group = makeGroup('foo', [], { attributes: [axesAttr] });
-
-      expect(getNxAxes(group)).toEqual(['X']);
-    });
-
-    it('should return empty array if group has no `axes` attribute', () => {
-      const group = makeGroup('foo');
-      expect(getNxAxes(group)).toEqual([]);
-    });
-
-    it('should throw if `axes` value is neither string nor array', () => {
-      const axesAttr = makeIntAttr('axes', 42);
-      const group = makeGroup('foo', [], { attributes: [axesAttr] });
-
-      expect(() => getNxAxes(group)).toThrow(/array/u);
     });
   });
 

--- a/src/h5web/vis-packs/nexus/utils.ts
+++ b/src/h5web/vis-packs/nexus/utils.ts
@@ -5,7 +5,6 @@ import type {
   HDF5SimpleShape,
 } from '../../providers/hdf5-models';
 import {
-  assertArray,
   assertDefined,
   assertStr,
   assertDataset,
@@ -47,18 +46,6 @@ export function findSignalDataset(
   assertNumericType(dataset);
 
   return dataset;
-}
-
-export function getNxAxes(group: Group): string[] {
-  const axisList = getAttributeValue(group, 'axes');
-  if (!axisList) {
-    return [];
-  }
-
-  const axisNames = typeof axisList === 'string' ? [axisList] : axisList;
-  assertArray<string>(axisNames);
-
-  return axisNames;
 }
 
 export function getDatasetLabel(dataset: Dataset): string {


### PR DESCRIPTION
In `useNxData`, we fetch the values of all of the children of the NXdata group at once and return an object that contains various information about the signal, errors and axes, as well their respective values. This approach is convenient but prevents us from doing more precise fetching of values based on the dimension mapping state for the `Heatmap` and `NxImage` visualizations.

As a first step, I refactor `useNxData` so that it returns the metadata objects of all the relevant datasets without their values. The values are now fetched in the vis containers. This will evolve a bit in the next PR, since we'll need to fetch values based on the dimension mapping state, which is currently managed in the mapped visualizations.