### PR TITLE
Build `Value` type from dataset rather than shape and type

### DIFF
--- a/src/h5web/providers/hdf5-models.ts
+++ b/src/h5web/providers/hdf5-models.ts
@@ -73,7 +73,7 @@ export interface HDF5ScalarShape {
   class: HDF5ShapeClass.Scalar;
 }
 
-interface HDF5NullShape {
+export interface HDF5NullShape {
   class: HDF5ShapeClass.Null;
 }
 

--- a/src/h5web/providers/models.ts
+++ b/src/h5web/providers/models.ts
@@ -6,6 +6,7 @@ import type {
   HDF5Link,
   HDF5NumericType,
   HDF5Shape,
+  HDF5ScalarShape,
   HDF5SimpleShape,
   HDF5StringType,
   HDF5Type,
@@ -60,10 +61,11 @@ type PrimitiveType<T extends HDF5Type> = T extends HDF5NumericType
   ? Complex
   : unknown;
 
-export type Value<
-  S extends HDF5Shape,
-  T extends HDF5Type
-> = S extends HDF5SimpleShape ? PrimitiveType<T>[] : PrimitiveType<T>;
+export type Value<D extends Dataset> = D['shape'] extends HDF5SimpleShape
+  ? PrimitiveType<D['type']>[]
+  : D['shape'] extends HDF5ScalarShape
+  ? PrimitiveType<D['type']>
+  : never;
 
 export type ComplexArray = (ComplexArray | Complex)[];
 

--- a/src/h5web/vis-packs/core/hooks.ts
+++ b/src/h5web/vis-packs/core/hooks.ts
@@ -13,24 +13,20 @@ import {
 } from './utils';
 import AxisSystemContext from './shared/AxisSystemContext';
 import type { AxisScale } from './models';
-import type { HDF5Shape, HDF5Type } from '../../providers/hdf5-models';
 import { ProviderContext } from '../../providers/context';
 import type { Dataset, Value } from '../../providers/models';
 import { isAxis } from '../../dimension-mapper/utils';
+import type { HDF5Value } from '../../providers/hdf5-models';
 
-export function useDatasetValue<
-  S extends HDF5Shape,
-  T extends HDF5Type,
-  D extends Dataset<S, T> | undefined
->(
+export function useDatasetValue<D extends Dataset | undefined>(
   dataset: D,
   dimMapping?: DimensionMapping
-): D extends Dataset<infer S, infer T> ? Value<S, T> : undefined;
+): D extends Dataset ? Value<D> : undefined;
 
 export function useDatasetValue(
   dataset: Dataset | undefined,
   dimMapping?: DimensionMapping
-) {
+): HDF5Value {
   const { valuesStore } = useContext(ProviderContext);
 
   if (!dataset) {
@@ -50,16 +46,17 @@ export function useDatasetValue(
   return valuesStore.get({ path: dataset.path, selection });
 }
 
-export function useDatasetValues<S extends HDF5Shape, T extends HDF5Type>(
-  datasets: Dataset<S, T>[]
-) {
+export function useDatasetValues<D extends Dataset>(
+  datasets: D[]
+): Record<string, Value<D>>;
+
+export function useDatasetValues(
+  datasets: Dataset[]
+): Record<string, HDF5Value> {
   const { valuesStore } = useContext(ProviderContext);
 
   return Object.fromEntries(
-    datasets.map(({ name, path }) => [
-      name,
-      valuesStore.get({ path }) as Value<S, T>,
-    ])
+    datasets.map(({ name, path }) => [name, valuesStore.get({ path })])
   );
 }
 


### PR DESCRIPTION
Part of #519 

A significant simplification of the `Value` type, which is used as the return type for the `useDatasetValue` and `useDatasetValues` hooks. Instead of two separate generics (`HDF5Shape` and `HDF5Type`), it now requires only one: `Dataset` (as this type already includes the types of the dataset's HDF5 shape and type).