### PR TITLE
Move `HDF5Shape` types to HSDS provider and simplify them

### DIFF
--- a/src/h5web/providers/hdf5-models.ts
+++ b/src/h5web/providers/hdf5-models.ts
@@ -11,16 +11,6 @@ export enum HDF5Collection {
   Datatypes = 'datatypes',
 }
 
-/* ---------------------- */
-/* ----- ATTRIBUTES ----- */
-
-export interface HDF5Attribute {
-  name: string;
-  shape: HDF5Shape;
-  type: HDF5Type;
-  value: HDF5Value;
-}
-
 /* ----------------- */
 /* ----- LINKS ----- */
 
@@ -50,31 +40,6 @@ export interface HDF5ExternalLink {
   title: string;
   file: string;
   h5path: string;
-}
-
-/* ----------------- */
-/* ----- SHAPE ----- */
-
-export type HDF5Shape = HDF5SimpleShape | HDF5ScalarShape | HDF5NullShape;
-
-export enum HDF5ShapeClass {
-  Simple = 'H5S_SIMPLE',
-  Scalar = 'H5S_SCALAR',
-  Null = 'H5S_NUL',
-}
-
-export interface HDF5SimpleShape {
-  class: HDF5ShapeClass.Simple;
-  dims: HDF5Dims;
-  maxdims?: HDF5Dims;
-}
-
-export interface HDF5ScalarShape {
-  class: HDF5ShapeClass.Scalar;
-}
-
-export interface HDF5NullShape {
-  class: HDF5ShapeClass.Null;
 }
 
 /* ---------------- */

--- a/src/h5web/providers/hsds/models.ts
+++ b/src/h5web/providers/hsds/models.ts
@@ -1,7 +1,5 @@
 import type {
   HDF5Id,
-  HDF5Shape,
-  HDF5Attribute,
   HDF5Value,
   HDF5ExternalLink,
   HDF5HardLink,
@@ -10,6 +8,72 @@ import type {
   HDF5Dims,
 } from '../hdf5-models';
 import type { Entity } from '../models';
+
+/* --------------------- */
+/* ----- RESPONSES ----- */
+
+export interface HsdsRootResponse {
+  root: HDF5Id;
+}
+
+export interface HsdsGroupResponse {
+  id: HDF5Id;
+  linkCount: number;
+  attributeCount: number;
+}
+
+export interface HsdsDatasetResponse {
+  id: HDF5Id;
+  shape: HsdsShape;
+  type: HsdsType;
+  attributeCount: number;
+}
+
+export interface HsdsDatatypeResponse {
+  id: HDF5Id;
+  type: HsdsType;
+}
+
+export interface HsdsAttributesResponse {
+  attributes: Omit<HsdsAttributeResponse, 'value'>[];
+}
+
+export interface HsdsAttributeResponse {
+  name: string;
+  shape: HsdsShape;
+  type: HsdsType;
+  value: HDF5Value;
+}
+
+export interface HsdsLinksResponse {
+  links: HsdsLink[];
+}
+
+export interface HsdsValueResponse {
+  value: HDF5Value;
+}
+
+/* ---------------------------- */
+/* ----- ENTITIES & VALUES----- */
+
+export type HsdsEntity<T extends Entity = Entity> = T & { id: HDF5Id };
+
+export type HsdsLink = HDF5HardLink | HDF5SoftLink | HsdsExternalLink;
+
+export interface HsdsExternalLink extends Omit<HDF5ExternalLink, 'file'> {
+  h5domain: string;
+}
+
+export type HsdsComplex = HsdsComplex[] | HsdsComplexValue;
+export type HsdsComplexValue = [number, number];
+
+/* ------------------------ */
+/* ----- SHAPE & TYPE ----- */
+
+export interface HsdsShape {
+  class: 'H5S_SIMPLE' | 'H5S_SCALAR' | 'H5S_NUL';
+  dims?: HDF5Dims;
+}
 
 export type HsdsType =
   | HsdsIntegerType
@@ -64,55 +128,3 @@ interface HsdsCompoundTypeField {
   name: string;
   type: HsdsType;
 }
-
-export interface HsdsRootResponse {
-  root: HDF5Id;
-}
-
-export interface HsdsGroupResponse {
-  id: HDF5Id;
-  linkCount: number;
-  attributeCount: number;
-}
-
-export interface HsdsDatasetResponse {
-  id: HDF5Id;
-  shape: HDF5Shape;
-  type: HsdsType;
-  attributeCount: number;
-}
-
-export interface HsdsDatatypeResponse {
-  id: HDF5Id;
-  type: HsdsType;
-}
-
-export interface HsdsAttributesResponse {
-  attributes: Omit<HDF5Attribute, 'value'>[];
-}
-
-export interface HsdsAttributeWithValueResponse {
-  name: string;
-  shape: HDF5Shape;
-  type: HsdsType;
-  value: HDF5Value;
-}
-
-export interface HsdsLinksResponse {
-  links: HsdsLink[];
-}
-
-export type HsdsLink = HDF5HardLink | HDF5SoftLink | HsdsExternalLink;
-
-export interface HsdsExternalLink extends Omit<HDF5ExternalLink, 'file'> {
-  h5domain: string;
-}
-
-export type HsdsEntity<T extends Entity = Entity> = T & { id: HDF5Id };
-
-export interface HsdsValueResponse {
-  value: HDF5Value;
-}
-
-export type HsdsComplex = HsdsComplex[] | HsdsComplexValue;
-export type HsdsComplexValue = [number, number];

--- a/src/h5web/providers/hsds/utils.ts
+++ b/src/h5web/providers/hsds/utils.ts
@@ -5,8 +5,6 @@ import {
   HDF5Endianness,
   HDF5FloatType,
   HDF5IntegerType,
-  HDF5Shape,
-  HDF5ShapeClass,
   HDF5Type,
   HDF5TypeClass,
 } from '../hdf5-models';
@@ -28,6 +26,7 @@ import type {
   HsdsComplexValue,
   HsdsEntity,
   HsdsAttributeWithValueResponse,
+  HsdsShape,
 } from './models';
 
 export function isHsdsExternalLink(link: HsdsLink): link is HsdsExternalLink {
@@ -56,15 +55,9 @@ export function assertHsdsDataset(
   }
 }
 
-export function convertHsdsShape(shape: HDF5Shape): Shape {
-  switch (shape.class) {
-    case HDF5ShapeClass.Simple:
-      return shape.dims;
-    case HDF5ShapeClass.Scalar:
-      return [];
-    default:
-      return null;
-  }
+export function convertHsdsShape(shape: HsdsShape): Shape {
+  const { class: shapeClass, dims } = shape;
+  return dims || (shapeClass === 'H5S_SCALAR' ? [] : null);
 }
 
 export function convertHsdsNumericType(


### PR DESCRIPTION
I can simplify the new `HsdsShape` type _a lot_ by being a bit less descriptive of what HSDS returns and by simplifying the conversion to `Shape`.

I'm also able to remove `HDF5Attribute`! 🎉 