### PR TITLE
Fix cancelling/retrying in NeXus visualizations

### DIFF
--- a/src/h5web/providers/Provider.tsx
+++ b/src/h5web/providers/Provider.tsx
@@ -39,9 +39,19 @@ function Provider(props: Props) {
   }, [api]);
 
   const valuesStore = useMemo(() => {
-    return createFetchStore(api.getValue.bind(api), {
+    const store = createFetchStore(api.getValue.bind(api), {
       type: 'Map',
       areEqual: (a, b) => a.path === b.path && a.selection === b.selection,
+    });
+
+    return Object.assign(store, {
+      cancelOngoing: () => api.cancelValueRequests(),
+      evictCancelled: () => {
+        api.cancelledValueRequests.forEach(({ params }) => {
+          valuesStore.evict(params);
+        });
+        api.cancelledValueRequests.clear();
+      },
     });
   }, [api]);
 
@@ -51,7 +61,6 @@ function Provider(props: Props) {
         filepath: api.filepath,
         entitiesStore,
         valuesStore,
-        cancel: () => api.cancel(),
       }}
     >
       {children}

--- a/src/h5web/providers/context.ts
+++ b/src/h5web/providers/context.ts
@@ -10,49 +10,70 @@ import axios, {
 
 // https://github.com/microsoft/TypeScript/issues/15300#issuecomment-771916993
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-export type GetValueParams = {
+export type ValueRequestParams = {
   path: string;
   selection?: string;
 };
 
+interface ValueRequest {
+  params: ValueRequestParams;
+  cancelSource: CancelTokenSource;
+}
+
 export abstract class ProviderApi {
   public readonly filepath: string;
+  public readonly cancelledValueRequests = new Set<ValueRequest>();
+
   protected readonly client: AxiosInstance;
-  protected readonly cancelSources = new Set<CancelTokenSource>();
+  protected readonly valueRequests = new Set<ValueRequest>();
 
   public constructor(filepath: string, config?: AxiosRequestConfig) {
     this.filepath = filepath;
     this.client = axios.create(config);
   }
 
-  public async cancellableGet<R>(endpoint: string): Promise<AxiosResponse<R>> {
+  public cancelValueRequests(): void {
+    // Cancel every active value request
+    this.valueRequests.forEach((request) => {
+      request.cancelSource.cancel(ProviderError.Cancelled);
+
+      // Save request so params can later be evicted from the values store (cf. `Provider.tsx`)
+      this.cancelledValueRequests.add(request);
+    });
+
+    this.valueRequests.clear();
+  }
+
+  protected async cancellableFetchValue<T>(
+    endpoint: string,
+    params: ValueRequestParams
+  ): Promise<AxiosResponse<T>> {
     const cancelSource = axios.CancelToken.source();
-    this.cancelSources.add(cancelSource);
+    const request = { params, cancelSource };
+    this.valueRequests.add(request);
 
     try {
       const { token: cancelToken } = cancelSource;
-      return await this.client.get<R>(endpoint, { cancelToken });
+      return await this.client.get<T>(endpoint, { cancelToken });
     } finally {
-      this.cancelSources.delete(cancelSource);
+      // Remove cancellation source when request fulfills
+      this.valueRequests.delete(request);
     }
   }
 
-  public cancel(): void {
-    this.cancelSources.forEach((source) => {
-      source.cancel(ProviderError.Cancelled);
-    });
-    this.cancelSources.clear();
-  }
-
   public abstract getEntity(path: string): Promise<Entity>;
-  public abstract getValue(params: GetValueParams): Promise<unknown>;
+  public abstract getValue(params: ValueRequestParams): Promise<unknown>;
+}
+
+interface ValuesStore extends FetchStore<unknown, ValueRequestParams> {
+  cancelOngoing: () => void;
+  evictCancelled: () => void;
 }
 
 interface Context {
   filepath: string;
   entitiesStore: FetchStore<Entity, string>;
-  valuesStore: FetchStore<unknown, GetValueParams>;
-  cancel: () => void;
+  valuesStore: ValuesStore;
 }
 
 export const ProviderContext = createContext<Context>({} as Context);

--- a/src/h5web/providers/hsds/api.ts
+++ b/src/h5web/providers/hsds/api.ts
@@ -21,7 +21,7 @@ import {
   ProviderError,
 } from '../models';
 import { assertDefined, assertGroup } from '../../guards';
-import { GetValueParams, ProviderApi } from '../context';
+import { ValueRequestParams, ProviderApi } from '../context';
 import {
   assertHsdsDataset,
   isHsdsGroup,
@@ -98,13 +98,13 @@ export class HsdsApi extends ProviderApi {
     return entity;
   }
 
-  public async getValue(params: GetValueParams): Promise<unknown> {
+  public async getValue(params: ValueRequestParams): Promise<unknown> {
     const { path, selection = '' } = params;
 
     const entity = await this.getEntity(path);
     assertHsdsDataset(entity);
 
-    const value = await this.fetchValue(entity.id, selection);
+    const value = await this.fetchValue(entity.id, params);
 
     // https://github.com/HDFGroup/hsds/issues/88
     // HSDS does not reduce the number of dimensions when selecting indices
@@ -169,10 +169,12 @@ export class HsdsApi extends ProviderApi {
 
   private async fetchValue(
     entityId: HsdsId,
-    selection: string
+    params: ValueRequestParams
   ): Promise<unknown> {
-    const { data } = await this.cancellableGet<HsdsValueResponse>(
-      `/datasets/${entityId}/value${selection && `?select=[${selection}]`}`
+    const { selection = '' } = params;
+    const { data } = await this.cancellableFetchValue<HsdsValueResponse>(
+      `/datasets/${entityId}/value${selection && `?select=[${selection}]`}`,
+      params
     );
     return data.value;
   }

--- a/src/h5web/providers/jupyter/api.ts
+++ b/src/h5web/providers/jupyter/api.ts
@@ -1,5 +1,5 @@
 import { Group, Dataset, Entity, EntityKind } from '../models';
-import { GetValueParams, ProviderApi } from '../context';
+import { ValueRequestParams, ProviderApi } from '../context';
 import {
   assertGroupContent,
   isDatasetResponse,
@@ -30,13 +30,12 @@ export class JupyterStableApi extends ProviderApi {
     return this.processEntity(path, 1);
   }
 
-  public async getValue(params: GetValueParams): Promise<unknown> {
-    const { path, selection = '' } = params;
-
+  public async getValue(params: ValueRequestParams): Promise<unknown> {
     const [value, entity] = await Promise.all([
-      this.fetchData(path, selection),
-      this.getEntity(path),
+      this.fetchData(params),
+      this.getEntity(params.path),
     ]);
+
     assertDataset(entity);
 
     if (hasComplexType(entity)) {
@@ -68,11 +67,12 @@ export class JupyterStableApi extends ProviderApi {
   }
 
   protected async fetchData(
-    path: string,
-    selection: string
+    params: ValueRequestParams
   ): Promise<JupyterDataResponse> {
-    const { data } = await this.cancellableGet<JupyterDataResponse>(
-      `/data/${this.filepath}?uri=${path}${selection && `&ixstr=${selection}`}`
+    const { path, selection = '' } = params;
+    const { data } = await this.cancellableFetchValue<JupyterDataResponse>(
+      `/data/${this.filepath}?uri=${path}${selection && `&ixstr=${selection}`}`,
+      params
     );
     return data;
   }

--- a/src/h5web/providers/jupyter/devApi.ts
+++ b/src/h5web/providers/jupyter/devApi.ts
@@ -7,7 +7,7 @@ import type {
   JupyterMetaResponse,
 } from './models';
 import { assertGroupContent, convertDtype } from './utils';
-import type { GetValueParams } from '../context';
+import type { ValueRequestParams } from '../context';
 
 interface DevJupyterAttrMeta {
   name: string;
@@ -32,9 +32,8 @@ export class JupyterDevApi extends JupyterStableApi {
     console.warn('Using Jupyter dev API');
   }
 
-  public async getValue(params: GetValueParams): Promise<unknown> {
-    const { path, selection = '' } = params;
-    return this.fetchData(path, selection);
+  public async getValue(params: ValueRequestParams): Promise<unknown> {
+    return this.fetchData(params);
   }
 
   protected async fetchMetadata(path: string): Promise<DevJupyterMetaResponse> {

--- a/src/h5web/vis-packs/core/containers/ComplexVisContainer.tsx
+++ b/src/h5web/vis-packs/core/containers/ComplexVisContainer.tsx
@@ -12,7 +12,6 @@ import ValueLoader from '../../../visualizer/ValueLoader';
 import MappedComplexVis from '../complex/MappedComplexVis';
 import { ErrorBoundary } from 'react-error-boundary';
 import ErrorFallback from '../../../visualizer/ErrorFallback';
-import { getSliceSelection } from '../utils';
 import { ProviderContext } from '../../../providers/context';
 
 function ComplexVisContainer(props: VisContainerProps) {
@@ -37,12 +36,7 @@ function ComplexVisContainer(props: VisContainerProps) {
       <ErrorBoundary
         resetKeys={[dimMapping]}
         FallbackComponent={ErrorFallback}
-        onReset={() => {
-          valuesStore.evict({
-            path: entity.path,
-            selection: getSliceSelection(dimMapping),
-          });
-        }}
+        onError={() => valuesStore.evictCancelled()}
       >
         <Suspense fallback={<ValueLoader message="Loading current slice" />}>
           <MappedComplexVis

--- a/src/h5web/vis-packs/core/containers/HeatmapVisContainer.tsx
+++ b/src/h5web/vis-packs/core/containers/HeatmapVisContainer.tsx
@@ -13,7 +13,6 @@ import ValueLoader from '../../../visualizer/ValueLoader';
 import { ErrorBoundary } from 'react-error-boundary';
 import ErrorFallback from '../../../visualizer/ErrorFallback';
 import { ProviderContext } from '../../../providers/context';
-import { getSliceSelection } from '../utils';
 
 function HeatmapVisContainer(props: VisContainerProps) {
   const { entity } = props;
@@ -37,12 +36,7 @@ function HeatmapVisContainer(props: VisContainerProps) {
       <ErrorBoundary
         resetKeys={[dimMapping]}
         FallbackComponent={ErrorFallback}
-        onReset={() => {
-          valuesStore.evict({
-            path: entity.path,
-            selection: getSliceSelection(dimMapping),
-          });
-        }}
+        onError={() => valuesStore.evictCancelled()}
       >
         <Suspense fallback={<ValueLoader message="Loading current slice" />}>
           <MappedHeatmapVis

--- a/src/h5web/vis-packs/core/containers/LineVisContainer.tsx
+++ b/src/h5web/vis-packs/core/containers/LineVisContainer.tsx
@@ -8,7 +8,10 @@ import type { VisContainerProps } from '../../models';
 import { useDimMappingState } from '../../hooks';
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import ValueLoader from '../../../visualizer/ValueLoader';
-import { Suspense } from 'react';
+import { Suspense, useContext } from 'react';
+import ErrorFallback from '../../../visualizer/ErrorFallback';
+import { ErrorBoundary } from 'react-error-boundary';
+import { ProviderContext } from '../../../providers/context';
 
 function LineVisContainer(props: VisContainerProps) {
   const { entity } = props;
@@ -19,6 +22,8 @@ function LineVisContainer(props: VisContainerProps) {
   const { shape: dims } = entity;
   const [dimMapping, setDimMapping] = useDimMappingState(dims, 1);
 
+  const { valuesStore } = useContext(ProviderContext);
+
   return (
     <>
       <DimensionMapper
@@ -26,13 +31,19 @@ function LineVisContainer(props: VisContainerProps) {
         mapperState={dimMapping}
         onChange={setDimMapping}
       />
-      <Suspense fallback={<ValueLoader message="Loading entire dataset" />}>
-        <MappedLineVis
-          valueDataset={entity}
-          dims={dims}
-          dimMapping={dimMapping}
-        />
-      </Suspense>
+      <ErrorBoundary
+        resetKeys={[dimMapping]}
+        FallbackComponent={ErrorFallback}
+        onError={() => valuesStore.evictCancelled()}
+      >
+        <Suspense fallback={<ValueLoader message="Loading entire dataset" />}>
+          <MappedLineVis
+            valueDataset={entity}
+            dims={dims}
+            dimMapping={dimMapping}
+          />
+        </Suspense>
+      </ErrorBoundary>
     </>
   );
 }

--- a/src/h5web/vis-packs/core/containers/MatrixVisContainer.tsx
+++ b/src/h5web/vis-packs/core/containers/MatrixVisContainer.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useContext } from 'react';
+import { Suspense, useContext } from 'react';
 import {
   assertPrintableType,
   assertDataset,
@@ -9,10 +9,9 @@ import type { VisContainerProps } from '../../models';
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useDimMappingState } from '../../hooks';
 import ValueLoader from '../../../visualizer/ValueLoader';
-import { ProviderContext } from '../../../providers/context';
 import ErrorFallback from '../../../visualizer/ErrorFallback';
-import { getSliceSelection } from '../utils';
 import { ErrorBoundary } from 'react-error-boundary';
+import { ProviderContext } from '../../../providers/context';
 
 function MatrixVisContainer(props: VisContainerProps) {
   const { entity } = props;
@@ -36,12 +35,7 @@ function MatrixVisContainer(props: VisContainerProps) {
       <ErrorBoundary
         resetKeys={[dimMapping]}
         FallbackComponent={ErrorFallback}
-        onReset={() => {
-          valuesStore.evict({
-            path: entity.path,
-            selection: getSliceSelection(dimMapping),
-          });
-        }}
+        onError={() => valuesStore.evictCancelled()}
       >
         <Suspense fallback={<ValueLoader message="Loading current slice" />}>
           <MappedMatrixVis

--- a/src/h5web/vis-packs/nexus/containers/NxComplexContainer.tsx
+++ b/src/h5web/vis-packs/nexus/containers/NxComplexContainer.tsx
@@ -8,7 +8,6 @@ import ValueLoader from '../../../visualizer/ValueLoader';
 import { ErrorBoundary } from 'react-error-boundary';
 import ErrorFallback from '../../../visualizer/ErrorFallback';
 import { ProviderContext } from '../../../providers/context';
-import { getSliceSelection } from '../../core/utils';
 import MappedComplexVis from '../../core/complex/MappedComplexVis';
 
 function NxComplexContainer(props: VisContainerProps) {
@@ -37,12 +36,7 @@ function NxComplexContainer(props: VisContainerProps) {
       <ErrorBoundary
         resetKeys={[dimMapping]}
         FallbackComponent={ErrorFallback}
-        onReset={() => {
-          valuesStore.evict({
-            path: signalDataset.path,
-            selection: getSliceSelection(dimMapping),
-          });
-        }}
+        onError={() => valuesStore.evictCancelled()}
       >
         <Suspense fallback={<ValueLoader />}>
           <MappedComplexVis

--- a/src/h5web/vis-packs/nexus/containers/NxImageContainer.tsx
+++ b/src/h5web/vis-packs/nexus/containers/NxImageContainer.tsx
@@ -9,7 +9,6 @@ import ValueLoader from '../../../visualizer/ValueLoader';
 import { ErrorBoundary } from 'react-error-boundary';
 import ErrorFallback from '../../../visualizer/ErrorFallback';
 import { ProviderContext } from '../../../providers/context';
-import { getSliceSelection } from '../../core/utils';
 
 function NxImageContainer(props: VisContainerProps) {
   const { entity } = props;
@@ -37,12 +36,7 @@ function NxImageContainer(props: VisContainerProps) {
       <ErrorBoundary
         resetKeys={[dimMapping]}
         FallbackComponent={ErrorFallback}
-        onReset={() => {
-          valuesStore.evict({
-            path: signalDataset.path,
-            selection: getSliceSelection(dimMapping),
-          });
-        }}
+        onError={() => valuesStore.evictCancelled()}
       >
         <Suspense fallback={<ValueLoader />}>
           <MappedHeatmapVis

--- a/src/h5web/visualizer/ValueLoader.tsx
+++ b/src/h5web/visualizer/ValueLoader.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 function ValueLoader(props: Props) {
   const { message = 'Loading data' } = props;
-  const { cancel } = useContext(ProviderContext);
+  const { valuesStore } = useContext(ProviderContext);
 
   // Wait a bit before showing loader to avoid flash
   const [isReady] = useTimeout(100);
@@ -36,7 +36,7 @@ function ValueLoader(props: Props) {
         <button
           className={styles.cancelBtn}
           type="button"
-          onClick={() => cancel()}
+          onClick={() => valuesStore.cancelOngoing()}
         >
           Cancel?
         </button>

--- a/src/h5web/visualizer/Visualizer.tsx
+++ b/src/h5web/visualizer/Visualizer.tsx
@@ -45,9 +45,7 @@ function Visualizer<T extends VisDef>(props: Props<T>) {
         <ErrorBoundary
           resetKeys={[entity.path]}
           FallbackComponent={ErrorFallback}
-          onReset={() => {
-            valuesStore.evict({ path: entity.path });
-          }}
+          onError={() => valuesStore.evictCancelled()}
         >
           <Suspense fallback={<ValueLoader />}>
             <Profiler id={activeVis.name}>


### PR DESCRIPTION
Retrying a cancelled NeXus vis now works, but leads to a waterfall effect.

The calls to `valuesStore.prefetch` are located in `useNxData`, itself called from the NeXus vis containers. When the error boundary in the container resets, it re-renders its children, not the container itself, so the prefetches aren't triggered and the requests in the mapped vis happen sequential instead of in parallel.

I will fix this behaviour in my next PR by moving the prefetching down into the mapped vis.

---

**UPDATE**

The initial solution had problems with the slicing. The new solution is much better, as it's completely generic.

Everything is done in in the base class of the provider APIs; the containers' error boundaries no longer have to evict requests from the store by passing the right cache keys. The API remembers the params of the requests that have been cancelled and allows the `Provider` to access them so it can evict them from its `valuesStore`.

This solution has the following added benefits:

- It does not evict values from the store that may have been fetched successfully.
- The error boundaries of both core and NeXus containers all share the same code: an `onError` handler that calls the `evictCancelledValues` method from the `ProviderContext`. This means we can extract the code more easily than we had previously discussed, into a single shared `VisContainer`.