### PR TITLE
Move base `ProviderApi` in its own file and rename providers' API files

### DIFF
--- a/src/h5web/providers/Provider.tsx
+++ b/src/h5web/providers/Provider.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useMemo } from 'react';
 import { createFetchStore } from 'react-suspense-fetch';
-import { ProviderApi, ProviderContext } from './context';
+import { ProviderContext } from './context';
+import type { ProviderApi } from './api';
 import type { Entity } from './models';
 import { isGroup } from '../guards';
 

--- a/src/h5web/providers/api.ts
+++ b/src/h5web/providers/api.ts
@@ -1,0 +1,57 @@
+import axios, {
+  AxiosInstance,
+  AxiosRequestConfig,
+  AxiosResponse,
+  CancelTokenSource,
+} from 'axios';
+import { Entity, ProviderError, ValueRequestParams } from './models';
+
+interface ValueRequest {
+  params: ValueRequestParams;
+  cancelSource: CancelTokenSource;
+}
+
+export abstract class ProviderApi {
+  public readonly filepath: string;
+  public readonly cancelledValueRequests = new Set<ValueRequest>();
+
+  protected readonly client: AxiosInstance;
+  protected readonly valueRequests = new Set<ValueRequest>();
+
+  public constructor(filepath: string, config?: AxiosRequestConfig) {
+    this.filepath = filepath;
+    this.client = axios.create(config);
+  }
+
+  public cancelValueRequests(): void {
+    // Cancel every active value request
+    this.valueRequests.forEach((request) => {
+      request.cancelSource.cancel(ProviderError.Cancelled);
+
+      // Save request so params can later be evicted from the values store (cf. `Provider.tsx`)
+      this.cancelledValueRequests.add(request);
+    });
+
+    this.valueRequests.clear();
+  }
+
+  protected async cancellableFetchValue<T>(
+    endpoint: string,
+    params: ValueRequestParams
+  ): Promise<AxiosResponse<T>> {
+    const cancelSource = axios.CancelToken.source();
+    const request = { params, cancelSource };
+    this.valueRequests.add(request);
+
+    try {
+      const { token: cancelToken } = cancelSource;
+      return await this.client.get<T>(endpoint, { cancelToken });
+    } finally {
+      // Remove cancellation source when request fulfills
+      this.valueRequests.delete(request);
+    }
+  }
+
+  public abstract getEntity(path: string): Promise<Entity>;
+  public abstract getValue(params: ValueRequestParams): Promise<unknown>;
+}

--- a/src/h5web/providers/context.ts
+++ b/src/h5web/providers/context.ts
@@ -1,69 +1,6 @@
 import { createContext } from 'react';
-import { Entity, ProviderError } from './models';
+import type { Entity, ValueRequestParams } from './models';
 import type { FetchStore } from 'react-suspense-fetch';
