### PR TITLE
Create tooltip formatters in custom hooks and fix perf issues on Heatmap

### DIFF
--- a/src/h5web/vis-packs/core/heatmap/hooks.ts
+++ b/src/h5web/vis-packs/core/heatmap/hooks.ts
@@ -1,5 +1,33 @@
+import { format } from 'd3-format';
+import type ndarray from 'ndarray';
 import { createMemo } from 'react-use';
-import { getVisDomain, getSafeDomain } from './utils';
+import { useValueToIndexScale } from '../hooks';
+import type { TooltipIndexFormatter, TooltipValueFormatter } from '../models';
+import { getVisDomain, getSafeDomain, getAxisValues } from './utils';
 
 export const useVisDomain = createMemo(getVisDomain);
 export const useSafeDomain = createMemo(getSafeDomain);
+export const useAxisValues = createMemo(getAxisValues);
+
+export function useTooltipFormatters(
+  abscissas: number[],
+  ordinates: number[],
+  abscissaLabel: string | undefined,
+  ordinateLabel: string | undefined,
+  dataArray: ndarray
+): {
+  formatIndex: TooltipIndexFormatter;
+  formatValue: TooltipValueFormatter;
+} {
+  const abscissaToIndex = useValueToIndexScale(abscissas);
+  const ordinateToIndex = useValueToIndexScale(ordinates);
+
+  return {
+    formatIndex: ([x, y]) =>
+      `${abscissaLabel || 'x'}=${abscissas[abscissaToIndex(x)]}, ` +
+      `${ordinateLabel || 'y'}=${ordinates[ordinateToIndex(y)]}`,
+
+    formatValue: ([x, y]) =>
+      format('.3')(dataArray.get(ordinateToIndex(y), abscissaToIndex(x))),
+  };
+}

--- a/src/h5web/vis-packs/core/heatmap/utils.ts
+++ b/src/h5web/vis-packs/core/heatmap/utils.ts
@@ -78,31 +78,28 @@ export function getLinearGradient(
   return `linear-gradient(to ${direction}, ${colorStops})`;
 }
 
