### PR TITLE
Let custom min fall back to custom max in one specific edge case

### DIFF
--- a/src/h5web/toolbar/controls/DomainSlider/BoundErrorMessage.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/BoundErrorMessage.tsx
@@ -29,7 +29,6 @@ function BoundErrorMessage(props: Props): ReactElement {
     return <></>;
   }
 
-  // eslint-disable-next-line sonarjs/no-small-switch
   switch (error) {
     case BoundError.InvalidWithLog:
       return (
@@ -37,6 +36,14 @@ function BoundErrorMessage(props: Props): ReactElement {
           Custom {bound} invalid with log scale
           <br />
           <FiCornerDownRight /> falling back to <strong>data {bound}</strong>
+        </p>
+      );
+    case BoundError.CustomMaxFallback:
+      return (
+        <p className={styles.error}>
+          Custom min invalid with log scale
+          <br />
+          <FiCornerDownRight /> falling back to <strong>custom max</strong>
         </p>
       );
     default:

--- a/src/h5web/vis-packs/core/heatmap/utils.ts
+++ b/src/h5web/vis-packs/core/heatmap/utils.ts
@@ -29,11 +29,19 @@ export function getSafeDomain(
   const [min, max] = minGreater ? fallbackDomain : domain;
 
   if (scaleType === ScaleType.Log) {
+    const logSafeMin = min <= 0 ? fallbackDomain[0] : min;
+    const logSafeMax = max <= 0 ? fallbackDomain[1] : max;
+    const logSafeMinGreater = logSafeMin > logSafeMax;
+
     return [
-      [min <= 0 ? fallbackDomain[0] : min, max <= 0 ? fallbackDomain[1] : max],
+      [logSafeMinGreater ? logSafeMax : logSafeMin, logSafeMax],
       {
         minGreater,
-        minError: min <= 0 ? BoundError.InvalidWithLog : undefined,
+        minError: logSafeMinGreater
+          ? BoundError.CustomMaxFallback
+          : min <= 0
+          ? BoundError.InvalidWithLog
+          : undefined,
         maxError: max <= 0 ? BoundError.InvalidWithLog : undefined,
       },
     ];

--- a/src/h5web/vis-packs/core/heatmap/utils.ts
+++ b/src/h5web/vis-packs/core/heatmap/utils.ts
@@ -25,29 +25,30 @@ export function getSafeDomain(
   fallbackDomain: Domain,
   scaleType: ScaleType
 ): [Domain, DomainErrors] {
-  const minGreater = domain[0] > domain[1];
-  const [min, max] = minGreater ? fallbackDomain : domain;
-
-  if (scaleType === ScaleType.Log) {
-    const logSafeMin = min <= 0 ? fallbackDomain[0] : min;
-    const logSafeMax = max <= 0 ? fallbackDomain[1] : max;
-    const logSafeMinGreater = logSafeMin > logSafeMax;
-
-    return [
-      [logSafeMinGreater ? logSafeMax : logSafeMin, logSafeMax],
-      {
-        minGreater,
-        minError: logSafeMinGreater
-          ? BoundError.CustomMaxFallback
-          : min <= 0
-          ? BoundError.InvalidWithLog
-          : undefined,
-        maxError: max <= 0 ? BoundError.InvalidWithLog : undefined,
-      },
-    ];
+  if (domain[0] > domain[1]) {
+    return [fallbackDomain, { minGreater: true }];
   }
 
-  return [[min, max], { minGreater }];
+  if (scaleType !== ScaleType.Log) {
+    return [domain, {}];
+  }
+
+  const [min, max] = domain;
+  const logSafeMin = min <= 0 ? fallbackDomain[0] : min;
+  const logSafeMax = max <= 0 ? fallbackDomain[1] : max;
+  const logSafeMinGreater = logSafeMin > logSafeMax;
+
+  return [
+    [logSafeMinGreater ? logSafeMax : logSafeMin, logSafeMax],
+    {
+      minError: logSafeMinGreater
+        ? BoundError.CustomMaxFallback
+        : min <= 0
+        ? BoundError.InvalidWithLog
+        : undefined,
+      maxError: max <= 0 ? BoundError.InvalidWithLog : undefined,
+    },
+  ];
 }
 
 export function getDims(dataArray: ndarray): Dims {

--- a/src/h5web/vis-packs/core/models.ts
+++ b/src/h5web/vis-packs/core/models.ts
@@ -22,7 +22,7 @@ export type Domain = [number, number];
 export type CustomDomain = [number | undefined, number | undefined];
 
 export interface DomainErrors {
-  minGreater: boolean;
+  minGreater?: boolean;
   minError?: BoundError;
   maxError?: BoundError;
 }

--- a/src/h5web/vis-packs/core/models.ts
+++ b/src/h5web/vis-packs/core/models.ts
@@ -29,6 +29,7 @@ export interface DomainErrors {
 
 export enum BoundError {
   InvalidWithLog = 'invalid-with-log',
+  CustomMaxFallback = 'custom-max-fallback',
 }
 
 export interface AxisConfig {


### PR DESCRIPTION
This resolves scenario 5 described in https://github.com/silx-kit/h5web/issues/510#issuecomment-797402408

To reproduce:

1. Go to http://localhost:3000/mock
2. Switch to log.
3. Enter a custom min value lower than or equal to 0.
4. Enter a custom max between 0 and data min (1), for instance 0.5

![image](https://user-images.githubusercontent.com/2936402/111459714-5b444680-871b-11eb-960b-d503844a2df7.png)

This introduces a noteworthy, but still logical, behaviour: in the same state as above, move the max thumb to the right 🡪 the two thumbs don't separate because the new custom max is still lower than data min. You have to move the max thumb again until you go past the data min:

![image](https://user-images.githubusercontent.com/2936402/111460039-c857dc00-871b-11eb-80aa-24288dc03814.png)

![image](https://user-images.githubusercontent.com/2936402/111460058-ce4dbd00-871b-11eb-9c84-fef61944000d.png)

... or instead, push the min thumb to the left with the max thumb so custom min becomes positive.