### PR TITLE
Allow inspection of unknown types

### DIFF
--- a/src/h5web/guards.ts
+++ b/src/h5web/guards.ts
@@ -115,51 +115,38 @@ export function hasMinDims(dataset: Dataset<ArrayShape>, min: number): boolean {
 export function hasPrintableType<S extends Shape>(
   entity: Dataset<S>
 ): entity is Dataset<S, PrintableType> {
-  return (
-    typeof entity.type !== 'string' &&
-    [
-      HDF5TypeClass.Integer,
-      HDF5TypeClass.Float,
-      HDF5TypeClass.String,
-      HDF5TypeClass.Bool,
-      HDF5TypeClass.Complex,
-    ].includes(entity.type.class)
-  );
+  return [
+    HDF5TypeClass.Integer,
+    HDF5TypeClass.Float,
+    HDF5TypeClass.String,
+    HDF5TypeClass.Bool,
+    HDF5TypeClass.Complex,
+  ].includes(entity.type.class);
 }
 
 export function hasBoolType<S extends Shape>(
   dataset: Dataset<S>
 ): dataset is Dataset<S, HDF5BooleanType> {
-  return (
-    typeof dataset.type !== 'string' &&
-    dataset.type.class === HDF5TypeClass.Bool
-  );
+  return dataset.type.class === HDF5TypeClass.Bool;
 }
 
 export function hasComplexType<S extends Shape>(
   dataset: Dataset<S>
 ): dataset is Dataset<S, HDF5ComplexType> {
-  return (
-    typeof dataset.type !== 'string' &&
-    dataset.type.class === HDF5TypeClass.Complex
-  );
+  return dataset.type.class === HDF5TypeClass.Complex;
 }
 
 export function hasStringType<S extends Shape>(
   dataset: Dataset<S>
 ): dataset is Dataset<S, HDF5StringType> {
-  return (
-    typeof dataset.type !== 'string' &&
-    dataset.type.class === HDF5TypeClass.String
-  );
+  return dataset.type.class === HDF5TypeClass.String;
 }
 
 export function hasNumericType<S extends Shape>(
   dataset: Dataset<S>
 ): dataset is Dataset<S, HDF5NumericType> {
-  return (
-    typeof dataset.type !== 'string' &&
-    [HDF5TypeClass.Integer, HDF5TypeClass.Float].includes(dataset.type.class)
+  return [HDF5TypeClass.Integer, HDF5TypeClass.Float].includes(
+    dataset.type.class
   );
 }
 

--- a/src/h5web/metadata-viewer/utils.ts
+++ b/src/h5web/metadata-viewer/utils.ts
@@ -24,10 +24,6 @@ export function renderShape(shape: Shape): string {
 }
 
 export function renderType(type: HDF5Type): string {
-  if (typeof type === 'string') {
-    return type;
-  }
-
   // Remove leading `H5T_`
   const classLabel = type.class.slice(4).toLowerCase();
 

--- a/src/h5web/providers/hdf5-models.ts
+++ b/src/h5web/providers/hdf5-models.ts
@@ -51,7 +51,6 @@ export type HDF5Type =
   | HDF5StringType
   | HDF5BooleanType
   | HDF5ComplexType
-  | HDF5Id
   | HDF5ArrayType
   | HDF5VLenType
   | HDF5CompoundType

--- a/src/h5web/providers/hdf5-models.ts
+++ b/src/h5web/providers/hdf5-models.ts
@@ -54,20 +54,22 @@ export type HDF5Type =
   | HDF5ArrayType
   | HDF5VLenType
   | HDF5CompoundType
-  | HDF5EnumType;
+  | HDF5EnumType
+  | HDF5UnknownType;
 
 export type HDF5NumericType = HDF5IntegerType | HDF5FloatType;
 
 export enum HDF5TypeClass {
+  Bool = 'H5T_BOOL',
   Integer = 'H5T_INTEGER',
   Float = 'H5T_FLOAT',
+  Complex = 'H5T_COMPLEX',
   String = 'H5T_STRING',
+  Compound = 'H5T_COMPOUND',
   Array = 'H5T_ARRAY',
   VLen = 'H5T_VLEN',
-  Compound = 'H5T_COMPOUND',
   Enum = 'H5T_ENUM',
-  Bool = 'H5T_BOOL',
-  Complex = 'H5T_COMPLEX',
+  Unknown = 'H5T_UNKNOWN',
 }
 
 export type HDF5Endianness = 'BE' | 'LE' | 'Native' | 'Not applicable';
@@ -126,4 +128,8 @@ export interface HDF5CompoundType {
 interface HDF5CompoundTypeField {
   name: string;
   type: HDF5Type;
+}
+
+interface HDF5UnknownType {
+  class: HDF5TypeClass.Unknown;
 }

--- a/src/h5web/providers/hsds/api.ts
+++ b/src/h5web/providers/hsds/api.ts
@@ -210,6 +210,7 @@ export class HsdsApi implements ProviderAPI {
       attributes: convertHsdsAttributes(attributes),
       shape: convertHsdsShape(shape),
       type: convertHsdsType(type),
+      rawType: type,
     };
   }
 
@@ -226,6 +227,7 @@ export class HsdsApi implements ProviderAPI {
       kind: EntityKind.Datatype,
       attributes: [],
       type: convertHsdsType(type),
+      rawType: type,
     };
   }
 

--- a/src/h5web/providers/hsds/models.ts
+++ b/src/h5web/providers/hsds/models.ts
@@ -82,8 +82,7 @@ export type HsdsType =
   | HsdsArrayType
   | HsdsVLenType
   | HsdsCompoundType
-  | HsdsEnumType
-  | HDF5Id;
+  | HsdsEnumType;
 
 export interface HsdsIntegerType {
   class: HDF5TypeClass.Integer;

--- a/src/h5web/providers/hsds/utils.test.ts
+++ b/src/h5web/providers/hsds/utils.test.ts
@@ -155,11 +155,11 @@ describe('convertHsdsType', () => {
     });
   });
 
-  it('should throw when encountering an unknown type', () => {
+  it('should handle unknown type', () => {
     const unknownType = { class: 'NO_CLASS' };
-    expect(() => convertHsdsType(unknownType as HsdsType)).toThrow(
-      /Unknown type/
-    );
+    expect(convertHsdsType(unknownType as HsdsType)).toEqual({
+      class: HDF5TypeClass.Unknown,
+    });
   });
 });
 

--- a/src/h5web/providers/hsds/utils.test.ts
+++ b/src/h5web/providers/hsds/utils.test.ts
@@ -1,5 +1,5 @@
 import Complex from 'complex.js';
-import { HDF5Type, HDF5Id, HDF5TypeClass } from '../hdf5-models';
+import { HDF5Type, HDF5TypeClass } from '../hdf5-models';
 import type {
   HsdsStringType,
   HsdsArrayType,
@@ -42,11 +42,6 @@ const beFloatType: TestType = {
 };
 
 describe('convertHsdsType', () => {
-  it('should left HDF5Id type unchanged', () => {
-    const idType: HDF5Id = 'aHdfId';
-    expect(convertHsdsType(idType)).toBe(idType);
-  });
-
   it('should convert ASCII string type', () => {
     const asciiStrType: HsdsStringType = {
       class: HDF5TypeClass.String,

--- a/src/h5web/providers/hsds/utils.ts
+++ b/src/h5web/providers/hsds/utils.ts
@@ -1,5 +1,4 @@
 import Complex from 'complex.js';
-import { isString } from 'lodash-es';
 import { isDataset, isGroup } from '../../guards';
 import {
   HDF5Endianness,
@@ -83,10 +82,6 @@ export function convertHsdsNumericType(
 }
 
 export function convertHsdsType(hsdsType: HsdsType): HDF5Type {
-  if (isString(hsdsType)) {
-    return hsdsType;
-  }
-
   switch (hsdsType.class) {
     case HDF5TypeClass.Enum:
       // Booleans are stored as Enum by h5py

--- a/src/h5web/providers/hsds/utils.ts
+++ b/src/h5web/providers/hsds/utils.ts
@@ -145,7 +145,7 @@ export function convertHsdsType(hsdsType: HsdsType): HDF5Type {
       return convertHsdsNumericType(hsdsType);
 
     default:
-      throw new Error(`Unknown type ${JSON.stringify(hsdsType)}`);
+      return { class: HDF5TypeClass.Unknown };
   }
 }
 

--- a/src/h5web/providers/jupyter/api.ts
+++ b/src/h5web/providers/jupyter/api.ts
@@ -126,8 +126,9 @@ export class JupyterApi implements ProviderAPI {
       return {
         ...baseEntity,
         kind,
-        type: convertDtype(dtype),
         shape,
+        type: convertDtype(dtype),
+        rawType: dtype,
       };
     }
 

--- a/src/h5web/providers/jupyter/utils.test.ts
+++ b/src/h5web/providers/jupyter/utils.test.ts
@@ -81,8 +81,8 @@ describe('convertDtype', () => {
     expect(() => convertDtype('^f8')).toThrow(/Unknown endianness symbol/);
   });
 
-  it('should throw when encountering an unknown type', () => {
-    expect(() => convertDtype('>notAType')).toThrow(/Unknown dtype/);
+  it('should handle unknown type', () => {
+    expect(convertDtype('>notAType')).toEqual({ class: HDF5TypeClass.Unknown });
   });
 });
 

--- a/src/h5web/providers/jupyter/utils.ts
+++ b/src/h5web/providers/jupyter/utils.ts
@@ -126,7 +126,7 @@ export function convertDtype(dtype: string): HDF5Type {
       };
 
     default:
-      throw new Error(`Unknown dtype ${dtype}`);
+      return { class: HDF5TypeClass.Unknown };
   }
 }
 

--- a/src/h5web/providers/models.ts
+++ b/src/h5web/providers/models.ts
@@ -35,6 +35,7 @@ export interface Dataset<S extends Shape = Shape, T extends HDF5Type = HDF5Type>
   kind: EntityKind.Dataset;
   shape: S;
   type: T;
+  rawType?: unknown;
 }
 
 export type NumArrayDataset = Dataset<ArrayShape, HDF5NumericType>;
@@ -42,6 +43,7 @@ export type NumArrayDataset = Dataset<ArrayShape, HDF5NumericType>;
 export interface Datatype<T = HDF5Type> extends Entity {
   kind: EntityKind.Datatype;
   type: T;
+  rawType?: unknown;
 }
 
 export interface Link<T extends HDF5Link = HDF5Link> extends Entity {
@@ -56,10 +58,9 @@ export interface Attribute {
   value: HDF5Value;
 }
 
-export type Shape = ArrayShape | ScalarShape | NullShape;
+export type Shape = ArrayShape | ScalarShape | null;
 export type ArrayShape = HDF5Dims;
 export type ScalarShape = never[];
-export type NullShape = null;
 
 type PrimitiveType<T extends HDF5Type> = T extends HDF5NumericType
   ? number


### PR DESCRIPTION
- I add a type called `UnknownType` to catch any type we don't yet support so users can still inspect them in the metadata viewer.
- I stop supporting `HDF5Id` as a valid type since we don't yet have proof that this type is returned by our back-end providers. If we discover that it can, then we'll re-introduce it but in a more meaningful way (e.g. for instance by resolving the datatype in the provider so the front doesn't "see" the ID).