### PR TITLE
Move dimension mappers up into containers

### DIFF
--- a/src/h5web/vis-packs/core/containers/HeatmapVisContainer.tsx
+++ b/src/h5web/vis-packs/core/containers/HeatmapVisContainer.tsx
@@ -7,6 +7,8 @@ import {
 } from '../../../guards';
 import MappedHeatmapVis from '../heatmap/MappedHeatmapVis';
 import type { VisContainerProps } from '../../models';
+import { useDimMappingState } from '../../hooks';
+import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 
 function HeatmapVisContainer(props: VisContainerProps): ReactElement {
   const { entity } = props;
@@ -21,8 +23,25 @@ function HeatmapVisContainer(props: VisContainerProps): ReactElement {
     throw new Error('Expected dataset with at least two dimensions');
   }
 
+  const [dimMapping, setDimMapping] = useDimMappingState(dims, 2);
+
   const value = useDatasetValue(path);
-  return <MappedHeatmapVis value={value} dims={dims} title={name} />;
+
+  return (
+    <>
+      <DimensionMapper
+        rawDims={dims}
+        mapperState={dimMapping}
+        onChange={setDimMapping}
+      />
+      <MappedHeatmapVis
+        value={value}
+        dims={dims}
+        dimMapping={dimMapping}
+        title={name}
+      />
+    </>
+  );
 }
 
 export default HeatmapVisContainer;

--- a/src/h5web/vis-packs/core/containers/LineVisContainer.tsx
+++ b/src/h5web/vis-packs/core/containers/LineVisContainer.tsx
@@ -7,6 +7,8 @@ import {
 } from '../../../guards';
 import MappedLineVis from '../line/MappedLineVis';
 import type { VisContainerProps } from '../../models';
