### PR TITLE
Infer type of dataset values from HDF5 type/shape instead of asserting

### DIFF
--- a/src/h5web/guards.ts
+++ b/src/h5web/guards.ts
@@ -174,6 +174,14 @@ export function assertSimpleShape<T extends HDF5Type>(
   }
 }
 
+export function assertBaseType<S extends HDF5Shape>(
+  dataset: Dataset<S>
+): asserts dataset is Dataset<S, HDF5BaseType> {
+  if (!hasStringType(dataset) && !hasNumericType(dataset)) {
+    throw new Error('Expected dataset to have string or numeric type');
+  }
+}
+
 export function assertStringType<S extends HDF5Shape>(
   dataset: Dataset<S>
 ): asserts dataset is Dataset<S, HDF5StringType> {

--- a/src/h5web/providers/mock/MockProvider.tsx
+++ b/src/h5web/providers/mock/MockProvider.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement, ReactNode } from 'react';
 import Provider from '../Provider';
-import { mockMetadata, mockDomain } from './metadata';
+import { mockDomain } from './metadata';
 import { assertMockDataset, findMockEntity } from './utils';
 
 interface Props {
@@ -24,7 +24,7 @@ function MockProvider(props: Props): ReactElement {
             });
           }
 
-          return findMockEntity(mockMetadata, path);
+          return findMockEntity(path);
         },
         getValue: async (path: string) => {
           if (path === errorOnPath) {
@@ -32,7 +32,7 @@ function MockProvider(props: Props): ReactElement {
             throw new Error('error');
           }
 
-          const dataset = findMockEntity(mockMetadata, path);
+          const dataset = findMockEntity(path);
           assertMockDataset(dataset);
 
           return dataset.value;

--- a/src/h5web/providers/mock/utils.test.ts
+++ b/src/h5web/providers/mock/utils.test.ts
@@ -1,27 +1,25 @@
-import { intType, makeDataset, makeGroup, scalarShape } from './metadata-utils';
+import type { Group } from '../models';
+import { mockMetadata } from './metadata';
 import { findMockEntity } from './utils';
 
 describe('MockProvider utilities', () => {
   describe('findMockEntity', () => {
-    const dataset = makeDataset('dataset', scalarShape, intType);
-    const childGroup1 = makeGroup('child1');
-    const childGroup2 = makeGroup('child2', [dataset]);
-    const rootGroup = makeGroup('root', [childGroup1, childGroup2]);
-
     it('should return entity at given path', () => {
-      expect(findMockEntity(rootGroup, '/')).toBe(rootGroup);
-      expect(findMockEntity(rootGroup, '/child1')).toBe(childGroup1);
-      expect(findMockEntity(rootGroup, '/child2/dataset')).toBe(dataset);
+      expect(findMockEntity('/')).toBe(mockMetadata);
+      expect(findMockEntity('/nD_datasets')).toBe(mockMetadata.children[1]);
+      expect(findMockEntity('/entities/raw')).toBe(
+        (mockMetadata.children[0] as Group).children[3]
+      );
     });
 
     it('should throw if path is relative', () => {
-      expect(() => findMockEntity(rootGroup, 'child1/foo')).toThrow(
+      expect(() => findMockEntity('nD_datasets')).toThrow(
         /path to start with '\/'/u
       );
     });
 
     it('should throw if no entity is found at given path', () => {
-      expect(() => findMockEntity(rootGroup, '/child1/foo')).toThrow(
+      expect(() => findMockEntity('/nD_datasets/foo')).toThrow(
         /entity at path/u
       );
     });

--- a/src/h5web/providers/mock/utils.ts
+++ b/src/h5web/providers/mock/utils.ts
@@ -9,7 +9,7 @@ import {
   isGroup,
 } from '../../guards';
 import { getChildEntity } from '../../utils';
-import type { Entity, Metadata } from '../models';
+import type { Entity } from '../models';
 import { mockMetadata } from './metadata';
 import type { MockDataset } from './models';
 
@@ -25,11 +25,11 @@ export function assertMockDataset(
   }
 }
 
-export function findMockEntity(root: Metadata, path: string): Entity {
+export function findMockEntity(path: string): Entity {
   assertAbsolutePath(path);
 
   if (path === '/') {
-    return root;
+    return mockMetadata;
   }
 
   const pathSegments = path.slice(1).split('/');
@@ -39,7 +39,7 @@ export function findMockEntity(root: Metadata, path: string): Entity {
         ? getChildEntity(parentEntity, currSegment)
         : undefined;
     },
-    root
+    mockMetadata
   );
 
   assertDefined(entity, `Expected entity at path "${path}"`);
@@ -47,7 +47,7 @@ export function findMockEntity(root: Metadata, path: string): Entity {
 }
 
 export function getMockDataArray(path: string): ndarray {
-  const dataset = findMockEntity(mockMetadata, path);
+  const dataset = findMockEntity(path);
   assertMockDataset(dataset);
 
   const { value } = dataset;

--- a/src/h5web/providers/models.ts
+++ b/src/h5web/providers/models.ts
@@ -43,5 +43,3 @@ export interface Link<T extends HDF5Link = HDF5Link> extends Entity {
   kind: EntityKind.Link;
   rawLink: T;
 }
-
-export type Metadata = Group;

--- a/src/h5web/providers/models.ts
+++ b/src/h5web/providers/models.ts
@@ -1,7 +1,10 @@
 import type {
   HDF5Attribute,
   HDF5Link,
+  HDF5NumericType,
   HDF5Shape,
+  HDF5SimpleShape,
+  HDF5StringType,
   HDF5Type,
 } from './hdf5-models';
 
@@ -43,3 +46,14 @@ export interface Link<T extends HDF5Link = HDF5Link> extends Entity {
   kind: EntityKind.Link;
   rawLink: T;
 }
+
+type PrimitiveType<T extends HDF5Type> = T extends HDF5NumericType
+  ? number
+  : T extends HDF5StringType
+  ? string
+  : unknown;
+
+export type Value<
+  S extends HDF5Shape,
+  T extends HDF5Type
+> = S extends HDF5SimpleShape ? PrimitiveType<T>[] : PrimitiveType<T>;

--- a/src/h5web/vis-packs/core/containers/HeatmapVisContainer.tsx
+++ b/src/h5web/vis-packs/core/containers/HeatmapVisContainer.tsx
@@ -16,7 +16,7 @@ function HeatmapVisContainer(props: VisContainerProps): ReactElement {
   assertSimpleShape(entity);
   assertNumericType(entity);
 
-  const { name, path, shape } = entity;
+  const { name, shape } = entity;
   const { dims } = shape;
 
   if (dims.length < 2) {
@@ -25,7 +25,7 @@ function HeatmapVisContainer(props: VisContainerProps): ReactElement {
 
   const [dimMapping, setDimMapping] = useDimMappingState(dims, 2);
 
-  const value = useDatasetValue(path);
+  const value = useDatasetValue(entity);
 
   return (
     <>

--- a/src/h5web/vis-packs/core/containers/LineVisContainer.tsx
+++ b/src/h5web/vis-packs/core/containers/LineVisContainer.tsx
@@ -16,12 +16,12 @@ function LineVisContainer(props: VisContainerProps): ReactElement {
   assertSimpleShape(entity);
   assertNumericType(entity);
 
-  const { name, path, shape } = entity;
+  const { name, shape } = entity;
   const { dims } = shape;
 
   const [dimMapping, setDimMapping] = useDimMappingState(dims, 1);
 
-  const value = useDatasetValue(path);
+  const value = useDatasetValue(entity);
 
   return (
     <>

--- a/src/h5web/vis-packs/core/containers/MatrixVisContainer.tsx
+++ b/src/h5web/vis-packs/core/containers/MatrixVisContainer.tsx
@@ -1,6 +1,10 @@
 import type { ReactElement } from 'react';
 import { useDatasetValue } from '../hooks';
-import { assertDataset, assertSimpleShape } from '../../../guards';
+import {
+  assertBaseType,
+  assertDataset,
+  assertSimpleShape,
+} from '../../../guards';
 import MappedMatrixVis from '../matrix/MappedMatrixVis';
 import type { VisContainerProps } from '../../models';
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
@@ -10,14 +14,13 @@ function MatrixVisContainer(props: VisContainerProps): ReactElement {
   const { entity } = props;
   assertDataset(entity);
   assertSimpleShape(entity);
+  assertBaseType(entity);
 
-  const { path, shape } = entity;
-  const { dims } = shape;
-
+  const { dims } = entity.shape;
   const axesCount = Math.min(dims.length, 2);
   const [dimMapping, setDimMapping] = useDimMappingState(dims, axesCount);
 
-  const value = useDatasetValue(path);
+  const value = useDatasetValue(entity);
 
   return (
     <>

--- a/src/h5web/vis-packs/core/containers/RawVisContainer.tsx
+++ b/src/h5web/vis-packs/core/containers/RawVisContainer.tsx
@@ -8,7 +8,7 @@ function RawVisContainer(props: VisContainerProps): ReactElement {
   const { entity } = props;
   assertDataset(entity);
 
-  const value = useDatasetValue(entity.path);
+  const value = useDatasetValue(entity);
   return <RawVis value={value} />;
 }
 

--- a/src/h5web/vis-packs/core/containers/ScalarVisContainer.tsx
+++ b/src/h5web/vis-packs/core/containers/ScalarVisContainer.tsx
@@ -1,14 +1,20 @@
 import type { ReactElement } from 'react';
 import ScalarVis from '../scalar/ScalarVis';
 import { useDatasetValue } from '../hooks';
-import { assertDataset } from '../../../guards';
+import {
+  assertBaseType,
+  assertDataset,
+  assertScalarShape,
+} from '../../../guards';
 import type { VisContainerProps } from '../../models';
 
 function ScalarVisContainer(props: VisContainerProps): ReactElement {
   const { entity } = props;
   assertDataset(entity);
+  assertScalarShape(entity);
+  assertBaseType(entity);
 
-  const value = useDatasetValue(entity.path);
+  const value = useDatasetValue(entity);
   return <ScalarVis value={value} />;
 }
 

--- a/src/h5web/vis-packs/core/heatmap/MappedHeatmapVis.tsx
+++ b/src/h5web/vis-packs/core/heatmap/MappedHeatmapVis.tsx
@@ -1,7 +1,5 @@
 import { ReactElement, useEffect, useMemo } from 'react';
-import type { HDF5Value } from '../../../providers/hdf5-models';
 import HeatmapVis from './HeatmapVis';
-import { assertArray } from '../../../guards';
 import { useBaseArray, useMappedArray } from '../hooks';
 import { useHeatmapConfig } from './config';
 import type { AxisMapping } from '../models';
@@ -9,7 +7,7 @@ import { getDomain } from '../utils';
 import type { DimensionMapping } from '../../../dimension-mapper/models';
 
 interface Props {
-  value: HDF5Value;
+  value: number[];
   dims: number[];
   dimMapping: DimensionMapping;
   axisMapping?: AxisMapping;
@@ -18,7 +16,6 @@ interface Props {
 
 function MappedHeatmapVis(props: Props): ReactElement {
   const { value, dims, dimMapping, axisMapping = [], title } = props;
-  assertArray<number>(value);
 
   const {
     customDomain,

--- a/src/h5web/vis-packs/core/hooks.ts
+++ b/src/h5web/vis-packs/core/hooks.ts
@@ -8,24 +8,31 @@ import type { DimensionMapping } from '../../dimension-mapper/models';
 import { getCanvasScale, getDomain } from './utils';
 import AxisSystemContext from './shared/AxisSystemContext';
 import type { AxisScale } from './models';
-import type { HDF5Value } from '../../providers/hdf5-models';
+import type { HDF5Shape, HDF5Type } from '../../providers/hdf5-models';
 import { ProviderContext } from '../../providers/context';
-import type { Dataset } from '../../providers/models';
+import type { Dataset, Value } from '../../providers/models';
 
-export function useDatasetValue(
-  path: string | undefined
-): HDF5Value | undefined {
+export function useDatasetValue<
+  S extends HDF5Shape,
+  T extends HDF5Type,
+  D extends Dataset<S, T> | undefined
+>(dataset: D): D extends Dataset<infer S, infer T> ? Value<S, T> : undefined;
+
+export function useDatasetValue(dataset: Dataset | undefined) {
   const { valuesStore } = useContext(ProviderContext);
-  return path !== undefined ? valuesStore.get(path) : undefined;
+  return dataset && valuesStore.get(dataset.path);
 }
 
-export function useDatasetValues(
-  datasets: Dataset[]
-): Record<string, HDF5Value> {
+export function useDatasetValues<S extends HDF5Shape, T extends HDF5Type>(
+  datasets: Dataset<S, T>[]
+) {
   const { valuesStore } = useContext(ProviderContext);
 
   return Object.fromEntries(
-    datasets.map(({ name, path }) => [name, valuesStore.get(path)])
+    datasets.map(({ name, path }) => [
+      name,
+      valuesStore.get(path) as Value<S, T>,
+    ])
   );
 }
 

--- a/src/h5web/vis-packs/core/line/MappedLineVis.tsx
+++ b/src/h5web/vis-packs/core/line/MappedLineVis.tsx
@@ -1,14 +1,12 @@
 import { ReactElement, useEffect } from 'react';
-import type { HDF5Value } from '../../../providers/hdf5-models';
 import LineVis from './LineVis';
-import { assertArray } from '../../../guards';
 import { useMappedArray, useDomain, useBaseArray } from '../hooks';
 import { useLineConfig } from './config';
 import type { AxisMapping, ScaleType } from '../models';
 import type { DimensionMapping } from '../../../dimension-mapper/models';
 
 interface Props {
-  value: HDF5Value;
+  value: number[];
   valueLabel?: string;
   valueScaleType?: ScaleType;
   dims: number[];
@@ -31,7 +29,6 @@ function MappedLineVis(props: Props): ReactElement {
     errors,
     showErrors,
   } = props;
-  assertArray<number>(value);
 
   const {
     yScaleType,

--- a/src/h5web/vis-packs/core/matrix/MappedMatrixVis.tsx
+++ b/src/h5web/vis-packs/core/matrix/MappedMatrixVis.tsx
@@ -1,19 +1,16 @@
 import type { ReactElement } from 'react';
-import type { HDF5Value } from '../../../providers/hdf5-models';
 import MatrixVis from './MatrixVis';
-import { assertArray } from '../../../guards';
 import { useBaseArray, useMappedArray } from '../hooks';
 import type { DimensionMapping } from '../../../dimension-mapper/models';
 
 interface Props {
-  value: HDF5Value;
+  value: (string | number)[];
   dims: number[];
   dimMapping: DimensionMapping;
 }
 
 function MappedMatrixVis(props: Props): ReactElement {
   const { value, dims, dimMapping } = props;
-  assertArray<number | string>(value);
 
   const baseArray = useBaseArray(value, dims);
   const mappedArray = useMappedArray(baseArray, dimMapping);

--- a/src/h5web/vis-packs/core/raw/RawVis.tsx
+++ b/src/h5web/vis-packs/core/raw/RawVis.tsx
@@ -1,9 +1,8 @@
 import type { ReactElement } from 'react';
 import styles from './RawVis.module.css';
-import type { HDF5Value } from '../../../providers/hdf5-models';
 
 interface Props {
-  value: HDF5Value;
+  value: unknown;
 }
 
 function RawVis(props: Props): ReactElement {

--- a/src/h5web/vis-packs/core/scalar/ScalarVis.tsx
+++ b/src/h5web/vis-packs/core/scalar/ScalarVis.tsx
@@ -1,10 +1,9 @@
 import type { ReactElement } from 'react';
 import styles from './ScalarVis.module.css';
-import type { HDF5Value } from '../../../providers/hdf5-models';
 import { assertNumOrStr } from '../../../guards';
 
 interface Props {
-  value: HDF5Value;
+  value: string | number;
 }
 
 function ScalarVis(props: Props): ReactElement {

--- a/src/h5web/vis-packs/nexus/containers/NxImageContainer.tsx
+++ b/src/h5web/vis-packs/nexus/containers/NxImageContainer.tsx
@@ -24,10 +24,10 @@ function NxImageContainer(props: VisContainerProps): ReactElement {
 
   const [dimMapping, setDimMapping] = useDimMappingState(dims, 2);
 
-  const value = useDatasetValue(signalDataset.path);
+  const value = useDatasetValue(signalDataset);
   assertArray<number>(value);
 
-  const title = useDatasetValue(titleDataset?.path);
+  const title = useDatasetValue(titleDataset);
   assertOptionalStr(title);
 
   const axisMapping = useAxisMapping(axisDatasetMapping, axesScaleType);

--- a/src/h5web/vis-packs/nexus/containers/NxSpectrumContainer.tsx
+++ b/src/h5web/vis-packs/nexus/containers/NxSpectrumContainer.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, useEffect } from 'react';
 import { isEqual } from 'lodash-es';
-import { assertArray, assertGroup, assertOptionalStr } from '../../../guards';
+import { assertGroup } from '../../../guards';
 import { useDatasetValue } from '../../core/hooks';
 import MappedLineVis from '../../core/line/MappedLineVis';
 import type { VisContainerProps } from '../../models';
@@ -35,14 +35,9 @@ function NxSpectrumContainer(props: VisContainerProps): ReactElement {
 
   const [dimMapping, setDimMapping] = useDimMappingState(signalDims, 1);
 
-  const value = useDatasetValue(signalDataset.path);
-  assertArray<number>(value);
-
-  const errors = useDatasetValue(errorsDataset?.path);
-  assertArray<number>(errors);
-
-  const title = useDatasetValue(titleDataset?.path);
-  assertOptionalStr(title);
+  const value = useDatasetValue(signalDataset);
+  const errors = useDatasetValue(errorsDataset);
+  const title = useDatasetValue(titleDataset);
 
   const axisMapping = useAxisMapping(axisDatasetMapping, axesScaleType);
 

--- a/src/h5web/vis-packs/nexus/hooks.ts
+++ b/src/h5web/vis-packs/nexus/hooks.ts
@@ -127,17 +127,10 @@ export function useAxisMapping(
   const axisValues = useDatasetValues(mapping.filter(isDefined));
 
   return mapping.map((dataset, i) => {
-    if (!dataset) {
-      return undefined;
-    }
-
-    const axisValue = axisValues[dataset.name];
-    assertArray<number>(axisValue);
-
     return (
       dataset && {
         label: getDatasetLabel(dataset),
-        value: axisValue,
+        value: axisValues[dataset.name],
         scaleType: axesScaleType && axesScaleType[i],
       }
     );


### PR DESCRIPTION
I'll probably be able to use the same approach to infer of types of attribute values.

---

Also, remove the need to pass `mockMetadata` to `findMockEntity` and remove `Metadata` model.