-import axios, {
-  AxiosInstance,
-  AxiosRequestConfig,
-  CancelTokenSource,
-  AxiosResponse,
-} from 'axios';
-
-// https://github.com/microsoft/TypeScript/issues/15300#issuecomment-771916993
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-export type ValueRequestParams = {
-  path: string;
-  selection?: string;
-};
-
-interface ValueRequest {
-  params: ValueRequestParams;
-  cancelSource: CancelTokenSource;
-}
-
-export abstract class ProviderApi {
-  public readonly filepath: string;
-  public readonly cancelledValueRequests = new Set<ValueRequest>();
-
-  protected readonly client: AxiosInstance;
-  protected readonly valueRequests = new Set<ValueRequest>();
-
-  public constructor(filepath: string, config?: AxiosRequestConfig) {
-    this.filepath = filepath;
-    this.client = axios.create(config);
-  }
-
-  public cancelValueRequests(): void {
-    // Cancel every active value request
-    this.valueRequests.forEach((request) => {
-      request.cancelSource.cancel(ProviderError.Cancelled);
-
-      // Save request so params can later be evicted from the values store (cf. `Provider.tsx`)
-      this.cancelledValueRequests.add(request);
-    });
-
-    this.valueRequests.clear();
-  }
-
-  protected async cancellableFetchValue<T>(
-    endpoint: string,
-    params: ValueRequestParams
-  ): Promise<AxiosResponse<T>> {
-    const cancelSource = axios.CancelToken.source();
-    const request = { params, cancelSource };
-    this.valueRequests.add(request);
-
-    try {
-      const { token: cancelToken } = cancelSource;
-      return await this.client.get<T>(endpoint, { cancelToken });
-    } finally {
-      // Remove cancellation source when request fulfills
-      this.valueRequests.delete(request);
-    }
-  }
-
-  public abstract getEntity(path: string): Promise<Entity>;
-  public abstract getValue(params: ValueRequestParams): Promise<unknown>;
-}
 
 interface ValuesStore extends FetchStore<unknown, ValueRequestParams> {
   cancelOngoing: () => void;
@@ -76,4 +13,4 @@ interface Context {
   valuesStore: ValuesStore;
 }
 
-export const ProviderContext = createContext<Context>({} as Context);
+export const ProviderContext = createContext({} as Context);

--- a/src/h5web/providers/hsds/HsdsProvider.tsx
+++ b/src/h5web/providers/hsds/HsdsProvider.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useMemo } from 'react';
-import { HsdsApi } from './api';
+import { HsdsApi } from './hsds-api';
 import Provider from '../Provider';
 
 interface Props {

--- a/src/h5web/providers/hsds/hsds-api.ts
+++ b/src/h5web/providers/hsds/hsds-api.ts
@@ -13,6 +13,7 @@ import type {
   HsdsId,
 } from './models';
 import {
+  ValueRequestParams,
   Dataset,
   Datatype,
   Entity,
@@ -21,7 +22,7 @@ import {
   ProviderError,
 } from '../models';
 import { assertDefined, assertGroup } from '../../guards';
-import { ValueRequestParams, ProviderApi } from '../context';
+import { ProviderApi } from '../api';
 import {
   assertHsdsDataset,
   isHsdsGroup,

--- a/src/h5web/providers/jupyter/JupyterProvider.tsx
+++ b/src/h5web/providers/jupyter/JupyterProvider.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useMemo } from 'react';
-import { JupyterStableApi } from './api';
-import { JupyterDevApi } from './devApi';
+import { JupyterStableApi } from './jupyter-api';
+import { JupyterDevApi } from './jupyter-dev-api';
 import Provider from '../Provider';
 
 interface Props {

--- a/src/h5web/providers/jupyter/jupyter-api.ts
+++ b/src/h5web/providers/jupyter/jupyter-api.ts
@@ -1,5 +1,11 @@
-import { Group, Dataset, Entity, EntityKind } from '../models';
-import { ValueRequestParams, ProviderApi } from '../context';
+import {
+  ValueRequestParams,
+  Group,
+  Dataset,
+  Entity,
+  EntityKind,
+} from '../models';
+import { ProviderApi } from '../api';
 import {
   assertGroupContent,
   isDatasetResponse,

--- a/src/h5web/providers/jupyter/jupyter-dev-api.ts
+++ b/src/h5web/providers/jupyter/jupyter-dev-api.ts
@@ -1,5 +1,5 @@
-import { JupyterStableApi } from './api';
-import type { Attribute } from '../models';
+import { JupyterStableApi } from './jupyter-api';
+import type { ValueRequestParams, Attribute } from '../models';
 import type {
   JupyterBaseEntity,
   JupyterContentGroupResponse,
@@ -7,7 +7,6 @@ import type {
   JupyterMetaResponse,
 } from './models';
 import { assertGroupContent, convertDtype } from './utils';
-import type { ValueRequestParams } from '../context';
 
 interface DevJupyterAttrMeta {
   name: string;

--- a/src/h5web/providers/mock/MockProvider.tsx
+++ b/src/h5web/providers/mock/MockProvider.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useMemo } from 'react';
 import Provider from '../Provider';
-import { MockApi } from './api';
+import { MockApi } from './mock-api';
 
 interface Props {
   children: ReactNode;

--- a/src/h5web/providers/mock/mock-api.ts
+++ b/src/h5web/providers/mock/mock-api.ts
@@ -2,8 +2,8 @@ import axios from 'axios';
 import ndarray from 'ndarray';
 import unpack from 'ndarray-unpack';
 import { assertArrayShape, assertPrintableType } from '../../guards';
-import { ValueRequestParams, ProviderApi } from '../context';
-import type { Entity } from '../models';
+import { ProviderApi } from '../api';
+import type { ValueRequestParams, Entity } from '../models';
 import { mockFilepath } from './metadata';
 import { assertMockDataset, findMockEntity } from './utils';
 

--- a/src/h5web/providers/models.ts
+++ b/src/h5web/providers/models.ts
@@ -1,3 +1,13 @@
+export interface ValueRequestParams {
+  path: string;
+  selection?: string;
+}
+
+export enum ProviderError {
+  NotFound = 'Entity not found',
+  Cancelled = 'Request cancelled',
+}
+
 /* -------------------- */
 /* ----- ENTITIES ----- */
 
@@ -158,8 +168,3 @@ export type Value<D extends Dataset> = D['shape'] extends ScalarShape
 
 export type H5WebComplex = [number, number];
 export type ComplexArray = (ComplexArray | H5WebComplex)[];
-
-export enum ProviderError {
-  NotFound = 'Entity not found',
-  Cancelled = 'Request cancelled',
-}


### PR DESCRIPTION
Just a quick clean up of the `providers` folder.