### PR TITLE
Move config providers higher up in the tree

### DIFF
--- a/src/h5web/App.tsx
+++ b/src/h5web/App.tsx
@@ -9,6 +9,7 @@ import { assertAbsolutePath } from './guards';
 import { ErrorBoundary } from 'react-error-boundary';
 import ErrorFallback from './visualizer/ErrorFallback';
 import LoadingFallback from './LoadingFallback';
+import VisConfigProvider from './VisConfigProvider';
 
 const DEFAULT_PATH = process.env.REACT_APP_DEFAULT_PATH || '/';
 assertAbsolutePath(DEFAULT_PATH);
@@ -42,21 +43,25 @@ function App() {
           onChangeInspecting={setInspecting}
           onSelectPath={setSelectedPath}
         />
-        <ErrorBoundary
-          resetKeys={[selectedPath, isInspecting]}
-          FallbackComponent={ErrorFallback}
-        >
-          <Suspense fallback={<LoadingFallback isInspecting={isInspecting} />}>
-            {isInspecting ? (
-              <MetadataViewer
-                path={selectedPath}
-                onSelectPath={setSelectedPath}
-              />
-            ) : (
-              <VisPackChooser path={selectedPath} />
-            )}
-          </Suspense>
-        </ErrorBoundary>
+        <VisConfigProvider>
+          <ErrorBoundary
+            resetKeys={[selectedPath, isInspecting]}
+            FallbackComponent={ErrorFallback}
+          >
+            <Suspense
+              fallback={<LoadingFallback isInspecting={isInspecting} />}
+            >
+              {isInspecting ? (
+                <MetadataViewer
+                  path={selectedPath}
+                  onSelectPath={setSelectedPath}
+                />
+              ) : (
+                <VisPackChooser path={selectedPath} />
+              )}
+            </Suspense>
+          </ErrorBoundary>
+        </VisConfigProvider>
       </ReflexElement>
     </ReflexContainer>
   );

--- a/src/h5web/VisConfigProvider.tsx
+++ b/src/h5web/VisConfigProvider.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react';
+import { isDefined } from './guards';
+import { CORE_VIS } from './vis-packs/core/visualizations';
+import { NEXUS_VIS } from './vis-packs/nexus/visualizations';
+
+const coreProviders = Object.values(CORE_VIS)
+  .map((vis) => vis.ConfigProvider)
+  .filter(isDefined);
+
+const nexusProviders = Object.values(NEXUS_VIS)
+  .map((vis) => vis.ConfigProvider)
+  .filter(isDefined);
+
+const allConfigProviders = new Set([...coreProviders, ...nexusProviders]);
+
+interface Props {
+  children: ReactNode;
+}
+
+function VisConfigProvider(props: Props) {
+  const { children } = props;
+
+  return (
+    <>
+      {[...allConfigProviders].reduce(
+        (accChildren, NextProvider) => (
+          <NextProvider>{accChildren}</NextProvider>
+        ),
+        children
+      )}
+    </>
+  );
+}
+
+export default VisConfigProvider;

