### PR TITLE
Improve error handling when entity is not found

### DIFF
--- a/src/h5web/metadata-viewer/MetadataViewer.tsx
+++ b/src/h5web/metadata-viewer/MetadataViewer.tsx
@@ -1,7 +1,8 @@
 import { memo, useContext } from 'react';
 import { isAbsolutePath } from '../guards';
 import { ProviderContext } from '../providers/context';
-import { buildEntityPath } from '../utils';
+import { ProviderError } from '../providers/models';
+import { buildEntityPath, handleError } from '../utils';
 import AttributesTable from './AttributesTable';
 import EntityTable from './EntityTable';
 import styles from './MetadataViewer.module.css';
@@ -13,9 +14,13 @@ interface Props {
 
 function MetadataViewer(props: Props) {
   const { path, onSelectPath } = props;
-
   const { entitiesStore } = useContext(ProviderContext);
-  const entity = entitiesStore.get(path);
+
+  const entity = handleError(
+    () => entitiesStore.get(path),
+    ProviderError.NotFound,
+    `No entity found at ${path}`
+  );
 
   return (
     <div className={styles.metadataViewer}>

--- a/src/h5web/providers/hsds/api.ts
+++ b/src/h5web/providers/hsds/api.ts
@@ -13,7 +13,14 @@ import type {
   HsdsCollection,
   HsdsId,
 } from './models';
-import { Dataset, Datatype, Entity, EntityKind, Group } from '../models';
+import {
+  Dataset,
+  Datatype,
+  Entity,
+  EntityKind,
+  Group,
+  ProviderError,
+} from '../models';
 import { assertDefined, assertGroup } from '../../guards';
 import type { GetValueParams, ProviderAPI } from '../context';
 import {
@@ -69,7 +76,7 @@ export class HsdsApi implements ProviderAPI {
 
     const childName = path.slice(path.lastIndexOf('/') + 1);
     const child = getChildEntity(parentGroup, childName);
-    assertDefined(child);
+    assertDefined(child, ProviderError.NotFound);
     assertHsdsEntity(child);
 
     const entity = isHsdsGroup(child)

--- a/src/h5web/providers/mock/utils.test.ts
+++ b/src/h5web/providers/mock/utils.test.ts
@@ -1,3 +1,4 @@
+import { ProviderError } from '../models';
 import { mockMetadata } from './metadata';
 import { findMockEntity } from './utils';
 
@@ -15,6 +16,8 @@ describe('findMockEntity', () => {
   });
 
   it('should throw if no entity is found at given path', () => {
-    expect(() => findMockEntity('/nD_datasets/foo')).toThrow(/entity at path/);
+    expect(() => findMockEntity('/nD_datasets/foo')).toThrow(
+      ProviderError.NotFound
+    );
   });
 });

--- a/src/h5web/providers/mock/utils.ts
+++ b/src/h5web/providers/mock/utils.ts
@@ -9,7 +9,7 @@ import {
   isGroup,
 } from '../../guards';
 import { getChildEntity } from '../../utils';
-import type { Entity } from '../models';
+import { Entity, ProviderError } from '../models';
 import { mockMetadata } from './metadata';
 import type { MockDataset } from './models';
 
@@ -42,7 +42,7 @@ export function findMockEntity(path: string): Entity {
     mockMetadata
   );
 
-  assertDefined(entity, `Expected entity at path "${path}"`);
+  assertDefined(entity, ProviderError.NotFound);
   return entity;
 }
 

--- a/src/h5web/providers/models.ts
+++ b/src/h5web/providers/models.ts
@@ -158,3 +158,7 @@ export type Value<D extends Dataset> = D['shape'] extends ScalarShape
 
 export type H5WebComplex = [number, number];
 export type ComplexArray = (ComplexArray | H5WebComplex)[];
+
+export enum ProviderError {
+  NotFound = 'NotFound',
+}

--- a/src/h5web/utils.ts
+++ b/src/h5web/utils.ts
@@ -18,3 +18,19 @@ export function buildEntityPath(
   const prefix = parentPath === '/' ? '' : parentPath;
   return `${prefix}/${entityNameOrRelativePath}`;
 }
+
+export function handleError<T>(
+  func: () => T,
+  errToCatch: string,
+  errToThrow: string
+): T {
+  try {
+    return func();
+  } catch (error: unknown) {
+    if (error instanceof Error && error.message === errToCatch) {
+      throw new Error(errToThrow);
+    }
+
+    throw error;
+  }
+}

--- a/src/h5web/vis-packs/VisPackChooser.tsx
+++ b/src/h5web/vis-packs/VisPackChooser.tsx
@@ -1,5 +1,7 @@
 import { useContext } from 'react';
 import { ProviderContext } from '../providers/context';
+import { ProviderError } from '../providers/models';
+import { handleError } from '../utils';
 import CorePack from './core/CorePack';
 import NexusPack from './nexus/NexusPack';
 import { getAttributeValue } from './nexus/utils';
@@ -18,7 +20,12 @@ function VisPackChooser(props: Props) {
   }
 
   const { entitiesStore } = useContext(ProviderContext);
-  const entity = entitiesStore.get(path);
+
+  const entity = handleError(
+    () => entitiesStore.get(path),
+    ProviderError.NotFound,
+    `No entity found at ${path}`
+  );
 
   if (
     getAttributeValue(entity, 'default') ||

--- a/src/h5web/vis-packs/nexus/NexusPack.test.tsx
+++ b/src/h5web/vis-packs/nexus/NexusPack.test.tsx
@@ -70,7 +70,9 @@ test('show error when encountering malformed NeXus metadata', async () => {
   expect(await screen.findByText(/to be a string/)).toBeVisible();
 
   await selectExplorerNode('default_not_found');
-  expect(await screen.findByText(/entity at path/)).toBeVisible();
+  expect(
+    await screen.findByText(/No entity found at NeXus default path/)
+  ).toBeVisible();
 
   await selectExplorerNode('no_signal');
   expect(await screen.findByText(/'signal' attribute/)).toBeVisible();

--- a/src/h5web/vis-packs/nexus/pack-utils.ts
+++ b/src/h5web/vis-packs/nexus/pack-utils.ts
@@ -1,7 +1,7 @@
 import type { FetchStore } from 'react-suspense-fetch';
-import { assertDefined, assertStr, hasMinDims, isGroup } from '../../guards';
-import type { Entity } from '../../providers/models';
-import { buildEntityPath } from '../../utils';
+import { assertStr, hasMinDims, isGroup } from '../../guards';
+import { Entity, ProviderError } from '../../providers/models';
+import { buildEntityPath, handleError } from '../../utils';
 import type { VisDef } from '../models';
 import { NxInterpretation } from './models';
 import { findSignalDataset, getAttributeValue, isNxDataGroup } from './utils';
@@ -21,8 +21,11 @@ export function getDefaultEntity(
     ? defaultPath
     : buildEntityPath(entity.path, defaultPath);
 
-  const defaultEntity = entitiesStore.get(path);
-  assertDefined(defaultEntity, `Expected entity at path "${path}"`);
+  const defaultEntity = handleError(
+    () => entitiesStore.get(path),
+    ProviderError.NotFound,
+    `No entity found at NeXus default path "${path}"`
+  );
 
   return getDefaultEntity(defaultEntity, entitiesStore);
 }


### PR DESCRIPTION
Fix partially #618 for mock and HSDS providers.

I throw a specific error message, `ProviderError.NotFound`, from the mock and HSDS providers, which I catch from the calls to `entitiesStore.get(path)`. I then rethrow a more specific error that can be caught by the error boundary and displayed to the user.

![image](https://user-images.githubusercontent.com/2936402/116051056-7c804700-a678-11eb-9547-6e43dd87cc76.png)

Three error cases are now properly handled with the mock and HSDS providers:

1. In "Display", when the default path is not found (`getDefaultEntity` in `NexusPack`).
2. In "Inspect", when the user follows a default path that is not found (`MetadataViewer`).
3. In "Display", when the user switches back from the `MetadataViewer` after following a path that was not found (`VisPackChooser`).