### PR TITLE
Adding boolean type, a subset of enum type

### DIFF
--- a/src/h5web/providers/hdf5-models.ts
+++ b/src/h5web/providers/hdf5-models.ts
@@ -90,7 +90,8 @@ type HDF5AdvancedType =
   | HDF5Id
   | HDF5ArrayType
   | HDF5VLenType
-  | HDF5CompoundType;
+  | HDF5CompoundType
+  | HDF5EnumType;
 
 export enum HDF5TypeClass {
   Integer = 'H5T_INTEGER',
@@ -99,9 +100,16 @@ export enum HDF5TypeClass {
   Array = 'H5T_ARRAY',
   VLen = 'H5T_VLEN',
   Compound = 'H5T_COMPOUND',
+  Enum = 'H5T_ENUM',
 }
 
 export type HDF5Endianness = 'BE' | 'LE' | 'Native' | 'Not applicable';
+
+export interface HDF5EnumType {
+  class: HDF5TypeClass.Enum;
+  base: HDF5BaseType;
+  mapping: Record<string, number>;
+}
 
 export interface HDF5IntegerType {
   class: HDF5TypeClass.Integer;

--- a/src/h5web/providers/hsds/models.ts
+++ b/src/h5web/providers/hsds/models.ts
@@ -26,6 +26,7 @@ export type HsdsType =
   | HsdsArrayType
   | HsdsVLenType
   | HsdsCompoundType
+  | HsdsEnumType
   | HDF5Id;
 
 export interface HsdsArrayType {
@@ -42,6 +43,12 @@ export interface HsdsVLenType {
 export interface HsdsCompoundType {
   class: HDF5TypeClass.Compound;
   fields: HsdsCompoundTypeField[];
+}
+
+export interface HsdsEnumType {
+  class: HDF5TypeClass.Enum;
+  base: HsdsBaseType;
+  mapping: Record<string, number>;
 }
 
 interface HsdsCompoundTypeField {

--- a/src/h5web/providers/hsds/utils.ts
+++ b/src/h5web/providers/hsds/utils.ts
@@ -70,6 +70,13 @@ export function convertHsdsType(hsdsType: HsdsType): HDF5Type {
   }
 
   switch (hsdsType.class) {
+    case HDF5TypeClass.Enum:
+      return {
+        class: HDF5TypeClass.Enum,
+        base: convertHsdsBaseType(hsdsType.base),
+        mapping: hsdsType.mapping,
+      };
+
     case HDF5TypeClass.Array:
       return {
         class: HDF5TypeClass.Array,

--- a/src/h5web/providers/jupyter/utils.ts
+++ b/src/h5web/providers/jupyter/utils.ts
@@ -51,6 +51,25 @@ export function convertEndianness(endianness: string): HDF5Endianness {
 }
 
 export function convertDtype(dtype: string): HDF5Type {
+  // Special case: booleans are stored as bytes
+  // See https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.bool
+  if (dtype === '|b1') {
+    // Booleans are stored as Enum by h5py
+    // https://docs.h5py.org/en/stable/faq.html#what-datatypes-are-supported
+    return {
+      class: HDF5TypeClass.Enum,
+      base: {
+        class: HDF5TypeClass.Integer,
+        endianness: 'Not applicable',
+        size: 8,
+      },
+      mapping: {
+        FALSE: 0,
+        TRUE: 1,
+      },
+    };
+  }
+
   const regexp = /([<>=|])?([A-z])(\d*)/u;
   const matches = regexp.exec(dtype);
 

--- a/src/h5web/providers/mock/metadata-utils.ts
+++ b/src/h5web/providers/mock/metadata-utils.ts
@@ -3,6 +3,7 @@ import {
   HDF5Attribute,
   HDF5CompoundType,
   HDF5Dims,
+  HDF5EnumType,
   HDF5ExternalLink,
   HDF5FloatType,
   HDF5IntegerType,
@@ -48,6 +49,19 @@ export const stringType: HDF5StringType = {
 export const compoundType: HDF5CompoundType = {
   class: HDF5TypeClass.Compound,
   fields: [{ name: 'int', type: intType }],
+};
+
+export const booleanType: HDF5EnumType = {
+  class: HDF5TypeClass.Enum,
+  base: {
+    class: HDF5TypeClass.Integer,
+    endianness: 'Not applicable',
+    size: 8,
+  },
+  mapping: {
+    FALSE: 0,
+    TRUE: 1,
+  },
 };
 
 export const scalarShape: HDF5ScalarShape = { class: HDF5ShapeClass.Scalar };

--- a/src/h5web/providers/mock/metadata.ts
+++ b/src/h5web/providers/mock/metadata.ts
@@ -15,6 +15,7 @@ import {
   makeNxGroup,
   makeSimpleDataset,
   makeAttr,
+  booleanType,
 } from './metadata-utils';
 
 export const mockDomain = 'source.h5';
@@ -31,6 +32,7 @@ export const mockMetadata = makeNxGroup(mockDomain, 'NXroot', {
       makeDataset('raw_large', scalarShape, compoundType),
       makeDataset('scalar_int', scalarShape, intType),
       makeDataset('scalar_str', scalarShape, stringType),
+      makeDataset('scalar_bool', scalarShape, booleanType),
     ]),
     makeGroup('nD_datasets', [
       makeSimpleDataset('oneD_linear', intType, [41]),

--- a/src/h5web/providers/mock/values.ts
+++ b/src/h5web/providers/mock/values.ts
@@ -22,6 +22,7 @@ export const mockValues = {
   raw_large: { str: '.'.repeat(1000) },
   scalar_int: 0,
   scalar_str: 'foo',
+  scalar_bool: true,
   oneD_linear: arr1,
   oneD,
   twoD,


### PR DESCRIPTION
A step towards #479 as even if not a base type, the boolean can be displayed using the Raw visu:
![image](https://user-images.githubusercontent.com/42204205/108079949-a82af380-706f-11eb-8b29-2fc805683d87.png)

Glad to have your feedback on this: on one hand, we add the support of the enum type, on the other, it might seem overthought only for booleans.