--- a/src/h5web/dimension-mapper/DimensionMapper.test.tsx
+++ b/src/h5web/dimension-mapper/DimensionMapper.test.tsx
@@ -4,7 +4,7 @@ import { renderApp, selectExplorerNode, selectVisTab } from '../test-utils';
 import { Vis } from '../vis-packs/core/visualizations';
 
 test('display mapping for X axis when visualizing 2D dataset as Line', async () => {
-  renderApp();
+  await renderApp();
   await selectExplorerNode('nD_datasets/twoD');
   await selectVisTab(Vis.Line);
 
@@ -32,7 +32,7 @@ test('display mapping for X axis when visualizing 2D dataset as Line', async () 
 });
 
 test('display mappings for X and Y axes when visualizing 2D dataset as Heatmap', async () => {
-  renderApp();
+  await renderApp();
   await selectExplorerNode('nD_datasets/twoD');
   await selectVisTab(Vis.Heatmap);
 
@@ -60,7 +60,7 @@ test('display mappings for X and Y axes when visualizing 2D dataset as Heatmap',
 });
 
 test('display one dimension slider and mappings for X and Y axes when visualizing 3D dataset as Matrix', async () => {
-  renderApp();
+  await renderApp();
   await selectExplorerNode('nD_datasets/threeD');
   await selectVisTab(Vis.Matrix);
 

--- a/src/h5web/explorer/Explorer.test.tsx
+++ b/src/h5web/explorer/Explorer.test.tsx
@@ -4,7 +4,7 @@ import { mockFilepath } from '../providers/mock/metadata';
 import { renderApp, selectExplorerNode } from '../test-utils';
 
 test('select root group by default', async () => {
-  renderApp();
+  await renderApp();
 
   const title = await screen.findByRole('heading', { name: mockFilepath });
   expect(title).toBeVisible();
@@ -15,7 +15,7 @@ test('select root group by default', async () => {
 });
 
 test('toggle explorer sidebar', async () => {
-  renderApp();
+  await renderApp();
 
   const fileBtn = await screen.findByRole('treeitem', {
     name: mockFilepath,
@@ -37,7 +37,7 @@ test('toggle explorer sidebar', async () => {
 });
 
 test('navigate groups in explorer', async () => {
-  renderApp();
+  await renderApp();
 
   const groupBtn = await screen.findByRole('treeitem', { name: 'entities' });
   expect(groupBtn).toHaveAttribute('aria-selected', 'false');
@@ -87,9 +87,9 @@ test('navigate groups in explorer', async () => {
 });
 
 test('show spinner when group metadata is slow to fetch', async () => {
-  renderApp();
-
   jest.useFakeTimers();
+  await renderApp();
+
   await selectExplorerNode('resilience/slow_metadata');
   expect(await screen.findByText(/Loading/)).toBeVisible();
   expect(screen.getByLabelText(/Loading group metadata/)).toBeVisible();
@@ -101,5 +101,6 @@ test('show spinner when group metadata is slow to fetch', async () => {
     ).not.toBeInTheDocument();
   });
 
+  jest.runOnlyPendingTimers();
   jest.useRealTimers();
 });

--- a/src/h5web/metadata-viewer/MetadataViewer.test.tsx
+++ b/src/h5web/metadata-viewer/MetadataViewer.test.tsx
@@ -8,7 +8,7 @@ import {
 } from '../test-utils';
 
 test('switch between "display" and "inspect" modes', async () => {
-  renderApp();
+  await renderApp();
 
   const inspectBtn = await screen.findByRole('tab', { name: 'Inspect' });
   const displayBtn = screen.getByRole('tab', { name: 'Display' });
@@ -27,7 +27,7 @@ test('switch between "display" and "inspect" modes', async () => {
 });
 
 test('inspect group', async () => {
-  renderApp();
+  await renderApp();
   userEvent.click(await screen.findByRole('tab', { name: 'Inspect' }));
   await selectExplorerNode('entities');
 
@@ -41,7 +41,7 @@ test('inspect group', async () => {
 });
 
 test('inspect scalar dataset', async () => {
-  renderApp();
+  await renderApp();
   userEvent.click(await screen.findByRole('tab', { name: 'Inspect' }));
   await selectExplorerNode('entities/scalar_int');
 
@@ -61,7 +61,7 @@ test('inspect scalar dataset', async () => {
 });
 
 test('inspect array dataset', async () => {
-  renderApp();
+  await renderApp();
   userEvent.click(await screen.findByRole('tab', { name: 'Inspect' }));
   await selectExplorerNode('nD_datasets/threeD');
 
@@ -70,7 +70,7 @@ test('inspect array dataset', async () => {
 });
 
 test('inspect empty dataset', async () => {
-  renderApp();
+  await renderApp();
   userEvent.click(await screen.findByRole('tab', { name: 'Inspect' }));
   await selectExplorerNode('entities/empty_dataset');
 
@@ -82,7 +82,7 @@ test('inspect empty dataset', async () => {
 });
 
 test('inspect datatype', async () => {
-  renderApp();
+  await renderApp();
   userEvent.click(await screen.findByRole('tab', { name: 'Inspect' }));
   await selectExplorerNode('entities/datatype');
 
@@ -100,7 +100,7 @@ test('inspect datatype', async () => {
 });
 
 test('inspect unresolved soft link', async () => {
-  renderApp();
+  await renderApp();
   userEvent.click(await screen.findByRole('tab', { name: 'Inspect' }));
   await selectExplorerNode('entities/unresolved_soft_link');
 
@@ -116,7 +116,7 @@ test('inspect unresolved soft link', async () => {
 });
 
 test('inspect unresolved external link', async () => {
-  renderApp();
+  await renderApp();
   userEvent.click(await screen.findByRole('tab', { name: 'Inspect' }));
   await selectExplorerNode('entities/unresolved_external_link');
 
@@ -128,7 +128,7 @@ test('inspect unresolved external link', async () => {
 });
 
 test('follow path attributes', async () => {
-  renderApp();
+  await renderApp();
   userEvent.click(await screen.findByRole('tab', { name: 'Inspect' }));
 
   userEvent.click(

--- a/src/h5web/providers/mock/metadata.ts
+++ b/src/h5web/providers/mock/metadata.ts
@@ -57,7 +57,6 @@ export const mockMetadata = makeNxGroup(mockFilepath, 'NXroot', {
       defaultPath: 'nx_process/nx_data',
       children: [
         makeNxGroup('nx_process', 'NXprocess', {
-          defaultPath: 'nx_data',
           children: [
             makeNxDataGroup('nx_data', {
               signal: makeNxDataset('twoD', intType, [20, 41]),

--- a/src/h5web/test-utils.tsx
+++ b/src/h5web/test-utils.tsx
@@ -1,21 +1,17 @@
-import {
-  fireEvent,
-  render,
-  RenderResult,
-  screen,
-  within,
-} from '@testing-library/react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import App from './App';
 import MockProvider from './providers/mock/MockProvider';
 import type { Vis } from './vis-packs/core/visualizations';
 
-export function renderApp(): RenderResult {
-  return render(
-    <MockProvider>
-      <App />
-    </MockProvider>
-  );
+export async function renderApp(): Promise<void> {
+  return act(async () => {
+    render(
+      <MockProvider>
+        <App />
+      </MockProvider>
+    );
+  });
 }
 
 export async function selectExplorerNode(path: string): Promise<void> {

--- a/src/h5web/toolbar/controls/DomainSlider/DomainSlider.test.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/DomainSlider.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { pressKey, renderApp, selectExplorerNode } from '../../../test-utils';
 
 test('show slider with two thumbs', async () => {
-  renderApp(); // default NeXus group renders heatmap and therefore domain slider
+  await renderApp(); // default NeXus group renders heatmap and therefore domain slider
   expect(await screen.findByRole('figure')).toBeVisible();
 
   const thumbs = await screen.findAllByRole('slider');
@@ -13,7 +13,7 @@ test('show slider with two thumbs', async () => {
 });
 
 test('show tooltip on hover', async () => {
-  renderApp();
+  await renderApp();
   expect(await screen.findByRole('figure')).toBeVisible();
 
   const editBtn = await screen.findByRole('button', { name: 'Edit domain' });
@@ -36,7 +36,7 @@ test('show tooltip on hover', async () => {
 });
 
 test('show min/max and data range in tooltip', async () => {
-  renderApp();
+  await renderApp();
   expect(await screen.findByRole('figure')).toBeVisible();
 
   const editBtn = await screen.findByRole('button', { name: 'Edit domain' });
@@ -56,7 +56,7 @@ test('show min/max and data range in tooltip', async () => {
 });
 
 test('update domain when moving thumbs (with keyboard)', async () => {
-  renderApp();
+  await renderApp();
   expect(await screen.findByRole('figure')).toBeVisible();
 
   // Give focus to min thumb (and hover to reveal tooltip)
@@ -103,7 +103,7 @@ test('update domain when moving thumbs (with keyboard)', async () => {
 });
 
 test('allow editing bounds manually', async () => {
-  renderApp();
+  await renderApp();
 
   const visArea = await screen.findByRole('figure');
   const editBtn = screen.getByRole('button', { name: 'Edit domain' });
@@ -149,7 +149,7 @@ test('allow editing bounds manually', async () => {
 });
 
 test('clamp domain in symlog scale', async () => {
-  renderApp();
+  await renderApp();
   expect(await screen.findByRole('figure')).toBeVisible();
 
   const editBtn = await screen.findByRole('button', { name: 'Edit domain' });
@@ -180,7 +180,7 @@ test('clamp domain in symlog scale', async () => {
 });
 
 test('show min/max autoscale toggles in tooltip (pressed by default)', async () => {
-  renderApp();
+  await renderApp();
   expect(await screen.findByRole('figure')).toBeVisible();
 
   const editBtn = await screen.findByRole('button', { name: 'Edit domain' });
@@ -195,7 +195,7 @@ test('show min/max autoscale toggles in tooltip (pressed by default)', async () 
 });
 
 test('control min/max autoscale behaviour', async () => {
-  renderApp();
+  await renderApp();
   expect(await screen.findByRole('figure')).toBeVisible();
 
   const minThumb = await screen.findByRole('slider', { name: /min/ });
@@ -224,7 +224,7 @@ test('control min/max autoscale behaviour', async () => {
 });
 
 test('handle empty domain', async () => {
-  renderApp();
+  await renderApp();
 
   const visArea = await screen.findByRole('figure');
   const editBtn = screen.getByRole('button', { name: 'Edit domain' });
@@ -262,7 +262,7 @@ test('handle empty domain', async () => {
 });
 
 test('handle min > max', async () => {
-  renderApp();
+  await renderApp();
 
   const visArea = await screen.findByRole('figure');
   const editBtn = screen.getByRole('button', { name: 'Edit domain' });
@@ -289,7 +289,7 @@ test('handle min > max', async () => {
 });
 
 test('handle min or max <= 0 in log scale', async () => {
-  renderApp();
+  await renderApp();
   await selectExplorerNode('nexus_entry/image');
   await screen.findByRole('button', { name: 'Log' }); // wait for switch to log scale
 
@@ -320,7 +320,7 @@ test('handle min or max <= 0 in log scale', async () => {
 });
 
 test('handle min <= 0 with custom max fallback in log scale', async () => {
-  renderApp();
+  await renderApp();
   await selectExplorerNode('nexus_entry/image');
   await screen.findByRole('button', { name: 'Log' }); // wait for switch to log scale
 

--- a/src/h5web/vis-packs/core/CorePack.test.tsx
+++ b/src/h5web/vis-packs/core/CorePack.test.tsx
@@ -9,7 +9,7 @@ import {
 import { Vis } from './visualizations';
 
 test('visualise raw dataset', async () => {
-  renderApp();
+  await renderApp();
   await selectExplorerNode('entities/raw');
 
   const tabs = await findVisSelectorTabs();
@@ -23,7 +23,7 @@ test('visualise raw dataset', async () => {
 test('log raw dataset to console if too large', async () => {
   const logSpy = mockConsoleMethod('log');
 
-  renderApp();
+  await renderApp();
   await selectExplorerNode('entities/raw_large');
 
   expect(await screen.findByText(/dataset is too big/)).toBeVisible();
@@ -31,7 +31,7 @@ test('log raw dataset to console if too large', async () => {
 });
 
 test('visualise scalar dataset', async () => {
-  renderApp();
+  await renderApp();
 
   await selectExplorerNode('entities/scalar_int');
   expect(await screen.findByText('0')).toBeVisible();
@@ -46,7 +46,7 @@ test('visualise scalar dataset', async () => {
 });
 
 test('visualize 1D dataset', async () => {
-  renderApp();
+  await renderApp();
   await selectExplorerNode('nD_datasets/oneD');
 
   const tabs = await findVisSelectorTabs();
@@ -57,7 +57,7 @@ test('visualize 1D dataset', async () => {
 });
 
 test('visualize 2D datasets', async () => {
-  renderApp();
+  await renderApp();
   await selectExplorerNode('nD_datasets/twoD');
 
   const tabs = await findVisSelectorTabs();

--- a/src/h5web/vis-packs/core/heatmap/config.tsx
+++ b/src/h5web/vis-packs/core/heatmap/config.tsx
@@ -34,7 +34,7 @@ interface HeatmapConfig extends State {
   toggleGrid: () => void;
 }
 
-function initialiseStore() {
+function initialiseStore(onRehydrated: () => void) {
   return create<HeatmapConfig>(
     persist(
       (set) => ({
@@ -78,6 +78,7 @@ function initialiseStore() {
           'invertColorMap',
         ],
         version: 6,
+        onRehydrateStorage: () => onRehydrated,
       }
     )
   );
@@ -99,7 +100,14 @@ export function useHeatmapConfig<U>(
 // https://github.com/pmndrs/zustand/issues/128#issuecomment-673398578
 export function HeatmapConfigProvider(props: ConfigProviderProps) {
   const { children } = props;
-  const [useStore] = useState(initialiseStore); // https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
 
-  return <Provider value={useStore}>{children}</Provider>;
+  // https://github.com/pmndrs/zustand/issues/346
+  const [reydrated, setRehydrated] = useState(false);
+
+  // https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
+  const [useStore] = useState(() => {
+    return initialiseStore(() => setRehydrated(true));
+  });
+
+  return reydrated ? <Provider value={useStore}>{children}</Provider> : null;
 }

--- a/src/h5web/vis-packs/core/line/config.tsx
+++ b/src/h5web/vis-packs/core/line/config.tsx
@@ -34,7 +34,7 @@ interface LineConfig extends State {
   disableErrors: (areErrorsDisabled: boolean) => void;
 }
 
-function initialiseStore() {
+function initialiseStore(onRehydrated: () => void) {
   return create<LineConfig>(
     persist(
       (set) => ({
@@ -73,6 +73,7 @@ function initialiseStore() {
           'showErrors',
         ],
         version: 2,
+        onRehydrateStorage: () => onRehydrated,
       }
     )
   );
@@ -94,7 +95,14 @@ export function useLineConfig<U>(
 // https://github.com/pmndrs/zustand/issues/128#issuecomment-673398578
 export function LineConfigProvider(props: ConfigProviderProps) {
   const { children } = props;
-  const [useStore] = useState(initialiseStore); // https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
 
-  return <Provider value={useStore}>{children}</Provider>;
+  // https://github.com/pmndrs/zustand/issues/346
+  const [reydrated, setRehydrated] = useState(false);
+
+  // https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
+  const [useStore] = useState(() => {
+    return initialiseStore(() => setRehydrated(true));
+  });
+
+  return reydrated ? <Provider value={useStore}>{children}</Provider> : null;
 }

--- a/src/h5web/vis-packs/nexus/NexusPack.test.tsx
+++ b/src/h5web/vis-packs/nexus/NexusPack.test.tsx
@@ -8,7 +8,7 @@ import {
 import { NexusVis } from './visualizations';
 
 test('visualize NXdata group with "spectrum" interpretation', async () => {
-  renderApp();
+  await renderApp();
   await selectExplorerNode('nexus_entry/spectrum');
 
   const tabs = await findVisSelectorTabs();
@@ -17,7 +17,7 @@ test('visualize NXdata group with "spectrum" interpretation', async () => {
 });
 
 test('visualize NXdata group with "image" interpretation', async () => {
-  renderApp();
+  await renderApp();
   await selectExplorerNode('nexus_entry/image');
 
   const tabs = await findVisSelectorTabs();
@@ -26,8 +26,9 @@ test('visualize NXdata group with "image" interpretation', async () => {
 });
 
 test('visualize NXdata group with 2D signal', async () => {
-  renderApp();
+  await renderApp();
   await selectExplorerNode('nexus_entry/nx_process/nx_data');
+  // expect(await screen.findByRole('figure')).toBeVisible();
 
   const tabs = await findVisSelectorTabs();
   expect(tabs).toHaveLength(1);
@@ -35,7 +36,7 @@ test('visualize NXdata group with 2D signal', async () => {
 });
 
 test('visualize NXentry group with relative path to 2D default signal', async () => {
-  renderApp();
+  await renderApp();
   await selectExplorerNode('nexus_entry');
 
   const tabs = await findVisSelectorTabs();
@@ -44,7 +45,7 @@ test('visualize NXentry group with relative path to 2D default signal', async ()
 });
 
 test('visualize NXentry group with absolute path to 2D default signal', async () => {
-  renderApp();
+  await renderApp();
   await selectExplorerNode('nexus_entry/nx_process/absolute_default_path');
 
   const tabs = await findVisSelectorTabs();
@@ -53,7 +54,7 @@ test('visualize NXentry group with absolute path to 2D default signal', async ()
 });
 
 test('visualize NXroot group with 2D default signal', async () => {
-  renderApp();
+  await renderApp();
 
   const tabs = await findVisSelectorTabs();
   expect(tabs).toHaveLength(1);
@@ -61,7 +62,7 @@ test('visualize NXroot group with 2D default signal', async () => {
 });
 
 test('show error when encountering malformed NeXus metadata', async () => {
-  renderApp();
+  await renderApp();
 
   const errorSpy = mockConsoleMethod('error');
   await selectExplorerNode('nexus_malformed');

--- a/src/h5web/vis-packs/nexus/containers/NxSpectrumContainer.tsx
+++ b/src/h5web/vis-packs/nexus/containers/NxSpectrumContainer.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useContext } from 'react';
+import { Suspense } from 'react';
 import { isEqual } from 'lodash-es';
 import { assertGroup } from '../../../guards';
 import MappedLineVis from '../../core/line/MappedLineVis';
@@ -6,7 +6,6 @@ import type { VisContainerProps } from '../../models';
 import { useNxData } from '../hooks';
 import { useDimMappingState } from '../../hooks';
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
-import { ProviderContext } from '../../../providers/context';
 import ValueLoader from '../../../visualizer/ValueLoader';
 import { getDatasetLabel } from '../utils';
 
@@ -34,12 +33,6 @@ function NxSpectrumContainer(props: VisContainerProps) {
   }
 
   const [dimMapping, setDimMapping] = useDimMappingState(signalDims, 1);
-
-  const { valuesStore } = useContext(ProviderContext);
-  valuesStore.prefetch({ path: signalDataset.path });
-  if (errorsDataset) {
-    valuesStore.prefetch({ path: errorsDataset.path });
-  }
 
   return (
     <>

--- a/src/h5web/vis-packs/nexus/hooks.ts
+++ b/src/h5web/vis-packs/nexus/hooks.ts
@@ -77,10 +77,17 @@ function useAssociatedDatasets(
 export function useNxData(group: Group): NxData {
   assertNxDataGroup(group);
   const signalDataset = findSignalDataset(group);
+  const errorsDataset = findErrorsDataset(group, signalDataset.name);
+
+  const { valuesStore } = useContext(ProviderContext);
+  valuesStore.prefetch({ path: signalDataset.path });
+  if (errorsDataset) {
+    valuesStore.prefetch({ path: errorsDataset.path });
+  }
 
   return {
     signalDataset,
-    errorsDataset: findErrorsDataset(group, signalDataset.name),
+    errorsDataset,
     titleDataset: useTitleDataset(group),
     axisDatasets: useAssociatedDatasets(group, 'axes'),
     silxStyle: getSilxStyle(group),

--- a/src/h5web/visualizer/Visualizer.tsx
+++ b/src/h5web/visualizer/Visualizer.tsx
@@ -1,4 +1,4 @@
-import { Fragment, Suspense, useContext } from 'react';
+import { Suspense, useContext } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import Profiler from '../Profiler';
 import type { Entity } from '../providers/models';
@@ -28,36 +28,34 @@ function Visualizer<T extends VisDef>(props: Props<T>) {
     );
   }
 
-  const { Container, Toolbar, ConfigProvider = Fragment } = activeVis;
+  const { Container, Toolbar } = activeVis;
 
   return (
     <div className={styles.visualizer}>
-      <ConfigProvider>
-        <div className={styles.visBar}>
-          <VisSelector
-            activeVis={activeVis}
-            choices={supportedVis}
-            onChange={onActiveVisChange}
-          />
-          {Toolbar && <Toolbar />}
-        </div>
+      <div className={styles.visBar}>
+        <VisSelector
+          activeVis={activeVis}
+          choices={supportedVis}
+          onChange={onActiveVisChange}
+        />
+        {Toolbar && <Toolbar />}
+      </div>
 
-        <div className={styles.displayArea}>
-          <ErrorBoundary
-            resetKeys={[entity.path]}
-            FallbackComponent={ErrorFallback}
-            onReset={() => {
-              valuesStore.evict({ path: entity.path });
-            }}
-          >
-            <Suspense fallback={<ValueLoader />}>
-              <Profiler id={activeVis.name}>
-                <Container key={entity.path} entity={entity} />
-              </Profiler>
-            </Suspense>
-          </ErrorBoundary>
-        </div>
-      </ConfigProvider>
+      <div className={styles.displayArea}>
+        <ErrorBoundary
+          resetKeys={[entity.path]}
+          FallbackComponent={ErrorFallback}
+          onReset={() => {
+            valuesStore.evict({ path: entity.path });
+          }}
+        >
+          <Suspense fallback={<ValueLoader />}>
+            <Profiler id={activeVis.name}>
+              <Container key={entity.path} entity={entity} />
+            </Profiler>
+          </Suspense>
+        </ErrorBoundary>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
... so they are not re-rendered every time the user switches to another visualization.

I also:

- moved the prefetching of values and errors into the `useNxData` hook;
- removed the `defaultPath` from `nx_process` as it was previously;
- made sure that the config providers wait until their stores are rehydrated before rendering their children;
- fixed all the tests by wrapping the main `render` of the app in `act`.