-export function getPixelEdges(
-  pixelCoordinates: number[] | undefined,
-  nPixels: number
+export function getAxisValues(
+  rawValues: number[] | undefined,
+  pixelCount: number
 ): number[] {
-  if (!pixelCoordinates) {
-    return range(nPixels + 1);
+  if (!rawValues) {
+    return range(pixelCount + 1);
   }
 
-  if (pixelCoordinates.length === nPixels + 1) {
-    return pixelCoordinates;
+  if (rawValues.length === pixelCount + 1) {
+    return rawValues;
   }
 
-  if (pixelCoordinates.length === nPixels) {
-    // Add the last edge assuming the pixelCoordinates are regularly spaced
-    const deltaCoord = pixelCoordinates[1] - pixelCoordinates[0];
-    return [
-      ...pixelCoordinates,
-      pixelCoordinates[pixelCoordinates.length - 1] + deltaCoord,
-    ];
+  if (rawValues.length === pixelCount) {
+    // Add value at right-hand side of last pixel, assuming raw values are regularly spaced
+    const deltaCoord = rawValues[1] - rawValues[0];
+    return [...rawValues, rawValues[rawValues.length - 1] + deltaCoord];
   }
 
   throw new Error(
-    `Supplied pixel coordinate array (${
-      pixelCoordinates.length
-    }) has not the expected length (${nPixels} or ${nPixels + 1})`
+    `Expected array to have length ${pixelCount} or ${pixelCount + 1}, not ${
+      rawValues.length
+    }`
   );
 }
 

--- a/src/h5web/vis-packs/core/hooks.ts
+++ b/src/h5web/vis-packs/core/hooks.ts
@@ -10,6 +10,7 @@ import {
   getCanvasScale,
   getCombinedDomain,
   getDomain,
+  getValueToIndexScale,
 } from './utils';
 import AxisSystemContext from './shared/AxisSystemContext';
 import type { AxisScale } from './models';
@@ -140,3 +141,5 @@ export function useMappedArrays(
 
   return [mappedArrays, autoScale ? mappedArrays : baseArrays];
 }
+
+export const useValueToIndexScale = createMemo(getValueToIndexScale);

--- a/src/h5web/vis-packs/core/line/hooks.ts
+++ b/src/h5web/vis-packs/core/line/hooks.ts
@@ -1,6 +1,9 @@
+import { format } from 'd3-format';
+import type ndarray from 'ndarray';
 import { useMemo } from 'react';
 import { Vector3 } from 'three';
-import { useCanvasScales } from '../hooks';
+import { useCanvasScales, useValueToIndexScale } from '../hooks';
+import type { TooltipIndexFormatter, TooltipValueFormatter } from '../models';
 
 const CAMERA_FAR = 1000; // R3F's default
 
@@ -53,4 +56,35 @@ export function useCanvasPoints(
 
     return { data: dataPoints, bars: errorBarSegments, caps: errorCapPoints };
   }, [abscissaScale, abscissas, errors, ordinateScale, ordinates]);
+}
+
+export function useTooltipFormatters(
+  abscissas: number[],
+  abscissaLabel: string | undefined,
+  dataArray: ndarray,
+  errorsArray: ndarray | undefined
+): {
+  formatIndex: TooltipIndexFormatter;
+  formatValue: TooltipValueFormatter;
+} {
+  const abscissaToIndex = useValueToIndexScale(abscissas, true);
+
+  return {
+    formatIndex: ([x]) =>
+      `${abscissaLabel || 'x'}=${format('0')(abscissas[abscissaToIndex(x)])}`,
+
+    formatValue: ([x]) => {
+      const index = abscissaToIndex(x);
+      const value = dataArray.get(index);
+
+      if (value === undefined) {
+        return undefined;
+      }
+
+      const error = errorsArray && errorsArray.get(index);
+      return error
+        ? `${format('.3f')(value)} ±${format('.3f')(error)}`
+        : `${format('.3f')(value)}`;
+    },
+  };
 }

--- a/src/h5web/vis-packs/core/models.ts
+++ b/src/h5web/vis-packs/core/models.ts
@@ -65,6 +65,10 @@ export type AxisMapping = (AxisParams | undefined)[];
 
 export type Bounds = [number, number, number];
 
+export type Coords = [number, number];
+export type TooltipIndexFormatter = (t: Coords) => string;
+export type TooltipValueFormatter = (t: Coords) => string | undefined;
+
 export type PrintableType =
   | BooleanType
   | NumericType

--- a/src/h5web/vis-packs/core/shared/TooltipMesh.tsx
+++ b/src/h5web/vis-packs/core/shared/TooltipMesh.tsx
@@ -6,14 +6,16 @@ import Html from './Html';
 import styles from './TooltipMesh.module.css';
 import { useCanvasScales } from '../hooks';
 import type { ThreeEvent } from '@react-three/fiber/dist/declarations/src/core/events';
-
-type Coords = [number, number];
-type Guides = 'horizontal' | 'vertical' | 'both';
+import type {
+  Coords,
+  TooltipIndexFormatter,
+  TooltipValueFormatter,
+} from '../models';
 
 interface Props {
-  formatIndex: (t: Coords) => string;
-  formatValue: (t: Coords) => string | undefined;
-  guides?: Guides;
+  formatIndex: TooltipIndexFormatter;
+  formatValue: TooltipValueFormatter;
+  guides?: 'horizontal' | 'vertical' | 'both';
 }
 
 function TooltipMesh(props: Props) {


### PR DESCRIPTION
As mentioned, I move the tooltip formatters into custom hooks. I think it's a lot cleaner, since it also moves the creation of the scales that are specifically used for the tooltips.

I also fix performance bottlenecks in the Heatmap: `getPixelEdges` and `getValueToIndexScale` weren't wrapped in `useMemo`, so they were probably slowing down slicing through big image stacks significantly (since they both loop through the abscissas/ordinates arrays, which don't change when slicing). Do we have a large image stack somewhere? The one at `/entry_0000/0_measurement` in the `water` file that I usually use is unavailable because of compression. 😢 