### PR TITLE
Clamp bounds typed in by user

### DIFF
--- a/src/h5web/toolbar/controls/DomainSlider/BoundEditor.module.css
+++ b/src/h5web/toolbar/controls/DomainSlider/BoundEditor.module.css
@@ -14,8 +14,8 @@
 }
 
 .value {
-  flex: 1 1 0%;
-  width: 0; /* ensures input shrinks before filling the available space */
+  flex: 1 0 auto;
+  width: 8.5em; /* -9.99999e+999 without overflowing */
   margin-right: 0.375rem;
   padding: 0.25rem 0.375rem;
   background-color: rgba(255, 255, 255, 0.5);

--- a/src/h5web/toolbar/controls/DomainSlider/BoundEditor.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/BoundEditor.tsx
@@ -2,6 +2,7 @@ import { ReactElement, useEffect, useRef, useState } from 'react';
 import { FiCheck, FiSlash } from 'react-icons/fi';
 import { formatPreciseValue } from '../../../utils';
 import type { Bound } from '../../../vis-packs/core/models';
+import { clampBound } from '../../../vis-packs/core/utils';
 import styles from './BoundEditor.module.css';
 
 interface Props {
@@ -45,10 +46,15 @@ function BoundEditor(props: Props): ReactElement {
       onSubmit={(evt) => {
         evt.preventDefault();
 
-        // In case user replaced minus with hyphen without actually changing the value
-        setInputValue(inputValue.replace('-', '−'));
+        const parsedValue = Number.parseFloat(inputValue.replace('−', '-')); // U+2212 minus gives `NaN`
+        const newValue = Number.isNaN(parsedValue)
+          ? value
+          : clampBound(parsedValue);
 
-        onChange(Number.parseFloat(inputValue.replace('−', '-'))); // `parseFloat` dislikes U+2212 minus
+        // Clean up input in case value hasn't changed (since `useEffect` won't be triggered)
+        setInputValue(formatPreciseValue(newValue));
+
+        onChange(newValue);
         onEditToggle(false);
       }}
     >

--- a/src/h5web/toolbar/controls/DomainSlider/DomainTooltip.module.css
+++ b/src/h5web/toolbar/controls/DomainSlider/DomainTooltip.module.css
@@ -1,7 +1,6 @@
 .tooltip {
   composes: popup from '../../Toolbar.module.css';
   left: 50%;
-  min-width: 17em;
   transform: translate(-50%, 100%);
 }
 

--- a/src/h5web/vis-packs/core/heatmap/utils.ts
+++ b/src/h5web/vis-packs/core/heatmap/utils.ts
@@ -25,15 +25,14 @@ export function getSafeDomain(
   fallbackDomain: Domain,
   scaleType: ScaleType
 ): [Domain, DomainErrors] {
+  const [min, max] = domain;
+
   if (scaleType === ScaleType.Log) {
     return [
-      [
-        domain[0] <= 0 ? fallbackDomain[0] : domain[0],
-        domain[1] <= 0 ? fallbackDomain[1] : domain[1],
-      ],
+      [min <= 0 ? fallbackDomain[0] : min, max <= 0 ? fallbackDomain[1] : max],
       {
-        minError: domain[0] <= 0 ? BoundError.InvalidWithLog : undefined,
-        maxError: domain[1] <= 0 ? BoundError.InvalidWithLog : undefined,
+        minError: min <= 0 ? BoundError.InvalidWithLog : undefined,
+        maxError: max <= 0 ? BoundError.InvalidWithLog : undefined,
       },
     ];
   }

--- a/src/h5web/vis-packs/core/utils.ts
+++ b/src/h5web/vis-packs/core/utils.ts
@@ -145,15 +145,15 @@ function extendEmptyDomain(
   return [value - extension, value + extension];
 }
 
-function clampBound(val: number): number {
+export function clampBound(val: number, withPositiveMin = false): number {
   const absVal = Math.abs(val);
 
-  if (absVal < Number.EPSILON) {
-    return val === 0 ? val : Math.sign(val) * Number.EPSILON;
+  if (withPositiveMin && absVal <= 0) {
+    return Number.MIN_VALUE;
   }
 
-  if (absVal > 1 / Number.EPSILON) {
-    return Math.sign(val) / Number.EPSILON;
+  if (absVal > Number.MAX_VALUE / 2) {
+    return (Math.sign(val) * Number.MAX_VALUE) / 2; // max domain length is `Number.MAX_VALUE`
   }
 
   return val;
@@ -169,8 +169,9 @@ export function extendDomain(
   }
 
   const [min, max] = domain;
+  const isLog = scaleType === ScaleType.Log;
 
-  if (min <= 0 && scaleType === ScaleType.Log) {
+  if (min <= 0 && isLog) {
     throw new Error('Expected domain compatible with log scale');
   }
 
@@ -181,8 +182,8 @@ export function extendDomain(
   const scale = createAxisScale({ type: scaleType, domain, range: [0, 1] });
 
   return [
-    clampBound(scale.invert(-extendFactor)),
-    clampBound(scale.invert(1 + extendFactor)),
+    clampBound(scale.invert(-extendFactor), isLog),
+    clampBound(scale.invert(1 + extendFactor), isLog),
   ];
 }
 


### PR DESCRIPTION
First, I change the values used for clamping (previously `Number.EPSILON` and `1 / Number.EPSILON`) to `Number.MIN_VALUE` and `Number.MAX_VALUE / 2`, thus giving users a much wider range of values (but with a precision of 6 significant digits).

Why not `Number.MAX_VALUE`? Because `scaleLinear` does not support domains wider than `Number.MAX_VALUE`:

```ts
const scale = scaleLinear([-Number.MAX_VALUE, Number.MAX_VALUE]).domain([1, 100]);
scale(Number.MAX_VALUE) // => NaN
```

Since allowing domains such as `[-Number.MAX_VALUE, 0]` would make the clamping behaviour non trivial (for us and for users), I decided to just clamp to `[-Number.MAX_VALUE / 2, Number.MAX_VALUE / 2]`.

With this done, I'm able to use `clampBound` in `BoundEditor` to clamp values entered by the user. I also:

- deal with cases where `parseFloat` returns `NaN` (when the first character is not a digit, a dot, a sign, etc.); and
- use `formatPreciseValue` to more thoroughly clean up the text field when the parsed value doesn't change (e.g. when you add a random letter in the middle of the number).