### PR TITLE
Change HDF5Type by parsing `base` into object fields

### DIFF
--- a/src/h5web/providers/hdf5-models.ts
+++ b/src/h5web/providers/hdf5-models.ts
@@ -101,42 +101,19 @@ export enum HDF5TypeClass {
   Compound = 'H5T_COMPOUND',
 }
 
+export type HDF5Endianness = 'BE' | 'LE';
+
 export interface HDF5IntegerType {
   class: HDF5TypeClass.Integer;
-  base:
-    | 'H5T_STD_I8BE'
-    | 'H5T_STD_I8LE'
-    | 'H5T_STD_I16BE'
-    | 'H5T_STD_I16LE'
-    | 'H5T_STD_I32BE'
-    | 'H5T_STD_I32LE'
-    | 'H5T_STD_I64BE'
-    | 'H5T_STD_I64LE'
-    | 'H5T_STD_U8BE'
-    | 'H5T_STD_U8LE'
-    | 'H5T_STD_U16BE'
-    | 'H5T_STD_U16LE'
-    | 'H5T_STD_U32BE'
-    | 'H5T_STD_U32LE'
-    | 'H5T_STD_U64BE'
-    | 'H5T_STD_U64LE'
-    | 'H5T_STD_B8BE'
-    | 'H5T_STD_B8LE'
-    | 'H5T_STD_B16BE'
-    | 'H5T_STD_B16LE'
-    | 'H5T_STD_B32BE'
-    | 'H5T_STD_B32LE'
-    | 'H5T_STD_B64BE'
-    | 'H5T_STD_B64LE';
+  size: number;
+  unsigned?: boolean;
+  endianness: HDF5Endianness;
 }
 
 export interface HDF5FloatType {
   class: HDF5TypeClass.Float;
-  base:
-    | 'H5T_IEEE_F32BE'
-    | 'H5T_IEEE_F32LE'
-    | 'H5T_IEEE_F64BE'
-    | 'H5T_IEEE_F64LE';
+  size: number;
+  endianness: HDF5Endianness;
 }
 
 export interface HDF5StringType {

--- a/src/h5web/providers/hsds/api.ts
+++ b/src/h5web/providers/hsds/api.ts
@@ -22,7 +22,12 @@ import {
 } from '../hdf5-models';
 import { assertDefined, assertGroup, isHardLink } from '../../guards';
 import type { ProviderAPI } from '../context';
-import { assertHsdsDataset, isHsdsExternalLink, isHsdsGroup } from './utils';
+import {
+  assertHsdsDataset,
+  isHsdsExternalLink,
+  isHsdsGroup,
+  convertHsdsType,
+} from './utils';
 import { buildEntityPath, getChildEntity } from '../../utils';
 
 export class HsdsApi implements ProviderAPI {
@@ -193,7 +198,7 @@ export class HsdsApi implements ProviderAPI {
       kind: EntityKind.Dataset,
       attributes,
       shape,
-      type,
+      type: convertHsdsType(type),
     };
   }
 
@@ -209,7 +214,7 @@ export class HsdsApi implements ProviderAPI {
       name,
       kind: EntityKind.Datatype,
       attributes: [],
-      type,
+      type: convertHsdsType(type),
     };
   }
 

--- a/src/h5web/providers/hsds/models.ts
+++ b/src/h5web/providers/hsds/models.ts
@@ -1,14 +1,48 @@
 import type {
   HDF5Id,
   HDF5Shape,
-  HDF5Type,
   HDF5Attribute,
   HDF5Value,
   HDF5ExternalLink,
   HDF5HardLink,
   HDF5SoftLink,
+  HDF5TypeClass,
+  HDF5StringType,
+  HDF5Dims,
 } from '../hdf5-models';
 import type { Dataset, Group } from '../models';
