### PR TITLE
Simplify HDF5 types and separate out HDF5 from HSDS type classes

### DIFF
--- a/src/h5web/guards.ts
+++ b/src/h5web/guards.ts
@@ -142,12 +142,18 @@ export function hasStringType<S extends Shape>(
   return dataset.type.class === HDF5TypeClass.String;
 }
 
+export function isNumericType(type: HDF5Type): type is HDF5NumericType {
+  return [
+    HDF5TypeClass.Integer,
+    HDF5TypeClass.Unsigned,
+    HDF5TypeClass.Float,
+  ].includes(type.class);
+}
+
 export function hasNumericType<S extends Shape>(
   dataset: Dataset<S>
 ): dataset is Dataset<S, HDF5NumericType> {
-  return [HDF5TypeClass.Integer, HDF5TypeClass.Float].includes(
-    dataset.type.class
-  );
+  return isNumericType(dataset.type);
 }
 
 export function isAbsolutePath(path: string) {

--- a/src/h5web/metadata-viewer/utils.ts
+++ b/src/h5web/metadata-viewer/utils.ts
@@ -1,4 +1,4 @@
-import { isScalarShape } from '../guards';
+import { isNumericType, isScalarShape } from '../guards';
 import { HDF5Type, HDF5TypeClass } from '../providers/hdf5-models';
 import type { Shape } from '../providers/models';
 
@@ -24,32 +24,22 @@ export function renderShape(shape: Shape): string {
 }
 
 export function renderType(type: HDF5Type): string {
-  // Remove leading `H5T_`
-  const classLabel = type.class.slice(4).toLowerCase();
-
-  if (
-    type.class === HDF5TypeClass.Integer ||
-    type.class === HDF5TypeClass.Float
-  ) {
+  if (isNumericType(type)) {
     const { endianness, size } = type;
-    const typeInfos = `${classLabel}, ${
-      type.class === HDF5TypeClass.Integer && type.unsigned ? 'unsigned' : ''
-    } ${size}-bit`;
+    const endiannessLabel = ENDIANNESS_LABELS[endianness];
 
-    if (endianness === 'Not applicable') {
-      return typeInfos;
-    }
-
-    return `${typeInfos}, ${ENDIANNESS_LABELS[endianness]}`;
+    return `${type.class}, ${size}-bit${
+      endiannessLabel ? `, ${endiannessLabel}` : ''
+    }`;
   }
 
   if (type.class === HDF5TypeClass.String) {
     const { length, charSet } = type;
 
-    return `${classLabel},
-    ${charSet},
-    ${Number.isInteger(length) ? `${length} characters` : 'variable length'}`;
+    return `${type.class}, ${charSet}, ${
+      Number.isInteger(length) ? `${length} characters` : 'variable length'
+    }`;
   }
 
-  return classLabel;
+  return type.class;
 }

--- a/src/h5web/providers/hdf5-models.ts
+++ b/src/h5web/providers/hdf5-models.ts
@@ -45,38 +45,41 @@ export interface HDF5ExternalLink {
 /* ---------------- */
 /* ----- TYPE ----- */
 
-// https://support.hdfgroup.org/HDF5/doc/RM/PredefDTypes.html
 export type HDF5Type =
   | HDF5NumericType
   | HDF5StringType
   | HDF5BooleanType
   | HDF5ComplexType
   | HDF5ArrayType
-  | HDF5VLenType
   | HDF5CompoundType
   | HDF5EnumType
   | HDF5UnknownType;
 
-export type HDF5NumericType = HDF5IntegerType | HDF5FloatType;
-
 export enum HDF5TypeClass {
-  Bool = 'H5T_BOOL',
-  Integer = 'H5T_INTEGER',
-  Float = 'H5T_FLOAT',
-  Complex = 'H5T_COMPLEX',
-  String = 'H5T_STRING',
-  Compound = 'H5T_COMPOUND',
-  Array = 'H5T_ARRAY',
-  VLen = 'H5T_VLEN',
-  Enum = 'H5T_ENUM',
-  Unknown = 'H5T_UNKNOWN',
+  Bool = 'boolean',
+  Integer = 'integer',
+  Unsigned = 'unsigned integer',
+  Float = 'float',
+  Complex = 'complex',
+  String = 'string',
+  Compound = 'compound',
+  Array = 'array',
+  VLen = 'vlen',
+  Enum = 'enum',
+  Unknown = 'unknown',
 }
-
-export type HDF5Endianness = 'BE' | 'LE' | 'Native' | 'Not applicable';
 
 export interface HDF5BooleanType {
   class: HDF5TypeClass.Bool;
 }
+
+export interface HDF5NumericType {
+  class: HDF5TypeClass.Integer | HDF5TypeClass.Float | HDF5TypeClass.Unsigned;
+  size: number;
+  endianness: HDF5Endianness;
+}
+
+export type HDF5Endianness = 'BE' | 'LE' | 'Native' | 'Not applicable';
 
 export interface HDF5ComplexType {
   class: HDF5TypeClass.Complex;
@@ -84,40 +87,10 @@ export interface HDF5ComplexType {
   imagType: HDF5Type;
 }
 
-export interface HDF5EnumType {
-  class: HDF5TypeClass.Enum;
-  base: HDF5Type;
-  mapping: Record<string, number>;
-}
-
-export interface HDF5IntegerType {
-  class: HDF5TypeClass.Integer;
-  size: number;
-  unsigned?: boolean;
-  endianness: HDF5Endianness;
-}
-
-export interface HDF5FloatType {
-  class: HDF5TypeClass.Float;
-  size: number;
-  endianness: HDF5Endianness;
-}
-
 export interface HDF5StringType {
   class: HDF5TypeClass.String;
   charSet: 'ASCII' | 'UTF8';
   length: number | 'H5T_VARIABLE';
-}
-
-interface HDF5ArrayType {
-  class: HDF5TypeClass.Array;
-  base: HDF5Type;
-  dims: HDF5Dims;
-}
-
-interface HDF5VLenType {
-  class: HDF5TypeClass.VLen;
-  base: HDF5Type;
 }
 
 export interface HDF5CompoundType {
@@ -128,6 +101,18 @@ export interface HDF5CompoundType {
 interface HDF5CompoundTypeField {
   name: string;
   type: HDF5Type;
+}
+
+export interface HDF5ArrayType {
+  class: HDF5TypeClass.Array | HDF5TypeClass.VLen;
+  base: HDF5Type;
+  dims?: HDF5Dims;
+}
+
+export interface HDF5EnumType {
+  class: HDF5TypeClass.Enum;
+  base: HDF5Type;
+  mapping: Record<string, number>;
 }
 
 interface HDF5UnknownType {

--- a/src/h5web/providers/hsds/models.ts
+++ b/src/h5web/providers/hsds/models.ts
@@ -4,7 +4,6 @@ import type {
   HDF5ExternalLink,
   HDF5HardLink,
   HDF5SoftLink,
-  HDF5TypeClass,
   HDF5Dims,
 } from '../hdf5-models';
 import type { Entity } from '../models';
@@ -76,54 +75,37 @@ export interface HsdsShape {
 }
 
 export type HsdsType =
-  | HsdsIntegerType
-  | HsdsFloatType
+  | HsdsNumericType
   | HsdsStringType
   | HsdsArrayType
-  | HsdsVLenType
   | HsdsCompoundType
   | HsdsEnumType;
 
-export interface HsdsIntegerType {
-  class: HDF5TypeClass.Integer;
-  base: string;
-}
-
-export interface HsdsFloatType {
-  class: HDF5TypeClass.Float;
+export interface HsdsNumericType {
+  class: 'H5T_INTEGER' | 'H5T_FLOAT';
   base: string;
 }
 
 export interface HsdsStringType {
-  class: HDF5TypeClass.String;
+  class: 'H5T_STRING';
   charSet: 'H5T_CSET_ASCII' | 'H5T_CSET_UTF8';
   strPad: 'H5T_STR_SPACEPAD' | 'H5T_STR_NULLTERM' | 'H5T_STR_NULLPAD';
   length: number | 'H5T_VARIABLE';
 }
 
 export interface HsdsArrayType {
-  class: HDF5TypeClass.Array;
+  class: 'H5T_ARRAY' | 'H5T_VLEN';
   base: HsdsType;
-  dims: HDF5Dims;
-}
-
-export interface HsdsVLenType {
-  class: HDF5TypeClass.VLen;
-  base: HsdsType;
+  dims?: HDF5Dims;
 }
 
 export interface HsdsCompoundType {
-  class: HDF5TypeClass.Compound;
-  fields: HsdsCompoundTypeField[];
+  class: 'H5T_COMPOUND';
+  fields: { name: string; type: HsdsType }[];
 }
 
 export interface HsdsEnumType {
-  class: HDF5TypeClass.Enum;
+  class: 'H5T_ENUM';
   base: HsdsType;
   mapping: Record<string, number>;
-}
-
-interface HsdsCompoundTypeField {
-  name: string;
-  type: HsdsType;
 }

--- a/src/h5web/providers/hsds/utils.test.ts
+++ b/src/h5web/providers/hsds/utils.test.ts
@@ -7,7 +7,6 @@ import type {
   HsdsCompoundType,
   HsdsEnumType,
   HsdsType,
-  HsdsVLenType,
 } from './models';
 import { convertHsdsType, parseComplex } from './utils';
 
@@ -17,34 +16,33 @@ interface TestType {
 }
 
 const leIntegerType: TestType = {
-  hsds: { class: HDF5TypeClass.Integer, base: 'H5T_STD_I8LE' },
+  hsds: { class: 'H5T_INTEGER', base: 'H5T_STD_I8LE' },
   hdf5: { class: HDF5TypeClass.Integer, size: 8, endianness: 'LE' },
 };
 
 const beIntegerType: TestType = {
-  hsds: { class: HDF5TypeClass.Integer, base: 'H5T_STD_U64BE' },
+  hsds: { class: 'H5T_INTEGER', base: 'H5T_STD_U64BE' },
   hdf5: {
-    class: HDF5TypeClass.Integer,
+    class: HDF5TypeClass.Unsigned,
     size: 64,
     endianness: 'BE',
-    unsigned: true,
   },
 };
 
 const leFloatType: TestType = {
-  hsds: { class: HDF5TypeClass.Float, base: 'H5T_IEEE_F32LE' },
+  hsds: { class: 'H5T_FLOAT', base: 'H5T_IEEE_F32LE' },
   hdf5: { class: HDF5TypeClass.Float, size: 32, endianness: 'LE' },
 };
 
 const beFloatType: TestType = {
-  hsds: { class: HDF5TypeClass.Float, base: 'H5T_IEEE_F64BE' },
+  hsds: { class: 'H5T_FLOAT', base: 'H5T_IEEE_F64BE' },
   hdf5: { class: HDF5TypeClass.Float, size: 64, endianness: 'BE' },
 };
 
 describe('convertHsdsType', () => {
   it('should convert ASCII string type', () => {
     const asciiStrType: HsdsStringType = {
-      class: HDF5TypeClass.String,
+      class: 'H5T_STRING',
       charSet: 'H5T_CSET_ASCII',
       strPad: 'H5T_STR_NULLPAD',
       length: 25,
@@ -58,7 +56,7 @@ describe('convertHsdsType', () => {
 
   it('should convert Unicode string type', () => {
     const unicodeStrType: HsdsStringType = {
-      class: HDF5TypeClass.String,
+      class: 'H5T_STRING',
       charSet: 'H5T_CSET_UTF8',
       strPad: 'H5T_STR_NULLTERM',
       length: 49,
@@ -83,7 +81,7 @@ describe('convertHsdsType', () => {
 
   it('should convert the base of Array type', () => {
     const arrayType: HsdsArrayType = {
-      class: HDF5TypeClass.Array,
+      class: 'H5T_ARRAY',
       base: leIntegerType.hsds,
       dims: [4, 5],
     };
@@ -95,8 +93,8 @@ describe('convertHsdsType', () => {
   });
 
   it('should convert the base of VLen type', () => {
-    const vlenType: HsdsVLenType = {
-      class: HDF5TypeClass.VLen,
+    const vlenType: HsdsArrayType = {
+      class: 'H5T_VLEN',
       base: leIntegerType.hsds,
     };
     expect(convertHsdsType(vlenType)).toEqual({
@@ -106,12 +104,12 @@ describe('convertHsdsType', () => {
   });
 
   it('should convert the field types of Compound type', () => {
-    const vlenType: HsdsVLenType = {
-      class: HDF5TypeClass.VLen,
+    const vlenType: HsdsArrayType = {
+      class: 'H5T_VLEN',
       base: leIntegerType.hsds,
     };
     const compoundType: HsdsCompoundType = {
-      class: HDF5TypeClass.Compound,
+      class: 'H5T_COMPOUND',
       fields: [
         { name: 'f1', type: beFloatType.hsds },
         { name: 'f2', type: vlenType },
@@ -131,8 +129,8 @@ describe('convertHsdsType', () => {
 
   it('should convert the enum with the boolean mapping to Boolean type', () => {
     const boolEnum: HsdsEnumType = {
-      class: HDF5TypeClass.Enum,
-      base: { class: HDF5TypeClass.Integer, base: 'H5T_STD_I8LE' },
+      class: 'H5T_ENUM',
+      base: { class: 'H5T_INTEGER', base: 'H5T_STD_I8LE' },
       mapping: { FALSE: 0, TRUE: 1 },
     };
     expect(convertHsdsType(boolEnum)).toEqual({
@@ -142,7 +140,7 @@ describe('convertHsdsType', () => {
 
   it('should convert the complex compound type into Complex type', () => {
     const complexCompound: HsdsCompoundType = {
-      class: HDF5TypeClass.Compound,
+      class: 'H5T_COMPOUND',
       fields: [
         { name: 'r', type: leFloatType.hsds },
         { name: 'i', type: leFloatType.hsds },

--- a/src/h5web/providers/jupyter/utils.test.ts
+++ b/src/h5web/providers/jupyter/utils.test.ts
@@ -27,10 +27,9 @@ describe('convertDtype', () => {
       endianness: 'LE',
     });
     expect(convertDtype('>u8')).toEqual({
-      class: HDF5TypeClass.Integer,
+      class: HDF5TypeClass.Unsigned,
       size: 64,
       endianness: 'BE',
-      unsigned: true,
     });
   });
 

--- a/src/h5web/providers/jupyter/utils.ts
+++ b/src/h5web/providers/jupyter/utils.ts
@@ -89,10 +89,9 @@ export function convertDtype(dtype: string): HDF5Type {
 
     case 'u':
       return {
-        class: HDF5TypeClass.Integer,
+        class: HDF5TypeClass.Unsigned,
         size: length * 8,
         endianness,
-        unsigned: true,
       };
 
     case 'c':

--- a/src/h5web/providers/mock/metadata-utils.ts
+++ b/src/h5web/providers/mock/metadata-utils.ts
@@ -15,8 +15,6 @@ import {
   HDF5CompoundType,
   HDF5Dims,
   HDF5ExternalLink,
-  HDF5FloatType,
-  HDF5IntegerType,
   HDF5Link,
   HDF5LinkClass,
   HDF5NumericType,
@@ -34,13 +32,13 @@ import { mockValues } from './values';
 /* -------------------------- */
 /* ----- TYPES & SHAPES ----- */
 
-export const intType: HDF5IntegerType = {
+export const intType: HDF5NumericType = {
   class: HDF5TypeClass.Integer,
   endianness: 'LE',
   size: 32,
 };
 
-export const floatType: HDF5FloatType = {
+export const floatType: HDF5NumericType = {
   class: HDF5TypeClass.Float,
   endianness: 'LE',
   size: 64,


### PR DESCRIPTION
I wasn't able to go as far as I'd planned by replacing the union of HDF5 types with `interface HDF5Type { class: HDF5TypeClass; }`. This led to some issues, notably when using `HDF5Type` as a return type of the provider's conversion functions. I realised that the significant benefit of a type union `A | B | C` is that TypeScript is able to infer the sub-types `A`, `B` and `C` inline, without the need for type guards.

So I've made only two changes:

1. I've merged a few HDF5 type interfaces together:
    - `HDF5FloatType` and `HDF5IntegerType` are now represented with a single `HDF5NumericType` interface.
    - Unsigned integers now have their own `HDF5TypeClass` entry and are also represented with `HDF5NumericType`.
    - `HDF5VLenType` is now represented by `HDF5ArrayType` (by making the latter's `dims` property optional).
2. I've completely separated out the HDF5 and HSDS type classes:
    - `HDF5TypeClass` now contains readable strings that we can render directly in the metadata viewer, like `integer`, 'boolean', etc.
    - `H5T_INTEGER` and the like, which are the classes returned by HSDS are no longer present anywhere outside of the HSDS provider code. This means we no longer have classes like `H5T_BOOL` that are never returned by HSDS.