### PR TITLE
Added two variants of ComplexVis: phase map and amplitude map

### DIFF
--- a/src/h5web/toolbar/ComplexToolbar.tsx
+++ b/src/h5web/toolbar/ComplexToolbar.tsx
@@ -1,0 +1,94 @@
+import { MdAspectRatio, MdGridOn } from 'react-icons/md';
+import ToggleBtn from './controls/ToggleBtn';
+import DomainSlider from './controls/DomainSlider/DomainSlider';
+import SnapshotButton from './controls/SnapshotButton';
+import Separator from './Separator';
+import Toolbar from './Toolbar';
+import ColorMapSelector from './controls/ColorMapSelector/ColorMapSelector';
+import ScaleSelector from './controls/ScaleSelector/ScaleSelector';
+import shallow from 'zustand/shallow';
+import { useComplexConfig } from '../vis-packs/core/complex/config';
+import {
+  ComplexVisType,
+  VIS_TYPE_SYMBOLS,
+} from '../vis-packs/core/complex/models';
+import Selector from './controls/Selector/Selector';
+import { useHeatmapConfig } from '../vis-packs/core/heatmap/config';
+
+function ComplexToolbar() {
+  const {
+    dataDomain,
+    customDomain,
+    setCustomDomain,
+    colorMap,
+    setColorMap,
+    scaleType,
+    setScaleType,
+    keepAspectRatio,
+    toggleAspectRatio,
+    showGrid,
+    toggleGrid,
+    invertColorMap,
+    toggleColorMapInversion,
+  } = useHeatmapConfig((state) => state, shallow);
+  const { visType, setVisType } = useComplexConfig((state) => state, shallow);
+
+  return (
+    <Toolbar>
+      {dataDomain && (
+        <DomainSlider
+          dataDomain={dataDomain}
+          customDomain={customDomain}
+          scaleType={scaleType}
+          onCustomDomainChange={setCustomDomain}
+        />
+      )}
+
+      {dataDomain && <Separator />}
+
+      <ColorMapSelector
+        value={colorMap}
+        onValueChange={setColorMap}
+        invert={invertColorMap}
+        onInversionChange={toggleColorMapInversion}
+      />
+
+      <Separator />
+
+      <ScaleSelector value={scaleType} onScaleChange={setScaleType} />
+
+      <Separator />
+
+      <ToggleBtn
+        label="Keep ratio"
+        icon={MdAspectRatio}
+        value={keepAspectRatio}
+        onChange={toggleAspectRatio}
+      />
+      <ToggleBtn
+        label="Grid"
+        icon={MdGridOn}
+        value={showGrid}
+        onChange={toggleGrid}
+      />
+
+      <Separator />
+
+      <Selector
+        value={visType}
+        onChange={(value: ComplexVisType) => setVisType(value)}
+        options={Object.values(ComplexVisType)}
+        optionComponent={({ option }) => (
+          // eslint-disable-next-line react/jsx-no-useless-fragment
+          <>{`${VIS_TYPE_SYMBOLS[option]} ${option}`}</>
+        )}
+      />
+
+      <Separator />
+
+      <SnapshotButton />
+    </Toolbar>
+  );
+}
+
+export default ComplexToolbar;

