### PR TITLE
Update only the domain bounds that change when interacting with the slider

### DIFF
--- a/src/h5web/toolbar/controls/DomainSlider/DomainSlider.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/DomainSlider.tsx
@@ -61,7 +61,12 @@ function DomainSlider(props: Props): ReactElement {
         isAutoMax={isAutoMax}
         disabled={disabled}
         onChange={setSliderDomain}
-        onAfterChange={onCustomDomainChange}
+        onAfterChange={(hasMinChanged, hasMaxChanged) => {
+          onCustomDomainChange([
+            hasMinChanged ? sliderDomain[0] : customDomain[0],
+            hasMaxChanged ? sliderDomain[1] : customDomain[1],
+          ]);
+        }}
       />
 
       <ToggleBtn

--- a/src/h5web/toolbar/controls/DomainSlider/ScaledSlider.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/ScaledSlider.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement, Ref } from 'react';
 import { FiSkipBack, FiSkipForward } from 'react-icons/fi';
 import ReactSlider from 'react-slider';
+import { useBoolean } from 'react-use';
 import { Domain, extendDomain, ScaleType } from '../../../../packages/lib';
 import { createAxisScale } from '../../../vis-packs/core/utils';
 import styles from './DomainSlider.module.css';
@@ -15,15 +16,22 @@ interface Props {
   disabled?: boolean;
   isAutoMin: boolean;
   isAutoMax: boolean;
-  onChange: (domain: Domain) => void;
-  onAfterChange: (domain: Domain) => void;
+  onChange: (
+    newValue: Domain,
+    hasMinChanged: boolean,
+    hasMaxChanged: boolean
+  ) => void;
+  onAfterChange: (hasMinChanged: boolean, hasMaxChanged: boolean) => void;
 }
 
 function ScaledSlider(props: Props): ReactElement {
   const { value, dataDomain, disabled, isAutoMin, isAutoMax } = props;
-  const { onChange, onAfterChange } = props;
+  const { onChange, onAfterChange: onDone } = props;
 
   const sliderExtent = extendDomain(dataDomain, EXTEND_FACTOR);
+
+  const [hasMinChanged, setMinChanged] = useBoolean(false);
+  const [hasMaxChanged, setMaxChanged] = useBoolean(false);
 
   const scale = createAxisScale({
     type: ScaleType.Linear,
@@ -31,6 +39,29 @@ function ScaledSlider(props: Props): ReactElement {
     range: SLIDER_RANGE,
     round: true,
   });
+
+  const scaledValue = value.map(scale) as Domain;
+
+  function handleChange(newScaledValue: Domain) {
+    const [newScaledMin, newScaledMax] = newScaledValue;
+    const hasMinChanged = newScaledMin !== scaledValue[0];
+    const hasMaxChanged = newScaledMax !== scaledValue[1];
+
+    const newValue: Domain = [
+      hasMinChanged ? scale.invert(newScaledMin) : value[0],
+      hasMaxChanged ? scale.invert(newScaledMax) : value[1],
+    ];
+
+    onChange(newValue, hasMinChanged, hasMaxChanged);
+    setMinChanged(hasMinChanged);
+    setMaxChanged(hasMaxChanged);
+  }
+
+  function handleAfterChange() {
+    onDone(hasMinChanged, hasMaxChanged);
+    setMinChanged(false);
+    setMaxChanged(false);
+  }
 
   return (
     <ReactSlider
@@ -41,16 +72,10 @@ function ScaledSlider(props: Props): ReactElement {
       pearling
       min={SLIDER_RANGE[0]}
       max={SLIDER_RANGE[1]}
-      value={value.map(scale) as Domain}
+      value={scaledValue}
       disabled={disabled}
-      onChange={(bounds) => {
-        onChange((bounds as Domain).map((val) => scale.invert(val)) as Domain);
-      }}
-      onAfterChange={(bounds) => {
-        onAfterChange(
-          (bounds as Domain).map((val) => scale.invert(val)) as Domain
-        );
-      }}
+      onChange={(bounds) => handleChange(bounds as Domain)}
+      onAfterChange={handleAfterChange}
       renderThumb={({ ref, ...thumbProps }, { index }) => (
         <Thumb
           ref={ref as Ref<HTMLDivElement>}


### PR DESCRIPTION
Not as straightforward as I was hoping... As a reminder, the initial goal was **to update only the `customDomain` bound that changed after moving a thumb**, so that the other bound could remain `undefined` (and therefore autoscaled) if applicable.

There were a couple of unforeseen challenges that made this more complicated than expected:

- The bound that doesn't change must also **_not_ be updated in `sliderDomain` _during_ the interaction**.

  Initially, I had `ScaledSlider` scale-invert both bounds and send the result to `DomainSlider` to set as is as the new `sliderDomain`. The problem is that `sliderDomain` is displayed in the popup (for real-time feedback when moving a thumb), and `scale()` rounds to the nearest integer, so `scale.invert()` doesn't always give back the same value... As a result, I'd see the value of the other bound change at the start of the interaction and be reset at the end...

- Because `ScaledSlider` is a controlled component, when `onAfterChange` is called, the slider's value that we get as argument to this callback has already been updated with the latest change, so it's impossible to determine as is which bound has changed in `onAfterChange`.

  To work around this, I had to use a couple of boolean states. I set them to `true` in `onChange`, and then reset them to `false` in `onAfterChange`.

- Because we enabled `pearling` on the slider, one thumb can push another during an interaction. Therefore, the two bounds can actually change at the same time, which means that sometimes, we do need to update both values in `sliderDomain` and `customDomain` during and after an interaction...

  That's why I use two separate boolean state and pass two separate arguments to the callbacks. Managing all this with a single enum value of some sort would have been too convoluted. That being said, the `onChange` callback could be smarter: I could pass a `CustomDomain` and convey that a bound has not changed by setting it to `undefined`. However, I'd like your opinion before implementing this solution, as you may find the current implementation satisfactory. Personally, I think two booleans make for a clearer callback signature, so I'm happy as it is.
  
