### PR TITLE
Adding data type row to the metadata inspector

### DIFF
--- a/src/h5web/metadata-viewer/EntityTable.tsx
+++ b/src/h5web/metadata-viewer/EntityTable.tsx
@@ -2,7 +2,7 @@ import { ReactElement, useContext } from 'react';
 import type { Entity } from '../providers/models';
 import styles from './MetadataViewer.module.css';
 import { hasSimpleShape, isDataset, isDatatype, isLink } from '../guards';
-import { renderShapeDims } from './utils';
+import { renderType, renderShapeDims } from './utils';
 import RawInspector from './RawInspector';
 import LinkInfo from './LinkInfo';
 import { capitalize } from 'lodash-es';
@@ -38,11 +38,7 @@ function EntityTable(props: Props): ReactElement {
         {(isDataset(entity) || isDatatype(entity)) && (
           <tr>
             <th scope="row">Type</th>
-            <td>
-              {typeof entity.type === 'string'
-                ? entity.type
-                : entity.type.class}
-            </td>
+            <td>{renderType(entity.type)}</td>
           </tr>
         )}
         {isDataset(entity) && (

--- a/src/h5web/metadata-viewer/MetadataViewer.test.tsx
+++ b/src/h5web/metadata-viewer/MetadataViewer.test.tsx
@@ -59,7 +59,7 @@ describe('MetadataViewer', () => {
     expect(nameRow).toHaveTextContent(/scalar_int/u);
     expect(pathRow).toHaveTextContent(/\/entities\/scalar_int/u);
     expect(shapeRow).toHaveTextContent(/H5S_SCALAR/u);
-    expect(typeRow).toHaveTextContent(/H5T_INTEGER/u);
+    expect(typeRow).toHaveTextContent(/integer/u);
   });
 
   test('inspect simple dataset', async () => {
@@ -86,7 +86,7 @@ describe('MetadataViewer', () => {
     expect(column).toBeVisible();
     expect(nameRow).toHaveTextContent(/datatype/u);
     expect(pathRow).toHaveTextContent(/\/entities\/datatype/u);
-    expect(typeRow).toHaveTextContent(/H5T_COMPOUND/u);
+    expect(typeRow).toHaveTextContent(/compound/u);
   });
 
   test('inspect external link', async () => {

--- a/src/h5web/metadata-viewer/utils.ts
+++ b/src/h5web/metadata-viewer/utils.ts
@@ -1,7 +1,51 @@
+import { HDF5Type, HDF5TypeClass } from '../providers/hdf5-models';
+
+const ENDIANNESS_LABELS = {
+  LE: 'little-endian',
+  BE: 'big-endian',
+  Native: 'native',
+  'Not applicable': '',
+};
+
 export function renderShapeDims(dims: number[]): string {
   if (dims.length > 1) {
     return `${dims.join(' x ')} = ${dims.reduce((acc, value) => acc * value)}`;
   }
 
   return dims.toString();
+}
+
+export function renderType(type: HDF5Type): string {
+  if (typeof type === 'string') {
+    return type;
+  }
+
+  // Remove leading `H5T_`
+  const classLabel = type.class.slice(4).toLowerCase();
+
+  if (
+    type.class === HDF5TypeClass.Integer ||
+    type.class === HDF5TypeClass.Float
+  ) {
+    const { endianness, size } = type;
+    const typeInfos = `${classLabel}, ${
+      type.class === HDF5TypeClass.Integer && type.unsigned ? 'unsigned' : ''
+    } ${size}-bit`;
+
+    if (endianness === 'Not applicable') {
+      return typeInfos;
+    }
+
+    return `${typeInfos}, ${ENDIANNESS_LABELS[endianness]}`;
+  }
+
+  if (type.class === HDF5TypeClass.String) {
+    const { length, charSet } = type;
+
+    return `${classLabel},
+    ${charSet},
+    ${Number.isInteger(length) ? `${length} characters` : 'variable length'}`;
+  }
+
+  return classLabel;
 }


### PR DESCRIPTION
Some examples:
- Scalar dataset with string type
![image](https://user-images.githubusercontent.com/42204205/107006676-ccdebb80-6791-11eb-81cb-e868f4f56ce5.png)

- 2D dataset with integer type
![image](https://user-images.githubusercontent.com/42204205/107007249-8ccc0880-6792-11eb-88fe-6590b5353f8e.png)

