### PR TITLE
Implement HSL color scale

### DIFF
--- a/src/h5web/toolbar/controls/ColorMapSelector.tsx
+++ b/src/h5web/toolbar/controls/ColorMapSelector.tsx
@@ -3,7 +3,7 @@ import {
   CYCLICAL,
   DIVERGING,
   INTERPOLATORS,
-  MOST_USED,
+  RECOMMENDED,
   MULTI_HUE,
   SINGLE_HUE,
 } from '../../vis-packs/core/heatmap/interpolators';
@@ -13,7 +13,7 @@ import Selector from './Selector/Selector';
 import styles from './ColorMapSelector.module.css';
 
 const COLORMAP_GROUPS = {
-  Common: Object.keys(MOST_USED) as ColorMap[],
+  Recommended: Object.keys(RECOMMENDED) as ColorMap[],
   'Single hue': Object.keys(SINGLE_HUE) as ColorMap[],
   'Multi hue': Object.keys(MULTI_HUE) as ColorMap[],
   Cyclical: Object.keys(CYCLICAL) as ColorMap[],

--- a/src/h5web/vis-packs/core/heatmap/interpolators.ts
+++ b/src/h5web/vis-packs/core/heatmap/interpolators.ts
@@ -1,3 +1,4 @@
+import { hsl } from 'd3-color';
 import {
   interpolateCool,
   interpolateMagma,
@@ -38,12 +39,17 @@ import {
   interpolateTurbo,
 } from 'd3-scale-chromatic';
 
+function interpolateHsl(t: number): string {
+  return hsl(t * 360, 1, 0.5).formatRgb();
+}
+
 export const MOST_USED = {
   Viridis: interpolateViridis,
   Inferno: interpolateInferno,
   Greys: interpolateGreys,
   RdBu: interpolateRdBu,
   Rainbow: interpolateRainbow,
+  Sinebow: interpolateSinebow,
 };
 
 export const SINGLE_HUE = {
@@ -81,6 +87,7 @@ export const MULTI_HUE = {
 export const CYCLICAL = {
   Rainbow: interpolateRainbow,
   Sinebow: interpolateSinebow,
+  HSL: interpolateHsl,
 };
 
 export const DIVERGING = {

--- a/src/h5web/vis-packs/core/heatmap/interpolators.ts
+++ b/src/h5web/vis-packs/core/heatmap/interpolators.ts
@@ -43,7 +43,7 @@ function interpolateHsl(t: number): string {
   return hsl(t * 360, 1, 0.5).formatRgb();
 }
 
-export const MOST_USED = {
+export const RECOMMENDED = {
   Viridis: interpolateViridis,
   Inferno: interpolateInferno,
   Greys: interpolateGreys,


### PR DESCRIPTION
Fixes #481.

HSL/HSV are the same thing since we only care about the hue. As discussed, since `Sinebow` is an improved version of `HSL`, I've put the former into the _Common_ group instead of `HSL`.

![image](https://user-images.githubusercontent.com/2936402/108214876-fb18af80-7130-11eb-962a-bdbc367bcc60.png)

![image](https://user-images.githubusercontent.com/2936402/108214912-023fbd80-7131-11eb-8593-f39be7b600be.png)
