### PR TITLE
Make responsive toolbar more efficient and flexible

### DIFF
--- a/src/h5web/toolbar/MeasuredControl.tsx
+++ b/src/h5web/toolbar/MeasuredControl.tsx
@@ -1,0 +1,30 @@
+import type { ReactElement } from 'react';
+import Measure from 'react-measure';
+import styles from './Toolbar.module.css';
+
+interface Props {
+  children: ReactElement;
+  onMeasure: (width: number) => void;
+}
+
+function MeasuredControl(props: Props) {
+  const { children: child, onMeasure } = props;
+
+  return (
+    <Measure
+      onResize={({ entry }) => {
+        if (entry) {
+          onMeasure(entry.width);
+        }
+      }}
+    >
+      {({ measureRef }) => (
+        <div ref={measureRef} className={styles.control}>
+          {child}
+        </div>
+      )}
+    </Measure>
+  );
+}
+
+export default MeasuredControl;

--- a/src/h5web/toolbar/Separator.module.css
+++ b/src/h5web/toolbar/Separator.module.css
@@ -1,4 +1,0 @@
-.sep {
-  margin: 0.375rem 0.25rem;
-  border-left: 1px solid rgba(0, 0, 0, 0.2);
-}

--- a/src/h5web/toolbar/Separator.tsx
+++ b/src/h5web/toolbar/Separator.tsx
@@ -1,6 +1,5 @@
 import type { ReactElement } from 'react';
-
-import styles from './Separator.module.css';
+import styles from './Toolbar.module.css';
 
 function Separator(): ReactElement {
   return <span className={styles.sep} />;

--- a/src/h5web/toolbar/Toolbar.module.css
+++ b/src/h5web/toolbar/Toolbar.module.css
@@ -13,12 +13,20 @@
   min-width: 0;
 }
 
