### PR TITLE
Show two solid colors in color bar when domain is empty

### DIFF
--- a/cypress/specs/app.spec.ts
+++ b/cypress/specs/app.spec.ts
@@ -94,6 +94,43 @@ describe('App', () => {
     }
   });
 
+  it('slice through 4D dataset when visualized as Heatmap', () => {
+    cy.findByRole('treeitem', { name: 'nD_datasets' }).click();
+    cy.findByRole('treeitem', { name: 'fourD' }).click();
+
+    cy.findByRole('figure', { name: 'fourD' }).should('exist');
+
+    cy.findAllByRole('slider', { name: 'Dimension slider' })
+      .should('have.length', 2)
+      .last()
+      .should('have.attr', 'aria-valuenow', 0)
+      .and('have.attr', 'aria-valuemin', 0)
+      .and('have.attr', 'aria-valuemax', 8)
+      .as('slider');
+
+    // Move slider up by three marks and check value
+    cy.get('@slider').type('{uparrow}{uparrow}{uparrow}');
+
+    cy.findByRole('figure', { name: 'fourD' }).should('exist');
+    cy.get('@slider').should('have.attr', 'aria-valuenow', 3);
+
+    if (!!Cypress.env('TAKE_SNAPSHOTS')) {
+      cy.wait(SNAPSHOT_DELAY);
+      cy.matchImageSnapshot('heatmap_4d_sliced');
+    }
+
+    // Move slider up by one mark to reach slice filled only with zeros
+    cy.get('@slider').type('{uparrow}');
+
+    cy.findByRole('figure', { name: 'fourD' }).should('exist');
+    cy.get('@slider').should('have.attr', 'aria-valuenow', 4);
+
+    if (!!Cypress.env('TAKE_SNAPSHOTS')) {
+      cy.wait(SNAPSHOT_DELAY);
+      cy.matchImageSnapshot('heatmap_4d_zeros');
+    }
+  });
+
   context('NeXus', () => {
     it('visualize default NXdata group as NxImage', () => {
       cy.findByRole('treeitem', { name: 'source.h5' }).click();

--- a/src/h5web/dimension-mapper/SlicingSlider.tsx
+++ b/src/h5web/dimension-mapper/SlicingSlider.tsx
@@ -30,6 +30,7 @@ function SlicingSlider(props: Props): ReactElement {
         // https://github.com/zillow/react-slider/issues/172
         key={`${mapperState.includes('y')}`}
         className={styles.slider}
+        ariaLabel="Dimension slider"
         trackClassName={styles.track}
         thumbClassName={styles.thumb}
         renderThumb={(thumbProps, state) => (

--- a/src/h5web/toolbar/controls/ColorMapSelector.tsx
+++ b/src/h5web/toolbar/controls/ColorMapSelector.tsx
@@ -8,7 +8,7 @@ import {
   SINGLE_HUE,
 } from '../../vis-packs/core/heatmap/interpolators';
 import type { ColorMap } from '../../vis-packs/core/heatmap/models';
-import { generateCSSLinearGradient } from '../../vis-packs/core/heatmap/utils';
+import { getLinearGradient } from '../../vis-packs/core/heatmap/utils';
 import Selector from './Selector/Selector';
 import styles from './ColorMapSelector.module.css';
 
@@ -22,10 +22,8 @@ const COLORMAP_GROUPS = {
 
 function ColorMapOption(props: { option: ColorMap }): ReactElement {
   const { option } = props;
-  const backgroundImage = generateCSSLinearGradient(
-    INTERPOLATORS[option],
-    'right'
-  );
+  const backgroundImage = getLinearGradient(INTERPOLATORS[option], 'right');
+
   return (
     <>
       {option}

--- a/src/h5web/vis-packs/core/heatmap/ColorBar.tsx
+++ b/src/h5web/vis-packs/core/heatmap/ColorBar.tsx
@@ -3,7 +3,7 @@ import { AxisRight, AxisBottom } from '@visx/axis';
 import { useMeasure } from 'react-use';
 import { adaptedNumTicks, createAxisScale } from '../utils';
 import styles from './ColorBar.module.css';
-import { generateCSSLinearGradient } from './utils';
+import { getLinearGradient } from './utils';
 import type { ScaleType, Domain } from '../models';
 import type { ColorMap } from './models';
 import { INTERPOLATORS } from './interpolators';
@@ -38,9 +38,10 @@ function ColorBar(props: Props): ReactElement {
         ref={gradientRef as (element: HTMLElement | null) => void} // https://github.com/streamich/react-use/issues/1264
         className={styles.gradient}
         style={{
-          backgroundImage: generateCSSLinearGradient(
+          backgroundImage: getLinearGradient(
             interpolator,
-            horizontal ? 'right' : 'top'
+            horizontal ? 'right' : 'top',
+            domain[0] === domain[1]
           ),
         }}
       />

--- a/src/h5web/vis-packs/core/heatmap/utils.test.ts
+++ b/src/h5web/vis-packs/core/heatmap/utils.test.ts
@@ -1,20 +1,28 @@
-import { interpolateRdBu } from 'd3-scale-chromatic';
-import { generateCSSLinearGradient } from './utils';
+import { interpolateGreys } from 'd3-scale-chromatic';
+import { getLinearGradient } from './utils';
 
-describe('generateCSSLinearGradient', () => {
-  it('should generate a linear gradient from first to last color', () => {
-    // Escape parentheses for literal matching
-    const firstColor = interpolateRdBu(0)
-      .replace('(', '\\(')
-      .replace(')', '\\)');
-    const lastColor = interpolateRdBu(1)
-      .replace('(', '\\(')
-      .replace(')', '\\)');
-    const regexp = new RegExp(
-      `linear-gradient\\(to top,${firstColor},.*${lastColor}\\)`,
-      'u'
+const white = 'rgb(255, 255, 255)';
+const black = 'rgb(0, 0, 0)';
+const gradientRegex = /^linear-gradient\(to top, (.+)\)$/u;
+
+describe('getLinearGradient', () => {
+  it('should generate linear gradient from first to last color', () => {
+    const gradient = getLinearGradient(interpolateGreys, 'top');
+
+    const [match, colorStops] = gradientRegex.exec(gradient) || [];
+    expect(match).toBeDefined();
+    expect(colorStops.startsWith(white)).toBe(true);
+    expect(colorStops.endsWith(black)).toBe(true);
+    expect(colorStops.match(/rgb/gu)?.length).toBe(21);
+  });
+
+  it('should generate linear gradient with two solid colors', () => {
+    const gradient = getLinearGradient(interpolateGreys, 'top', true);
+
+    const [match, colorStops] = gradientRegex.exec(gradient) || [];
+    expect(match).toBeDefined();
+    expect(colorStops).toEqual(
+      `${white}, ${white} 50%, ${black} 50%, ${black}`
     );
-    const result = generateCSSLinearGradient(interpolateRdBu, 'top');
-    expect(result).toEqual(expect.stringMatching(regexp));
   });
 });

--- a/src/h5web/vis-packs/core/heatmap/utils.ts
+++ b/src/h5web/vis-packs/core/heatmap/utils.ts
@@ -2,20 +2,34 @@ import { range } from 'lodash-es';
 import type ndarray from 'ndarray';
 import type { D3Interpolator, Dims } from './models';
 
+const GRADIENT_PRECISION = 1 / 20;
+const GRADIENT_RANGE = range(0, 1 + GRADIENT_PRECISION, GRADIENT_PRECISION);
+
 export function getDims(dataArray: ndarray): Dims {
   const [rows, cols] = dataArray.shape;
   return { rows, cols };
 }
 
-export function generateCSSLinearGradient(
+function getColorStops(
   interpolator: D3Interpolator,
-  direction: 'top' | 'bottom' | 'right' | 'left'
+  minMaxOnly: boolean
 ): string {
-  const gradientColors = range(0, 1.1, 0.1)
-    .map(interpolator)
-    .reduce((acc, val) => `${acc},${val}`);
+  if (minMaxOnly) {
+    const min = interpolator(0);
+    const max = interpolator(1);
+    return `${min}, ${min} 50%, ${max} 50%, ${max}`;
+  }
 
-  return `linear-gradient(to ${direction},${gradientColors})`;
+  return GRADIENT_RANGE.map(interpolator).join(', ');
+}
+
+export function getLinearGradient(
+  interpolator: D3Interpolator,
+  direction: 'top' | 'bottom' | 'right' | 'left',
+  minMaxOnly = false
+): string {
+  const colorStops = getColorStops(interpolator, minMaxOnly);
+  return `linear-gradient(to ${direction}, ${colorStops})`;
 }
 
 export function getPixelEdges(

--- a/src/packages/lib.ts
+++ b/src/packages/lib.ts
@@ -26,7 +26,7 @@ export { useDomain } from '../h5web/vis-packs/core/hooks';
 
 export {
   getDims,
-  generateCSSLinearGradient,
+  getLinearGradient,
 } from '../h5web/vis-packs/core/heatmap/utils';
 
 // Models

--- a/src/stories/Home.stories.mdx
+++ b/src/stories/Home.stories.mdx
@@ -104,4 +104,4 @@ If you use only the top-level visualization components, the only utilities you n
 - **`extendDomain(bareDomain: Domain, extendFactor: number, isLog?: boolean): Domain`** - Extend a domain by a given factor.
 - **`computeVisSize(availableSize: Size, aspectRatio?: number): Size | undefined`** - Compute the optimal size for a visualization to fill the available space given an optional aspect ratio.
 - **`getDims(dataArray: DataArray): Dims`** - Get the dimensions of a `ndarray` as a `{ rows, cols }` object.
-- **`generateCSSLinearGradient(interpolator: D3Interpolator, direction: 'top' | 'bottom' | 'right' | 'left'): string`** - Generate a CSS linear gradient for a given D3 interpolator, to be used as `background-image`.
+- **`getLinearGradient(interpolator: D3Interpolator, direction: 'top' | 'bottom' | 'right' | 'left'): string`** - Generate a CSS linear gradient for a given D3 interpolator, to be used as `background-image`.


### PR DESCRIPTION
When the domain has no size (i.e. `[x, x]`), the colour bar axis has a single tick, centred in the middle of the colour bar, but the colour bar itself still shows a gradient. In the visualization, any value below `x` is represented with the colour map's min colour and any value above `x` with the colour map's max colour, so the colour bar does not represent the visualization accurately.

This PR deals with this edge case by showing two solid colours in the colour bar instead of a gradient (though it is still a CSS linear-gradient under the hood).

FYI, my next PR will be about showing the min/max under/above the colour bar. In the case of an empty domain, I was thinking of actually showing `-Infinity` and `+Infinity` to accurately convey what's going on in the visualization.

### BEFORE

![image](https://user-images.githubusercontent.com/2936402/108051660-7011b980-704b-11eb-98df-a1ccac133c90.png)

### AFTER

![image](https://user-images.githubusercontent.com/2936402/108051796-99324a00-704b-11eb-8ce8-05b3e2e4d2d5.png)