--- a/src/h5web/utils.ts
+++ b/src/h5web/utils.ts
@@ -12,12 +12,12 @@ export function formatComplex(value: H5WebComplex, specifier = '') {
   }
 
   if (real === 0) {
-    return `${formatFunction(imag)}i`;
+    return `${formatFunction(imag)}ⅈ`;
   }
 
   return `${formatFunction(real)}${
     Math.sign(imag) === 1 ? ' + ' : ' − '
-  }${formatFunction(Math.abs(imag))}i`;
+  }${formatFunction(Math.abs(imag))}ⅈ`;
 }
 
 export function getChildEntity(

--- a/src/h5web/vis-packs/core/complex/MappedComplexVis.tsx
+++ b/src/h5web/vis-packs/core/complex/MappedComplexVis.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo } from 'react';
 import { useDatasetValue, useMappedArray } from '../hooks';
-import { useHeatmapConfig } from '../heatmap/config';
 import type { AxisMapping, ScaleType } from '../models';
 import type { DimensionMapping } from '../../../dimension-mapper/models';
 import { isAxis } from '../../../dimension-mapper/utils';
@@ -14,6 +13,9 @@ import type {
 import { usePhaseAmplitude } from './hooks';
 import HeatmapVis from '../heatmap/HeatmapVis';
 import { DEFAULT_DOMAIN } from '../utils';
+import { ComplexVisType } from './models';
+import { useComplexConfig } from './config';
+import { useHeatmapConfig } from '../heatmap/config';
 
 interface Props {
   dataset: Dataset<ArrayShape, ComplexType>;
@@ -45,6 +47,8 @@ function MappedComplexVis(props: Props) {
     invertColorMap,
   } = useHeatmapConfig((state) => state, shallow);
 
+  const { visType } = useComplexConfig((state) => state, shallow);
+
   const value = useDatasetValue(dataset, dimMapping);
 
   const [slicedDims, slicedMapping] = useMemo(
@@ -62,18 +66,18 @@ function MappedComplexVis(props: Props) {
     phaseDomain = DEFAULT_DOMAIN,
     amplitudeArray,
     amplitudeDomain = DEFAULT_DOMAIN,
-  } = usePhaseAmplitude(mappedArray, colorScaleType);
+  } = usePhaseAmplitude(mappedArray, scaleType);
 
-  const visPhaseDomain = useVisDomain(customDomain, phaseDomain);
-  const [safePhaseDomain] = useSafeDomain(
-    visPhaseDomain,
-    phaseDomain,
-    scaleType
-  );
+  const dataArray =
+    visType !== ComplexVisType.Amplitude ? phaseArray : amplitudeArray;
+  const dataDomain =
+    visType !== ComplexVisType.Amplitude ? phaseDomain : amplitudeDomain;
 
+  const visDomain = useVisDomain(customDomain, dataDomain);
+  const [safeDomain] = useSafeDomain(visDomain, dataDomain, scaleType);
   useEffect(() => {
-    setDataDomain(phaseDomain);
-  }, [phaseDomain, setDataDomain]);
+    setDataDomain(dataDomain);
+  }, [dataDomain, setDataDomain]);
 
   useEffect(() => {
     if (colorScaleType) {
@@ -83,11 +87,15 @@ function MappedComplexVis(props: Props) {
 
   return (
     <HeatmapVis
-      dataArray={phaseArray}
-      domain={safePhaseDomain}
-      alphaArray={amplitudeArray}
-      alphaDomain={amplitudeDomain}
-      title={title}
+      dataArray={dataArray}
+      domain={safeDomain}
+      alphaArray={
+        visType === ComplexVisType.PhaseAmplitude ? amplitudeArray : undefined
+      }
+      alphaDomain={
+        visType === ComplexVisType.PhaseAmplitude ? amplitudeDomain : undefined
+      }
+      title={title ? `${title} (${visType.toLowerCase()})` : visType}
       colorMap={colorMap}
       scaleType={scaleType}
       keepAspectRatio={keepAspectRatio}

--- a/src/h5web/vis-packs/core/complex/MappedComplexVis.tsx
+++ b/src/h5web/vis-packs/core/complex/MappedComplexVis.tsx
@@ -24,7 +24,7 @@ interface Props {
   colorScaleType?: ScaleType;
 }
 
-function MappedPhaseMapVis(props: Props) {
+function MappedComplexVis(props: Props) {
   const {
     dataset,
     dims,
@@ -99,4 +99,4 @@ function MappedPhaseMapVis(props: Props) {
   );
 }
 
-export default MappedPhaseMapVis;
+export default MappedComplexVis;

--- a/src/h5web/vis-packs/core/complex/config.tsx
+++ b/src/h5web/vis-packs/core/complex/config.tsx
@@ -1,0 +1,48 @@
+import create from 'zustand';
+import { persist } from 'zustand/middleware';
+import { useState } from 'react';
+import type { ConfigProviderProps } from '../../models';
+import createContext from 'zustand/context';
+import { ComplexVisType } from './models';
+
+interface ComplexConfig {
+  visType: ComplexVisType;
+  setVisType: (visType: ComplexVisType) => void;
+}
+
+function initialiseStore(onRehydrated: () => void) {
+  return create<ComplexConfig>(
+    persist(
+      (set) => ({
+        visType: ComplexVisType.Amplitude,
+        setVisType: (visType: ComplexVisType) => set(() => ({ visType })),
+      }),
+      {
+        name: 'h5web:complex',
+        whitelist: ['visType'],
+        version: 1,
+        onRehydrateStorage: () => onRehydrated,
+      }
+    )
+  );
+}
+
+const { Provider, useStore } = createContext<ComplexConfig>();
+export const useComplexConfig = useStore;
+
+// https://github.com/pmndrs/zustand/issues/128#issuecomment-673398578
+export function ComplexConfigProvider(props: ConfigProviderProps) {
+  const { children } = props;
+
+  // https://github.com/pmndrs/zustand/issues/346
+  const [rehydrated, setRehydrated] = useState(false);
+
+  // https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
+  const [store] = useState(() => {
+    return initialiseStore(() => setRehydrated(true));
+  });
+
+  return rehydrated ? (
+    <Provider initialStore={store}>{children}</Provider>
+  ) : null;
+}

--- a/src/h5web/vis-packs/core/complex/models.ts
+++ b/src/h5web/vis-packs/core/complex/models.ts
@@ -1,0 +1,11 @@
+export enum ComplexVisType {
+  Phase = 'Phase',
+  Amplitude = 'Amplitude',
+  PhaseAmplitude = 'Phase and amplitude',
+}
+
+export const VIS_TYPE_SYMBOLS = {
+  [ComplexVisType.Phase]: 'φ',
+  [ComplexVisType.Amplitude]: '𝓐',
+  [ComplexVisType.PhaseAmplitude]: 'φ𝓐',
+};

--- a/src/h5web/vis-packs/core/containers/ComplexVisContainer.tsx
+++ b/src/h5web/vis-packs/core/containers/ComplexVisContainer.tsx
@@ -9,13 +9,13 @@ import type { VisContainerProps } from '../../models';
 import { useDimMappingState } from '../../hooks';
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import ValueLoader from '../../../visualizer/ValueLoader';
-import MappedPhaseMapVis from '../complex/MappedPhaseMapVis';
+import MappedComplexVis from '../complex/MappedComplexVis';
 import { ErrorBoundary } from 'react-error-boundary';
 import ErrorFallback from '../../../visualizer/ErrorFallback';
 import { getSliceSelection } from '../utils';
 import { ProviderContext } from '../../../providers/context';
 
-function PhaseMapVisContainer(props: VisContainerProps) {
+function ComplexVisContainer(props: VisContainerProps) {
   const { entity } = props;
   assertDataset(entity);
   assertArrayShape(entity);
@@ -45,7 +45,7 @@ function PhaseMapVisContainer(props: VisContainerProps) {
         }}
       >
         <Suspense fallback={<ValueLoader message="Loading current slice" />}>
-          <MappedPhaseMapVis
+          <MappedComplexVis
             dataset={entity}
             dims={dims}
             dimMapping={dimMapping}
@@ -57,4 +57,4 @@ function PhaseMapVisContainer(props: VisContainerProps) {
   );
 }
 
-export default PhaseMapVisContainer;
+export default ComplexVisContainer;

--- a/src/h5web/vis-packs/core/containers/index.ts
+++ b/src/h5web/vis-packs/core/containers/index.ts
@@ -3,4 +3,4 @@ export { default as ScalarVisContainer } from './ScalarVisContainer';
 export { default as MatrixVisContainer } from './MatrixVisContainer';
 export { default as LineVisContainer } from './LineVisContainer';
 export { default as HeatmapVisContainer } from './HeatmapVisContainer';
-export { default as PhaseMapVisContainer } from './PhaseMapVisContainer';
+export { default as ComplexVisContainer } from './ComplexVisContainer';

--- a/src/h5web/vis-packs/core/heatmap/config.tsx
+++ b/src/h5web/vis-packs/core/heatmap/config.tsx
@@ -87,14 +87,14 @@ export function HeatmapConfigProvider(props: ConfigProviderProps) {
   const { children } = props;
 
   // https://github.com/pmndrs/zustand/issues/346
-  const [reydrated, setRehydrated] = useState(false);
+  const [rehydrated, setRehydrated] = useState(false);
 
   // https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
   const [store] = useState(() => {
     return initialiseStore(() => setRehydrated(true));
   });
 
-  return reydrated ? (
+  return rehydrated ? (
     <Provider initialStore={store}>{children}</Provider>
   ) : null;
 }

--- a/src/h5web/vis-packs/core/line/config.tsx
+++ b/src/h5web/vis-packs/core/line/config.tsx
@@ -85,14 +85,14 @@ export function LineConfigProvider(props: ConfigProviderProps) {
   const { children } = props;
 
   // https://github.com/pmndrs/zustand/issues/346
-  const [reydrated, setRehydrated] = useState(false);
+  const [rehydrated, setRehydrated] = useState(false);
 
   // https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
   const [store] = useState(() => {
     return initialiseStore(() => setRehydrated(true));
   });
 
-  return reydrated ? (
+  return rehydrated ? (
     <Provider initialStore={store}>{children}</Provider>
   ) : null;
 }

--- a/src/h5web/vis-packs/core/matrix/MappedMatrixVis.tsx
+++ b/src/h5web/vis-packs/core/matrix/MappedMatrixVis.tsx
@@ -35,7 +35,7 @@ function MappedMatrixVis(props: Props) {
       <MatrixVis
         dataArray={mappedArray}
         formatter={(dataValue) => renderComplex(dataValue, '.2e')}
-        cellWidth={216} // To accommodate the longer complex numbers
+        cellWidth={232} // To accommodate the longer complex numbers
       />
     );
   }

--- a/src/h5web/vis-packs/core/visualizations.test.ts
+++ b/src/h5web/vis-packs/core/visualizations.test.ts
@@ -121,8 +121,8 @@ describe('Heatmap', () => {
   });
 });
 
-describe('Phase map', () => {
-  const { supportsDataset } = CORE_VIS['Phase map'];
+describe('Complex', () => {
+  const { supportsDataset } = CORE_VIS.Complex;
 
   it('should support array dataset with complex type and at least two dimensions', () => {
     expect(supportsDataset(datasetCplx2D)).toBe(true);

--- a/src/h5web/vis-packs/core/visualizations.ts
+++ b/src/h5web/vis-packs/core/visualizations.ts
@@ -17,7 +17,7 @@ import {
   MatrixVisContainer,
   LineVisContainer,
   HeatmapVisContainer,
-  PhaseMapVisContainer,
+  ComplexVisContainer,
 } from './containers';
 import type { VisDef } from '../models';
 import { LineConfigProvider } from './line/config';
@@ -29,7 +29,7 @@ export enum Vis {
   Matrix = 'Matrix',
   Line = 'Line',
   Heatmap = 'Heatmap',
-  PhaseMap = 'Phase map',
+  Complex = 'Complex',
 }
 
 export interface CoreVisDef extends VisDef {
@@ -88,11 +88,11 @@ export const CORE_VIS: Record<Vis, CoreVisDef> = {
     },
   },
 
-  [Vis.PhaseMap]: {
-    name: Vis.PhaseMap,
+  [Vis.Complex]: {
+    name: Vis.Complex,
     Icon: FiMap,
     Toolbar: HeatmapToolbar,
-    Container: PhaseMapVisContainer,
+    Container: ComplexVisContainer,
     ConfigProvider: HeatmapConfigProvider,
     supportsDataset: (dataset) => {
       return (

--- a/src/h5web/vis-packs/core/visualizations.ts
+++ b/src/h5web/vis-packs/core/visualizations.ts
@@ -22,6 +22,8 @@ import {
 import type { VisDef } from '../models';
 import { LineConfigProvider } from './line/config';
 import { HeatmapConfigProvider } from './heatmap/config';
+import ComplexToolbar from '../../toolbar/ComplexToolbar';
+import { ComplexConfigProvider } from './complex/config';
 
 export enum Vis {
   Raw = 'Raw',
@@ -91,9 +93,9 @@ export const CORE_VIS: Record<Vis, CoreVisDef> = {
   [Vis.Complex]: {
     name: Vis.Complex,
     Icon: FiMap,
-    Toolbar: HeatmapToolbar,
+    Toolbar: ComplexToolbar,
     Container: ComplexVisContainer,
-    ConfigProvider: HeatmapConfigProvider,
+    ConfigProvider: ComplexConfigProvider,
     supportsDataset: (dataset) => {
       return (
         hasComplexType(dataset) &&


### PR DESCRIPTION
Continuation of work on #310 

![image](https://user-images.githubusercontent.com/42204205/117415114-377dcf80-af18-11eb-8f69-71320bc48e7d.png)

Also changed the aspect of imaginary `i` when displaying complex data:
![image](https://user-images.githubusercontent.com/42204205/117415191-52504400-af18-11eb-95bd-f03ddfb6e38e.png)
![image](https://user-images.githubusercontent.com/42204205/117415291-6d22b880-af18-11eb-9927-3e3d16cda12d.png)