-.measuringContainer {
+.controlsInner {
+  display: flex;
+}
+
+.control {
+  display: flex;
+}
+
+.controlsInner[data-all-measured='false'] {
   position: relative;
   overflow: hidden;
 }
 
-.measuredControl {
+.controlsInner[data-all-measured='false'] > .control {
   position: absolute;
 }
 

--- a/src/h5web/toolbar/Toolbar.module.css
+++ b/src/h5web/toolbar/Toolbar.module.css
@@ -23,7 +23,7 @@
 
 .controlsInner[data-all-measured='false'] {
   position: relative;
-  overflow: hidden;
+  overflow: hidden; /* hide controls while they are being measured */
 }
 
 .controlsInner[data-all-measured='false'] > .control {

--- a/src/h5web/toolbar/Toolbar.module.css
+++ b/src/h5web/toolbar/Toolbar.module.css
@@ -30,6 +30,11 @@
   position: absolute;
 }
 
+.sep {
+  margin: 0.375rem 0.25rem;
+  border-left: 1px solid rgba(0, 0, 0, 0.2);
+}
+
 .btn {
   composes: btn-clean from global;
   display: flex;

--- a/src/h5web/toolbar/Toolbar.tsx
+++ b/src/h5web/toolbar/Toolbar.tsx
@@ -1,48 +1,38 @@
-import { ReactElement, Children, Fragment } from 'react';
-import { useMeasure, useMap } from 'react-use';
+import { ReactElement, Children, ReactNode } from 'react';
+import { useMeasure, useList } from 'react-use';
 import styles from './Toolbar.module.css';
 import Separator from './Separator';
 import OverflowMenu from './OverflowMenu';
 import MeasuredControl from './MeasuredControl';
 
 interface Props {
-  // Toolbar controls must be direct children of `Toolbar` (no fragment)
-  children?: (ReactElement | undefined)[] | ReactElement;
+  children?: ReactNode[];
 }
 
 function Toolbar(props: Props): ReactElement {
   const { children } = props;
   const allChildren = Children.toArray(children) as ReactElement[];
 
-  if (allChildren.filter((child) => child.type === Fragment).length > 0) {
-    throw new Error('Fragment not allowed as child of Toolbar');
-  }
-
   const [containerRef, { width: availableWidth }] = useMeasure();
-  const [childrenWidths, { set: setChildWidth }] = useMap<
-    Record<string, number>
-  >();
+  const [childrenWidths, { updateAt: setChildWidth }] = useList<number>();
 
-  // Filter out children that haven't been measured or with width of `0`
-  const measuredChildren = allChildren.filter(
-    (child) => !!childrenWidths[child.key as string]
+  // Group visible and hidden children based on their accumulated width
+  const [visibleChildren, hiddenChildren, allMeasured] = allChildren.reduce(
+    ([accVisible, accHidden, accAllMeasured, accWidth], child, index) => {
+      const width = childrenWidths[index] ?? 0;
+      const isMeasured = width > 0;
+      const isOverflowing = accWidth + width > availableWidth;
+
+      return [
+        isMeasured && !isOverflowing ? [...accVisible, child] : accVisible,
+        isMeasured && isOverflowing ? [...accHidden, child] : accHidden,
+        accAllMeasured && isMeasured,
+        accWidth + width,
+      ];
+    },
+    [[] as ReactElement[], [] as ReactElement[], true, 0]
   );
 
-  // Measure cumulative widths to find index of first overflowing child
-  const cumulativeWidths = measuredChildren.reduce<number[]>((acc, child) => {
-    const width = childrenWidths[child.key as string];
-    return [...acc, (acc[acc.length - 1] ?? 0) + width];
-  }, []);
-
-  const firstOverflowIndex = [...cumulativeWidths, Infinity].findIndex(
-    (width) => width > availableWidth
-  );
-
-  // Group visible and hidden children
-  const visibleChildren = measuredChildren.slice(0, firstOverflowIndex);
-  const hiddenChildren = measuredChildren.slice(firstOverflowIndex);
-
-  const allMeasured = measuredChildren.length === allChildren.length;
   const isSeparatorLast =
     visibleChildren[visibleChildren.length - 1]?.type === Separator;
 
@@ -62,7 +52,9 @@ function Toolbar(props: Props): ReactElement {
           {allOrVisibleChildren.map((child) => (
             <MeasuredControl
               key={`measure-${child.key || ''}`}
-              onMeasure={(width) => setChildWidth(child.key as string, width)}
+              onMeasure={(width) => {
+                setChildWidth(allChildren.indexOf(child), width);
+              }}
             >
               {child}
             </MeasuredControl>

--- a/src/h5web/toolbar/controls/ColorMapSelector.tsx
+++ b/src/h5web/toolbar/controls/ColorMapSelector.tsx
@@ -36,20 +36,18 @@ function ColorMapOption(props: { option: ColorMap }): ReactElement {
 
 interface Props {
   value: ColorMap;
-  disabled?: boolean;
   onValueChange: (colorMap: ColorMap) => void;
   invert: boolean;
   onInversionChange: () => void;
 }
 
 function ColorMapSelector(props: Props): ReactElement {
-  const { value, disabled, onValueChange, invert, onInversionChange } = props;
+  const { value, onValueChange, invert, onInversionChange } = props;
 
   return (
     <div className={styles.selectorWrapper}>
       <Selector
         value={value}
-        disabled={disabled}
         onChange={onValueChange}
         options={COLORMAP_GROUPS}
         optionComponent={ColorMapOption}

--- a/src/h5web/toolbar/controls/DomainSlider/DomainSlider.module.css
+++ b/src/h5web/toolbar/controls/DomainSlider/DomainSlider.module.css
@@ -15,8 +15,3 @@
   font-size: 0.75rem;
   cursor: pointer;
 }
-
-.slider:global(.disabled) {
-  opacity: 0.5;
-  pointer-events: none;
-}

--- a/src/h5web/toolbar/controls/DomainSlider/DomainSlider.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/DomainSlider.tsx
@@ -21,12 +21,11 @@ interface Props {
   dataDomain: Domain;
   customDomain: CustomDomain;
   scaleType: ScaleType;
-  disabled?: boolean;
   onCustomDomainChange: (domain: CustomDomain) => void;
 }
 
 function DomainSlider(props: Props): ReactElement {
-  const { dataDomain, customDomain, scaleType, disabled } = props;
+  const { dataDomain, customDomain, scaleType } = props;
   const { onCustomDomainChange } = props;
 
   const visDomain = useVisDomain(customDomain, dataDomain);
@@ -72,7 +71,6 @@ function DomainSlider(props: Props): ReactElement {
         dataDomain={dataDomain}
         scaleType={scaleType}
         errors={errors}
-        disabled={disabled}
         isAutoMin={isAutoMin}
         isAutoMax={isAutoMax}
         onChange={(newValue) => {
@@ -93,7 +91,6 @@ function DomainSlider(props: Props): ReactElement {
         label="Edit domain"
         icon={FiEdit3}
         value={isEditing}
-        disabled={disabled}
         onChange={() => toggleEditing(!isEditing)}
       />
 

--- a/src/h5web/toolbar/controls/DomainSlider/ScaledSlider.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/ScaledSlider.tsx
@@ -21,7 +21,6 @@ interface Props {
   safeVisDomain: Domain;
   scaleType: ScaleType;
   errors: DomainErrors;
-  disabled?: boolean;
   isAutoMin: boolean;
   isAutoMax: boolean;
   onChange: (newValue: Domain) => void;
@@ -35,7 +34,6 @@ function ScaledSlider(props: Props): ReactElement {
     safeVisDomain,
     scaleType,
     errors,
-    disabled,
     isAutoMin,
     isAutoMax,
   } = props;
@@ -79,7 +77,6 @@ function ScaledSlider(props: Props): ReactElement {
       min={SLIDER_RANGE[0]}
       max={SLIDER_RANGE[1]}
       value={scaledValue}
-      disabled={disabled}
       onBeforeChange={(bounds) => setBeforeChangeValue(bounds as Domain)}
       onChange={(bounds) => handleChange(bounds as Domain)}
       onAfterChange={(bounds) => handleChange(bounds as Domain, true)}
@@ -89,7 +86,6 @@ function ScaledSlider(props: Props): ReactElement {
           isAuto={index === 0 ? isAutoMin : isAutoMax}
           hasError={minGreater || (index === 0 ? !!minError : !!maxError)}
           AutoIcon={index === 0 ? FiSkipBack : FiSkipForward}
-          disabled={disabled}
           {...thumbProps}
         />
       )}

--- a/src/h5web/toolbar/controls/DomainSlider/Thumb.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/Thumb.tsx
@@ -7,18 +7,16 @@ type Props = HTMLProps<HTMLDivElement> & {
   isAuto: boolean;
   hasError: boolean;
   AutoIcon: IconType;
-  disabled?: boolean;
 };
 
 const Thumb = forwardRef<HTMLDivElement, Props>((props, ref) => {
-  const { isAuto, hasError, disabled, AutoIcon, ...thumbProps } = props;
+  const { isAuto, hasError, AutoIcon, ...thumbProps } = props;
 
   return (
     <div
       ref={ref}
       {...thumbProps}
       className={styles.thumb}
-      tabIndex={disabled ? -1 : 0}
       data-auto={isAuto}
       data-error={hasError || undefined}
     >

--- a/src/h5web/toolbar/controls/ScaleSelector/ScaleSelector.tsx
+++ b/src/h5web/toolbar/controls/ScaleSelector/ScaleSelector.tsx
@@ -7,12 +7,11 @@ import ScaleOption from './ScaleOption';
 interface Props {
   value: ScaleType;
   label?: string;
-  disabled?: boolean;
   onScaleChange: (scale: ScaleType) => void;
 }
 
 function ScaleSelector(props: Props): ReactElement {
-  const { value, label, disabled, onScaleChange } = props;
+  const { value, label, onScaleChange } = props;
 
   return (
     <div className={styles.root}>
@@ -20,7 +19,6 @@ function ScaleSelector(props: Props): ReactElement {
       <Selector
         value={value}
         onChange={onScaleChange}
-        disabled={disabled}
         options={Object.values(ScaleType)}
         optionComponent={ScaleOption}
       />

--- a/src/h5web/toolbar/controls/SnapshotButton.tsx
+++ b/src/h5web/toolbar/controls/SnapshotButton.tsx
@@ -2,21 +2,13 @@ import type { ReactElement } from 'react';
 import { MdCameraAlt } from 'react-icons/md';
 import styles from './SnapshotButton.module.css';
 
-interface Props {
-  disabled?: boolean;
-}
-
-function SnapshotButton(props: Props): ReactElement {
-  const { disabled } = props;
-
+function SnapshotButton(): ReactElement {
   return (
     <a
       className={styles.link}
       href="/"
       target="_blank"
       aria-label="Snapshot"
-      aria-disabled={disabled ? 'true' : undefined}
-      tabIndex={disabled ? -1 : undefined}
       onClick={(evt) => {
         const canvas = document.querySelector('canvas');
 


### PR DESCRIPTION
I've created separate commits, which will probably be easier to review.

The gist of it is that the previous implementation did not allow the toolbar controls to be feature tested. We used to render every control twice:

- Once visibly (or in the overflow menu) but only when measured.
- A second time (with `React.clone`) invisibly and disabled in order to measure them (and keep the measurements up to date).

Since JSDom does not support measuring elements, the controls were never "measured" and would remain hidden and disabled. React Testing Library excludes disabled elements when querying, so it would never find any controls in the toolbar.

The new implementation renders every control only once and never disabled. It uses CSS to hide the controls while they are being measured, and once all of them have been measured, it shows them (and moves those that don't fit in the overflow menu).

The behaviour is the same as before with one exception: the measurements of the controls in the overflow menu are not kept up to date. In other words, even if one control shrinks enough to fit on the toolbar, it will stay in the overflow menu. The reasoning is that it's best to avoid moving things around if we don't have to. This is very specific and affects neither the opposite behaviour (i.e. when a control visible on the toolbar shrinks or grows) nor the resize behaviour (controls from the overflow menu will still move in/out of the overflow menu on resize).