+
+export type HsdsBaseType =
+  | { class: HDF5TypeClass.Integer; base: string }
+  | { class: HDF5TypeClass.Float; base: string }
+  | HDF5StringType;
+
+export type HsdsType =
+  | HsdsBaseType
+  | HsdsArrayType
+  | HsdsVLenType
+  | HsdsCompoundType;
+
+interface HsdsArrayType {
+  class: HDF5TypeClass.Array;
+  base: HsdsBaseType;
+  dims: HDF5Dims;
+}
+
+interface HsdsVLenType {
+  class: HDF5TypeClass.VLen;
+  base: HsdsBaseType;
+}
+
+export interface HsdsCompoundType {
+  class: HDF5TypeClass.Compound;
+  fields: HsdsCompoundTypeField[];
+}
+
+interface HsdsCompoundTypeField {
+  name: string;
+  type: HsdsType;
+}
 
 export interface HsdsRootResponse {
   root: HDF5Id;
@@ -23,13 +57,13 @@ export interface HsdsGroupResponse {
 export interface HsdsDatasetResponse {
   id: HDF5Id;
   shape: HDF5Shape;
-  type: HDF5Type;
+  type: HsdsType;
   attributeCount: number;
 }
 
 export interface HsdsDatatypeResponse {
   id: HDF5Id;
-  type: HDF5Type;
+  type: HsdsType;
 }
 
 export interface HsdsAttributesResponse {

--- a/src/h5web/providers/hsds/utils.ts
+++ b/src/h5web/providers/hsds/utils.ts
@@ -1,10 +1,19 @@
+import { isString } from 'lodash-es';
 import { isDataset, isGroup } from '../../guards';
+import {
+  HDF5BaseType,
+  HDF5Endianness,
+  HDF5Type,
+  HDF5TypeClass,
+} from '../hdf5-models';
 import type { Entity } from '../models';
 import type {
   HsdsLink,
   HsdsExternalLink,
   HsdsDataset,
   HsdsGroup,
+  HsdsType,
+  HsdsBaseType,
 } from './models';
 
 export function isHsdsExternalLink(link: HsdsLink): link is HsdsExternalLink {
@@ -24,5 +33,67 @@ export function assertHsdsDataset(
 ): asserts entity is HsdsDataset {
   if (!isHsdsDataset(entity)) {
     throw new Error('Expected entity to be HSDS dataset');
+  }
+}
+
+export function convertHsdsBaseType(hsdsBaseType: HsdsBaseType): HDF5BaseType {
+  if (hsdsBaseType.class === HDF5TypeClass.String) {
+    return hsdsBaseType;
+  }
+
+  const { class: hsdsClass, base } = hsdsBaseType;
+
+  const regex = /H5T_(?:STD|IEEE)_([A-Z])(\d+)(BE|LE)/u;
+  const matches = regex.exec(base);
+
+  if (!matches) {
+    throw new Error(`Unrecognized base ${base}`);
+  }
+
+  const [, sign, size, endianness] = matches;
+
+  return {
+    class: hsdsClass,
+    endianness: endianness as HDF5Endianness,
+    size: Number.parseInt(size, 10),
+    unsigned: sign === 'U' || undefined,
+  };
+}
+
+export function convertHsdsType(hsdsType: HsdsType): HDF5Type {
+  if (isString(hsdsType)) {
+    return hsdsType;
+  }
+
+  switch (hsdsType.class) {
+    case HDF5TypeClass.Array:
+      return {
+        class: HDF5TypeClass.Array,
+        base: convertHsdsBaseType(hsdsType.base),
+        dims: hsdsType.dims,
+      };
+
+    case HDF5TypeClass.VLen:
+      return {
+        class: HDF5TypeClass.VLen,
+        base: convertHsdsBaseType(hsdsType.base),
+      };
+
+    case HDF5TypeClass.Compound:
+      return {
+        class: HDF5TypeClass.Compound,
+        fields: hsdsType.fields.map((v) => ({
+          name: v.name,
+          type: convertHsdsType(v.type),
+        })),
+      };
+
+    case HDF5TypeClass.Integer:
+    case HDF5TypeClass.Float:
+    case HDF5TypeClass.String:
+      return convertHsdsBaseType(hsdsType);
+
+    default:
+      throw new Error(`Unknown type ${JSON.stringify(hsdsType)}`);
   }
 }

--- a/src/h5web/providers/mock/metadata-utils.ts
+++ b/src/h5web/providers/mock/metadata-utils.ts
@@ -29,12 +29,14 @@ import { mockValues } from './values';
 
 export const intType: HDF5IntegerType = {
   class: HDF5TypeClass.Integer,
-  base: 'H5T_STD_I32LE',
+  endianness: 'LE',
+  size: 32,
 };
 
 export const floatType: HDF5FloatType = {
   class: HDF5TypeClass.Float,
-  base: 'H5T_IEEE_F64LE',
+  endianness: 'LE',
+  size: 64,
 };
 
 export const stringType: HDF5StringType = {


### PR DESCRIPTION
A refactoring in preparation of #406.

`HDF5FloatType` and `HDF5IntegerType` no longer holds a `base` string but directly the information that can be deduced from it (endianness, number of bits, sign). This will allow a much easier handling in the `JupyterProvider` (for type inferring) and in the `MetadataViewer` (for displaying the HDF5Type of a dataset).

The `base` string is now parsed in the `HsdsProvider` to add the relevant fields to `HDF5Type`. Note that some advanced types that hold reference to other types need to be recursively parsed.