### PR TITLE
Use output from `match-tag-to-package-version` action in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Match tag to package version 🧐
-        uses: geritol/match-tag-to-package-version@0.0.2
+        id: packageVersion
+        uses: geritol/match-tag-to-package-version@0.1.0
         env:
           TAG_PREFIX: refs/tags/v
-
-      - name: Expose version as env var 🤓
-        uses: nyaayaya/package-version@v1
 
       - name: Use Node 12 🕹️
         uses: actions/setup-node@v1
@@ -38,13 +36,13 @@ jobs:
       - name: Set @h5web/app version 📌
         uses: reedyuk/npm-version@1.0.1
         with:
-          version: ${{ env.PACKAGE_VERSION }}
+          version: ${{ steps.packageVersion.outputs.PACKAGE_VERSION }}
           package: 'packages/app/dist'
 
       - name: Set @h5web/lib version 📌
         uses: reedyuk/npm-version@1.0.1
         with:
-          version: ${{ env.PACKAGE_VERSION }}
+          version: ${{ steps.packageVersion.outputs.PACKAGE_VERSION }}
           package: 'packages/lib/dist'
 
       - name: Publish @h5web/app 🥳


### PR DESCRIPTION
- https://github.com/geritol/match-tag-to-package-version/issues/2
- https://github.com/geritol/match-tag-to-package-version/releases/tag/0.1.0