### PR TITLE
Avoid recomputing bounds on scaleType changes

### DIFF
--- a/src/h5web/toolbar/controls/DomainSlider/DomainSlider.test.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/DomainSlider.test.tsx
@@ -4,6 +4,7 @@ import { pressKey, renderApp, selectExplorerNode } from '../../../test-utils';
 
 test('show slider with two thumbs', async () => {
   renderApp(); // default NeXus group renders heatmap and therefore domain slider
+  expect(await screen.findByRole('figure')).toBeVisible();
 
   const thumbs = await screen.findAllByRole('slider');
   expect(thumbs).toHaveLength(2);
@@ -13,6 +14,7 @@ test('show slider with two thumbs', async () => {
 
 test('show tooltip on hover', async () => {
   renderApp();
+  expect(await screen.findByRole('figure')).toBeVisible();
 
   const editBtn = await screen.findByRole('button', { name: 'Edit domain' });
   const tooltip = screen.getByRole('dialog', { hidden: true });
@@ -35,6 +37,7 @@ test('show tooltip on hover', async () => {
 
 test('show min/max and data range in tooltip', async () => {
   renderApp();
+  expect(await screen.findByRole('figure')).toBeVisible();
 
   const editBtn = await screen.findByRole('button', { name: 'Edit domain' });
   userEvent.hover(editBtn);
@@ -54,6 +57,7 @@ test('show min/max and data range in tooltip', async () => {
 
 test('update domain when moving thumbs (with keyboard)', async () => {
   renderApp();
+  expect(await screen.findByRole('figure')).toBeVisible();
 
   // Give focus to min thumb (and hover to reveal tooltip)
   const minThumb = await screen.findByRole('slider', { name: /min/ });
@@ -146,6 +150,7 @@ test('allow editing bounds manually', async () => {
 
 test('clamp domain in symlog scale', async () => {
   renderApp();
+  expect(await screen.findByRole('figure')).toBeVisible();
 
   const editBtn = await screen.findByRole('button', { name: 'Edit domain' });
   userEvent.click(editBtn);
@@ -176,6 +181,7 @@ test('clamp domain in symlog scale', async () => {
 
 test('show min/max autoscale toggles in tooltip (pressed by default)', async () => {
   renderApp();
+  expect(await screen.findByRole('figure')).toBeVisible();
 
   const editBtn = await screen.findByRole('button', { name: 'Edit domain' });
   userEvent.hover(editBtn);
@@ -190,6 +196,7 @@ test('show min/max autoscale toggles in tooltip (pressed by default)', async () 
 
 test('control min/max autoscale behaviour', async () => {
   renderApp();
+  expect(await screen.findByRole('figure')).toBeVisible();
 
   const minThumb = await screen.findByRole('slider', { name: /min/ });
   userEvent.hover(minThumb);

--- a/src/h5web/vis-packs/core/hooks.ts
+++ b/src/h5web/vis-packs/core/hooks.ts
@@ -7,15 +7,15 @@ import type { DimensionMapping } from '../../dimension-mapper/models';
 import {
   applyMapping,
   getBaseArray,
+  getBounds,
   getCanvasScale,
   getCombinedDomain,
-  getDomain,
-  getDomains,
   getSliceSelection,
+  getValidDomainForScale,
   getValueToIndexScale,
 } from './utils';
 import AxisSystemContext from './shared/AxisSystemContext';
-import type { AxisScale } from './models';
+import { AxisScale, ScaleType } from './models';
 import { ProviderContext } from '../../providers/context';
 import type { Dataset, Value } from '../../providers/models';
 
@@ -57,8 +57,31 @@ export function useDatasetValues(datasets: Dataset[]): Record<string, unknown> {
   );
 }
 
-export const useDomain = createMemo(getDomain);
-export const useDomains = createMemo(getDomains);
+const useBounds = createMemo(getBounds);
+const useValidDomainForScale = createMemo(getValidDomainForScale);
+
+export function useDomain(
+  valuesArray: ndarray | number[],
+  scaleType: ScaleType = ScaleType.Linear,
+  errorArray?: ndarray | number[]
+) {
+  const bounds = useBounds(valuesArray, errorArray);
+  return useValidDomainForScale(bounds, scaleType);
+}
+
+export function useDomains(
+  valuesArrays: (ndarray | number[])[],
+  scaleType: ScaleType = ScaleType.Linear
+) {
+  const allBounds = useMemo(() => {
+    return valuesArrays.map((arr) => getBounds(arr));
+  }, [valuesArrays]);
+
+  return useMemo(
+    () => allBounds.map((bounds) => getValidDomainForScale(bounds, scaleType)),
+    [allBounds, scaleType]
+  );
+}
 
 export function useFrameRendering(): void {
   const [, setNum] = useState(0);

--- a/src/h5web/vis-packs/core/utils.ts
+++ b/src/h5web/vis-packs/core/utils.ts
@@ -92,11 +92,10 @@ export function toArray(arr: ndarray | number[]): number[] {
   return 'data' in arr ? (arr.data as number[]) : arr;
 }
 
-export function getDomain(
+export function getBounds(
   valuesArray: ndarray | number[],
-  scaleType: ScaleType = ScaleType.Linear,
   errorArray?: ndarray | number[]
-): Domain | undefined {
+): Bounds | undefined {
   assertDataLength(errorArray, valuesArray, 'error');
 
   const values = toArray(valuesArray);
@@ -106,7 +105,7 @@ export function getDomain(
     return undefined;
   }
 
-  const bounds = values.reduce<Bounds>(
+  return values.reduce<Bounds>(
     (acc, val, i) => {
       const newBounds = getNewBounds(acc, val);
       const err = errors && errors[i];
@@ -116,6 +115,14 @@ export function getDomain(
     },
     { min: values[0], max: values[0], positiveMin: Infinity }
   );
+}
+
+export function getDomain(
+  valuesArray: ndarray | number[],
+  scaleType: ScaleType = ScaleType.Linear,
+  errorArray?: ndarray | number[]
+): Domain | undefined {
+  const bounds = getBounds(valuesArray, errorArray);
 
   return getValidDomainForScale(bounds, scaleType);
 }
@@ -328,9 +335,13 @@ export function applyMapping<T>(
 }
 
 export function getValidDomainForScale(
-  bounds: Bounds,
+  bounds: Bounds | undefined,
   scaleType: ScaleType
 ): Domain | undefined {
+  if (bounds === undefined) {
+    return undefined;
+  }
+
   const { min, max, positiveMin } = bounds;
   if (scaleType !== ScaleType.Log || min * max > 0) {
     return [min, max];


### PR DESCRIPTION
Fix #636 

I had some inconsistent test failures locally on the `DomainSlider` but it passes on the CI...

 @axelboc can you try on your end to see if tests are passing ?