### PR TITLE
Fetch values by slice in Heatmap and Matrix vis

### DIFF
--- a/src/h5web/dimension-mapper/utils.ts
+++ b/src/h5web/dimension-mapper/utils.ts
@@ -1,0 +1,6 @@
+import { isNumber } from 'lodash-es';
+import type { Axis } from './models';
+
+export function isAxis(elem: number | Axis): elem is Axis {
+  return !isNumber(elem);
+}

--- a/src/h5web/providers/Provider.tsx
+++ b/src/h5web/providers/Provider.tsx
@@ -3,6 +3,7 @@ import { createFetchStore } from 'react-suspense-fetch';
 import { ProviderAPI, ProviderContext } from './context';
 import type { Entity } from './models';
 import { isGroup } from '../guards';
+import { createObjectKeyStore } from './utils';
 
 interface Props {
   api: ProviderAPI;
@@ -39,7 +40,7 @@ function Provider(props: Props): ReactElement {
   }, [api]);
 
   const valuesStore = useMemo(() => {
-    return createFetchStore(api.getValue.bind(api));
+    return createObjectKeyStore(api.getValue.bind(api));
   }, [api]);
 
   return (

--- a/src/h5web/providers/context.ts
+++ b/src/h5web/providers/context.ts
@@ -2,15 +2,21 @@ import { createContext } from 'react';
 import type { Entity } from './models';
 import type { HDF5Value } from './hdf5-models';
 import type { FetchStore } from 'react-suspense-fetch';
+import type { ObjectKeyStore } from './utils';
+
+export interface GetValueParams {
+  path: string;
+  selection?: string;
+}
 
 export abstract class ProviderAPI {
   abstract domain: string;
   abstract getEntity(path: string): Promise<Entity>;
-  abstract getValue(path: string): Promise<HDF5Value>;
+  abstract getValue(params: GetValueParams): Promise<HDF5Value>;
 }
 
 export const ProviderContext = createContext<{
   domain: string;
   entitiesStore: FetchStore<Entity, string>;
-  valuesStore: FetchStore<HDF5Value, string>;
+  valuesStore: ObjectKeyStore<HDF5Value, GetValueParams>;
 }>({} as any); // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/src/h5web/providers/hsds/api.ts
+++ b/src/h5web/providers/hsds/api.ts
@@ -21,7 +21,7 @@ import {
   HDF5Link,
 } from '../hdf5-models';
 import { assertDefined, assertGroup, isHardLink } from '../../guards';
-import type { ProviderAPI } from '../context';
+import type { GetValueParams, ProviderAPI } from '../context';
 import {
   assertHsdsDataset,
   isHsdsExternalLink,
@@ -82,12 +82,14 @@ export class HsdsApi implements ProviderAPI {
     return entity;
   }
 
-  public async getValue(path: string): Promise<HDF5Value> {
+  public async getValue(params: GetValueParams): Promise<HDF5Value> {
+    const { path, selection = '' } = params;
+
     const entity = await this.getEntity(path);
     assertHsdsDataset(entity);
 
     const { data } = await this.client.get<HsdsValueResponse>(
-      `/datasets/${entity.id}/value`
+      `/datasets/${entity.id}/value${selection && `?select=[${selection}]`}`
     );
     return data.value;
   }

--- a/src/h5web/providers/jupyter/api.ts
+++ b/src/h5web/providers/jupyter/api.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance } from 'axios';
 import { Group, Dataset, EntityKind, Link, Entity } from '../models';
-import type { ProviderAPI } from '../context';
+import type { GetValueParams, ProviderAPI } from '../context';
 import {
   assertGroupContent,
   isDatasetResponse,
@@ -36,9 +36,11 @@ export class JupyterApi implements ProviderAPI {
     return this.processEntity(path, 1);
   }
 
-  public async getValue(path: string): Promise<HDF5Value> {
+  public async getValue(params: GetValueParams): Promise<HDF5Value> {
+    const { path, selection = '' } = params;
+
     const { data } = await this.client.get<JupyterDataResponse>(
-      `/data/${this.domain}?uri=${path}`
+      `/data/${this.domain}?uri=${path}${selection && `&ixstr=${selection}`}`
     );
     return data;
   }

--- a/src/h5web/providers/utils.ts
+++ b/src/h5web/providers/utils.ts
@@ -1,0 +1,43 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { pickBy } from 'lodash-es';
+import { createFetchStore } from 'react-suspense-fetch';
+
+export interface ObjectKeyStore<R, I extends {}> {
+  get: (obj: I) => R;
+  prefetch: (obj: I) => void;
+  evict: (obj: I) => void;
+}
+
+/**
+ * Create a suspense store with a reliable `Map` cache around an async
+ * function with an object parameter. `react-suspense-fetch` uses a
+ * `WeakMap` cache in this case.
+ *
+ * Interaction with the underlying `react-suspense-fetch` store is done by
+ * JSON-stringifying/parsing the input object.
+ */
+export function createObjectKeyStore<R, I extends {}>(
+  fetchFunc: (obj: I) => Promise<R>
+): ObjectKeyStore<R, I> {
+  const store = createFetchStore((key: string) => {
+    return fetchFunc(JSON.parse(key));
+  });
+
+  function wrapMethod<T>(method: (key: string) => T) {
+    return (params: I) => {
+      /* Remove optional params that are explicitely set to `undefined`.
+       * This is to guarantee that, for instance, `{ foo: undefined; }` and `{}`
+       * are both stringified to (and cached with) "{}" */
+      const pickedParams = pickBy(params, (v) => v !== undefined);
+
+      return method(JSON.stringify(pickedParams));
+    };
+  }
+
+  const { get, prefetch, evict } = store;
+  return {
+    get: wrapMethod(get),
+    prefetch: wrapMethod(prefetch),
+    evict: wrapMethod(evict),
+  };
+}

--- a/src/h5web/vis-packs/core/heatmap/MappedHeatmapVis.tsx
+++ b/src/h5web/vis-packs/core/heatmap/MappedHeatmapVis.tsx
@@ -10,6 +10,7 @@ import type {
   HDF5NumericType,
   HDF5SimpleShape,
 } from '../../../providers/hdf5-models';
+import { isAxis } from '../../../dimension-mapper/utils';
 import shallow from 'zustand/shallow';
 
 interface Props {
@@ -41,9 +42,18 @@ function MappedHeatmapVis(props: Props): ReactElement {
     setScaleType,
   } = useHeatmapConfig((state) => state, shallow);
 
-  const value = useDatasetValue(dataset);
-  const baseArray = useBaseArray(value, dims);
-  const dataArray = useMappedArray(baseArray, dimMapping);
+  const value = useDatasetValue(dataset, dimMapping);
+
+  const [slicedDims, slicedMapping] = useMemo(
+    () => [
+      dims.filter((_, i) => isAxis(dimMapping[i])),
+      dimMapping.filter((dim) => isAxis(dim)),
+    ],
+    [dims, dimMapping]
+  );
+
+  const baseArray = useBaseArray(value, slicedDims);
+  const dataArray = useMappedArray(baseArray, slicedMapping);
 
   const domain = useMemo(() => {
     return customDomain || getDomain(dataArray.data as number[], scaleType);

--- a/src/h5web/vis-packs/core/matrix/MappedMatrixVis.tsx
+++ b/src/h5web/vis-packs/core/matrix/MappedMatrixVis.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from 'react';
+import { ReactElement, useMemo } from 'react';
 import MatrixVis from './MatrixVis';
 import { useBaseArray, useDatasetValue, useMappedArray } from '../hooks';
 import type { DimensionMapping } from '../../../dimension-mapper/models';
@@ -7,6 +7,7 @@ import type {
   HDF5SimpleShape,
 } from '../../../providers/hdf5-models';
 import type { Dataset } from '../../../providers/models';
+import { isAxis } from '../../../dimension-mapper/utils';
 
 interface Props {
   dataset: Dataset<HDF5SimpleShape, HDF5BaseType>;
@@ -17,9 +18,18 @@ interface Props {
 function MappedMatrixVis(props: Props): ReactElement {
   const { dataset, dims, dimMapping } = props;
 
-  const value = useDatasetValue(dataset);
-  const baseArray = useBaseArray(value, dims);
-  const mappedArray = useMappedArray(baseArray, dimMapping);
+  const value = useDatasetValue(dataset, dimMapping);
+
+  const [slicedDims, slicedMapping] = useMemo(
+    () => [
+      dims.filter((_, i) => isAxis(dimMapping[i])),
+      dimMapping.filter((dim) => isAxis(dim)),
+    ],
+    [dimMapping, dims]
+  );
+
+  const baseArray = useBaseArray(value, slicedDims);
+  const mappedArray = useMappedArray(baseArray, slicedMapping);
 
   return <MatrixVis dataArray={mappedArray} />;
 }

--- a/src/h5web/vis-packs/nexus/containers/NxSpectrumContainer.tsx
+++ b/src/h5web/vis-packs/nexus/containers/NxSpectrumContainer.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from 'react';
+import { ReactElement, useContext } from 'react';
 import { isEqual } from 'lodash-es';
 import { assertGroup } from '../../../guards';
 import { useDatasetValue } from '../../core/hooks';
@@ -8,6 +8,7 @@ import { useAxisMapping, useNxData } from '../hooks';
 import { getDatasetLabel } from '../utils';
 import { useDimMappingState } from '../../hooks';
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
+import { ProviderContext } from '../../../providers/context';
 
 function NxSpectrumContainer(props: VisContainerProps): ReactElement {
   const { entity } = props;
@@ -33,6 +34,12 @@ function NxSpectrumContainer(props: VisContainerProps): ReactElement {
   }
 
   const [dimMapping, setDimMapping] = useDimMappingState(signalDims, 1);
+
+  const { valuesStore } = useContext(ProviderContext);
+  valuesStore.prefetch({ path: signalDataset.path });
+  if (errorsDataset) {
+    valuesStore.prefetch({ path: errorsDataset.path });
+  }
 
   const title = useDatasetValue(titleDataset);
   const axisMapping = useAxisMapping(axisDatasetMapping, axesScaleType);

--- a/src/h5web/vis-packs/nexus/hooks.ts
+++ b/src/h5web/vis-packs/nexus/hooks.ts
@@ -27,39 +27,8 @@ import {
   getDatasetLabel,
   getAttributeValue,
   getSilxStyle,
+  findErrorsDataset,
 } from './utils';
-
-function useSignalDataset(
-  group: Group
-): Dataset<HDF5SimpleShape, HDF5NumericType> {
-  const { valuesStore } = useContext(ProviderContext);
-
-  const dataset = findSignalDataset(group);
-  valuesStore.prefetch(dataset.path);
-  return dataset;
-}
-
-function useErrorsDataset(
-  group: Group,
-  signalName: string
-): Dataset<HDF5SimpleShape, HDF5NumericType> | undefined {
-  const { valuesStore } = useContext(ProviderContext);
-
-  const dataset =
-    getChildEntity(group, `${signalName}_errors`) ||
-    getChildEntity(group, 'errors');
-
-  if (!dataset) {
-    return undefined;
-  }
-
-  assertDataset(dataset);
-  assertSimpleShape(dataset);
-  assertNumericType(dataset);
-
-  valuesStore.prefetch(dataset.path);
-  return dataset;
-}
 
 function useTitleDataset(
   group: Group
@@ -75,7 +44,7 @@ function useTitleDataset(
   assertScalarShape(dataset);
   assertStringType(dataset);
 
-  valuesStore.prefetch(dataset.path);
+  valuesStore.prefetch({ path: dataset.path });
   return dataset;
 }
 
@@ -99,22 +68,19 @@ function useAxesDatasets(
     assertSimpleShape(dataset);
     assertNumericType(dataset);
 
-    valuesStore.prefetch(dataset.path);
+    valuesStore.prefetch({ path: dataset.path });
     return dataset;
   });
 }
 
 export function useNxData(group: Group): NxData {
   assertNxDataGroup(group);
-
-  const signalDataset = useSignalDataset(group);
-  const errorsDataset = useErrorsDataset(group, signalDataset.name);
-  const titleDataset = useTitleDataset(group);
+  const signalDataset = findSignalDataset(group);
 
   return {
     signalDataset,
-    errorsDataset,
-    titleDataset,
+    errorsDataset: findErrorsDataset(group, signalDataset.name),
+    titleDataset: useTitleDataset(group),
     axisDatasetMapping: useAxesDatasets(group),
     silxStyle: getSilxStyle(group),
   };

--- a/src/h5web/vis-packs/nexus/utils.ts
+++ b/src/h5web/vis-packs/nexus/utils.ts
@@ -48,6 +48,24 @@ export function findSignalDataset(
   return dataset;
 }
 
+export function findErrorsDataset(
+  group: Group,
+  signalName: string
+): Dataset<HDF5SimpleShape, HDF5NumericType> | undefined {
+  const dataset =
+    getChildEntity(group, `${signalName}_errors`) ||
+    getChildEntity(group, 'errors');
+
+  if (!dataset) {
+    return undefined;
+  }
+
+  assertDataset(dataset);
+  assertSimpleShape(dataset);
+  assertNumericType(dataset);
+  return dataset;
+}
+
 export function getDatasetLabel(dataset: Dataset): string {
   const longName = getAttributeValue(dataset, 'long_name');
   if (longName && typeof longName === 'string') {

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -4,9 +4,7 @@
 declare module 'ndarray-unpack' {
   import ndarray from 'ndarray';
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   function unpack<LT = T>(a: ndarray<T>): LT[];
-
   export = unpack;
 }
 


### PR DESCRIPTION
In order to fetch values by slice, I need to pass an extra `selection` parameter (of the form `0,0,:,:`) along with the entity `path`. I also need the values store to use both the path and the selection as keys when caching results.

`react-suspense-fetch` accepts fetch functions with a single string or object parameter. An object parameter would do the job, but when `react-suspense-fetch` encounters an object parameter, it stores it in a `WeakMap` cache internally, which means that cached results would disappear as soon as the input objects were garbage collected...

The workaround is to stringify an input object before passing it to the store, and then parsing the string back into an object inside the fetch function:

```ts
const store = createFetchStore(async (key: string) => {
  const { path, selection } = JSON.parse(key);
  // ...
});

store.get(JSON.stringify({ path, selection }));
```

To avoid cluttering the code, enforce good typing and work around challenges posed by the fact that passing a `selection` should be optional, I implemented a thin wrapper around `react-suspense-fetch`: `createObjectKeyStore`. This store accepts fetch function with a single object parameter of any shape.

If an optional property of the object parameter is passed explicitly as `undefined`, the property is removed from the object so that `JSON.stringify` doesn't convert it to `null` -- this ensures that `{ path: 'foo', selection: undefined }` and `{ path: 'foo' }` are stored with the same key in the cache.