### PR TITLE
Refactor Heatmap config to support auto-scaling a single domain bound

### DIFF
--- a/.env
+++ b/.env
@@ -28,3 +28,5 @@ ESLINT_NO_DEV_ERRORS=true
 # Don't override this variable in `.env.local`, as this file is not used during tests
 # https://testing-library.com/docs/dom-testing-library/api-debugging#automatic-logging
 DEBUG_PRINT_LIMIT=
+
+REACT_APP_DEV_SLIDER=

--- a/src/h5web/toolbar/controls/DomainSlider.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from 'react';
 import ReactSlider from 'react-slider';
 import { format } from 'd3-format';
 import styles from './DomainSlider.module.css';
-import type { Domain } from '../../vis-packs/core/models';
+import type { CustomDomain, Domain } from '../../vis-packs/core/models';
 import { extendDomain } from '../../vis-packs/core/utils';
 import ToggleBtn from './ToggleBtn';
 import { FiZap } from 'react-icons/fi';
@@ -12,9 +12,9 @@ const NB_DECIMALS = 1;
 
 interface Props {
   dataDomain: Domain;
-  value?: Domain;
+  value: CustomDomain;
   disabled?: boolean;
-  onChange: (value: Domain | undefined) => void;
+  onChange: (value: CustomDomain) => void;
 }
 
 function DomainSlider(props: Props): ReactElement {
@@ -22,6 +22,10 @@ function DomainSlider(props: Props): ReactElement {
 
   const [extendedMin, extendedMax] = extendDomain(dataDomain, EXTEND_FACTOR);
   const step = Math.max((extendedMax - extendedMin) / 100, 10 ** -NB_DECIMALS);
+
+  const isAutoMin = value[0] === undefined;
+  const isAutoMax = value[1] === undefined;
+  const isAutoScaling = isAutoMin || isAutoMax;
 
   return (
     <div className={styles.sliderWrapper}>
@@ -38,7 +42,7 @@ function DomainSlider(props: Props): ReactElement {
             </div>
           </div>
         )}
-        value={[...(value || dataDomain)]}
+        value={[value[0] ?? dataDomain[0], value[1] ?? dataDomain[1]]}
         onAfterChange={(bounds) => {
           onChange(bounds as Domain);
         }}
@@ -50,11 +54,17 @@ function DomainSlider(props: Props): ReactElement {
 
       <ToggleBtn
         small
-        label="Auto"
+        label={`Auto${
+          isAutoMin && !isAutoMax
+            ? ' (min)'
+            : isAutoMax && !isAutoMin
+            ? ' (max)'
+            : ''
+        }`}
         icon={FiZap}
-        value={value === undefined}
+        value={isAutoScaling}
         onChange={() => {
-          onChange(value === undefined ? dataDomain : undefined);
+          onChange(isAutoScaling ? dataDomain : [undefined, undefined]);
         }}
         disabled={disabled}
       />

--- a/src/h5web/vis-packs/core/heatmap/config.ts
+++ b/src/h5web/vis-packs/core/heatmap/config.ts
@@ -1,15 +1,14 @@
 import create, { State } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { ColorMap } from './models';
-import { Domain, ScaleType } from '../models';
-import { DEFAULT_DOMAIN } from '../utils';
+import { CustomDomain, Domain, ScaleType } from '../models';
 
 interface HeatmapConfig extends State {
   dataDomain: Domain | undefined;
-  setDataDomain: (dataDomain: Domain | undefined) => void;
+  setDataDomain: (dataDomain: Domain) => void;
 
-  customDomain: Domain | undefined;
-  setCustomDomain: (customDomain: Domain | undefined) => void;
+  customDomain: CustomDomain;
+  setCustomDomain: (customDomain: CustomDomain) => void;
 
   colorMap: ColorMap;
   setColorMap: (colorMap: ColorMap) => void;
@@ -31,12 +30,10 @@ export const useHeatmapConfig = create<HeatmapConfig>(
   persist(
     (set) => ({
       dataDomain: undefined,
-      setDataDomain: (dataDomain: Domain | undefined) =>
-        set({ dataDomain: dataDomain || DEFAULT_DOMAIN }),
+      setDataDomain: (dataDomain: Domain) => set({ dataDomain }),
 
-      customDomain: undefined,
-      setCustomDomain: (customDomain: Domain | undefined) =>
-        set({ customDomain }),
+      customDomain: [undefined, undefined],
+      setCustomDomain: (customDomain: CustomDomain) => set({ customDomain }),
 
       colorMap: 'Viridis',
       setColorMap: (colorMap: ColorMap) => set({ colorMap }),
@@ -64,7 +61,7 @@ export const useHeatmapConfig = create<HeatmapConfig>(
         'showGrid',
         'invertColorMap',
       ],
-      version: 4,
+      version: 5,
     }
   )
 );

--- a/src/h5web/vis-packs/core/heatmap/hooks.ts
+++ b/src/h5web/vis-packs/core/heatmap/hooks.ts
@@ -1,0 +1,12 @@
+import { useMemo } from 'react';
+import type { CustomDomain, Domain } from '../models';
+
+export function useVisDomain(
+  dataDomain: Domain,
+  customDomain: CustomDomain
+): Domain {
+  const min = customDomain[0] ?? dataDomain[0];
+  const max = customDomain[1] ?? dataDomain[1];
+
+  return useMemo(() => [min, max], [min, max]);
+}

--- a/src/h5web/vis-packs/core/models.ts
+++ b/src/h5web/vis-packs/core/models.ts
@@ -18,6 +18,7 @@ export interface Size {
 }
 
 export type Domain = [number, number];
+export type CustomDomain = [number | undefined, number | undefined];
 
 export interface AxisConfig {
   isIndexAxis?: boolean;


### PR DESCRIPTION
Preparation for #510 

I change the `customDomain` state to `[number | undefined, number | undefined]` instead of `Domain | undefined`. This change is required if we want to support auto-scaling the domain bounds independently.