### PR TITLE
Remove top-level describe blocks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -72,6 +72,7 @@ module.exports = createConfig({
         'jest/no-focused-tests': 'warn', // warning instead of error
         'jest/prefer-strict-equal': 'off', // `toEqual` is shorter and sufficient in most cases
         'jest-formatting/padding-around-all': 'off', // allow writing concise two-line tests
+        'jest/require-top-level-describe': 'off', // filename should already be meaningful, extra nesting is unnecessary
       },
     },
     {

--- a/src/h5web/dimension-mapper/DimensionMapper.test.tsx
+++ b/src/h5web/dimension-mapper/DimensionMapper.test.tsx
@@ -2,83 +2,81 @@ import { fireEvent, screen, within } from '@testing-library/react';
 import { renderApp, selectExplorerNode, selectVisTab } from '../test-utils';
 import { Vis } from '../vis-packs/core/visualizations';
 
-describe('DimensionMapper', () => {
-  test('display mapping for X axis when visualizing 2D dataset as Line', async () => {
-    renderApp();
-    await selectExplorerNode('nD_datasets/twoD');
-    await selectVisTab(Vis.Line);
+test('display mapping for X axis when visualizing 2D dataset as Line', async () => {
+  renderApp();
+  await selectExplorerNode('nD_datasets/twoD');
+  await selectVisTab(Vis.Line);
 
-    // Ensure that the dimension mapper is only visible for X (and not for Y)
-    const xRadioGroup = screen.getByLabelText('Dimension as x axis');
-    expect(xRadioGroup).toBeVisible();
-    const xDimsButtons = within(xRadioGroup).getAllByRole('radio');
-    expect(xDimsButtons).toHaveLength(2);
-    const yRadioGroup = screen.queryByLabelText('Dimension as y axis');
-    expect(yRadioGroup).not.toBeInTheDocument();
+  // Ensure that the dimension mapper is only visible for X (and not for Y)
+  const xRadioGroup = screen.getByLabelText('Dimension as x axis');
+  expect(xRadioGroup).toBeVisible();
+  const xDimsButtons = within(xRadioGroup).getAllByRole('radio');
+  expect(xDimsButtons).toHaveLength(2);
+  const yRadioGroup = screen.queryByLabelText('Dimension as y axis');
+  expect(yRadioGroup).not.toBeInTheDocument();
 
-    // Ensure that the default mapping is [0, 'x']
-    expect(xDimsButtons[0]).not.toBeChecked();
-    expect(xDimsButtons[1]).toBeChecked();
-    const D0Slider = screen.getByRole('slider');
-    expect(D0Slider).toHaveAttribute('aria-valueNow', '0');
+  // Ensure that the default mapping is [0, 'x']
+  expect(xDimsButtons[0]).not.toBeChecked();
+  expect(xDimsButtons[1]).toBeChecked();
+  const D0Slider = screen.getByRole('slider');
+  expect(D0Slider).toHaveAttribute('aria-valueNow', '0');
 
-    // Ensure that the swap from [0, 'x'] to ['x', 0] works
-    fireEvent.click(xDimsButtons[0]);
+  // Ensure that the swap from [0, 'x'] to ['x', 0] works
+  fireEvent.click(xDimsButtons[0]);
 
-    expect(xDimsButtons[0]).toBeChecked();
-    expect(xDimsButtons[1]).not.toBeChecked();
-    const D1Slider = screen.getByRole('slider');
-    expect(D1Slider).toHaveAttribute('aria-valueNow', '0');
-  });
+  expect(xDimsButtons[0]).toBeChecked();
+  expect(xDimsButtons[1]).not.toBeChecked();
+  const D1Slider = screen.getByRole('slider');
+  expect(D1Slider).toHaveAttribute('aria-valueNow', '0');
+});
 
-  test('display mappings for X and Y axes when visualizing 2D dataset as Heatmap', async () => {
-    renderApp();
-    await selectExplorerNode('nD_datasets/twoD');
-    await selectVisTab(Vis.Heatmap);
+test('display mappings for X and Y axes when visualizing 2D dataset as Heatmap', async () => {
+  renderApp();
+  await selectExplorerNode('nD_datasets/twoD');
+  await selectVisTab(Vis.Heatmap);
 
-    // Ensure that the dimension mapper is visible for X and Y
-    const xRadioGroup = screen.getByLabelText('Dimension as x axis');
-    expect(xRadioGroup).toBeVisible();
-    const yRadioGroup = screen.getByLabelText('Dimension as y axis');
-    expect(yRadioGroup).toBeVisible();
+  // Ensure that the dimension mapper is visible for X and Y
+  const xRadioGroup = screen.getByLabelText('Dimension as x axis');
+  expect(xRadioGroup).toBeVisible();
+  const yRadioGroup = screen.getByLabelText('Dimension as y axis');
+  expect(yRadioGroup).toBeVisible();
 
-    // Ensure that the default mapping is ['y', 'x']
-    const xD1Button = within(xRadioGroup).getByRole('radio', { name: 'D1' });
-    expect(xD1Button).toBeChecked();
-    const yD0Button = within(yRadioGroup).getByRole('radio', { name: 'D0' });
-    expect(yD0Button).toBeChecked();
+  // Ensure that the default mapping is ['y', 'x']
+  const xD1Button = within(xRadioGroup).getByRole('radio', { name: 'D1' });
+  expect(xD1Button).toBeChecked();
+  const yD0Button = within(yRadioGroup).getByRole('radio', { name: 'D0' });
+  expect(yD0Button).toBeChecked();
 
-    // Ensure that the swap from ['y', 'x'] to ['x', 'y'] works
-    const xD0Button = within(xRadioGroup).getByRole('radio', { name: 'D0' });
-    fireEvent.click(xD0Button);
-    expect(xD0Button).toBeChecked();
-    expect(xD1Button).not.toBeChecked();
+  // Ensure that the swap from ['y', 'x'] to ['x', 'y'] works
+  const xD0Button = within(xRadioGroup).getByRole('radio', { name: 'D0' });
+  fireEvent.click(xD0Button);
+  expect(xD0Button).toBeChecked();
+  expect(xD1Button).not.toBeChecked();
 
-    const yD1Button = within(yRadioGroup).getByRole('radio', { name: 'D1' });
-    expect(yD0Button).not.toBeChecked();
-    expect(yD1Button).toBeChecked();
-  });
+  const yD1Button = within(yRadioGroup).getByRole('radio', { name: 'D1' });
+  expect(yD0Button).not.toBeChecked();
+  expect(yD1Button).toBeChecked();
+});
 
-  test('display one dimension slider and mappings for X and Y axes when visualizing 3D dataset as Matrix', async () => {
-    renderApp();
-    await selectExplorerNode('nD_datasets/threeD');
-    await selectVisTab(Vis.Matrix);
+test('display one dimension slider and mappings for X and Y axes when visualizing 3D dataset as Matrix', async () => {
+  renderApp();
+  await selectExplorerNode('nD_datasets/threeD');
+  await selectVisTab(Vis.Matrix);
 
-    // Ensure that the dimension mapper is visible for X and Y
-    const xRadioGroup = await screen.findByLabelText('Dimension as x axis');
-    expect(xRadioGroup).toBeVisible();
-    const xDimsButtons = within(xRadioGroup).getAllByRole('radio');
-    expect(xDimsButtons).toHaveLength(3);
+  // Ensure that the dimension mapper is visible for X and Y
+  const xRadioGroup = await screen.findByLabelText('Dimension as x axis');
+  expect(xRadioGroup).toBeVisible();
+  const xDimsButtons = within(xRadioGroup).getAllByRole('radio');
+  expect(xDimsButtons).toHaveLength(3);
 
-    const yRadioGroup = screen.getByLabelText('Dimension as y axis');
-    expect(yRadioGroup).toBeVisible();
-    const yDimsButtons = within(yRadioGroup).getAllByRole('radio');
-    expect(yDimsButtons).toHaveLength(3);
+  const yRadioGroup = screen.getByLabelText('Dimension as y axis');
+  expect(yRadioGroup).toBeVisible();
+  const yDimsButtons = within(yRadioGroup).getAllByRole('radio');
+  expect(yDimsButtons).toHaveLength(3);
 
-    // Ensure that the default mapping is [0, 'y', 'x']
-    expect(xDimsButtons[2]).toBeChecked();
-    expect(yDimsButtons[1]).toBeChecked();
-    const D0Slider = screen.getByRole('slider');
-    expect(D0Slider).toHaveAttribute('aria-valueNow', '0');
-  });
+  // Ensure that the default mapping is [0, 'y', 'x']
+  expect(xDimsButtons[2]).toBeChecked();
+  expect(yDimsButtons[1]).toBeChecked();
+  const D0Slider = screen.getByRole('slider');
+  expect(D0Slider).toHaveAttribute('aria-valueNow', '0');
 });

--- a/src/h5web/explorer/Explorer.test.tsx
+++ b/src/h5web/explorer/Explorer.test.tsx
@@ -2,87 +2,85 @@ import { fireEvent, screen } from '@testing-library/react';
 import { mockFilepath } from '../providers/mock/metadata';
 import { renderApp } from '../test-utils';
 
-describe('Explorer', () => {
-  test('select root group by default', async () => {
-    renderApp();
+test('select root group by default', async () => {
+  renderApp();
 
-    const title = await screen.findByRole('heading', { name: mockFilepath });
-    expect(title).toBeVisible();
+  const title = await screen.findByRole('heading', { name: mockFilepath });
+  expect(title).toBeVisible();
 
-    const fileBtn = screen.getByRole('treeitem', { name: mockFilepath });
-    expect(fileBtn).toBeVisible();
-    expect(fileBtn).toHaveAttribute('aria-selected', 'true');
+  const fileBtn = screen.getByRole('treeitem', { name: mockFilepath });
+  expect(fileBtn).toBeVisible();
+  expect(fileBtn).toHaveAttribute('aria-selected', 'true');
+});
+
+test('toggle explorer sidebar', async () => {
+  renderApp();
+
+  const fileBtn = await screen.findByRole('treeitem', {
+    name: mockFilepath,
+  });
+  const sidebarBtn = screen.getByRole('button', {
+    name: 'Toggle explorer sidebar',
   });
 
-  test('toggle explorer sidebar', async () => {
-    renderApp();
+  expect(fileBtn).toBeVisible();
+  expect(sidebarBtn).toHaveAttribute('aria-pressed', 'true');
 
-    const fileBtn = await screen.findByRole('treeitem', {
-      name: mockFilepath,
-    });
-    const sidebarBtn = screen.getByRole('button', {
-      name: 'Toggle explorer sidebar',
-    });
+  fireEvent.click(sidebarBtn);
+  expect(fileBtn).not.toBeVisible();
+  expect(sidebarBtn).toHaveAttribute('aria-pressed', 'false');
 
-    expect(fileBtn).toBeVisible();
-    expect(sidebarBtn).toHaveAttribute('aria-pressed', 'true');
+  fireEvent.click(sidebarBtn);
+  expect(fileBtn).toBeVisible();
+  expect(sidebarBtn).toHaveAttribute('aria-pressed', 'true');
+});
 
-    fireEvent.click(sidebarBtn);
-    expect(fileBtn).not.toBeVisible();
-    expect(sidebarBtn).toHaveAttribute('aria-pressed', 'false');
+test('navigate groups in explorer', async () => {
+  renderApp();
 
-    fireEvent.click(sidebarBtn);
-    expect(fileBtn).toBeVisible();
-    expect(sidebarBtn).toHaveAttribute('aria-pressed', 'true');
+  const groupBtn = await screen.findByRole('treeitem', { name: 'entities' });
+  expect(groupBtn).toHaveAttribute('aria-selected', 'false');
+  expect(groupBtn).toHaveAttribute('aria-expanded', 'false');
+
+  // Expand `entities` group
+  fireEvent.click(groupBtn);
+
+  expect(groupBtn).toHaveAttribute('aria-selected', 'true');
+  expect(groupBtn).toHaveAttribute('aria-expanded', 'true');
+
+  const childGroupBtn = await screen.findByRole('treeitem', {
+    name: 'empty_group',
   });
+  expect(childGroupBtn).toHaveAttribute('aria-selected', 'false');
+  expect(childGroupBtn).toHaveAttribute('aria-expanded', 'false');
 
-  test('navigate groups in explorer', async () => {
-    renderApp();
+  // Expand `empty_group` child group
+  fireEvent.click(childGroupBtn);
 
-    const groupBtn = await screen.findByRole('treeitem', { name: 'entities' });
-    expect(groupBtn).toHaveAttribute('aria-selected', 'false');
-    expect(groupBtn).toHaveAttribute('aria-expanded', 'false');
+  expect(groupBtn).toHaveAttribute('aria-selected', 'false');
+  expect(groupBtn).toHaveAttribute('aria-expanded', 'true');
+  expect(childGroupBtn).toHaveAttribute('aria-selected', 'true');
+  expect(childGroupBtn).toHaveAttribute('aria-expanded', 'true');
 
-    // Expand `entities` group
-    fireEvent.click(groupBtn);
+  // Collapse `empty_group` child group
+  fireEvent.click(childGroupBtn);
 
-    expect(groupBtn).toHaveAttribute('aria-selected', 'true');
-    expect(groupBtn).toHaveAttribute('aria-expanded', 'true');
+  expect(childGroupBtn).toHaveAttribute('aria-selected', 'true');
+  expect(childGroupBtn).toHaveAttribute('aria-expanded', 'false');
 
-    const childGroupBtn = await screen.findByRole('treeitem', {
-      name: 'empty_group',
-    });
-    expect(childGroupBtn).toHaveAttribute('aria-selected', 'false');
-    expect(childGroupBtn).toHaveAttribute('aria-expanded', 'false');
+  // Select `entities` group
+  fireEvent.click(groupBtn);
 
-    // Expand `empty_group` child group
-    fireEvent.click(childGroupBtn);
+  expect(groupBtn).toHaveAttribute('aria-selected', 'true');
+  expect(groupBtn).toHaveAttribute('aria-expanded', 'true'); // remains expanded as it wasn't previously selected
+  expect(childGroupBtn).toHaveAttribute('aria-selected', 'false');
 
-    expect(groupBtn).toHaveAttribute('aria-selected', 'false');
-    expect(groupBtn).toHaveAttribute('aria-expanded', 'true');
-    expect(childGroupBtn).toHaveAttribute('aria-selected', 'true');
-    expect(childGroupBtn).toHaveAttribute('aria-expanded', 'true');
+  // Collapse `entities` group
+  fireEvent.click(groupBtn);
 
-    // Collapse `empty_group` child group
-    fireEvent.click(childGroupBtn);
-
-    expect(childGroupBtn).toHaveAttribute('aria-selected', 'true');
-    expect(childGroupBtn).toHaveAttribute('aria-expanded', 'false');
-
-    // Select `entities` group
-    fireEvent.click(groupBtn);
-
-    expect(groupBtn).toHaveAttribute('aria-selected', 'true');
-    expect(groupBtn).toHaveAttribute('aria-expanded', 'true'); // remains expanded as it wasn't previously selected
-    expect(childGroupBtn).toHaveAttribute('aria-selected', 'false');
-
-    // Collapse `entities` group
-    fireEvent.click(groupBtn);
-
-    expect(
-      screen.queryByRole('treeitem', { name: 'empty_group' })
-    ).not.toBeInTheDocument();
-    expect(groupBtn).toHaveAttribute('aria-selected', 'true');
-    expect(groupBtn).toHaveAttribute('aria-expanded', 'false');
-  });
+  expect(
+    screen.queryByRole('treeitem', { name: 'empty_group' })
+  ).not.toBeInTheDocument();
+  expect(groupBtn).toHaveAttribute('aria-selected', 'true');
+  expect(groupBtn).toHaveAttribute('aria-expanded', 'false');
 });

--- a/src/h5web/metadata-viewer/MetadataViewer.test.tsx
+++ b/src/h5web/metadata-viewer/MetadataViewer.test.tsx
@@ -6,104 +6,100 @@ import {
   selectExplorerNode,
 } from '../test-utils';
 
-describe('MetadataViewer', () => {
-  test('switch between "display" and "inspect" modes', async () => {
-    renderApp();
+test('switch between "display" and "inspect" modes', async () => {
+  renderApp();
 
-    const inspectBtn = await screen.findByRole('tab', { name: 'Inspect' });
-    const displayBtn = screen.getByRole('tab', { name: 'Display' });
+  const inspectBtn = await screen.findByRole('tab', { name: 'Inspect' });
+  const displayBtn = screen.getByRole('tab', { name: 'Display' });
 
-    // Switch to "inspect" mode
-    fireEvent.click(inspectBtn);
+  // Switch to "inspect" mode
+  fireEvent.click(inspectBtn);
 
-    expect(queryVisSelector()).not.toBeInTheDocument();
-    expect(screen.getByRole('row', { name: /^Path/u })).toBeVisible();
+  expect(queryVisSelector()).not.toBeInTheDocument();
+  expect(screen.getByRole('row', { name: /^Path/u })).toBeVisible();
 
-    // Switch back to "display" mode
-    fireEvent.click(displayBtn);
+  // Switch back to "display" mode
+  fireEvent.click(displayBtn);
 
-    expect(await findVisSelector()).toBeVisible();
-    expect(
-      screen.queryByRole('row', { name: /^Path/u })
-    ).not.toBeInTheDocument();
+  expect(await findVisSelector()).toBeVisible();
+  expect(screen.queryByRole('row', { name: /^Path/u })).not.toBeInTheDocument();
+});
+
+test('inspect group', async () => {
+  renderApp();
+  fireEvent.click(await screen.findByRole('tab', { name: 'Inspect' }));
+  await selectExplorerNode('entities');
+
+  const column = await screen.findByRole('columnheader', { name: /^Group/u });
+  const nameRow = screen.getByRole('row', { name: /^Name/u });
+  const pathRow = screen.getByRole('row', { name: /^Path/u });
+
+  expect(column).toBeVisible();
+  expect(nameRow).toHaveTextContent(/entities/u);
+  expect(pathRow).toHaveTextContent(/\/entities/u);
+});
+
+test('inspect scalar dataset', async () => {
+  renderApp();
+  fireEvent.click(await screen.findByRole('tab', { name: 'Inspect' }));
+  await selectExplorerNode('entities/scalar_int');
+
+  const column = await screen.findByRole('columnheader', {
+    name: /Dataset/u,
   });
+  const nameRow = screen.getByRole('row', { name: /^Name/u });
+  const pathRow = screen.getByRole('row', { name: /^Path/u });
+  const shapeRow = screen.getByRole('row', { name: /^Shape/u });
+  const typeRow = screen.getByRole('row', { name: /^Type/u });
 
-  test('inspect group', async () => {
-    renderApp();
-    fireEvent.click(await screen.findByRole('tab', { name: 'Inspect' }));
-    await selectExplorerNode('entities');
+  expect(column).toBeVisible();
+  expect(nameRow).toHaveTextContent(/scalar_int/u);
+  expect(pathRow).toHaveTextContent(/\/entities\/scalar_int/u);
+  expect(shapeRow).toHaveTextContent(/H5S_SCALAR/u);
+  expect(typeRow).toHaveTextContent(/integer/u);
+});
 
-    const column = await screen.findByRole('columnheader', { name: /^Group/u });
-    const nameRow = screen.getByRole('row', { name: /^Name/u });
-    const pathRow = screen.getByRole('row', { name: /^Path/u });
+test('inspect simple dataset', async () => {
+  renderApp();
+  fireEvent.click(await screen.findByRole('tab', { name: 'Inspect' }));
+  await selectExplorerNode('nD_datasets/threeD');
 
-    expect(column).toBeVisible();
-    expect(nameRow).toHaveTextContent(/entities/u);
-    expect(pathRow).toHaveTextContent(/\/entities/u);
+  const shapeRow = await screen.findByRole('row', { name: /^Shape/u });
+  expect(shapeRow).toHaveTextContent(/9 x 20 x 41 = 7380/u);
+});
+
+test('inspect datatype', async () => {
+  renderApp();
+  fireEvent.click(await screen.findByRole('tab', { name: 'Inspect' }));
+  await selectExplorerNode('entities/datatype');
+
+  const column = await screen.findByRole('columnheader', {
+    name: /Datatype/u,
   });
+  const nameRow = screen.getByRole('row', { name: /^Name/u });
+  const pathRow = screen.getByRole('row', { name: /^Path/u });
+  const typeRow = screen.getByRole('row', { name: /^Type/u });
 
-  test('inspect scalar dataset', async () => {
-    renderApp();
-    fireEvent.click(await screen.findByRole('tab', { name: 'Inspect' }));
-    await selectExplorerNode('entities/scalar_int');
+  expect(column).toBeVisible();
+  expect(nameRow).toHaveTextContent(/datatype/u);
+  expect(pathRow).toHaveTextContent(/\/entities\/datatype/u);
+  expect(typeRow).toHaveTextContent(/compound/u);
+});
 
-    const column = await screen.findByRole('columnheader', {
-      name: /Dataset/u,
-    });
-    const nameRow = screen.getByRole('row', { name: /^Name/u });
-    const pathRow = screen.getByRole('row', { name: /^Path/u });
-    const shapeRow = screen.getByRole('row', { name: /^Shape/u });
-    const typeRow = screen.getByRole('row', { name: /^Type/u });
+test('inspect external link', async () => {
+  renderApp();
+  fireEvent.click(await screen.findByRole('tab', { name: 'Inspect' }));
+  await selectExplorerNode('entities/external_link');
 
-    expect(column).toBeVisible();
-    expect(nameRow).toHaveTextContent(/scalar_int/u);
-    expect(pathRow).toHaveTextContent(/\/entities\/scalar_int/u);
-    expect(shapeRow).toHaveTextContent(/H5S_SCALAR/u);
-    expect(typeRow).toHaveTextContent(/integer/u);
-  });
+  const column = await screen.findByRole('columnheader', { name: /Link/u });
+  const nameRow = screen.getByRole('row', { name: /^Name/u });
+  const pathRow = screen.getByRole('row', { name: /^Path/u });
+  const fileRow = screen.getByRole('row', { name: /^File/u });
+  const h5pathRow = screen.getByRole('row', { name: /^H5Path/u });
 
-  test('inspect simple dataset', async () => {
-    renderApp();
-    fireEvent.click(await screen.findByRole('tab', { name: 'Inspect' }));
-    await selectExplorerNode('nD_datasets/threeD');
-
-    const shapeRow = await screen.findByRole('row', { name: /^Shape/u });
-    expect(shapeRow).toHaveTextContent(/9 x 20 x 41 = 7380/u);
-  });
-
-  test('inspect datatype', async () => {
-    renderApp();
-    fireEvent.click(await screen.findByRole('tab', { name: 'Inspect' }));
-    await selectExplorerNode('entities/datatype');
-
-    const column = await screen.findByRole('columnheader', {
-      name: /Datatype/u,
-    });
-    const nameRow = screen.getByRole('row', { name: /^Name/u });
-    const pathRow = screen.getByRole('row', { name: /^Path/u });
-    const typeRow = screen.getByRole('row', { name: /^Type/u });
-
-    expect(column).toBeVisible();
-    expect(nameRow).toHaveTextContent(/datatype/u);
-    expect(pathRow).toHaveTextContent(/\/entities\/datatype/u);
-    expect(typeRow).toHaveTextContent(/compound/u);
-  });
-
-  test('inspect external link', async () => {
-    renderApp();
-    fireEvent.click(await screen.findByRole('tab', { name: 'Inspect' }));
-    await selectExplorerNode('entities/external_link');
-
-    const column = await screen.findByRole('columnheader', { name: /Link/u });
-    const nameRow = screen.getByRole('row', { name: /^Name/u });
-    const pathRow = screen.getByRole('row', { name: /^Path/u });
-    const fileRow = screen.getByRole('row', { name: /^File/u });
-    const h5pathRow = screen.getByRole('row', { name: /^H5Path/u });
-
-    expect(column).toBeVisible();
-    expect(nameRow).toHaveTextContent(/external_link/u);
-    expect(pathRow).toHaveTextContent(/\/entities\/external_link/u);
-    expect(fileRow).toHaveTextContent(/my_file/u);
-    expect(h5pathRow).toHaveTextContent(/entry_000\/dataset/u);
-  });
+  expect(column).toBeVisible();
+  expect(nameRow).toHaveTextContent(/external_link/u);
+  expect(pathRow).toHaveTextContent(/\/entities\/external_link/u);
+  expect(fileRow).toHaveTextContent(/my_file/u);
+  expect(h5pathRow).toHaveTextContent(/entry_000\/dataset/u);
 });

--- a/src/h5web/metadata-viewer/utils.test.ts
+++ b/src/h5web/metadata-viewer/utils.test.ts
@@ -1,17 +1,15 @@
 import { renderShapeDims } from './utils';
 
-describe('Metadata Viewer utilities', () => {
-  describe('renderShapeDims', () => {
-    it('should render shape with zero dimension', () => {
-      expect(renderShapeDims([])).toBe('');
-    });
+describe('renderShapeDims', () => {
+  it('should render shape with zero dimension', () => {
+    expect(renderShapeDims([])).toBe('');
+  });
 
-    it('should render shape with one dimension', () => {
-      expect(renderShapeDims([5])).toBe('5');
-    });
+  it('should render shape with one dimension', () => {
+    expect(renderShapeDims([5])).toBe('5');
+  });
 
-    it('should render shape with multiple dimensions', () => {
-      expect(renderShapeDims([10, 2, 6])).toBe('10 x 2 x 6 = 120');
-    });
+  it('should render shape with multiple dimensions', () => {
+    expect(renderShapeDims([10, 2, 6])).toBe('10 x 2 x 6 = 120');
   });
 });

--- a/src/h5web/providers/hsds/models.ts
+++ b/src/h5web/providers/hsds/models.ts
@@ -31,7 +31,7 @@ export interface HsdsFloatType {
   base: string;
 }
 
-interface HsdsStringType {
+export interface HsdsStringType {
   class: HDF5TypeClass.String;
   charSet: 'H5T_CSET_ASCII' | 'H5T_CSET_UTF8';
   strPad: 'H5T_STR_SPACEPAD' | 'H5T_STR_NULLTERM' | 'H5T_STR_NULLPAD';

--- a/src/h5web/providers/hsds/utils.test.ts
+++ b/src/h5web/providers/hsds/utils.test.ts
@@ -1,6 +1,7 @@
 import Complex from 'complex.js';
 import { HDF5Type, HDF5Id, HDF5TypeClass } from '../hdf5-models';
 import type {
+  HsdsStringType,
   HsdsArrayType,
   HsdsComplexValue,
   HsdsCompoundType,
@@ -10,220 +11,185 @@ import type {
 } from './models';
 import { convertHsdsType, parseComplex } from './utils';
 
-describe('HsdsProvider utilities', () => {
-  describe('convertHsdsType', () => {
-    interface TestType {
-      hsds: HsdsType;
-      hdf5: HDF5Type;
-    }
+interface TestType {
+  hsds: HsdsType;
+  hdf5: HDF5Type;
+}
 
-    const asciiStrType: TestType = {
-      hsds: {
-        class: HDF5TypeClass.String,
-        charSet: 'H5T_CSET_ASCII',
-        strPad: 'H5T_STR_NULLPAD',
-        length: 25,
-      },
-      hdf5: {
-        class: HDF5TypeClass.String,
-        charSet: 'ASCII',
-        length: 25,
-      },
+const leIntegerType: TestType = {
+  hsds: { class: HDF5TypeClass.Integer, base: 'H5T_STD_I8LE' },
+  hdf5: { class: HDF5TypeClass.Integer, size: 8, endianness: 'LE' },
+};
+
+const beIntegerType: TestType = {
+  hsds: { class: HDF5TypeClass.Integer, base: 'H5T_STD_U64BE' },
+  hdf5: {
+    class: HDF5TypeClass.Integer,
+    size: 64,
+    endianness: 'BE',
+    unsigned: true,
+  },
+};
+
+const leFloatType: TestType = {
+  hsds: { class: HDF5TypeClass.Float, base: 'H5T_IEEE_F32LE' },
+  hdf5: { class: HDF5TypeClass.Float, size: 32, endianness: 'LE' },
+};
+
+const beFloatType: TestType = {
+  hsds: { class: HDF5TypeClass.Float, base: 'H5T_IEEE_F64BE' },
+  hdf5: { class: HDF5TypeClass.Float, size: 64, endianness: 'BE' },
+};
+
+describe('convertHsdsType', () => {
+  it('should left HDF5Id type unchanged', () => {
+    const idType: HDF5Id = 'aHdfId';
+    expect(convertHsdsType(idType)).toBe(idType);
+  });
+
+  it('should convert ASCII string type', () => {
+    const asciiStrType: HsdsStringType = {
+      class: HDF5TypeClass.String,
+      charSet: 'H5T_CSET_ASCII',
+      strPad: 'H5T_STR_NULLPAD',
+      length: 25,
     };
-    const unicodeStrType: TestType = {
-      hsds: {
-        class: HDF5TypeClass.String,
-        charSet: 'H5T_CSET_UTF8',
-        strPad: 'H5T_STR_NULLTERM',
-        length: 49,
-      },
-      hdf5: {
-        class: HDF5TypeClass.String,
-        charSet: 'UTF8',
-        length: 49,
-      },
-    };
-
-    const leIntegerType: TestType = {
-      hsds: {
-        class: HDF5TypeClass.Integer,
-        base: 'H5T_STD_I8LE',
-      },
-      hdf5: {
-        class: HDF5TypeClass.Integer,
-        size: 8,
-        endianness: 'LE',
-      },
-    };
-
-    const beIntegerType: TestType = {
-      hsds: { class: HDF5TypeClass.Integer, base: 'H5T_STD_U64BE' },
-      hdf5: {
-        class: HDF5TypeClass.Integer,
-        size: 64,
-        endianness: 'BE',
-        unsigned: true,
-      },
-    };
-
-    const leFloatType: TestType = {
-      hsds: {
-        class: HDF5TypeClass.Float,
-        base: 'H5T_IEEE_F32LE',
-      },
-      hdf5: {
-        class: HDF5TypeClass.Float,
-        size: 32,
-        endianness: 'LE',
-      },
-    };
-
-    const beFloatType: TestType = {
-      hsds: {
-        class: HDF5TypeClass.Float,
-        base: 'H5T_IEEE_F64BE',
-      },
-      hdf5: {
-        class: HDF5TypeClass.Float,
-        size: 64,
-        endianness: 'BE',
-      },
-    };
-
-    it('should left HDF5Id type unchanged', () => {
-      const idType: HDF5Id = 'aHdfId';
-      expect(convertHsdsType(idType)).toBe(idType);
-    });
-
-    it('should convert string types', () => {
-      expect(convertHsdsType(asciiStrType.hsds)).toEqual(asciiStrType.hdf5);
-      expect(convertHsdsType(unicodeStrType.hsds)).toEqual(unicodeStrType.hdf5);
-    });
-
-    it('should convert integer types', () => {
-      expect(convertHsdsType(leIntegerType.hsds)).toEqual(leIntegerType.hdf5);
-      expect(convertHsdsType(beIntegerType.hsds)).toEqual(beIntegerType.hdf5);
-    });
-
-    it('should convert float types', () => {
-      expect(convertHsdsType(leFloatType.hsds)).toEqual(leFloatType.hdf5);
-      expect(convertHsdsType(beFloatType.hsds)).toEqual(beFloatType.hdf5);
-    });
-
-    it('should convert the base of Array type', () => {
-      const arrayType: HsdsArrayType = {
-        class: HDF5TypeClass.Array,
-        base: leIntegerType.hsds,
-        dims: [4, 5],
-      };
-      expect(convertHsdsType(arrayType)).toEqual({
-        class: HDF5TypeClass.Array,
-        base: leIntegerType.hdf5,
-        dims: [4, 5],
-      });
-    });
-
-    it('should convert the base of VLen type', () => {
-      const vlenType: HsdsVLenType = {
-        class: HDF5TypeClass.VLen,
-        base: leIntegerType.hsds,
-      };
-      expect(convertHsdsType(vlenType)).toEqual({
-        class: HDF5TypeClass.VLen,
-        base: leIntegerType.hdf5,
-      });
-    });
-
-    it('should convert the field types of Compound type', () => {
-      const vlenType: HsdsVLenType = {
-        class: HDF5TypeClass.VLen,
-        base: leIntegerType.hsds,
-      };
-      const compoundType: HsdsCompoundType = {
-        class: HDF5TypeClass.Compound,
-        fields: [
-          { name: 'f1', type: beFloatType.hsds },
-          { name: 'f2', type: vlenType },
-        ],
-      };
-      expect(convertHsdsType(compoundType)).toEqual({
-        class: HDF5TypeClass.Compound,
-        fields: [
-          { name: 'f1', type: beFloatType.hdf5 },
-          {
-            name: 'f2',
-            type: {
-              class: HDF5TypeClass.VLen,
-              base: leIntegerType.hdf5,
-            },
-          },
-        ],
-      });
-    });
-
-    it('should convert the enum with the boolean mapping to Boolean type', () => {
-      const boolEnum: HsdsEnumType = {
-        class: HDF5TypeClass.Enum,
-        base: {
-          class: HDF5TypeClass.Integer,
-          base: 'H5T_STD_I8LE',
-        },
-        mapping: {
-          FALSE: 0,
-          TRUE: 1,
-        },
-      };
-      expect(convertHsdsType(boolEnum)).toEqual({
-        class: HDF5TypeClass.Bool,
-      });
-    });
-
-    it('should convert the complex compound type into Complex type', () => {
-      const complexCompound: HsdsCompoundType = {
-        class: HDF5TypeClass.Compound,
-        fields: [
-          { name: 'r', type: leFloatType.hsds },
-          { name: 'i', type: leFloatType.hsds },
-        ],
-      };
-      expect(convertHsdsType(complexCompound)).toEqual({
-        class: HDF5TypeClass.Complex,
-        realType: leFloatType.hdf5,
-        imagType: leFloatType.hdf5,
-      });
-    });
-
-    it('should throw when encountering an unknown type', () => {
-      const unknownType = { class: 'NO_CLASS' };
-      expect(() => convertHsdsType(unknownType as HsdsType)).toThrow(
-        /Unknown type/u
-      );
+    expect(convertHsdsType(asciiStrType)).toEqual({
+      class: HDF5TypeClass.String,
+      charSet: 'ASCII',
+      length: 25,
     });
   });
 
-  describe('parseComplex', () => {
-    it('should parse scalar complex', () => {
-      expect((parseComplex([1, 5]) as Complex).equals(new Complex(1, 5))).toBe(
-        true
-      );
-    });
+  it('should convert Unicode string type', () => {
+    const unicodeStrType: HsdsStringType = {
+      class: HDF5TypeClass.String,
+      charSet: 'H5T_CSET_UTF8',
+      strPad: 'H5T_STR_NULLTERM',
+      length: 49,
+    };
 
-    it('should parse complex array', () => {
-      const hsdsComplexArray: HsdsComplexValue[][] = [
-        [
-          [0, 0],
-          [0, 1],
-        ],
-        [
-          [1, 0],
-          [2, 1],
-        ],
-      ];
-      const convertedArray = parseComplex(hsdsComplexArray) as Complex[][];
-      expect(convertedArray).toEqual([
-        [new Complex(0, 0), new Complex(0, 1)],
-        [new Complex(1, 0), new Complex(2, 1)],
-      ]);
+    expect(convertHsdsType(unicodeStrType)).toEqual({
+      class: HDF5TypeClass.String,
+      charSet: 'UTF8',
+      length: 49,
     });
+  });
+
+  it('should convert integer types', () => {
+    expect(convertHsdsType(leIntegerType.hsds)).toEqual(leIntegerType.hdf5);
+    expect(convertHsdsType(beIntegerType.hsds)).toEqual(beIntegerType.hdf5);
+  });
+
+  it('should convert float types', () => {
+    expect(convertHsdsType(leFloatType.hsds)).toEqual(leFloatType.hdf5);
+    expect(convertHsdsType(beFloatType.hsds)).toEqual(beFloatType.hdf5);
+  });
+
+  it('should convert the base of Array type', () => {
+    const arrayType: HsdsArrayType = {
+      class: HDF5TypeClass.Array,
+      base: leIntegerType.hsds,
+      dims: [4, 5],
+    };
+    expect(convertHsdsType(arrayType)).toEqual({
+      class: HDF5TypeClass.Array,
+      base: leIntegerType.hdf5,
+      dims: [4, 5],
+    });
+  });
+
+  it('should convert the base of VLen type', () => {
+    const vlenType: HsdsVLenType = {
+      class: HDF5TypeClass.VLen,
+      base: leIntegerType.hsds,
+    };
+    expect(convertHsdsType(vlenType)).toEqual({
+      class: HDF5TypeClass.VLen,
+      base: leIntegerType.hdf5,
+    });
+  });
+
+  it('should convert the field types of Compound type', () => {
+    const vlenType: HsdsVLenType = {
+      class: HDF5TypeClass.VLen,
+      base: leIntegerType.hsds,
+    };
+    const compoundType: HsdsCompoundType = {
+      class: HDF5TypeClass.Compound,
+      fields: [
+        { name: 'f1', type: beFloatType.hsds },
+        { name: 'f2', type: vlenType },
+      ],
+    };
+    expect(convertHsdsType(compoundType)).toEqual({
+      class: HDF5TypeClass.Compound,
+      fields: [
+        { name: 'f1', type: beFloatType.hdf5 },
+        {
+          name: 'f2',
+          type: { class: HDF5TypeClass.VLen, base: leIntegerType.hdf5 },
+        },
+      ],
+    });
+  });
+
+  it('should convert the enum with the boolean mapping to Boolean type', () => {
+    const boolEnum: HsdsEnumType = {
+      class: HDF5TypeClass.Enum,
+      base: { class: HDF5TypeClass.Integer, base: 'H5T_STD_I8LE' },
+      mapping: { FALSE: 0, TRUE: 1 },
+    };
+    expect(convertHsdsType(boolEnum)).toEqual({
+      class: HDF5TypeClass.Bool,
+    });
+  });
+
+  it('should convert the complex compound type into Complex type', () => {
+    const complexCompound: HsdsCompoundType = {
+      class: HDF5TypeClass.Compound,
+      fields: [
+        { name: 'r', type: leFloatType.hsds },
+        { name: 'i', type: leFloatType.hsds },
+      ],
+    };
+    expect(convertHsdsType(complexCompound)).toEqual({
+      class: HDF5TypeClass.Complex,
+      realType: leFloatType.hdf5,
+      imagType: leFloatType.hdf5,
+    });
+  });
+
+  it('should throw when encountering an unknown type', () => {
+    const unknownType = { class: 'NO_CLASS' };
+    expect(() => convertHsdsType(unknownType as HsdsType)).toThrow(
+      /Unknown type/u
+    );
+  });
+});
+
+describe('parseComplex', () => {
+  it('should parse scalar complex', () => {
+    expect((parseComplex([1, 5]) as Complex).equals(new Complex(1, 5))).toBe(
+      true
+    );
+  });
+
+  it('should parse complex array', () => {
+    const hsdsComplexArray: HsdsComplexValue[][] = [
+      [
+        [0, 0],
+        [0, 1],
+      ],
+      [
+        [1, 0],
+        [2, 1],
+      ],
+    ];
+    const convertedArray = parseComplex(hsdsComplexArray) as Complex[][];
+    expect(convertedArray).toEqual([
+      [new Complex(0, 0), new Complex(0, 1)],
+      [new Complex(1, 0), new Complex(2, 1)],
+    ]);
   });
 });

--- a/src/h5web/providers/jupyter/utils.test.ts
+++ b/src/h5web/providers/jupyter/utils.test.ts
@@ -3,107 +3,105 @@ import { HDF5TypeClass } from '../hdf5-models';
 import type { JupyterComplexValue } from './models';
 import { convertDtype, parseComplex } from './utils';
 
-describe('JupyterProvider utilities', () => {
-  describe('convertDtype', () => {
-    it('should convert unicode string dtypes', () => {
-      expect(convertDtype('|U25')).toEqual({
-        class: HDF5TypeClass.String,
-        charSet: 'UTF8',
-        length: 25,
-      });
-    });
-
-    it('should convert bytes string dtypes', () => {
-      expect(convertDtype('|S')).toEqual({
-        class: HDF5TypeClass.String,
-        charSet: 'ASCII',
-        length: 'H5T_VARIABLE',
-      });
-    });
-
-    it('should convert integer dtypes', () => {
-      expect(convertDtype('<i4')).toEqual({
-        class: HDF5TypeClass.Integer,
-        size: 32,
-        endianness: 'LE',
-      });
-      expect(convertDtype('>u8')).toEqual({
-        class: HDF5TypeClass.Integer,
-        size: 64,
-        endianness: 'BE',
-        unsigned: true,
-      });
-    });
-
-    it('should convert float dtypes', () => {
-      expect(convertDtype('<f4')).toEqual({
-        class: HDF5TypeClass.Float,
-        size: 32,
-        endianness: 'LE',
-      });
-      expect(convertDtype('>f8')).toEqual({
-        class: HDF5TypeClass.Float,
-        size: 64,
-        endianness: 'BE',
-      });
-    });
-
-    it('should convert complex dtypes', () => {
-      expect(convertDtype('<c8')).toEqual({
-        class: HDF5TypeClass.Complex,
-        realType: {
-          class: HDF5TypeClass.Float,
-          endianness: 'LE',
-          size: 32,
-        },
-        imagType: {
-          class: HDF5TypeClass.Float,
-          endianness: 'LE',
-          size: 32,
-        },
-      });
-    });
-
-    it('should interpret objects as strings', () => {
-      expect(convertDtype('|O')).toEqual({
-        class: HDF5TypeClass.String,
-        charSet: 'UTF8',
-        length: 'H5T_VARIABLE',
-      });
-    });
-
-    it('should interpret |b1 as booleans', () => {
-      expect(convertDtype('|b1')).toEqual({
-        class: HDF5TypeClass.Bool,
-      });
-    });
-
-    it('should throw when encountering an unknown endianness symbol', () => {
-      expect(() => convertDtype('^f8')).toThrow(/Unknown endianness symbol/u);
-    });
-
-    it('should throw when encountering an unknown type', () => {
-      expect(() => convertDtype('>notAType')).toThrow(/Unknown dtype/u);
+describe('convertDtype', () => {
+  it('should convert unicode string dtypes', () => {
+    expect(convertDtype('|U25')).toEqual({
+      class: HDF5TypeClass.String,
+      charSet: 'UTF8',
+      length: 25,
     });
   });
 
-  describe('parseComplex', () => {
-    it('should parse scalar complex', () => {
-      expect(
-        (parseComplex('(1+5j)') as Complex).equals(new Complex(1, 5))
-      ).toBe(true);
+  it('should convert bytes string dtypes', () => {
+    expect(convertDtype('|S')).toEqual({
+      class: HDF5TypeClass.String,
+      charSet: 'ASCII',
+      length: 'H5T_VARIABLE',
     });
+  });
 
-    it('should parse complex array', () => {
-      const hsdsComplexArray: JupyterComplexValue[][] = [
-        ['0j', '1j'],
-        ['(1+0j)', '(1-2j)'],
-      ];
-      const convertedArray = parseComplex(hsdsComplexArray) as Complex[][];
-      expect(convertedArray).toEqual([
-        [new Complex(0, 0), new Complex(0, 1)],
-        [new Complex(1, 0), new Complex(1, -2)],
-      ]);
+  it('should convert integer dtypes', () => {
+    expect(convertDtype('<i4')).toEqual({
+      class: HDF5TypeClass.Integer,
+      size: 32,
+      endianness: 'LE',
     });
+    expect(convertDtype('>u8')).toEqual({
+      class: HDF5TypeClass.Integer,
+      size: 64,
+      endianness: 'BE',
+      unsigned: true,
+    });
+  });
+
+  it('should convert float dtypes', () => {
+    expect(convertDtype('<f4')).toEqual({
+      class: HDF5TypeClass.Float,
+      size: 32,
+      endianness: 'LE',
+    });
+    expect(convertDtype('>f8')).toEqual({
+      class: HDF5TypeClass.Float,
+      size: 64,
+      endianness: 'BE',
+    });
+  });
+
+  it('should convert complex dtypes', () => {
+    expect(convertDtype('<c8')).toEqual({
+      class: HDF5TypeClass.Complex,
+      realType: {
+        class: HDF5TypeClass.Float,
+        endianness: 'LE',
+        size: 32,
+      },
+      imagType: {
+        class: HDF5TypeClass.Float,
+        endianness: 'LE',
+        size: 32,
+      },
+    });
+  });
+
+  it('should interpret objects as strings', () => {
+    expect(convertDtype('|O')).toEqual({
+      class: HDF5TypeClass.String,
+      charSet: 'UTF8',
+      length: 'H5T_VARIABLE',
+    });
+  });
+
+  it('should interpret |b1 as booleans', () => {
+    expect(convertDtype('|b1')).toEqual({
+      class: HDF5TypeClass.Bool,
+    });
+  });
+
+  it('should throw when encountering an unknown endianness symbol', () => {
+    expect(() => convertDtype('^f8')).toThrow(/Unknown endianness symbol/u);
+  });
+
+  it('should throw when encountering an unknown type', () => {
+    expect(() => convertDtype('>notAType')).toThrow(/Unknown dtype/u);
+  });
+});
+
+describe('parseComplex', () => {
+  it('should parse scalar complex', () => {
+    expect((parseComplex('(1+5j)') as Complex).equals(new Complex(1, 5))).toBe(
+      true
+    );
+  });
+
+  it('should parse complex array', () => {
+    const hsdsComplexArray: JupyterComplexValue[][] = [
+      ['0j', '1j'],
+      ['(1+0j)', '(1-2j)'],
+    ];
+    const convertedArray = parseComplex(hsdsComplexArray) as Complex[][];
+    expect(convertedArray).toEqual([
+      [new Complex(0, 0), new Complex(0, 1)],
+      [new Complex(1, 0), new Complex(1, -2)],
+    ]);
   });
 });

--- a/src/h5web/providers/mock/utils.test.ts
+++ b/src/h5web/providers/mock/utils.test.ts
@@ -2,26 +2,22 @@ import type { Group } from '../models';
 import { mockMetadata } from './metadata';
 import { findMockEntity } from './utils';
 
-describe('MockProvider utilities', () => {
-  describe('findMockEntity', () => {
-    it('should return entity at given path', () => {
-      expect(findMockEntity('/')).toBe(mockMetadata);
-      expect(findMockEntity('/nD_datasets')).toBe(mockMetadata.children[1]);
-      expect(findMockEntity('/entities/raw')).toBe(
-        (mockMetadata.children[0] as Group).children[3]
-      );
-    });
+describe('findMockEntity', () => {
+  it('should return entity at given path', () => {
+    expect(findMockEntity('/')).toBe(mockMetadata);
+    expect(findMockEntity('/nD_datasets')).toBe(mockMetadata.children[1]);
+    expect(findMockEntity('/entities/raw')).toBe(
+      (mockMetadata.children[0] as Group).children[3]
+    );
+  });
 
-    it('should throw if path is relative', () => {
-      expect(() => findMockEntity('nD_datasets')).toThrow(
-        /path to start with '\/'/u
-      );
-    });
+  it('should throw if path is relative', () => {
+    expect(() => findMockEntity('nD_datasets')).toThrow(
+      /path to start with '\/'/u
+    );
+  });
 
-    it('should throw if no entity is found at given path', () => {
-      expect(() => findMockEntity('/nD_datasets/foo')).toThrow(
-        /entity at path/u
-      );
-    });
+  it('should throw if no entity is found at given path', () => {
+    expect(() => findMockEntity('/nD_datasets/foo')).toThrow(/entity at path/u);
   });
 });

--- a/src/h5web/utils.test.ts
+++ b/src/h5web/utils.test.ts
@@ -6,34 +6,30 @@ import {
 } from './providers/mock/metadata-utils';
 import { buildEntityPath, getChildEntity } from './utils';
 
-describe('Global utilities', () => {
-  describe('getChildEntity', () => {
-    const dataset = makeDataset('dataset', scalarShape, intType);
-    const childGroup = makeGroup('group');
-    const rootGroup = makeGroup('root', [childGroup, dataset]);
+describe('getChildEntity', () => {
+  const dataset = makeDataset('dataset', scalarShape, intType);
+  const childGroup = makeGroup('group');
+  const rootGroup = makeGroup('root', [childGroup, dataset]);
 
-    it('should return child entity', () => {
-      expect(getChildEntity(rootGroup, 'dataset')).toBe(dataset);
-      expect(getChildEntity(rootGroup, 'group')).toBe(childGroup);
-    });
-
-    it("should return `undefined` if child doesn't exist", () => {
-      expect(getChildEntity(childGroup, 'unknown')).toBeUndefined();
-    });
+  it('should return child entity', () => {
+    expect(getChildEntity(rootGroup, 'dataset')).toBe(dataset);
+    expect(getChildEntity(rootGroup, 'group')).toBe(childGroup);
   });
 
-  describe('buildEntityPath', () => {
-    it('should build absolute path with entity name', () => {
-      expect(buildEntityPath('/', 'group')).toBe('/group');
-      expect(buildEntityPath('/foo', 'group')).toBe('/foo/group');
-      expect(buildEntityPath('/foo/bar', 'group')).toBe('/foo/bar/group');
-    });
+  it("should return `undefined` if child doesn't exist", () => {
+    expect(getChildEntity(childGroup, 'unknown')).toBeUndefined();
+  });
+});
 
-    it('should build absolute path with relative path', () => {
-      expect(buildEntityPath('/', 'group/dataset')).toBe('/group/dataset');
-      expect(buildEntityPath('/foo', 'group/dataset')).toBe(
-        '/foo/group/dataset'
-      );
-    });
+describe('buildEntityPath', () => {
+  it('should build absolute path with entity name', () => {
+    expect(buildEntityPath('/', 'group')).toBe('/group');
+    expect(buildEntityPath('/foo', 'group')).toBe('/foo/group');
+    expect(buildEntityPath('/foo/bar', 'group')).toBe('/foo/bar/group');
+  });
+
+  it('should build absolute path with relative path', () => {
+    expect(buildEntityPath('/', 'group/dataset')).toBe('/group/dataset');
+    expect(buildEntityPath('/foo', 'group/dataset')).toBe('/foo/group/dataset');
   });
 });

--- a/src/h5web/vis-packs/core/CorePack.test.tsx
+++ b/src/h5web/vis-packs/core/CorePack.test.tsx
@@ -8,64 +8,62 @@ import {
 } from '../../test-utils';
 import { Vis } from './visualizations';
 
-describe('CorePack', () => {
-  test('visualise raw dataset', async () => {
-    renderApp();
-    await selectExplorerNode('entities/raw');
+test('visualise raw dataset', async () => {
+  renderApp();
+  await selectExplorerNode('entities/raw');
 
-    const tabs = await findVisSelectorTabs();
-    expect(tabs).toHaveLength(1);
-    expect(tabs[0]).toHaveTextContent(Vis.Raw);
-    expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+  const tabs = await findVisSelectorTabs();
+  expect(tabs).toHaveLength(1);
+  expect(tabs[0]).toHaveTextContent(Vis.Raw);
+  expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
 
-    expect(await screen.findByText(/"int": 42/u)).toBeVisible();
-  });
+  expect(await screen.findByText(/"int": 42/u)).toBeVisible();
+});
 
-  test('log raw dataset to console if too large', async () => {
-    const logSpy = mockConsoleMethod('log');
+test('log raw dataset to console if too large', async () => {
+  const logSpy = mockConsoleMethod('log');
 
-    renderApp();
-    await selectExplorerNode('entities/raw_large');
+  renderApp();
+  await selectExplorerNode('entities/raw_large');
 
-    expect(await screen.findByText(/dataset is too big/u)).toBeVisible();
-    expect(logSpy).toHaveBeenCalledWith(mockValues.raw_large);
-  });
+  expect(await screen.findByText(/dataset is too big/u)).toBeVisible();
+  expect(logSpy).toHaveBeenCalledWith(mockValues.raw_large);
+});
 
-  test('visualise scalar dataset', async () => {
-    renderApp();
+test('visualise scalar dataset', async () => {
+  renderApp();
 
-    await selectExplorerNode('entities/scalar_int');
-    expect(await screen.findByText('0')).toBeVisible();
+  await selectExplorerNode('entities/scalar_int');
+  expect(await screen.findByText('0')).toBeVisible();
 
-    const tabs = await findVisSelectorTabs();
-    expect(tabs).toHaveLength(1);
-    expect(tabs[0]).toHaveTextContent(Vis.Scalar);
-    expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+  const tabs = await findVisSelectorTabs();
+  expect(tabs).toHaveLength(1);
+  expect(tabs[0]).toHaveTextContent(Vis.Scalar);
+  expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
 
-    await selectExplorerNode('scalar_str');
-    expect(await screen.findByText(mockValues.scalar_str)).toBeVisible();
-  });
+  await selectExplorerNode('scalar_str');
+  expect(await screen.findByText(mockValues.scalar_str)).toBeVisible();
+});
 
-  test('visualize 1D dataset', async () => {
-    renderApp();
-    await selectExplorerNode('nD_datasets/oneD');
+test('visualize 1D dataset', async () => {
+  renderApp();
+  await selectExplorerNode('nD_datasets/oneD');
 
-    const tabs = await findVisSelectorTabs();
-    expect(tabs).toHaveLength(2);
-    expect(tabs[0]).toHaveTextContent(Vis.Matrix);
-    expect(tabs[1]).toHaveTextContent(Vis.Line);
-    expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
-  });
+  const tabs = await findVisSelectorTabs();
+  expect(tabs).toHaveLength(2);
+  expect(tabs[0]).toHaveTextContent(Vis.Matrix);
+  expect(tabs[1]).toHaveTextContent(Vis.Line);
+  expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
+});
 
-  test('visualize 2D datasets', async () => {
-    renderApp();
-    await selectExplorerNode('nD_datasets/twoD');
+test('visualize 2D datasets', async () => {
+  renderApp();
+  await selectExplorerNode('nD_datasets/twoD');
 
-    const tabs = await findVisSelectorTabs();
-    expect(tabs).toHaveLength(3);
-    expect(tabs[0]).toHaveTextContent(Vis.Matrix);
-    expect(tabs[1]).toHaveTextContent(Vis.Line);
-    expect(tabs[2]).toHaveTextContent(Vis.Heatmap);
-    expect(tabs[2]).toHaveAttribute('aria-selected', 'true');
-  });
+  const tabs = await findVisSelectorTabs();
+  expect(tabs).toHaveLength(3);
+  expect(tabs[0]).toHaveTextContent(Vis.Matrix);
+  expect(tabs[1]).toHaveTextContent(Vis.Line);
+  expect(tabs[2]).toHaveTextContent(Vis.Heatmap);
+  expect(tabs[2]).toHaveAttribute('aria-selected', 'true');
 });

--- a/src/h5web/vis-packs/core/pack-utils.test.ts
+++ b/src/h5web/vis-packs/core/pack-utils.test.ts
@@ -9,27 +9,25 @@ import {
 } from '../../providers/mock/metadata-utils';
 import { CORE_VIS } from './visualizations';
 
-describe('Core pack utilities', () => {
-  describe('getSupportedVis', () => {
-    it('should return supported visualizations', () => {
-      const datasetRaw = makeDataset('raw', scalarShape, compoundType);
-      const supportedVis = getSupportedVis(datasetRaw);
+describe('getSupportedVis', () => {
+  it('should return supported visualizations', () => {
+    const datasetRaw = makeDataset('raw', scalarShape, compoundType);
+    const supportedVis = getSupportedVis(datasetRaw);
 
-      expect(supportedVis).toEqual([CORE_VIS.Raw]);
-    });
+    expect(supportedVis).toEqual([CORE_VIS.Raw]);
+  });
 
-    it('should not include Raw vis if any other visualization is supported', () => {
-      const datasetInt1D = makeSimpleDataset('dataset', intType, [5]);
-      const supportedVis = getSupportedVis(datasetInt1D);
+  it('should not include Raw vis if any other visualization is supported', () => {
+    const datasetInt1D = makeSimpleDataset('dataset', intType, [5]);
+    const supportedVis = getSupportedVis(datasetInt1D);
 
-      expect(supportedVis).toEqual([CORE_VIS.Matrix, CORE_VIS.Line]);
-    });
+    expect(supportedVis).toEqual([CORE_VIS.Matrix, CORE_VIS.Line]);
+  });
 
-    it('should return empty array if no visualization is supported', () => {
-      const groupEmpty = makeGroup('group_empty');
-      const supportedVis = getSupportedVis(groupEmpty);
+  it('should return empty array if no visualization is supported', () => {
+    const groupEmpty = makeGroup('group_empty');
+    const supportedVis = getSupportedVis(groupEmpty);
 
-      expect(supportedVis).toEqual([]);
-    });
+    expect(supportedVis).toEqual([]);
   });
 });

--- a/src/h5web/vis-packs/core/utils.test.ts
+++ b/src/h5web/vis-packs/core/utils.test.ts
@@ -13,272 +13,264 @@ import { Domain, ScaleType } from './models';
 const MAX = Number.MAX_VALUE / 2;
 const POS_MIN = Number.MIN_VALUE;
 
-describe('Shared visualization utilities', () => {
-  describe('computeVisSize', () => {
-    describe('with aspect ratio > 1', () => {
-      it('should return available size with width reduced', () => {
-        const availableSize = { width: 20, height: 10 };
-        const size = computeVisSize(availableSize, 1.5);
+describe('computeVisSize', () => {
+  describe('with aspect ratio > 1', () => {
+    it('should return available size with width reduced', () => {
+      const availableSize = { width: 20, height: 10 };
+      const size = computeVisSize(availableSize, 1.5);
 
-        expect(size?.width).toBeLessThanOrEqual(availableSize.width);
-        expect(size?.height).toBeLessThanOrEqual(availableSize.height);
-        expect(size).toEqual({ width: 10 * 1.5, height: 10 });
-      });
-
-      it('should return available size with height reduced', () => {
-        const availableSize = { width: 12, height: 50 };
-        const size = computeVisSize(availableSize, 3);
-
-        expect(size?.width).toBeLessThanOrEqual(availableSize.width);
-        expect(size?.height).toBeLessThanOrEqual(availableSize.height);
-        expect(size).toEqual({ width: 12, height: 12 / 3 });
-      });
+      expect(size?.width).toBeLessThanOrEqual(availableSize.width);
+      expect(size?.height).toBeLessThanOrEqual(availableSize.height);
+      expect(size).toEqual({ width: 10 * 1.5, height: 10 });
     });
 
-    describe('with aspect ratio < 1', () => {
-      it('should return available size with width reduced', () => {
-        const availableSize = { width: 20, height: 10 };
-        const size = computeVisSize(availableSize, 0.5);
+    it('should return available size with height reduced', () => {
+      const availableSize = { width: 12, height: 50 };
+      const size = computeVisSize(availableSize, 3);
 
-        expect(size?.width).toBeLessThanOrEqual(availableSize.width);
-        expect(size?.height).toBeLessThanOrEqual(availableSize.height);
-        expect(size).toEqual({ width: 10 * 0.5, height: 10 });
-      });
-
-      it('should return available size with height reduced', () => {
-        const availableSize = { width: 12, height: 50 };
-        const size = computeVisSize(availableSize, 0.75);
-
-        expect(size?.width).toBeLessThanOrEqual(availableSize.width);
-        expect(size?.height).toBeLessThanOrEqual(availableSize.height);
-        expect(size).toEqual({ width: 12, height: 12 / 0.75 });
-      });
-    });
-
-    it('should return available size when no aspect ratio is provided', () => {
-      const size = computeVisSize({ width: 20, height: 10 }, undefined);
-      expect(size).toEqual({ width: 20, height: 10 });
-    });
-
-    it('should return `undefined` when no space is available for visualization', () => {
-      const size = computeVisSize({ width: 0, height: 0 }, 1);
-      expect(size).toBeUndefined();
+      expect(size?.width).toBeLessThanOrEqual(availableSize.width);
+      expect(size?.height).toBeLessThanOrEqual(availableSize.height);
+      expect(size).toEqual({ width: 12, height: 12 / 3 });
     });
   });
 
-  describe('getDomain', () => {
-    it('should return min and max values of data array', () => {
-      const data = [2, 0, 10, 5, 2, -1];
-      const domain = getDomain(data);
-      expect(domain).toEqual([-1, 10]);
+  describe('with aspect ratio < 1', () => {
+    it('should return available size with width reduced', () => {
+      const availableSize = { width: 20, height: 10 };
+      const size = computeVisSize(availableSize, 0.5);
+
+      expect(size?.width).toBeLessThanOrEqual(availableSize.width);
+      expect(size?.height).toBeLessThanOrEqual(availableSize.height);
+      expect(size).toEqual({ width: 10 * 0.5, height: 10 });
     });
 
-    it('should return `undefined` if data is empty', () => {
-      const domain = getDomain([]);
+    it('should return available size with height reduced', () => {
+      const availableSize = { width: 12, height: 50 };
+      const size = computeVisSize(availableSize, 0.75);
+
+      expect(size?.width).toBeLessThanOrEqual(availableSize.width);
+      expect(size?.height).toBeLessThanOrEqual(availableSize.height);
+      expect(size).toEqual({ width: 12, height: 12 / 0.75 });
+    });
+  });
+
+  it('should return available size when no aspect ratio is provided', () => {
+    const size = computeVisSize({ width: 20, height: 10 }, undefined);
+    expect(size).toEqual({ width: 20, height: 10 });
+  });
+
+  it('should return `undefined` when no space is available for visualization', () => {
+    const size = computeVisSize({ width: 0, height: 0 }, 1);
+    expect(size).toBeUndefined();
+  });
+});
+
+describe('getDomain', () => {
+  it('should return min and max values of data array', () => {
+    const data = [2, 0, 10, 5, 2, -1];
+    const domain = getDomain(data);
+    expect(domain).toEqual([-1, 10]);
+  });
+
+  it('should return `undefined` if data is empty', () => {
+    const domain = getDomain([]);
+    expect(domain).toBeUndefined();
+  });
+
+  describe('with log scale', () => {
+    it('should support negative domain', () => {
+      const domain = getDomain([-2, -10, -5, -2, -1], ScaleType.Log);
+      expect(domain).toEqual([-10, -1]);
+    });
+
+    it('should clamp domain min to first positive value when domain crosses zero', () => {
+      const domain = getDomain([2, 0, 10, 5, 2, -1], ScaleType.Log);
+      expect(domain).toEqual([2, 10]);
+    });
+
+    it('should return `undefined` if domain is not supported', () => {
+      const domain = getDomain([-2, 0, -10, -5, -2, -1], ScaleType.Log);
       expect(domain).toBeUndefined();
     });
+  });
+});
 
-    describe('with log scale', () => {
-      it('should support negative domain', () => {
-        const domain = getDomain([-2, -10, -5, -2, -1], ScaleType.Log);
-        expect(domain).toEqual([-10, -1]);
-      });
-
-      it('should clamp domain min to first positive value when domain crosses zero', () => {
-        const domain = getDomain([2, 0, 10, 5, 2, -1], ScaleType.Log);
-        expect(domain).toEqual([2, 10]);
-      });
-
-      it('should return `undefined` if domain is not supported', () => {
-        const domain = getDomain([-2, 0, -10, -5, -2, -1], ScaleType.Log);
-        expect(domain).toBeUndefined();
-      });
-    });
+describe('clampBound', () => {
+  it('should clamp to `Number.MAX_VALUE / 2` and keep sign', () => {
+    expect(clampBound(Infinity)).toEqual(MAX);
+    expect(clampBound(-Infinity)).toEqual(-MAX);
+    expect(clampBound(MAX)).toEqual(MAX);
+    expect(clampBound(-MAX)).toEqual(-MAX);
+    expect(clampBound(MAX - 1)).toEqual(MAX - 1);
+    expect(clampBound(-MAX + 1)).toEqual(-MAX + 1);
   });
 
-  describe('clampBound', () => {
-    it('should clamp to `Number.MAX_VALUE / 2` and keep sign', () => {
-      expect(clampBound(Infinity)).toEqual(MAX);
-      expect(clampBound(-Infinity)).toEqual(-MAX);
-      expect(clampBound(MAX)).toEqual(MAX);
-      expect(clampBound(-MAX)).toEqual(-MAX);
-      expect(clampBound(MAX - 1)).toEqual(MAX - 1);
-      expect(clampBound(-MAX + 1)).toEqual(-MAX + 1);
-    });
+  it('should clamp to `Number.MIN_VALUE` when requested', () => {
+    expect(clampBound(0)).toEqual(0);
 
-    it('should clamp to `Number.MIN_VALUE` when requested', () => {
-      expect(clampBound(0)).toEqual(0);
+    expect(clampBound(0, true)).toEqual(POS_MIN);
+    expect(clampBound(POS_MIN, true)).toEqual(POS_MIN);
+    expect(clampBound(POS_MIN * 2, true)).toEqual(POS_MIN * 2);
+  });
+});
 
-      expect(clampBound(0, true)).toEqual(POS_MIN);
-      expect(clampBound(POS_MIN, true)).toEqual(POS_MIN);
-      expect(clampBound(POS_MIN * 2, true)).toEqual(POS_MIN * 2);
-    });
+describe('extendDomain', () => {
+  it('should extend domain with linear scale', () => {
+    const extendedDomain = extendDomain([0, 100], 0.5);
+    expect(extendedDomain).toEqual([-50, 150]);
   });
 
-  describe('extendDomain', () => {
-    it('should extend domain with linear scale', () => {
-      const extendedDomain = extendDomain([0, 100], 0.5);
-      expect(extendedDomain).toEqual([-50, 150]);
-    });
-
-    it('should extend domain with symlog scale', () => {
-      const [min, max] = [-10, 0];
-      const [extMin, extMax] = extendDomain([min, max], 0.1, ScaleType.SymLog);
-      expect(extMin).toBeLessThan(min);
-      expect(extMax).toBeGreaterThan(max);
-    });
-
-    it('should extend domain with log scale', () => {
-      const [min, max] = [1, 10];
-      const [extMin1, extMax1] = extendDomain([min, max], 0.1, ScaleType.Log);
-      expect(extMin1).toBeLessThan(min);
-      expect(extMax1).toBeGreaterThan(max);
-
-      // Extension factor of 1 for log scale means one decade
-      const [extMin2, extMax2] = extendDomain([10, 100], 1, ScaleType.Log);
-      expect(extMin2).toBeCloseTo(1);
-      expect(extMax2).toBeCloseTo(1000);
-    });
-
-    it('should extend positive single-value domain', () => {
-      expect(extendDomain([2, 2], 0.5)).toEqual([1, 3]);
-      expect(extendDomain([1, 1], 1)).toEqual([0, 2]);
-      expect(extendDomain([1, 1], 1, ScaleType.Log)).toEqual([0.1, 10]);
-    });
-
-    it('should extend negative single-value domain', () => {
-      expect(extendDomain([-1, -1], 0.5)).toEqual([-1.5, -0.5]);
-      expect(extendDomain([-2, -2], 1, ScaleType.SymLog)).toEqual([-4, 0]);
-    });
-
-    it('should return [-1, 1] regardless of factor when trying to extend [0, 0]', () => {
-      expect(extendDomain([0, 0], 0.5)).toEqual([-1, 1]);
-      expect(extendDomain([0, 0], 1, ScaleType.SymLog)).toEqual([-1, 1]);
-    });
-
-    it('should not extend domain when factor is 0', () => {
-      const extendedDomain = extendDomain([10, 100], 0, ScaleType.Log);
-      expect(extendedDomain).toEqual([10, 100]);
-    });
-
-    it('should not extend domain outside of supported values', () => {
-      const domain: Domain = [-MAX + 1, MAX - 1];
-      const extendedDomain = extendDomain(domain, 0.5);
-      expect(extendedDomain).toEqual([-MAX, MAX]);
-    });
-
-    it('should not extend domain outside of supported values with log scale', () => {
-      const domain: Domain = [POS_MIN * 2, MAX];
-      const extendedDomain = extendDomain(domain, 0.75, ScaleType.Log);
-      expect(extendedDomain).toEqual([POS_MIN, MAX]);
-    });
-
-    it('should throw if domain is not compatible with log scale', () => {
-      const errRegex = /compatible with log scale/u;
-      expect(() => extendDomain([-1, 1], 0.5, ScaleType.Log)).toThrow(errRegex);
-      expect(() => extendDomain([0, 1], 0.5, ScaleType.Log)).toThrow(errRegex);
-    });
+  it('should extend domain with symlog scale', () => {
+    const [min, max] = [-10, 0];
+    const [extMin, extMax] = extendDomain([min, max], 0.1, ScaleType.SymLog);
+    expect(extMin).toBeLessThan(min);
+    expect(extMax).toBeGreaterThan(max);
   });
 
-  describe('getValueToIndexScale', () => {
-    it('should create threshold scale from values to indices', () => {
-      const scale = getValueToIndexScale([10, 20, 30]);
+  it('should extend domain with log scale', () => {
+    const [min, max] = [1, 10];
+    const [extMin1, extMax1] = extendDomain([min, max], 0.1, ScaleType.Log);
+    expect(extMin1).toBeLessThan(min);
+    expect(extMax1).toBeGreaterThan(max);
 
-      expect(scale(0)).toEqual(0);
-      expect(scale(10)).toEqual(0);
-      expect(scale(19.9)).toEqual(0);
-      expect(scale(20)).toEqual(1);
-      expect(scale(100)).toEqual(2);
-    });
-
-    it('should allow scale to switch at midpoints', () => {
-      const scale = getValueToIndexScale([10, 20, 30], true);
-
-      expect(scale(0)).toEqual(0);
-      expect(scale(14.9)).toEqual(0);
-      expect(scale(15)).toEqual(1);
-      expect(scale(24.9)).toEqual(1);
-      expect(scale(25)).toEqual(2);
-      expect(scale(100)).toEqual(2);
-    });
+    // Extension factor of 1 for log scale means one decade
+    const [extMin2, extMax2] = extendDomain([10, 100], 1, ScaleType.Log);
+    expect(extMin2).toBeCloseTo(1);
+    expect(extMax2).toBeCloseTo(1000);
   });
 
-  describe('getIntegerTicks', () => {
-    it('should return zero tick values when visible domain spans zero indices', () => {
-      const prop1 = getIntegerTicks([0.2, 0.8], 3);
-      expect(prop1).toEqual([]);
-
-      const prop2 = getIntegerTicks([5.01, 5.02], 3);
-      expect(prop2).toEqual([]);
-    });
-
-    it('should return as many integer tick values as indices when space allows for it', () => {
-      const prop1 = getIntegerTicks([0, 3], 10);
-      expect(prop1).toEqual([0, 1, 2, 3]);
-
-      const prop2 = getIntegerTicks([5.4, 6.9], 10);
-      expect(prop2).toEqual([6]);
-    });
-
-    it('should return evenly-spaced tick values for available space', () => {
-      const prop1 = getIntegerTicks([0.8, 20.2], 10); // domain has 20 potential ticks but space allows for 10
-      expect(prop1).toEqual([2, 4, 6, 8, 10, 12, 14, 16, 18, 20]);
-
-      const prop2 = getIntegerTicks([2, 7], 3); // domain has 8 potential ticks but space allows for 3
-      expect(prop2).toEqual([2, 4, 6]);
-    });
-
-    it('should always return integer tick values', () => {
-      // Tick count is not always respected, which is acceptable
-      const prop1 = getIntegerTicks([0, 4], 3); // domain has 5 potential ticks but space allows for 3
-      expect(prop1).toEqual([0, 1, 2, 3, 4]);
-
-      // This is because `d3.tickStep` is not too worried about the count...
-      expect(tickStep(0, 4, 3)).toBe(1); // step should actually be 2 to end up with 3 ticks: `[0, 2, 4]`
-
-      // Unfortunately, this behaviour can lead to decimal tick values (i.e. step < 1)...
-      expect(tickStep(0, 2, 3)).toBe(0.5); // we'd end up with `[0, 0.5, 1, 1.5, 2]` instead of `[0, 1, 2]`
-
-      // So we specifically work around it by forcing the step to be greater than or equal to 1
-      const prop2 = getIntegerTicks([0, 2], 3);
-      expect(prop2).toEqual([0, 1, 2]);
-    });
+  it('should extend positive single-value domain', () => {
+    expect(extendDomain([2, 2], 0.5)).toEqual([1, 3]);
+    expect(extendDomain([1, 1], 1)).toEqual([0, 2]);
+    expect(extendDomain([1, 1], 1, ScaleType.Log)).toEqual([0.1, 10]);
   });
 
-  describe('getCombinedDomain', () => {
-    it('should return the minimum of minima and the maximum of maxima', () => {
-      const combinedDomain = getCombinedDomain(
-        [0, 1],
-        [
-          [-1, 0.5],
-          [-0.2, 10],
-        ]
-      );
-      expect(combinedDomain).toEqual([-1, 10]);
-    });
+  it('should extend negative single-value domain', () => {
+    expect(extendDomain([-1, -1], 0.5)).toEqual([-1.5, -0.5]);
+    expect(extendDomain([-2, -2], 1, ScaleType.SymLog)).toEqual([-4, 0]);
+  });
 
-    it('should return the domain when there is no domain to combine', () => {
-      const combinedDomain = getCombinedDomain([0, 1], []);
-      expect(combinedDomain).toEqual([0, 1]);
-    });
+  it('should return [-1, 1] regardless of factor when trying to extend [0, 0]', () => {
+    expect(extendDomain([0, 0], 0.5)).toEqual([-1, 1]);
+    expect(extendDomain([0, 0], 1, ScaleType.SymLog)).toEqual([-1, 1]);
+  });
 
-    it('should return the defined domain when all other domains are undefined', () => {
-      const combinedDomain = getCombinedDomain(undefined, [[0, 1], undefined]);
-      expect(combinedDomain).toEqual([0, 1]);
+  it('should not extend domain when factor is 0', () => {
+    const extendedDomain = extendDomain([10, 100], 0, ScaleType.Log);
+    expect(extendedDomain).toEqual([10, 100]);
+  });
 
-      const combinedDomain2 = getCombinedDomain(
-        [-5, 8],
-        [undefined, undefined]
-      );
-      expect(combinedDomain2).toEqual([-5, 8]);
-    });
+  it('should not extend domain outside of supported values', () => {
+    const domain: Domain = [-MAX + 1, MAX - 1];
+    const extendedDomain = extendDomain(domain, 0.5);
+    expect(extendedDomain).toEqual([-MAX, MAX]);
+  });
 
-    it('should return undefined when all domains are undefined', () => {
-      const combinedDomain = getCombinedDomain(undefined, [
-        undefined,
-        undefined,
-      ]);
-      expect(combinedDomain).toBeUndefined();
-    });
+  it('should not extend domain outside of supported values with log scale', () => {
+    const domain: Domain = [POS_MIN * 2, MAX];
+    const extendedDomain = extendDomain(domain, 0.75, ScaleType.Log);
+    expect(extendedDomain).toEqual([POS_MIN, MAX]);
+  });
+
+  it('should throw if domain is not compatible with log scale', () => {
+    const errRegex = /compatible with log scale/u;
+    expect(() => extendDomain([-1, 1], 0.5, ScaleType.Log)).toThrow(errRegex);
+    expect(() => extendDomain([0, 1], 0.5, ScaleType.Log)).toThrow(errRegex);
+  });
+});
+
+describe('getValueToIndexScale', () => {
+  it('should create threshold scale from values to indices', () => {
+    const scale = getValueToIndexScale([10, 20, 30]);
+
+    expect(scale(0)).toEqual(0);
+    expect(scale(10)).toEqual(0);
+    expect(scale(19.9)).toEqual(0);
+    expect(scale(20)).toEqual(1);
+    expect(scale(100)).toEqual(2);
+  });
+
+  it('should allow scale to switch at midpoints', () => {
+    const scale = getValueToIndexScale([10, 20, 30], true);
+
+    expect(scale(0)).toEqual(0);
+    expect(scale(14.9)).toEqual(0);
+    expect(scale(15)).toEqual(1);
+    expect(scale(24.9)).toEqual(1);
+    expect(scale(25)).toEqual(2);
+    expect(scale(100)).toEqual(2);
+  });
+});
+
+describe('getIntegerTicks', () => {
+  it('should return zero tick values when visible domain spans zero indices', () => {
+    const prop1 = getIntegerTicks([0.2, 0.8], 3);
+    expect(prop1).toEqual([]);
+
+    const prop2 = getIntegerTicks([5.01, 5.02], 3);
+    expect(prop2).toEqual([]);
+  });
+
+  it('should return as many integer tick values as indices when space allows for it', () => {
+    const prop1 = getIntegerTicks([0, 3], 10);
+    expect(prop1).toEqual([0, 1, 2, 3]);
+
+    const prop2 = getIntegerTicks([5.4, 6.9], 10);
+    expect(prop2).toEqual([6]);
+  });
+
+  it('should return evenly-spaced tick values for available space', () => {
+    const prop1 = getIntegerTicks([0.8, 20.2], 10); // domain has 20 potential ticks but space allows for 10
+    expect(prop1).toEqual([2, 4, 6, 8, 10, 12, 14, 16, 18, 20]);
+
+    const prop2 = getIntegerTicks([2, 7], 3); // domain has 8 potential ticks but space allows for 3
+    expect(prop2).toEqual([2, 4, 6]);
+  });
+
+  it('should always return integer tick values', () => {
+    // Tick count is not always respected, which is acceptable
+    const prop1 = getIntegerTicks([0, 4], 3); // domain has 5 potential ticks but space allows for 3
+    expect(prop1).toEqual([0, 1, 2, 3, 4]);
+
+    // This is because `d3.tickStep` is not too worried about the count...
+    expect(tickStep(0, 4, 3)).toBe(1); // step should actually be 2 to end up with 3 ticks: `[0, 2, 4]`
+
+    // Unfortunately, this behaviour can lead to decimal tick values (i.e. step < 1)...
+    expect(tickStep(0, 2, 3)).toBe(0.5); // we'd end up with `[0, 0.5, 1, 1.5, 2]` instead of `[0, 1, 2]`
+
+    // So we specifically work around it by forcing the step to be greater than or equal to 1
+    const prop2 = getIntegerTicks([0, 2], 3);
+    expect(prop2).toEqual([0, 1, 2]);
+  });
+});
+
+describe('getCombinedDomain', () => {
+  it('should return the minimum of minima and the maximum of maxima', () => {
+    const combinedDomain = getCombinedDomain(
+      [0, 1],
+      [
+        [-1, 0.5],
+        [-0.2, 10],
+      ]
+    );
+    expect(combinedDomain).toEqual([-1, 10]);
+  });
+
+  it('should return the domain when there is no domain to combine', () => {
+    const combinedDomain = getCombinedDomain([0, 1], []);
+    expect(combinedDomain).toEqual([0, 1]);
+  });
+
+  it('should return the defined domain when all other domains are undefined', () => {
+    const combinedDomain = getCombinedDomain(undefined, [[0, 1], undefined]);
+    expect(combinedDomain).toEqual([0, 1]);
+
+    const combinedDomain2 = getCombinedDomain([-5, 8], [undefined, undefined]);
+    expect(combinedDomain2).toEqual([-5, 8]);
+  });
+
+  it('should return undefined when all domains are undefined', () => {
+    const combinedDomain = getCombinedDomain(undefined, [undefined, undefined]);
+    expect(combinedDomain).toBeUndefined();
   });
 });

--- a/src/h5web/vis-packs/core/visualizations.test.ts
+++ b/src/h5web/vis-packs/core/visualizations.test.ts
@@ -25,101 +25,99 @@ const datasetCplx2D = makeSimpleDataset('dataset_cplx_2D', complexType, [2, 2]);
 const datasetStr2D = makeSimpleDataset('dataset_str_2d', stringType, [5, 3]);
 const datasetFlt3D = makeSimpleDataset('dataset_flt_3d', intType, [5, 3, 1]);
 
-describe('Core visualizations', () => {
-  describe('Raw', () => {
-    const { supportsDataset } = CORE_VIS.Raw;
+describe('Raw', () => {
+  const { supportsDataset } = CORE_VIS.Raw;
 
-    it('should support any dataset', () => {
-      expect(supportsDataset(datasetIntScalar)).toBe(true);
-      expect(supportsDataset(datasetStr2D)).toBe(true);
-    });
+  it('should support any dataset', () => {
+    expect(supportsDataset(datasetIntScalar)).toBe(true);
+    expect(supportsDataset(datasetStr2D)).toBe(true);
+  });
+});
+
+describe('Scalar', () => {
+  const { supportsDataset } = CORE_VIS.Scalar;
+
+  it('should support dataset with displayable type and scalar shape', () => {
+    expect(supportsDataset(datasetIntScalar)).toBe(true);
+    expect(supportsDataset(datasetFltScalar)).toBe(true);
+    expect(supportsDataset(datasetStrScalar)).toBe(true);
+    expect(supportsDataset(datasetBoolScalar)).toBe(true);
+    expect(supportsDataset(datasetCplxScalar)).toBe(true);
   });
 
-  describe('Scalar', () => {
-    const { supportsDataset } = CORE_VIS.Scalar;
-
-    it('should support dataset with displayable type and scalar shape', () => {
-      expect(supportsDataset(datasetIntScalar)).toBe(true);
-      expect(supportsDataset(datasetFltScalar)).toBe(true);
-      expect(supportsDataset(datasetStrScalar)).toBe(true);
-      expect(supportsDataset(datasetBoolScalar)).toBe(true);
-      expect(supportsDataset(datasetCplxScalar)).toBe(true);
-    });
-
-    it('should not support dataset with non-displayable type', () => {
-      const dataset = makeDataset('foo', scalarShape, compoundType);
-      expect(supportsDataset(dataset)).toBe(false);
-    });
-
-    it('should not support dataset with non-scalar shape', () => {
-      expect(supportsDataset(datasetInt1D)).toBe(false);
-    });
+  it('should not support dataset with non-displayable type', () => {
+    const dataset = makeDataset('foo', scalarShape, compoundType);
+    expect(supportsDataset(dataset)).toBe(false);
   });
 
-  describe('Matrix', () => {
-    const { supportsDataset } = CORE_VIS.Matrix;
+  it('should not support dataset with non-scalar shape', () => {
+    expect(supportsDataset(datasetInt1D)).toBe(false);
+  });
+});
 
-    it('should support dataset with displayable type, simple shape and at least one dimension', () => {
-      expect(supportsDataset(datasetInt1D)).toBe(true);
-      expect(supportsDataset(datasetStr2D)).toBe(true);
-      expect(supportsDataset(datasetCplx2D)).toBe(true);
-      expect(supportsDataset(datasetFlt3D)).toBe(true);
-      expect(supportsDataset(datasetBool1D)).toBe(true);
-    });
+describe('Matrix', () => {
+  const { supportsDataset } = CORE_VIS.Matrix;
 
-    it('should not support dataset with non-displayable type', () => {
-      const dataset = makeDataset('foo', makeSimpleShape([1]), compoundType);
-      expect(supportsDataset(dataset)).toBe(false);
-    });
-
-    it('should not support dataset with non-simple shape', () => {
-      expect(supportsDataset(datasetIntScalar)).toBe(false);
-    });
-
-    it('should not support dataset with no dimension', () => {
-      expect(supportsDataset(datasetInt0D)).toBe(false);
-    });
+  it('should support dataset with displayable type, simple shape and at least one dimension', () => {
+    expect(supportsDataset(datasetInt1D)).toBe(true);
+    expect(supportsDataset(datasetStr2D)).toBe(true);
+    expect(supportsDataset(datasetCplx2D)).toBe(true);
+    expect(supportsDataset(datasetFlt3D)).toBe(true);
+    expect(supportsDataset(datasetBool1D)).toBe(true);
   });
 
-  describe('Line', () => {
-    const { supportsDataset } = CORE_VIS.Line;
-
-    it('should support dataset with numeric type, simple shape and at least one dimension', () => {
-      expect(supportsDataset(datasetInt1D)).toBe(true);
-      expect(supportsDataset(datasetFlt3D)).toBe(true);
-    });
-
-    it('should not support dataset with non-numeric type', () => {
-      expect(supportsDataset(datasetStr2D)).toBe(false);
-    });
-
-    it('should not support dataset with non-simple shape', () => {
-      expect(supportsDataset(datasetIntScalar)).toBe(false);
-    });
-
-    it('should not support dataset with no dimension', () => {
-      expect(supportsDataset(datasetInt0D)).toBe(false);
-    });
+  it('should not support dataset with non-displayable type', () => {
+    const dataset = makeDataset('foo', makeSimpleShape([1]), compoundType);
+    expect(supportsDataset(dataset)).toBe(false);
   });
 
-  describe('Heatmap', () => {
-    const { supportsDataset } = CORE_VIS.Heatmap;
+  it('should not support dataset with non-simple shape', () => {
+    expect(supportsDataset(datasetIntScalar)).toBe(false);
+  });
 
-    it('should support dataset with numeric type, simple shape and at least two dimensions', () => {
-      expect(supportsDataset(datasetInt2D)).toBe(true);
-      expect(supportsDataset(datasetFlt3D)).toBe(true);
-    });
+  it('should not support dataset with no dimension', () => {
+    expect(supportsDataset(datasetInt0D)).toBe(false);
+  });
+});
 
-    it('should not support dataset with non-numeric type', () => {
-      expect(supportsDataset(datasetStr2D)).toBe(false);
-    });
+describe('Line', () => {
+  const { supportsDataset } = CORE_VIS.Line;
 
-    it('should not support dataset with non-simple shape', () => {
-      expect(supportsDataset(datasetIntScalar)).toBe(false);
-    });
+  it('should support dataset with numeric type, simple shape and at least one dimension', () => {
+    expect(supportsDataset(datasetInt1D)).toBe(true);
+    expect(supportsDataset(datasetFlt3D)).toBe(true);
+  });
 
-    it('should not support dataset with less than two dimensions', () => {
-      expect(supportsDataset(datasetInt1D)).toBe(false);
-    });
+  it('should not support dataset with non-numeric type', () => {
+    expect(supportsDataset(datasetStr2D)).toBe(false);
+  });
+
+  it('should not support dataset with non-simple shape', () => {
+    expect(supportsDataset(datasetIntScalar)).toBe(false);
+  });
+
+  it('should not support dataset with no dimension', () => {
+    expect(supportsDataset(datasetInt0D)).toBe(false);
+  });
+});
+
+describe('Heatmap', () => {
+  const { supportsDataset } = CORE_VIS.Heatmap;
+
+  it('should support dataset with numeric type, simple shape and at least two dimensions', () => {
+    expect(supportsDataset(datasetInt2D)).toBe(true);
+    expect(supportsDataset(datasetFlt3D)).toBe(true);
+  });
+
+  it('should not support dataset with non-numeric type', () => {
+    expect(supportsDataset(datasetStr2D)).toBe(false);
+  });
+
+  it('should not support dataset with non-simple shape', () => {
+    expect(supportsDataset(datasetIntScalar)).toBe(false);
+  });
+
+  it('should not support dataset with less than two dimensions', () => {
+    expect(supportsDataset(datasetInt1D)).toBe(false);
   });
 });

--- a/src/h5web/vis-packs/nexus/NexusPack.test.tsx
+++ b/src/h5web/vis-packs/nexus/NexusPack.test.tsx
@@ -7,78 +7,76 @@ import {
 } from '../../test-utils';
 import { NexusVis } from './visualizations';
 
-describe('NexusPack', () => {
-  test('visualize NXdata group with "spectrum" interpretation', async () => {
-    renderApp();
-    await selectExplorerNode('nexus_entry/spectrum');
+test('visualize NXdata group with "spectrum" interpretation', async () => {
+  renderApp();
+  await selectExplorerNode('nexus_entry/spectrum');
 
-    const tabs = await findVisSelectorTabs();
-    expect(tabs).toHaveLength(1);
-    expect(tabs[0]).toHaveTextContent(NexusVis.NxSpectrum);
-  });
+  const tabs = await findVisSelectorTabs();
+  expect(tabs).toHaveLength(1);
+  expect(tabs[0]).toHaveTextContent(NexusVis.NxSpectrum);
+});
 
-  test('visualize NXdata group with "image" interpretation', async () => {
-    renderApp();
-    await selectExplorerNode('nexus_entry/image');
+test('visualize NXdata group with "image" interpretation', async () => {
+  renderApp();
+  await selectExplorerNode('nexus_entry/image');
 
-    const tabs = await findVisSelectorTabs();
-    expect(tabs).toHaveLength(1);
-    expect(tabs[0]).toHaveTextContent(NexusVis.NxImage);
-  });
+  const tabs = await findVisSelectorTabs();
+  expect(tabs).toHaveLength(1);
+  expect(tabs[0]).toHaveTextContent(NexusVis.NxImage);
+});
 
-  test('visualize NXdata group with 2D signal', async () => {
-    renderApp();
-    await selectExplorerNode('nexus_entry/nx_process/nx_data');
+test('visualize NXdata group with 2D signal', async () => {
+  renderApp();
+  await selectExplorerNode('nexus_entry/nx_process/nx_data');
 
-    const tabs = await findVisSelectorTabs();
-    expect(tabs).toHaveLength(1);
-    expect(tabs[0]).toHaveTextContent(NexusVis.NxImage);
-  });
+  const tabs = await findVisSelectorTabs();
+  expect(tabs).toHaveLength(1);
+  expect(tabs[0]).toHaveTextContent(NexusVis.NxImage);
+});
 
-  test('visualize NXentry group with relative path to 2D default signal', async () => {
-    renderApp();
-    await selectExplorerNode('nexus_entry');
+test('visualize NXentry group with relative path to 2D default signal', async () => {
+  renderApp();
+  await selectExplorerNode('nexus_entry');
 
-    const tabs = await findVisSelectorTabs();
-    expect(tabs).toHaveLength(1);
-    expect(tabs[0]).toHaveTextContent(NexusVis.NxImage);
-  });
+  const tabs = await findVisSelectorTabs();
+  expect(tabs).toHaveLength(1);
+  expect(tabs[0]).toHaveTextContent(NexusVis.NxImage);
+});
 
-  test('visualize NXentry group with absolute path to 2D default signal', async () => {
-    renderApp();
-    await selectExplorerNode('nexus_entry/nx_process/absolute_default_path');
+test('visualize NXentry group with absolute path to 2D default signal', async () => {
+  renderApp();
+  await selectExplorerNode('nexus_entry/nx_process/absolute_default_path');
 
-    const tabs = await findVisSelectorTabs();
-    expect(tabs).toHaveLength(1);
-    expect(tabs[0]).toHaveTextContent(NexusVis.NxImage);
-  });
+  const tabs = await findVisSelectorTabs();
+  expect(tabs).toHaveLength(1);
+  expect(tabs[0]).toHaveTextContent(NexusVis.NxImage);
+});
 
-  test('visualize NXroot group with 2D default signal', async () => {
-    renderApp();
+test('visualize NXroot group with 2D default signal', async () => {
+  renderApp();
 
-    const tabs = await findVisSelectorTabs();
-    expect(tabs).toHaveLength(1);
-    expect(tabs[0]).toHaveTextContent(NexusVis.NxImage);
-  });
+  const tabs = await findVisSelectorTabs();
+  expect(tabs).toHaveLength(1);
+  expect(tabs[0]).toHaveTextContent(NexusVis.NxImage);
+});
 
-  test('show error when encountering malformed NeXus metadata', async () => {
-    renderApp();
+test('show error when encountering malformed NeXus metadata', async () => {
+  renderApp();
 
-    const errorSpy = mockConsoleMethod('error');
-    await selectExplorerNode('nexus_malformed');
+  const errorSpy = mockConsoleMethod('error');
+  await selectExplorerNode('nexus_malformed');
 
-    await selectExplorerNode('default_not_string');
-    expect(await screen.findByText(/to be a string/u)).toBeVisible();
+  await selectExplorerNode('default_not_string');
+  expect(await screen.findByText(/to be a string/u)).toBeVisible();
 
-    await selectExplorerNode('default_not_found');
-    expect(await screen.findByText(/entity at path/u)).toBeVisible();
+  await selectExplorerNode('default_not_found');
+  expect(await screen.findByText(/entity at path/u)).toBeVisible();
 
-    await selectExplorerNode('no_signal');
-    expect(await screen.findByText(/'signal' attribute/u)).toBeVisible();
+  await selectExplorerNode('no_signal');
+  expect(await screen.findByText(/'signal' attribute/u)).toBeVisible();
 
-    await selectExplorerNode('signal_not_found');
-    expect(await screen.findByText(/to exist/u)).toBeVisible();
+  await selectExplorerNode('signal_not_found');
+  expect(await screen.findByText(/to exist/u)).toBeVisible();
 
-    expect(errorSpy).toHaveBeenCalledTimes(8); // React logs two stack traces per error
-  });
+  expect(errorSpy).toHaveBeenCalledTimes(8); // React logs two stack traces per error
 });

--- a/src/h5web/vis-packs/nexus/pack-utils.test.ts
+++ b/src/h5web/vis-packs/nexus/pack-utils.test.ts
@@ -17,73 +17,69 @@ const datasetInt1D = makeSimpleDataset('dataset_int_1d', intType, [5]);
 const datasetInt2D = makeSimpleDataset('dataset_int_2d', intType, [5, 3]);
 const datasetFlt3D = makeSimpleDataset('dataset_flt_3d', floatType, [5, 3, 1]);
 
-describe('Nexus pack utilities', () => {
-  describe('getSupportedVis', () => {
-    it('should not include NxSpectrum vis if any other visualization is supported', () => {
-      const datasetInt2D = makeSimpleDataset('dataset', intType, [5, 3]);
-      const nxDataSignal2D = makeNxDataGroup('foo', { signal: datasetInt2D });
-      const supportedVis = getSupportedVis(nxDataSignal2D);
+describe('getSupportedVis', () => {
+  it('should not include NxSpectrum vis if any other visualization is supported', () => {
+    const datasetInt2D = makeSimpleDataset('dataset', intType, [5, 3]);
+    const nxDataSignal2D = makeNxDataGroup('foo', { signal: datasetInt2D });
+    const supportedVis = getSupportedVis(nxDataSignal2D);
 
-      expect(supportedVis).toEqual(NEXUS_VIS.image);
+    expect(supportedVis).toEqual(NEXUS_VIS.image);
+  });
+
+  it('should get supported visualization based on `interpretation` attribute', () => {
+    const spectrum1D = makeNxDataGroup('foo', {
+      signal: withNxInterpretation(datasetInt1D, NxInterpretation.Spectrum),
     });
 
-    it('should get supported visualization based on `interpretation` attribute', () => {
-      const spectrum1D = makeNxDataGroup('foo', {
-        signal: withNxInterpretation(datasetInt1D, NxInterpretation.Spectrum),
-      });
-
-      const spectrum2D = makeNxDataGroup('foo', {
-        signal: withNxInterpretation(datasetInt2D, NxInterpretation.Spectrum),
-      });
-
-      const image2D = makeNxDataGroup('foo', {
-        signal: withNxInterpretation(datasetInt2D, NxInterpretation.Image),
-      });
-
-      expect(getSupportedVis(spectrum1D)).toBe(NEXUS_VIS.spectrum);
-      expect(getSupportedVis(spectrum2D)).toBe(NEXUS_VIS.spectrum);
-      expect(getSupportedVis(image2D)).toBe(NEXUS_VIS.image);
+    const spectrum2D = makeNxDataGroup('foo', {
+      signal: withNxInterpretation(datasetInt2D, NxInterpretation.Spectrum),
     });
 
-    it('should get supported visualization based on dataset shape', () => {
-      const signal1D = makeNxDataGroup('foo', { signal: datasetInt1D });
-      expect(getSupportedVis(signal1D)).toBe(NEXUS_VIS.spectrum);
-
-      const signal2D = makeNxDataGroup('foo', { signal: datasetInt2D });
-      expect(getSupportedVis(signal2D)).toBe(NEXUS_VIS.image);
-
-      const signal3D = makeNxDataGroup('foo', { signal: datasetFlt3D });
-      expect(getSupportedVis(signal3D)).toBe(NEXUS_VIS.image);
+    const image2D = makeNxDataGroup('foo', {
+      signal: withNxInterpretation(datasetInt2D, NxInterpretation.Image),
     });
 
-    it('should fallback to dataset shape when interpretation is unknown', () => {
-      const unknown = makeNxDataGroup('foo', {
-        signal: withAttributes(datasetInt2D, [
-          makeStrAttr('interpretation', 'unknown'),
-        ]),
-      });
+    expect(getSupportedVis(spectrum1D)).toBe(NEXUS_VIS.spectrum);
+    expect(getSupportedVis(spectrum2D)).toBe(NEXUS_VIS.spectrum);
+    expect(getSupportedVis(image2D)).toBe(NEXUS_VIS.image);
+  });
 
-      expect(getSupportedVis(unknown)).toBe(NEXUS_VIS.image);
+  it('should get supported visualization based on dataset shape', () => {
+    const signal1D = makeNxDataGroup('foo', { signal: datasetInt1D });
+    expect(getSupportedVis(signal1D)).toBe(NEXUS_VIS.spectrum);
+
+    const signal2D = makeNxDataGroup('foo', { signal: datasetInt2D });
+    expect(getSupportedVis(signal2D)).toBe(NEXUS_VIS.image);
+
+    const signal3D = makeNxDataGroup('foo', { signal: datasetFlt3D });
+    expect(getSupportedVis(signal3D)).toBe(NEXUS_VIS.image);
+  });
+
+  it('should fallback to dataset shape when interpretation is unknown', () => {
+    const unknown = makeNxDataGroup('foo', {
+      signal: withAttributes(datasetInt2D, [
+        makeStrAttr('interpretation', 'unknown'),
+      ]),
     });
 
-    it('should return undefined if no visualization is supported', () => {
-      expect(getSupportedVis(datasetInt1D)).toBeUndefined();
+    expect(getSupportedVis(unknown)).toBe(NEXUS_VIS.image);
+  });
 
-      const emptyGroup = makeGroup('group_empty');
-      expect(getSupportedVis(emptyGroup)).toBeUndefined();
+  it('should return undefined if no visualization is supported', () => {
+    expect(getSupportedVis(datasetInt1D)).toBeUndefined();
 
-      const nxEntryGroup = makeNxGroup('nxentry', 'NXentry');
-      expect(getSupportedVis(nxEntryGroup)).toBeUndefined();
+    const emptyGroup = makeGroup('group_empty');
+    expect(getSupportedVis(emptyGroup)).toBeUndefined();
+
+    const nxEntryGroup = makeNxGroup('nxentry', 'NXentry');
+    expect(getSupportedVis(nxEntryGroup)).toBeUndefined();
+  });
+
+  it('should throw if entity has malformed NeXus metadata', () => {
+    const noSignal = makeNxGroup('foo', 'NXdata', {
+      attributes: [makeStrAttr('signal', 'bar')],
     });
 
-    it('should throw if entity has malformed NeXus metadata', () => {
-      const noSignal = makeNxGroup('foo', 'NXdata', {
-        attributes: [makeStrAttr('signal', 'bar')],
-      });
-
-      expect(() => getSupportedVis(noSignal)).toThrow(
-        /signal entity to exist/u
-      );
-    });
+    expect(() => getSupportedVis(noSignal)).toThrow(/signal entity to exist/u);
   });
 });

--- a/src/h5web/vis-packs/nexus/utils.test.ts
+++ b/src/h5web/vis-packs/nexus/utils.test.ts
@@ -19,188 +19,186 @@ import {
   getSilxStyle,
 } from './utils';
 
-describe('NeXus utilities', () => {
-  describe('getAttributeValue', () => {
+describe('getAttributeValue', () => {
+  const group = makeGroup('group', [], {
+    attributes: [
+      makeStrAttr('signal', 'my_signal'),
+      makeAttr('axes', makeSimpleShape([1]), stringType, ['X']),
+    ],
+  });
+
+  it("should return an attribute's value", () => {
+    expect(getAttributeValue(group, 'signal')).toBe('my_signal');
+    expect(getAttributeValue(group, 'axes')).toEqual(['X']);
+  });
+
+  it("should return `undefined` if attribute doesn't exist", () => {
+    expect(getAttributeValue(group, 'NX_class')).toBeUndefined();
+  });
+});
+
+describe('findSignalDataset', () => {
+  it("should return dataset named 'signal'", () => {
+    const dataset = makeDataset('dataset', makeSimpleShape([1]), intType);
+    const group = makeGroup('group', [dataset], {
+      attributes: [makeStrAttr('signal', 'dataset')],
+    });
+
+    expect(findSignalDataset(group)).toBe(dataset);
+  });
+
+  it("should throw if group doesn't have 'signal' attribute", () => {
+    const group = makeGroup('group');
+    expect(() => findSignalDataset(group)).toThrow(/'signal' attribute$/u);
+  });
+
+  it("should throw if group has 'signal' attribute with wrong type", () => {
     const group = makeGroup('group', [], {
+      attributes: [makeIntAttr('signal', 42)],
+    });
+
+    expect(() => findSignalDataset(group)).toThrow(/to be a string/u);
+  });
+
+  it("should throw if signal entity doesn't exist", () => {
+    const group = makeGroup('group', [], {
+      attributes: [makeStrAttr('signal', 'foo')],
+    });
+
+    expect(() => findSignalDataset(group)).toThrow(/to exist/u);
+  });
+
+  it('should throw if signal entity is not a dataset', () => {
+    const group = makeGroup('group', [makeGroup('foo')], {
+      attributes: [makeStrAttr('signal', 'foo')],
+    });
+
+    expect(() => findSignalDataset(group)).toThrow(/to be a dataset/u);
+  });
+
+  it('should throw if signal dataset has non-simple shape', () => {
+    const dataset = makeDataset('dataset', scalarShape, intType);
+    const group = makeGroup('group', [dataset], {
+      attributes: [makeStrAttr('signal', 'dataset')],
+    });
+
+    expect(() => findSignalDataset(group)).toThrow(/to have simple shape/u);
+  });
+
+  it('should throw if signal dataset has no dimensions', () => {
+    const dataset = makeDataset('dataset', makeSimpleShape([]), stringType);
+    const group = makeGroup('group', [dataset], {
+      attributes: [makeStrAttr('signal', 'dataset')],
+    });
+
+    expect(() => findSignalDataset(group)).toThrow(/to have dimensions/u);
+  });
+
+  it('should throw if signal dataset has non-numeric type', () => {
+    const dataset = makeDataset('dataset', makeSimpleShape([1]), stringType);
+    const group = makeGroup('group', [dataset], {
+      attributes: [makeStrAttr('signal', 'dataset')],
+    });
+
+    expect(() => findSignalDataset(group)).toThrow(/to have numeric type/u);
+  });
+});
+
+describe('getDatasetLabel', () => {
+  it('should return value of `long_name` attribute in priority if available', () => {
+    const dataset = makeDataset('foo', scalarShape, intType, {
       attributes: [
-        makeStrAttr('signal', 'my_signal'),
-        makeAttr('axes', makeSimpleShape([1]), stringType, ['X']),
+        makeStrAttr('long_name', 'Foobar'),
+        makeStrAttr('units', 'nm'),
       ],
     });
 
-    it("should return an attribute's value", () => {
-      expect(getAttributeValue(group, 'signal')).toBe('my_signal');
-      expect(getAttributeValue(group, 'axes')).toEqual(['X']);
-    });
-
-    it("should return `undefined` if attribute doesn't exist", () => {
-      expect(getAttributeValue(group, 'NX_class')).toBeUndefined();
-    });
+    expect(getDatasetLabel(dataset)).toBe('Foobar');
   });
 
-  describe('findSignalDataset', () => {
-    it("should return dataset named 'signal'", () => {
-      const dataset = makeDataset('dataset', makeSimpleShape([1]), intType);
-      const group = makeGroup('group', [dataset], {
-        attributes: [makeStrAttr('signal', 'dataset')],
-      });
-
-      expect(findSignalDataset(group)).toBe(dataset);
+  it('should combine dataset name and value of `units` attribute if available', () => {
+    const dataset = makeDataset('foo', scalarShape, intType, {
+      attributes: [makeStrAttr('units', 'nm')],
     });
 
-    it("should throw if group doesn't have 'signal' attribute", () => {
-      const group = makeGroup('group');
-      expect(() => findSignalDataset(group)).toThrow(/'signal' attribute$/u);
-    });
-
-    it("should throw if group has 'signal' attribute with wrong type", () => {
-      const group = makeGroup('group', [], {
-        attributes: [makeIntAttr('signal', 42)],
-      });
-
-      expect(() => findSignalDataset(group)).toThrow(/to be a string/u);
-    });
-
-    it("should throw if signal entity doesn't exist", () => {
-      const group = makeGroup('group', [], {
-        attributes: [makeStrAttr('signal', 'foo')],
-      });
-
-      expect(() => findSignalDataset(group)).toThrow(/to exist/u);
-    });
-
-    it('should throw if signal entity is not a dataset', () => {
-      const group = makeGroup('group', [makeGroup('foo')], {
-        attributes: [makeStrAttr('signal', 'foo')],
-      });
-
-      expect(() => findSignalDataset(group)).toThrow(/to be a dataset/u);
-    });
-
-    it('should throw if signal dataset has non-simple shape', () => {
-      const dataset = makeDataset('dataset', scalarShape, intType);
-      const group = makeGroup('group', [dataset], {
-        attributes: [makeStrAttr('signal', 'dataset')],
-      });
-
-      expect(() => findSignalDataset(group)).toThrow(/to have simple shape/u);
-    });
-
-    it('should throw if signal dataset has no dimensions', () => {
-      const dataset = makeDataset('dataset', makeSimpleShape([]), stringType);
-      const group = makeGroup('group', [dataset], {
-        attributes: [makeStrAttr('signal', 'dataset')],
-      });
-
-      expect(() => findSignalDataset(group)).toThrow(/to have dimensions/u);
-    });
-
-    it('should throw if signal dataset has non-numeric type', () => {
-      const dataset = makeDataset('dataset', makeSimpleShape([1]), stringType);
-      const group = makeGroup('group', [dataset], {
-        attributes: [makeStrAttr('signal', 'dataset')],
-      });
-
-      expect(() => findSignalDataset(group)).toThrow(/to have numeric type/u);
-    });
+    expect(getDatasetLabel(dataset)).toBe('foo (nm)');
   });
 
-  describe('getDatasetLabel', () => {
-    it('should return value of `long_name` attribute in priority if available', () => {
-      const dataset = makeDataset('foo', scalarShape, intType, {
-        attributes: [
-          makeStrAttr('long_name', 'Foobar'),
-          makeStrAttr('units', 'nm'),
-        ],
-      });
-
-      expect(getDatasetLabel(dataset)).toBe('Foobar');
+  it('should fall back to dataset name when other attributes are absent or not string', () => {
+    const dataset1 = makeDataset('foo', scalarShape, intType);
+    const dataset2 = makeDataset('foo', scalarShape, intType, {
+      attributes: [makeIntAttr('long_name', 42), makeIntAttr('units', 42)],
     });
 
-    it('should combine dataset name and value of `units` attribute if available', () => {
-      const dataset = makeDataset('foo', scalarShape, intType, {
-        attributes: [makeStrAttr('units', 'nm')],
-      });
-
-      expect(getDatasetLabel(dataset)).toBe('foo (nm)');
-    });
-
-    it('should fall back to dataset name when other attributes are absent or not string', () => {
-      const dataset1 = makeDataset('foo', scalarShape, intType);
-      const dataset2 = makeDataset('foo', scalarShape, intType, {
-        attributes: [makeIntAttr('long_name', 42), makeIntAttr('units', 42)],
-      });
-
-      expect(getDatasetLabel(dataset1)).toBe('foo');
-      expect(getDatasetLabel(dataset2)).toBe('foo');
-    });
+    expect(getDatasetLabel(dataset1)).toBe('foo');
+    expect(getDatasetLabel(dataset2)).toBe('foo');
   });
+});
 
-  describe('getSilxStyle', () => {
-    it('should parse `SILX_style` attribute', () => {
-      const silxStyle = {
-        signalScaleType: ScaleType.SymLog,
-        axesScaleType: [ScaleType.Log],
-      };
-
-      const group = makeGroup('foo', [], {
-        attributes: [makeSilxStyleAttr(silxStyle)],
-      });
-
-      expect(getSilxStyle(group)).toEqual(silxStyle);
-    });
-
-    it('should support single axis scale type', () => {
-      const silxStyle = { axes_scale_type: ScaleType.Log };
-      const group = makeGroup('foo', [], {
-        attributes: [makeStrAttr('SILX_style', JSON.stringify(silxStyle))],
-      });
-
-      expect(getSilxStyle(group)).toEqual({
-        axesScaleType: [ScaleType.Log],
-      });
-    });
-
-    it('should ignore unknown `SILX_style` options and invalid values', () => {
-      const silxStyle = {
-        unknown: ScaleType.Log,
-        signal_scale_type: 'invalid',
-        axes_scale_type: [ScaleType.Linear, 'invalid'],
-      };
-
-      const group = makeGroup('foo', [], {
-        attributes: [makeStrAttr('SILX_style', JSON.stringify(silxStyle))],
-      });
-
-      expect(getSilxStyle(group)).toEqual({
-        signalScaleType: undefined,
-        axesScaleType: undefined,
-      });
-    });
-  });
-
-  it('should return empty object and warn to console if `SILX_style` attribute value is not valid, stringified JSON', () => {
-    const warnSpy = mockConsoleMethod('warn');
+describe('getSilxStyle', () => {
+  it('should parse `SILX_style` attribute', () => {
+    const silxStyle = {
+      signalScaleType: ScaleType.SymLog,
+      axesScaleType: [ScaleType.Log],
+    };
 
     const group = makeGroup('foo', [], {
-      attributes: [makeStrAttr('SILX_style', '{')],
+      attributes: [makeSilxStyleAttr(silxStyle)],
     });
 
-    expect(getSilxStyle(group)).toEqual({});
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/Malformed/u));
+    expect(getSilxStyle(group)).toEqual(silxStyle);
   });
 
-  it("should return empty object if `SILX_style` attribute doesn't exist, is empty or is not string", () => {
-    const group1 = makeGroup('foo');
-    const group2 = makeGroup('foo', [], {
-      attributes: [makeStrAttr('SILX_style', '')],
-    });
-    const group3 = makeGroup('foo', [], {
-      attributes: [makeIntAttr('SILX_style', 42)],
+  it('should support single axis scale type', () => {
+    const silxStyle = { axes_scale_type: ScaleType.Log };
+    const group = makeGroup('foo', [], {
+      attributes: [makeStrAttr('SILX_style', JSON.stringify(silxStyle))],
     });
 
-    expect(getSilxStyle(group1)).toEqual({});
-    expect(getSilxStyle(group2)).toEqual({});
-    expect(getSilxStyle(group3)).toEqual({});
+    expect(getSilxStyle(group)).toEqual({
+      axesScaleType: [ScaleType.Log],
+    });
   });
+
+  it('should ignore unknown `SILX_style` options and invalid values', () => {
+    const silxStyle = {
+      unknown: ScaleType.Log,
+      signal_scale_type: 'invalid',
+      axes_scale_type: [ScaleType.Linear, 'invalid'],
+    };
+
+    const group = makeGroup('foo', [], {
+      attributes: [makeStrAttr('SILX_style', JSON.stringify(silxStyle))],
+    });
+
+    expect(getSilxStyle(group)).toEqual({
+      signalScaleType: undefined,
+      axesScaleType: undefined,
+    });
+  });
+});
+
+it('should return empty object and warn to console if `SILX_style` attribute value is not valid, stringified JSON', () => {
+  const warnSpy = mockConsoleMethod('warn');
+
+  const group = makeGroup('foo', [], {
+    attributes: [makeStrAttr('SILX_style', '{')],
+  });
+
+  expect(getSilxStyle(group)).toEqual({});
+  expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/Malformed/u));
+});
+
+it("should return empty object if `SILX_style` attribute doesn't exist, is empty or is not string", () => {
+  const group1 = makeGroup('foo');
+  const group2 = makeGroup('foo', [], {
+    attributes: [makeStrAttr('SILX_style', '')],
+  });
+  const group3 = makeGroup('foo', [], {
+    attributes: [makeIntAttr('SILX_style', 42)],
+  });
+
+  expect(getSilxStyle(group1)).toEqual({});
+  expect(getSilxStyle(group2)).toEqual({});
+  expect(getSilxStyle(group3)).toEqual({});
 });

--- a/src/h5web/visualizer/Visualizer.test.tsx
+++ b/src/h5web/visualizer/Visualizer.test.tsx
@@ -9,48 +9,46 @@ import {
   selectExplorerNode,
 } from '../test-utils';
 
-describe('Visualizer', () => {
-  test('switch between visualisations', async () => {
-    renderApp();
-    await selectExplorerNode('nD_datasets/oneD');
+test('switch between visualisations', async () => {
+  renderApp();
+  await selectExplorerNode('nD_datasets/oneD');
 
-    const lineTab = await screen.findByRole('tab', { name: 'Line' });
-    expect(lineTab).toBeVisible();
-    expect(lineTab).toHaveAttribute('aria-selected', 'true');
+  const lineTab = await screen.findByRole('tab', { name: 'Line' });
+  expect(lineTab).toBeVisible();
+  expect(lineTab).toHaveAttribute('aria-selected', 'true');
 
-    const matrixTab = screen.getByRole('tab', { name: 'Matrix' });
-    expect(matrixTab).toBeVisible();
-    expect(matrixTab).toHaveAttribute('aria-selected', 'false');
+  const matrixTab = screen.getByRole('tab', { name: 'Matrix' });
+  expect(matrixTab).toBeVisible();
+  expect(matrixTab).toHaveAttribute('aria-selected', 'false');
 
-    // Switch to Matrix visualisation
-    fireEvent.click(matrixTab);
-    expect(matrixTab).toHaveAttribute('aria-selected', 'true');
-    expect(lineTab).toHaveAttribute('aria-selected', 'false');
-  });
+  // Switch to Matrix visualisation
+  fireEvent.click(matrixTab);
+  expect(matrixTab).toHaveAttribute('aria-selected', 'true');
+  expect(lineTab).toHaveAttribute('aria-selected', 'false');
+});
 
-  test('show fallback message when no visualization is supported', async () => {
-    renderApp();
-    await selectExplorerNode('entities'); // simple group
+test('show fallback message when no visualization is supported', async () => {
+  renderApp();
+  await selectExplorerNode('entities'); // simple group
 
-    expect(await screen.findByText('Nothing to visualize')).toBeInTheDocument();
-    expect(queryVisSelector()).not.toBeInTheDocument();
-  });
+  expect(await screen.findByText('Nothing to visualize')).toBeInTheDocument();
+  expect(queryVisSelector()).not.toBeInTheDocument();
+});
 
-  test("show error when dataset value can't be fetched and reset when selecting another dataset", async () => {
-    render(
-      <MockProvider errorOnPath="/entities/raw">
-        <App />
-      </MockProvider>
-    );
+test("show error when dataset value can't be fetched and reset when selecting another dataset", async () => {
+  render(
+    <MockProvider errorOnPath="/entities/raw">
+      <App />
+    </MockProvider>
+  );
 
-    const errorSpy = mockConsoleMethod('error');
-    await selectExplorerNode('entities/raw');
+  const errorSpy = mockConsoleMethod('error');
+  await selectExplorerNode('entities/raw');
 
-    expect(await screen.findByText('error')).toBeVisible();
-    expect(errorSpy).toHaveBeenCalledTimes(2); // React logs two stack traces
-    errorSpy.mockRestore();
+  expect(await screen.findByText('error')).toBeVisible();
+  expect(errorSpy).toHaveBeenCalledTimes(2); // React logs two stack traces
+  errorSpy.mockRestore();
 
-    await selectExplorerNode('scalar_str');
-    expect(await screen.findByText(mockValues.scalar_str)).toBeVisible();
-  });
+  await selectExplorerNode('scalar_str');
+  expect(await screen.findByText(mockValues.scalar_str)).toBeVisible();
 });


### PR DESCRIPTION
Came across this: https://kentcdodds.com/blog/avoid-nesting-when-youre-testing ... and I whole-heartily agree: top-level describe blocks don't add much value when you consider that the file path/name already appears in Jest's output. They increase the nesting level for no good reason.