+import { useDimMappingState } from '../../hooks';
+import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 
 function LineVisContainer(props: VisContainerProps): ReactElement {
   const { entity } = props;
@@ -15,9 +17,27 @@ function LineVisContainer(props: VisContainerProps): ReactElement {
   assertNumericType(entity);
 
   const { name, path, shape } = entity;
+  const { dims } = shape;
+
+  const [dimMapping, setDimMapping] = useDimMappingState(dims, 1);
+
   const value = useDatasetValue(path);
 
-  return <MappedLineVis value={value} dims={shape.dims} title={name} />;
+  return (
+    <>
+      <DimensionMapper
+        rawDims={dims}
+        mapperState={dimMapping}
+        onChange={setDimMapping}
+      />
+      <MappedLineVis
+        value={value}
+        dims={dims}
+        dimMapping={dimMapping}
+        title={name}
+      />
+    </>
+  );
 }
 
 export default LineVisContainer;

--- a/src/h5web/vis-packs/core/containers/MatrixVisContainer.tsx
+++ b/src/h5web/vis-packs/core/containers/MatrixVisContainer.tsx
@@ -3,6 +3,8 @@ import { useDatasetValue } from '../hooks';
 import { assertDataset, assertSimpleShape } from '../../../guards';
 import MappedMatrixVis from '../matrix/MappedMatrixVis';
 import type { VisContainerProps } from '../../models';
+import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
+import { useDimMappingState } from '../../hooks';
 
 function MatrixVisContainer(props: VisContainerProps): ReactElement {
   const { entity } = props;
@@ -10,9 +12,23 @@ function MatrixVisContainer(props: VisContainerProps): ReactElement {
   assertSimpleShape(entity);
 
   const { path, shape } = entity;
+  const { dims } = shape;
+
+  const axesCount = Math.min(dims.length, 2);
+  const [dimMapping, setDimMapping] = useDimMappingState(dims, axesCount);
+
   const value = useDatasetValue(path);
 
-  return <MappedMatrixVis value={value} dims={shape.dims} />;
+  return (
+    <>
+      <DimensionMapper
+        rawDims={dims}
+        mapperState={dimMapping}
+        onChange={setDimMapping}
+      />
+      <MappedMatrixVis value={value} dims={dims} dimMapping={dimMapping} />
+    </>
+  );
 }
 
 export default MatrixVisContainer;

--- a/src/h5web/vis-packs/core/heatmap/MappedHeatmapVis.tsx
+++ b/src/h5web/vis-packs/core/heatmap/MappedHeatmapVis.tsx
@@ -5,19 +5,19 @@ import { assertArray } from '../../../guards';
 import { useBaseArray, useMappedArray } from '../hooks';
 import { useHeatmapConfig } from './config';
 import type { AxisMapping } from '../models';
-import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { getDomain } from '../utils';
-import { useDimMappingState } from '../../hooks';
+import type { DimensionMapping } from '../../../dimension-mapper/models';
 
 interface Props {
   value: HDF5Value;
   dims: number[];
-  title?: string;
+  dimMapping: DimensionMapping;
   axisMapping?: AxisMapping;
+  title?: string;
 }
 
 function MappedHeatmapVis(props: Props): ReactElement {
-  const { value, axisMapping = [], title, dims } = props;
+  const { value, dims, dimMapping, axisMapping = [], title } = props;
   assertArray<number>(value);
 
   const {
@@ -28,8 +28,6 @@ function MappedHeatmapVis(props: Props): ReactElement {
     showGrid,
     setDataDomain,
   } = useHeatmapConfig();
-
-  const [dimMapping, setDimMapping] = useDimMappingState(dims, 2);
 
   const baseArray = useBaseArray(value, dims);
   const dataArray = useMappedArray(baseArray, dimMapping);
@@ -46,24 +44,17 @@ function MappedHeatmapVis(props: Props): ReactElement {
   }, [customDomain, domain, setDataDomain]);
 
   return (
-    <>
-      <DimensionMapper
-        rawDims={dims}
-        mapperState={dimMapping}
-        onChange={setDimMapping}
-      />
-      <HeatmapVis
-        dataArray={dataArray}
-        title={title}
-        domain={domain}
-        colorMap={colorMap}
-        scaleType={scaleType}
-        keepAspectRatio={keepAspectRatio}
-        showGrid={showGrid}
-        abscissaParams={axisMapping[dimMapping.indexOf('x')]}
-        ordinateParams={axisMapping[dimMapping.indexOf('y')]}
-      />
-    </>
+    <HeatmapVis
+      dataArray={dataArray}
+      title={title}
+      domain={domain}
+      colorMap={colorMap}
+      scaleType={scaleType}
+      keepAspectRatio={keepAspectRatio}
+      showGrid={showGrid}
+      abscissaParams={axisMapping[dimMapping.indexOf('x')]}
+      ordinateParams={axisMapping[dimMapping.indexOf('y')]}
+    />
   );
 }
 

--- a/src/h5web/vis-packs/core/line/MappedLineVis.tsx
+++ b/src/h5web/vis-packs/core/line/MappedLineVis.tsx
@@ -5,14 +5,14 @@ import { assertArray } from '../../../guards';
 import { useMappedArray, useDomain, useBaseArray } from '../hooks';
 import { useLineConfig } from './config';
 import type { AxisMapping, ScaleType } from '../models';
-import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
-import { useDimMappingState } from '../../hooks';
+import type { DimensionMapping } from '../../../dimension-mapper/models';
 
 interface Props {
   value: HDF5Value;
-  dims: number[];
   valueLabel?: string;
   valueScaleType?: ScaleType;
+  dims: number[];
+  dimMapping: DimensionMapping;
   axisMapping?: AxisMapping;
   title?: string;
   errors?: number[];
@@ -24,8 +24,9 @@ function MappedLineVis(props: Props): ReactElement {
     value,
     valueLabel,
     valueScaleType,
-    axisMapping = [],
     dims,
+    dimMapping,
+    axisMapping = [],
     title,
     errors,
     showErrors,
@@ -42,8 +43,6 @@ function MappedLineVis(props: Props): ReactElement {
     autoScale,
     disableAutoScale,
   } = useLineConfig();
-
-  const [dimMapping, setDimMapping] = useDimMappingState(dims, 1);
 
   const baseDataArray = useBaseArray(value, dims);
   const dataArray = useMappedArray(baseDataArray, dimMapping);
@@ -81,29 +80,22 @@ function MappedLineVis(props: Props): ReactElement {
   }, [setYScaleType, valueScaleType]);
 
   return (
-    <>
-      <DimensionMapper
-        rawDims={dims}
-        mapperState={dimMapping}
-        onChange={setDimMapping}
-      />
-      <LineVis
-        dataArray={dataArray}
-        domain={dataDomain}
-        scaleType={yScaleType}
-        curveType={curveType}
-        showGrid={showGrid}
-        abscissaParams={{
-          label: mappedAbscissaParams?.label,
-          value: mappedAbscissaParams?.value,
-          scaleType: xScaleType,
-        }}
-        ordinateLabel={valueLabel}
-        title={title}
-        errorsArray={errorArray}
-        showErrors={showErrors}
-      />
-    </>
+    <LineVis
+      dataArray={dataArray}
+      domain={dataDomain}
+      scaleType={yScaleType}
+      curveType={curveType}
+      showGrid={showGrid}
+      abscissaParams={{
+        label: mappedAbscissaParams?.label,
+        value: mappedAbscissaParams?.value,
+        scaleType: xScaleType,
+      }}
+      ordinateLabel={valueLabel}
+      title={title}
+      errorsArray={errorArray}
+      showErrors={showErrors}
+    />
   );
 }
 

--- a/src/h5web/vis-packs/core/matrix/MappedMatrixVis.tsx
+++ b/src/h5web/vis-packs/core/matrix/MappedMatrixVis.tsx
@@ -3,34 +3,22 @@ import type { HDF5Value } from '../../../providers/hdf5-models';
 import MatrixVis from './MatrixVis';
 import { assertArray } from '../../../guards';
 import { useBaseArray, useMappedArray } from '../hooks';
-import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
-import { useDimMappingState } from '../../hooks';
+import type { DimensionMapping } from '../../../dimension-mapper/models';
 
 interface Props {
   value: HDF5Value;
   dims: number[];
+  dimMapping: DimensionMapping;
 }
 
 function MappedMatrixVis(props: Props): ReactElement {
-  const { value, dims } = props;
+  const { value, dims, dimMapping } = props;
   assertArray<number | string>(value);
-
-  const axesCount = Math.min(dims.length, 2);
-  const [dimMapping, setDimMapping] = useDimMappingState(dims, axesCount);
 
   const baseArray = useBaseArray(value, dims);
   const mappedArray = useMappedArray(baseArray, dimMapping);
 
-  return (
-    <>
-      <DimensionMapper
-        rawDims={dims}
-        mapperState={dimMapping}
-        onChange={setDimMapping}
-      />
-      <MatrixVis dataArray={mappedArray} />
-    </>
-  );
+  return <MatrixVis dataArray={mappedArray} />;
 }
 
 export default MappedMatrixVis;

--- a/src/h5web/vis-packs/nexus/containers/NxImageContainer.tsx
+++ b/src/h5web/vis-packs/nexus/containers/NxImageContainer.tsx
@@ -6,6 +6,8 @@ import { useHeatmapConfig } from '../../core/heatmap/config';
 import { useAxisMapping, useNxData } from '../hooks';
 import { useDatasetValue } from '../../core/hooks';
 import { getDatasetLabel } from '../utils';
+import { useDimMappingState } from '../../hooks';
+import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 
 function NxImageContainer(props: VisContainerProps): ReactElement {
   const { entity } = props;
@@ -19,6 +21,8 @@ function NxImageContainer(props: VisContainerProps): ReactElement {
   if (dims.length < 2) {
     throw new Error('Expected signal dataset with at least two dimensions');
   }
+
+  const [dimMapping, setDimMapping] = useDimMappingState(dims, 2);
 
   const value = useDatasetValue(signalDataset.path);
   assertArray<number>(value);
@@ -36,12 +40,20 @@ function NxImageContainer(props: VisContainerProps): ReactElement {
   }, [setScaleType, signalScaleType]);
 
   return (
-    <MappedHeatmapVis
-      value={value}
-      title={title || getDatasetLabel(signalDataset)}
-      dims={dims}
-      axisMapping={axisMapping}
-    />
+    <>
+      <DimensionMapper
+        rawDims={dims}
+        mapperState={dimMapping}
+        onChange={setDimMapping}
+      />
+      <MappedHeatmapVis
+        value={value}
+        dims={dims}
+        dimMapping={dimMapping}
+        axisMapping={axisMapping}
+        title={title || getDatasetLabel(signalDataset)}
+      />
+    </>
   );
 }
 

--- a/src/h5web/vis-packs/nexus/containers/NxSpectrumContainer.tsx
+++ b/src/h5web/vis-packs/nexus/containers/NxSpectrumContainer.tsx
@@ -7,6 +7,8 @@ import type { VisContainerProps } from '../../models';
 import { useAxisMapping, useNxData } from '../hooks';
 import { useNxSpectrumConfig } from '../spectrum/config';
 import { getDatasetLabel } from '../utils';
+import { useDimMappingState } from '../../hooks';
+import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 
 function NxSpectrumContainer(props: VisContainerProps): ReactElement {
   const { entity } = props;
@@ -31,6 +33,8 @@ function NxSpectrumContainer(props: VisContainerProps): ReactElement {
     throw new Error(`Signal and errors dimensions don't match: ${dimsStr}`);
   }
 
+  const [dimMapping, setDimMapping] = useDimMappingState(signalDims, 1);
+
   const value = useDatasetValue(signalDataset.path);
   assertArray<number>(value);
 
@@ -48,16 +52,24 @@ function NxSpectrumContainer(props: VisContainerProps): ReactElement {
   }, [disableErrors, errors]);
 
   return (
-    <MappedLineVis
-      value={value}
-      valueLabel={signalLabel}
-      valueScaleType={signalScaleType}
-      axisMapping={axisMapping}
-      dims={signalDims}
-      title={title || signalLabel}
-      errors={errors}
-      showErrors={showErrors}
-    />
+    <>
+      <DimensionMapper
+        rawDims={signalDims}
+        mapperState={dimMapping}
+        onChange={setDimMapping}
+      />
+      <MappedLineVis
+        value={value}
+        valueLabel={signalLabel}
+        valueScaleType={signalScaleType}
+        dims={signalDims}
+        dimMapping={dimMapping}
+        axisMapping={axisMapping}
+        title={title || signalLabel}
+        errors={errors}
+        showErrors={showErrors}
+      />
+    </>
   );
 }
 


### PR DESCRIPTION
The dimension mapping state now comes before the calls to `useDatasetValue`, which means we'll be able to pass the current slice's "address" to the hook.