### PR TITLE
Fall back to data domain when min is greater than max

### DIFF
--- a/src/h5web/toolbar/controls/DomainSlider/DomainTooltip.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/DomainTooltip.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from 'react';
+import { FiCornerDownRight } from 'react-icons/fi';
 import type { Domain } from '../../../../packages/lib';
 import { formatValue } from '../../../utils';
 import type { DomainErrors } from '../../../vis-packs/core/models';
@@ -37,16 +38,24 @@ function DomainTooltip(props: Props): ReactElement {
     onChangeMax,
   } = props;
 
-  const { minError, maxError } = errors;
+  const { minGreater: minMaxSwapped, minError, maxError } = errors;
 
   return (
     <div id={id} className={styles.tooltip} role="tooltip" hidden={!open}>
       <div className={styles.tooltipInner}>
+        {minMaxSwapped && (
+          <p className={styles.error}>
+            Min greater than max
+            <br />
+            <FiCornerDownRight /> falling back to <strong>data range</strong>
+          </p>
+        )}
+
         <BoundEditor
           bound="min"
           value={sliderDomain[0]}
           isEditing={isEditingMin}
-          hasError={!!minError}
+          hasError={minMaxSwapped || !!minError}
           onEditToggle={onEditMin}
           onChange={onChangeMin}
         />
@@ -56,7 +65,7 @@ function DomainTooltip(props: Props): ReactElement {
           bound="max"
           value={sliderDomain[1]}
           isEditing={isEditingMax}
-          hasError={!!maxError}
+          hasError={minMaxSwapped || !!maxError}
           onEditToggle={onEditMax}
           onChange={onChangeMax}
         />

--- a/src/h5web/toolbar/controls/DomainSlider/ScaledSlider.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/ScaledSlider.tsx
@@ -24,11 +24,7 @@ interface Props {
   disabled?: boolean;
   isAutoMin: boolean;
   isAutoMax: boolean;
-  onChange: (
-    newValue: Domain,
-    hasMinChanged: boolean,
-    hasMaxChanged: boolean
-  ) => void;
+  onChange: (newValue: Domain) => void;
   onAfterChange: (hasMinChanged: boolean, hasMaxChanged: boolean) => void;
 }
 
@@ -44,7 +40,7 @@ function ScaledSlider(props: Props): ReactElement {
     isAutoMax,
   } = props;
   const { onChange, onAfterChange: onDone } = props;
-  const { minError, maxError } = errors;
+  const { minGreater, minError, maxError } = errors;
 
   const sliderExtent = extendDomain(safeVisDomain, EXTEND_FACTOR, scaleType);
   const scale = createAxisScale({
@@ -65,14 +61,14 @@ function ScaledSlider(props: Props): ReactElement {
     const hasMaxChanged = newScaledMax !== beforeChangeValue[1];
 
     const newValue: Domain = [
-      hasMinChanged ? scale.invert(newScaledMin) : safeValue[0],
-      hasMaxChanged ? scale.invert(newScaledMax) : safeValue[1],
+      hasMinChanged ? scale.invert(newScaledMin) : value[0],
+      hasMaxChanged ? scale.invert(newScaledMax) : value[1],
     ];
 
     if (done) {
       onDone(hasMinChanged, hasMaxChanged);
     } else {
-      onChange(newValue, hasMinChanged, hasMaxChanged);
+      onChange(newValue);
     }
   }
 
@@ -91,7 +87,7 @@ function ScaledSlider(props: Props): ReactElement {
         <Thumb
           ref={ref as Ref<HTMLDivElement>}
           isAuto={index === 0 ? isAutoMin : isAutoMax}
-          hasError={index === 0 ? !!minError : !!maxError}
+          hasError={minGreater || (index === 0 ? !!minError : !!maxError)}
           AutoIcon={index === 0 ? FiSkipBack : FiSkipForward}
           disabled={disabled}
           {...thumbProps}

--- a/src/h5web/toolbar/controls/DomainSlider/Thumb.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/Thumb.tsx
@@ -24,7 +24,9 @@ const Thumb = forwardRef<HTMLDivElement, Props>((props, ref) => {
     >
       <div className={styles.thumbBtnLike}>
         {isAuto && <AutoIcon className={styles.icon} />}
-        {hasError && <FiAlertCircle className={styles.icon} strokeWidth="3" />}
+        {!isAuto && hasError && (
+          <FiAlertCircle className={styles.icon} strokeWidth="3" />
+        )}
       </div>
     </div>
   );

--- a/src/h5web/vis-packs/core/heatmap/utils.ts
+++ b/src/h5web/vis-packs/core/heatmap/utils.ts
@@ -25,19 +25,21 @@ export function getSafeDomain(
   fallbackDomain: Domain,
   scaleType: ScaleType
 ): [Domain, DomainErrors] {
-  const [min, max] = domain;
+  const minGreater = domain[0] > domain[1];
+  const [min, max] = minGreater ? fallbackDomain : domain;
 
   if (scaleType === ScaleType.Log) {
     return [
       [min <= 0 ? fallbackDomain[0] : min, max <= 0 ? fallbackDomain[1] : max],
       {
+        minGreater,
         minError: min <= 0 ? BoundError.InvalidWithLog : undefined,
         maxError: max <= 0 ? BoundError.InvalidWithLog : undefined,
       },
     ];
   }
 
-  return [domain, {}];
+  return [[min, max], { minGreater }];
 }
 
 export function getDims(dataArray: ndarray): Dims {

--- a/src/h5web/vis-packs/core/models.ts
+++ b/src/h5web/vis-packs/core/models.ts
@@ -22,6 +22,7 @@ export type Domain = [number, number];
 export type CustomDomain = [number | undefined, number | undefined];
 
 export interface DomainErrors {
+  minGreater: boolean;
   minError?: BoundError;
   maxError?: BoundError;
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2936402/111449447-b2dcb500-870f-11eb-847d-3069ee3889a8.png)

I've identified two remaining edge cases:

### `min > max` (fallback to `dataDomain`) + `custom max << data min` (or `custom min >> data max`)

1. Go to http://localhost:3000/mock 
2. Change max bound to `-400` 🡪 `visDomain=[-95, -400]`, so `min > max` and `safeVisDomain=[-95, 400]`. Note that custom max (-400) is much lower than data min (-95), so custom max is still lower than the slider's extent min.
3. Click to the left of the min bound 🡪 the custom min changes to a value still greater than custom max, so `safeVisDomain` and the slider's extent don't change.
4. Click to the left of the min bound again 🡪 the custom min doesn't change or very little, because the slider's extent stays the same after every click.

I don't believe there's a way around this. To restore normal behaviour, the user has to move the max thumb or edit the values manually.

### log + `custom min <= 0` (fallback to data min) + `custom max < data min`

1. Go to http://localhost:3000/mock 
2. Switch to log.
3. Enter a custom min value lower than or equal to 0.
4. Enter a custom max between 0 and data min (1), for instance 0.5 🡪 custom min is lower than max but not in `safeVisDomain`, so the slider is reversed.

I will fix this in my next PR by making custom min to fall back to custom max is this specific case.