### PR TITLE
Followable attributes array members can be used for navigation

### DIFF
--- a/src/h5web/metadata-viewer/AttributeValueLink.tsx
+++ b/src/h5web/metadata-viewer/AttributeValueLink.tsx
@@ -1,0 +1,46 @@
+import { Fragment } from 'react';
+import { FiChevronsRight } from 'react-icons/fi';
+import styles from './MetadataViewer.module.css';
+
+interface Props {
+  onFollowPath: (value: string) => void;
+  value: unknown;
+}
+
+function AttributeValueLink(props: Props) {
+  const { onFollowPath, value } = props;
+
+  if (Array.isArray(value)) {
+    return (
+      <div className={styles.attrValueWrapper}>
+        <span>[</span>
+        {value.map((val, i) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <Fragment key={i}>
+            <AttributeValueLink onFollowPath={onFollowPath} value={val} />
+            {i < value.length - 1 && <span>,</span>}
+          </Fragment>
+        ))}
+        <span>]</span>
+      </div>
+    );
+  }
+
+  if (typeof value === 'string' && value !== '.') {
+    return (
+      <button
+        className={styles.attrValueBtn}
+        type="button"
+        aria-label={`Inspect ${value}`}
+        onClick={() => onFollowPath(value)}
+      >
+        {value}
+        <FiChevronsRight />
+      </button>
+    );
+  }
+
+  return <>{JSON.stringify(value)}</>;
+}
+
+export default AttributeValueLink;

--- a/src/h5web/metadata-viewer/AttributesTable.tsx
+++ b/src/h5web/metadata-viewer/AttributesTable.tsx
@@ -1,5 +1,5 @@
-import { FiChevronsRight } from 'react-icons/fi';
 import type { Attribute } from '../providers/models';
+import AttributeValueLink from './AttributeValueLink';
 import styles from './MetadataViewer.module.css';
 
 const FOLLOWABLE_ATTRS = new Set([
@@ -35,16 +35,8 @@ function AttributesTable(props: Props) {
           <tr key={name}>
             <th scope="row">{name}</th>
             <td>
-              {FOLLOWABLE_ATTRS.has(name) && typeof value === 'string' ? (
-                <button
-                  className={styles.attrValueBtn}
-                  type="button"
-                  aria-label={`Inspect ${value}`}
-                  onClick={() => onFollowPath(value)}
-                >
-                  {value}
-                  <FiChevronsRight />
-                </button>
+              {FOLLOWABLE_ATTRS.has(name) ? (
+                <AttributeValueLink onFollowPath={onFollowPath} value={value} />
               ) : (
                 JSON.stringify(value)
               )}

--- a/src/h5web/metadata-viewer/MetadataViewer.module.css
+++ b/src/h5web/metadata-viewer/MetadataViewer.module.css
@@ -72,3 +72,12 @@
   margin-left: 0.25rem;
   transform: translateY(1px);
 }
+
+.attrValueWrapper {
+  display: flex;
+  margin: 0 -0.25rem;
+}
+
+.attrValueWrapper > span {
+  margin: 0 0.25rem;
+}


### PR DESCRIPTION
Fix #582 

Not a huge fan of the resulting code, I may have missed a simpler solution. Perhaps I need my :coffee: :smile: 

**Before:**
![image](https://user-images.githubusercontent.com/42204205/114666790-f6224780-9cfe-11eb-9d5e-f784bb4e58b9.png)

**After:**
![image](https://user-images.githubusercontent.com/42204205/114666697-d4c15b80-9cfe-11eb-9f40-d82a09032034.png)
