### PR TITLE
Fix HSDS responses containing NaN (which is invalid JSON)

### DIFF
--- a/src/h5web/providers/hsds/api.ts
+++ b/src/h5web/providers/hsds/api.ts
@@ -46,6 +46,22 @@ export class HsdsApi extends ProviderApi {
       baseURL: url,
       params: { domain: filepath },
       auth: { username, password },
+      transformResponse: (data: unknown) => {
+        if (typeof data !== 'string') {
+          return data;
+        }
+
+        try {
+          return JSON.parse(data);
+        } catch {
+          // https://github.com/HDFGroup/hsds/issues/87
+          try {
+            return JSON.parse(data.replace('NaN', '"NaN"'));
+          } catch {
+            return data;
+          }
+        }
+      },
     });
   }
 


### PR DESCRIPTION
A temporary fix to work around https://github.com/HDFGroup/hsds/issues/87

To be removed when the issue is solved in HSDS.