### PR TITLE
Render React in Strict Mode

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,6 @@
 import 'react-app-polyfill/stable';
 
+import { StrictMode } from 'react';
 import ReactDOM from 'react-dom';
 
 import 'react-reflex/styles.css';
@@ -8,4 +9,9 @@ import './styles/index.css';
 
 import DemoApp from './demo-app/DemoApp';
 
-ReactDOM.render(<DemoApp />, document.querySelector('#root'));
+ReactDOM.render(
+  <StrictMode>
+    <DemoApp />
+  </StrictMode>,
+  document.querySelector('#root')
+);


### PR DESCRIPTION
https://reactjs.org/docs/strict-mode.html

I think we weren't using Strict Mode because of the `UNSAFE_componentWillReceiveProps` warnings caused by React-Reflex. Now that it's resolved #578, might as well! I can't see any new warnings yet, which is great 😄 