### PR TITLE
Start implementing shaders-based heatmap behind flag

### DIFF
--- a/.env
+++ b/.env
@@ -18,6 +18,9 @@ REACT_APP_HSDS_FALLBACK_DOMAIN="/home/reader/water"
 REACT_APP_JLAB_URL=
 REACT_APP_JLAB_FALLBACK_DOMAIN="water_224.h5"
 
+# Development-only feature flags
+REACT_APP_DEV_SHADERS=false
+
 # Rendering performance profiling (local development only)
 REACT_APP_PROFILING_ENABLED=false
 

--- a/src/h5web/vis-packs/core/heatmap/HeatmapVis.tsx
+++ b/src/h5web/vis-packs/core/heatmap/HeatmapVis.tsx
@@ -6,6 +6,7 @@ import ColorBar from './ColorBar';
 import Mesh from './Mesh';
 import TooltipMesh from '../shared/TooltipMesh';
 import PanZoomMesh from '../shared/PanZoomMesh';
+import ShadersMesh from './ShadersMesh';
 import VisCanvas from '../shared/VisCanvas';
 import { getDims, getPixelEdges } from './utils';
 import { Domain, ScaleType, AxisParams } from '../models';
@@ -85,15 +86,24 @@ function HeatmapVis(props: Props): ReactElement {
           guides="both"
         />
         <PanZoomMesh />
-        <Mesh
-          rows={rows}
-          cols={cols}
-          values={dataArray.data as number[]}
-          domain={domain}
-          scaleType={scaleType}
-          colorMap={colorMap}
-          showLoader={showLoader}
-        />
+        {process.env.REACT_APP_DEV_SHADERS === 'true' ? (
+          <ShadersMesh
+            rows={rows}
+            cols={cols}
+            values={dataArray.data as number[]}
+            domain={domain}
+          />
+        ) : (
+          <Mesh
+            rows={rows}
+            cols={cols}
+            values={dataArray.data as number[]}
+            domain={domain}
+            scaleType={scaleType}
+            colorMap={colorMap}
+            showLoader={showLoader}
+          />
+        )}
       </VisCanvas>
       <ColorBar domain={domain} scaleType={scaleType} colorMap={colorMap} />
     </figure>

--- a/src/h5web/vis-packs/core/heatmap/Mesh.tsx
+++ b/src/h5web/vis-packs/core/heatmap/Mesh.tsx
@@ -45,7 +45,7 @@ function Mesh(props: Props): ReactElement {
     <>
       {material && (
         <mesh material={material}>
-          <planeBufferGeometry attach="geometry" args={[width, height]} />
+          <planeGeometry attach="geometry" args={[width, height]} />
         </mesh>
       )}
       {showLoader && (

--- a/src/h5web/vis-packs/core/heatmap/ShadersMesh.tsx
+++ b/src/h5web/vis-packs/core/heatmap/ShadersMesh.tsx
@@ -1,0 +1,76 @@
+import { ReactElement, memo } from 'react';
+import { useThree } from 'react-three-fiber';
+import { DataTexture, FloatType, RedFormat } from 'three';
+import type { Domain } from '../models';
+
+interface Props {
+  rows: number;
+  cols: number;
+  values: number[];
+  domain: Domain;
+}
+
+function ShadersMesh(props: Props): ReactElement {
+  const { rows, cols, values, domain } = props;
+
+  const shader = {
+    uniforms: {
+      data: {
+        value: new DataTexture(
+          Float32Array.from(values),
+          cols,
+          rows,
+          RedFormat,
+          FloatType
+        ),
+      },
+      min: { value: domain[0] },
+      oneOverRange: { value: 1 / (domain[1] - domain[0]) },
+    },
+    vertexShader: `
+      varying vec2 coords;
+
+      void main() {
+        coords = uv;
+        gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+      }
+    `,
+    fragmentShader: `
+      uniform sampler2D data;
+      uniform float min;
+      uniform float oneOverRange;
+
+      varying vec2 coords;
+
+      vec3 inferno(float t) {
+        const vec3 c0 = vec3(0.0002189403691192265, 0.001651004631001012, -0.01948089843709184);
+        const vec3 c1 = vec3(0.1065134194856116, 0.5639564367884091, 3.932712388889277);
+        const vec3 c2 = vec3(11.60249308247187, -3.972853965665698, -15.9423941062914);
+        const vec3 c3 = vec3(-41.70399613139459, 17.43639888205313, 44.35414519872813);
+        const vec3 c4 = vec3(77.162935699427, -33.40235894210092, -81.80730925738993);
+        const vec3 c5 = vec3(-71.31942824499214, 32.62606426397723, 73.20951985803202);
+        const vec3 c6 = vec3(25.13112622477341, -12.24266895238567, -23.07032500287172);
+
+        return c0+t*(c1+t*(c2+t*(c3+t*(c4+t*(c5+t*c6)))));
+      }
+
+      void main() {
+        float value = texture2D(data, coords).r;
+        float normalizedValue = clamp(oneOverRange * (value - min), 0., 1.);
+        gl_FragColor = vec4(inferno(normalizedValue), 1.);
+      }
+    `,
+  };
+
+  const { size } = useThree();
+  const { width, height } = size;
+
+  return (
+    <mesh scale={[width, height, 1]}>
+      <planeGeometry attach="geometry" args={[1, 1]} />
+      <shaderMaterial attach="material" args={[shader]} />
+    </mesh>
+  );
+}
+
+export default memo(ShadersMesh);

--- a/src/h5web/vis-packs/core/shared/PanZoomMesh.tsx
+++ b/src/h5web/vis-packs/core/shared/PanZoomMesh.tsx
@@ -94,7 +94,7 @@ function PanZoomMesh(): ReactElement {
   return (
     <mesh {...{ onPointerMove, onPointerUp, onPointerDown, onWheel }}>
       <meshBasicMaterial attach="material" opacity={0} transparent />
-      <planeBufferGeometry attach="geometry" args={[width, height]} />
+      <planeGeometry attach="geometry" args={[width, height]} />
     </mesh>
   );
 }

--- a/src/h5web/vis-packs/core/shared/TooltipMesh.tsx
+++ b/src/h5web/vis-packs/core/shared/TooltipMesh.tsx
@@ -73,7 +73,7 @@ function TooltipMesh(props: Props): ReactElement {
     <>
       <mesh {...{ onPointerMove, onPointerOut, onPointerDown, onPointerUp }}>
         <meshBasicMaterial attach="material" opacity={0} transparent />
-        <planeBufferGeometry attach="geometry" args={[width, height]} />
+        <planeGeometry attach="geometry" args={[width, height]} />
       </mesh>
       <Html>
         {tooltipOpen && tooltipData && value && (


### PR DESCRIPTION
This is an initial implementation to get things moving. For now, I use the inferno colour map function in the shader (instead of passing the colour map as a texture, as discussed). Also, only the linear scale is supported.

![image](https://user-images.githubusercontent.com/2936402/107520527-ce551d00-6bb1-11eb-8c47-da9dd74444bb.png)
