### PR TITLE
Abstract values fetching out of mapped vis components

### DIFF
--- a/src/h5web/guards.ts
+++ b/src/h5web/guards.ts
@@ -14,7 +14,6 @@ import {
   StringType,
   BooleanType,
   ComplexType,
-  UnresolvedEntity,
   ComplexArray,
   H5WebComplex,
 } from './providers/models';
@@ -43,25 +42,9 @@ export function assertStr(
   }
 }
 
-export function assertOptionalStr(
-  val: unknown
-): asserts val is string | undefined {
-  if (val !== undefined) {
-    assertStr(val);
-  }
-}
-
 export function assertArray<T>(val: unknown): asserts val is T[] {
   if (!Array.isArray(val)) {
     throw new TypeError('Expected array');
-  }
-}
-
-export function assertOptionalArray<T>(
-  val: unknown
-): asserts val is T[] | undefined {
-  if (val !== undefined) {
-    assertArray<T>(val);
   }
 }
 
@@ -75,10 +58,6 @@ export function isDataset(entity: Entity): entity is Dataset {
 
 export function isDatatype(entity: Entity): entity is Datatype {
   return entity.kind === EntityKind.Datatype;
-}
-
-export function isUnresolvedEntity(entity: Entity): entity is UnresolvedEntity {
-  return entity.kind === EntityKind.Unresolved;
 }
 
 export function isScalarShape(shape: Shape): shape is ScalarShape {
@@ -120,7 +99,7 @@ export function hasPrintableType<S extends Shape>(
   ].includes(entity.type.class);
 }
 
-export function hasBoolType<S extends Shape>(
+function hasBoolType<S extends Shape>(
   dataset: Dataset<S>
 ): dataset is Dataset<S, BooleanType> {
   return dataset.type.class === DTypeClass.Bool;
@@ -132,7 +111,7 @@ export function hasComplexType<S extends Shape>(
   return dataset.type.class === DTypeClass.Complex;
 }
 
-export function hasStringType<S extends Shape>(
+function hasStringType<S extends Shape>(
   dataset: Dataset<S>
 ): dataset is Dataset<S, StringType> {
   return dataset.type.class === DTypeClass.String;
@@ -275,13 +254,6 @@ export function isH5WebComplex(
   complex: H5WebComplex | ComplexArray
 ): complex is H5WebComplex {
   return typeof complex[0] === 'number';
-}
-
-export function isComplexArray(
-  type: DType,
-  arr: NdArray<unknown>
-): arr is NdArray<H5WebComplex> {
-  return type.class === DTypeClass.Complex;
 }
 
 export function assertComplexType<S extends Shape>(

--- a/src/h5web/providers/jupyter/models.ts
+++ b/src/h5web/providers/jupyter/models.ts
@@ -17,13 +17,13 @@ export interface JupyterMetaGroupResponse extends JupyterMetaResponse {
   type: EntityKind.Group;
 }
 
-export interface JupyterContent {
+interface JupyterContent {
   type: EntityKind;
   name: string;
   uri: string;
 }
 
-export interface JupyterContentDatasetResponse extends JupyterContent {
+interface JupyterContentDatasetResponse extends JupyterContent {
   content: JupyterMetaDatasetResponse;
   type: EntityKind.Dataset;
 }

--- a/src/h5web/providers/jupyter/utils.ts
+++ b/src/h5web/providers/jupyter/utils.ts
@@ -34,14 +34,6 @@ export function isDatasetResponse(
   return response.type === EntityKind.Dataset;
 }
 
-export function assertGroupResponse(
-  response: JupyterMetaResponse
-): asserts response is JupyterMetaGroupResponse {
-  if (!isGroupResponse(response)) {
-    throw new Error('Expected group response');
-  }
-}
-
 export function assertGroupContent(
   contents: JupyterContentResponse
 ): asserts contents is JupyterContentGroupResponse {

--- a/src/h5web/providers/mock/metadata-utils.ts
+++ b/src/h5web/providers/mock/metadata-utils.ts
@@ -16,6 +16,7 @@ import {
   ComplexType,
   CompoundType,
   LinkClass,
+  UnresolvedEntity,
 } from '../models';
 import type { NxInterpretation, SilxStyle } from '../../vis-packs/nexus/models';
 import { isGroup } from '../../guards';
@@ -196,7 +197,7 @@ export function makeUnresolvedEntity(
   linkClass: LinkClass,
   pathToEntity?: string,
   file?: string
-): Entity {
+): UnresolvedEntity {
   return {
     name,
     path: `/${name}`,

--- a/src/h5web/providers/models.ts
+++ b/src/h5web/providers/models.ts
@@ -50,7 +50,7 @@ export interface UnresolvedEntity extends Entity {
 }
 
 export type LinkClass = 'Hard' | 'Soft' | 'External';
-export interface Link {
+interface Link {
   class: LinkClass;
   path?: string;
   file?: string;

--- a/src/h5web/vis-packs/core/ValueFetcher.tsx
+++ b/src/h5web/vis-packs/core/ValueFetcher.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react';
+import type { DimensionMapping } from '../../dimension-mapper/models';
+import type { Dataset, Value } from '../../providers/models';
+import { useDatasetValue } from './hooks';
+
+interface Props<D extends Dataset> {
+  dataset: D;
+  dimMapping?: DimensionMapping; // for slice-by-slice fetching
+  render: (val: Value<D>) => ReactNode;
+}
+
+function ValueFetcher<D extends Dataset>(props: Props<D>) {
+  const { dataset, dimMapping, render } = props;
+
+  const value = useDatasetValue(dataset, dimMapping);
+  return <>{render(value)}</>;
+}
+
+export default ValueFetcher;

--- a/src/h5web/vis-packs/core/VisBoundary.tsx
+++ b/src/h5web/vis-packs/core/VisBoundary.tsx
@@ -1,0 +1,30 @@
+import { ReactNode, Suspense, useContext } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+import { ProviderContext } from '../../providers/context';
+import ErrorFallback from '../../visualizer/ErrorFallback';
+import ValueLoader from '../../visualizer/ValueLoader';
+
+interface Props {
+  resetKey: unknown;
+  loadingMessage?: string;
+  children: ReactNode;
+}
+
+function VisBoundary(props: Props) {
+  const { resetKey, loadingMessage, children } = props;
+  const { valuesStore } = useContext(ProviderContext);
+
+  return (
+    <ErrorBoundary
+      resetKeys={[resetKey]}
+      FallbackComponent={ErrorFallback}
+      onError={() => valuesStore.evictCancelled()}
+    >
+      <Suspense fallback={<ValueLoader message={loadingMessage} />}>
+        {children}
+      </Suspense>
+    </ErrorBoundary>
+  );
+}
+
+export default VisBoundary;

--- a/src/h5web/vis-packs/core/complex/MappedComplexVis.tsx
+++ b/src/h5web/vis-packs/core/complex/MappedComplexVis.tsx
@@ -1,45 +1,34 @@
 import { useEffect, useMemo } from 'react';
-import { useDatasetValue, useMappedArray } from '../hooks';
-import type { ScaleType } from '../models';
+import { useMappedArray } from '../hooks';
+import type { AxisMapping, ScaleType } from '../models';
 import type { DimensionMapping } from '../../../dimension-mapper/models';
 import { isAxis } from '../../../dimension-mapper/utils';
 import shallow from 'zustand/shallow';
 import { useSafeDomain, useVisDomain } from '../heatmap/hooks';
-import type {
-  ArrayShape,
-  ComplexType,
-  Dataset,
-  ScalarShape,
-  StringType,
-} from '../../../providers/models';
+import type { H5WebComplex } from '../../../providers/models';
 import { usePhaseAmplitude } from './hooks';
 import HeatmapVis from '../heatmap/HeatmapVis';
 import { DEFAULT_DOMAIN } from '../utils';
 import { ComplexVisType } from './models';
 import { useComplexConfig } from './config';
 import { useHeatmapConfig } from '../heatmap/config';
-import { useAxisMapping } from '../../nexus/hooks';
-import type { AxisDatasetMapping } from '../../nexus/models';
-import { getDatasetLabel } from '../../nexus/utils';
 
 interface Props {
-  dataset: Dataset<ArrayShape, ComplexType>;
+  value: H5WebComplex[];
   dims: number[];
   dimMapping: DimensionMapping;
-  titleDataset?: Dataset<ScalarShape, StringType>;
-  axisDatasets?: AxisDatasetMapping;
+  axisMapping?: AxisMapping;
+  title: string;
   colorScaleType?: ScaleType;
-  axisScaleTypes?: ScaleType[];
 }
 
 function MappedComplexVis(props: Props) {
   const {
-    dataset,
+    value,
     dims,
     dimMapping,
-    axisDatasets = [],
-    titleDataset,
-    axisScaleTypes,
+    axisMapping = [],
+    title,
     colorScaleType,
   } = props;
 
@@ -55,11 +44,6 @@ function MappedComplexVis(props: Props) {
   } = useHeatmapConfig((state) => state, shallow);
 
   const { visType } = useComplexConfig((state) => state, shallow);
-
-  const value = useDatasetValue(dataset, dimMapping);
-
-  const title = useDatasetValue(titleDataset) || getDatasetLabel(dataset);
-  const axisMapping = useAxisMapping(axisDatasets, axisScaleTypes);
 
   const [slicedDims, slicedMapping] = useMemo(
     () => [

--- a/src/h5web/vis-packs/core/containers/ComplexVisContainer.tsx
+++ b/src/h5web/vis-packs/core/containers/ComplexVisContainer.tsx
@@ -1,4 +1,3 @@
-import { Suspense, useContext } from 'react';
 import {
   assertDataset,
   assertMinDims,
@@ -7,12 +6,10 @@ import {
 } from '../../../guards';
 import type { VisContainerProps } from '../../models';
 import { useDimMappingState } from '../../hooks';
-import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
-import ValueLoader from '../../../visualizer/ValueLoader';
 import MappedComplexVis from '../complex/MappedComplexVis';
-import { ErrorBoundary } from 'react-error-boundary';
-import ErrorFallback from '../../../visualizer/ErrorFallback';
-import { ProviderContext } from '../../../providers/context';
+import VisBoundary from '../VisBoundary';
+import ValueFetcher from '../ValueFetcher';
+import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 
 function ComplexVisContainer(props: VisContainerProps) {
   const { entity } = props;
@@ -24,8 +21,6 @@ function ComplexVisContainer(props: VisContainerProps) {
   const { shape: dims } = entity;
   const [dimMapping, setDimMapping] = useDimMappingState(dims, 2);
 
-  const { valuesStore } = useContext(ProviderContext);
-
   return (
     <>
       <DimensionMapper
@@ -33,19 +28,20 @@ function ComplexVisContainer(props: VisContainerProps) {
         mapperState={dimMapping}
         onChange={setDimMapping}
       />
-      <ErrorBoundary
-        resetKeys={[dimMapping]}
-        FallbackComponent={ErrorFallback}
-        onError={() => valuesStore.evictCancelled()}
-      >
-        <Suspense fallback={<ValueLoader message="Loading current slice" />}>
-          <MappedComplexVis
-            dataset={entity}
-            dims={dims}
-            dimMapping={dimMapping}
-          />
-        </Suspense>
-      </ErrorBoundary>
+      <VisBoundary resetKey={dimMapping} loadingMessage="Loading current slice">
+        <ValueFetcher
+          dataset={entity}
+          dimMapping={dimMapping}
+          render={(value) => (
+            <MappedComplexVis
+              value={value}
+              dims={dims}
+              dimMapping={dimMapping}
+              title={entity.name}
+            />
+          )}
+        />
+      </VisBoundary>
     </>
   );
 }

--- a/src/h5web/vis-packs/core/containers/HeatmapVisContainer.tsx
+++ b/src/h5web/vis-packs/core/containers/HeatmapVisContainer.tsx
@@ -1,4 +1,3 @@
-import { Suspense, useContext } from 'react';
 import {
   assertDataset,
   assertMinDims,
@@ -8,11 +7,9 @@ import {
 import MappedHeatmapVis from '../heatmap/MappedHeatmapVis';
 import type { VisContainerProps } from '../../models';
 import { useDimMappingState } from '../../hooks';
+import VisBoundary from '../VisBoundary';
+import ValueFetcher from '../ValueFetcher';
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
-import ValueLoader from '../../../visualizer/ValueLoader';
-import { ErrorBoundary } from 'react-error-boundary';
-import ErrorFallback from '../../../visualizer/ErrorFallback';
-import { ProviderContext } from '../../../providers/context';
 
 function HeatmapVisContainer(props: VisContainerProps) {
   const { entity } = props;
@@ -24,8 +21,6 @@ function HeatmapVisContainer(props: VisContainerProps) {
   const { shape: dims } = entity;
   const [dimMapping, setDimMapping] = useDimMappingState(dims, 2);
 
-  const { valuesStore } = useContext(ProviderContext);
-
   return (
     <>
       <DimensionMapper
@@ -33,19 +28,20 @@ function HeatmapVisContainer(props: VisContainerProps) {
         mapperState={dimMapping}
         onChange={setDimMapping}
       />
-      <ErrorBoundary
-        resetKeys={[dimMapping]}
-        FallbackComponent={ErrorFallback}
-        onError={() => valuesStore.evictCancelled()}
-      >
-        <Suspense fallback={<ValueLoader message="Loading current slice" />}>
-          <MappedHeatmapVis
-            dataset={entity}
-            dims={dims}
-            dimMapping={dimMapping}
-          />
-        </Suspense>
-      </ErrorBoundary>
+      <VisBoundary resetKey={dimMapping} loadingMessage="Loading current slice">
+        <ValueFetcher
+          dataset={entity}
+          dimMapping={dimMapping}
+          render={(value) => (
+            <MappedHeatmapVis
+              value={value}
+              dims={dims}
+              dimMapping={dimMapping}
+              title={entity.name}
+            />
+          )}
+        />
+      </VisBoundary>
     </>
   );
 }

--- a/src/h5web/vis-packs/core/containers/RawVisContainer.tsx
+++ b/src/h5web/vis-packs/core/containers/RawVisContainer.tsx
@@ -1,15 +1,22 @@
 import RawVis from '../raw/RawVis';
 import type { VisContainerProps } from '../../models';
-import { useDatasetValue } from '../hooks';
 import { assertDataset, assertNonNullShape } from '../../../guards';
+import VisBoundary from '../VisBoundary';
+import ValueFetcher from '../ValueFetcher';
 
 function RawVisContainer(props: VisContainerProps) {
   const { entity } = props;
   assertDataset(entity);
   assertNonNullShape(entity);
 
-  const value = useDatasetValue(entity);
-  return <RawVis value={value} />;
+  return (
+    <VisBoundary resetKey={entity}>
+      <ValueFetcher
+        dataset={entity}
+        render={(value) => <RawVis value={value} />}
+      />
+    </VisBoundary>
+  );
 }
 
 export default RawVisContainer;

--- a/src/h5web/vis-packs/core/containers/ScalarVisContainer.tsx
+++ b/src/h5web/vis-packs/core/containers/ScalarVisContainer.tsx
@@ -1,13 +1,13 @@
 import ScalarVis from '../scalar/ScalarVis';
-import { useDatasetValue } from '../hooks';
 import {
   assertPrintableType,
   assertDataset,
   assertScalarShape,
-  isComplexValue,
 } from '../../../guards';
 import type { VisContainerProps } from '../../models';
-import { formatComplex } from '../../../utils';
+import { getFormatter } from '../scalar/utils';
+import ValueFetcher from '../ValueFetcher';
+import VisBoundary from '../VisBoundary';
 
 function ScalarVisContainer(props: VisContainerProps) {
   const { entity } = props;
@@ -15,13 +15,16 @@ function ScalarVisContainer(props: VisContainerProps) {
   assertScalarShape(entity);
   assertPrintableType(entity);
 
-  const value = useDatasetValue(entity);
+  const formatter = getFormatter(entity);
 
-  if (isComplexValue(entity.type, value)) {
-    return <ScalarVis value={value} formatter={formatComplex} />;
-  }
-
-  return <ScalarVis value={value} formatter={() => value.toString()} />;
+  return (
+    <VisBoundary resetKey={entity}>
+      <ValueFetcher
+        dataset={entity}
+        render={(value) => <ScalarVis value={value} formatter={formatter} />}
+      />
+    </VisBoundary>
+  );
 }
 
 export default ScalarVisContainer;

--- a/src/h5web/vis-packs/core/heatmap/MappedHeatmapVis.tsx
+++ b/src/h5web/vis-packs/core/heatmap/MappedHeatmapVis.tsx
@@ -1,41 +1,30 @@
 import { useEffect, useMemo } from 'react';
 import HeatmapVis from './HeatmapVis';
-import { useDomain, useDatasetValue, useMappedArray } from '../hooks';
+import { useDomain, useMappedArray } from '../hooks';
 import { useHeatmapConfig } from './config';
-import type { ScaleType } from '../models';
+import type { AxisMapping, ScaleType } from '../models';
 import { DEFAULT_DOMAIN } from '../utils';
 import type { DimensionMapping } from '../../../dimension-mapper/models';
 import { isAxis } from '../../../dimension-mapper/utils';
 import shallow from 'zustand/shallow';
 import { useSafeDomain, useVisDomain } from './hooks';
-import type {
-  Dataset,
-  NumArrayDataset,
-  ScalarShape,
-  StringType,
-} from '../../../providers/models';
-import { useAxisMapping } from '../../nexus/hooks';
-import { getDatasetLabel } from '../../nexus/utils';
-import type { AxisDatasetMapping } from '../../nexus/models';
 
 interface Props {
-  dataset: NumArrayDataset;
+  value: number[];
   dims: number[];
   dimMapping: DimensionMapping;
-  titleDataset?: Dataset<ScalarShape, StringType>;
-  axisDatasets?: AxisDatasetMapping;
+  axisMapping?: AxisMapping;
+  title: string;
   colorScaleType?: ScaleType;
-  axisScaleTypes?: ScaleType[];
 }
 
 function MappedHeatmapVis(props: Props) {
   const {
-    dataset,
+    value,
     dims,
     dimMapping,
-    axisDatasets = [],
-    titleDataset,
-    axisScaleTypes,
+    axisMapping = [],
+    title,
     colorScaleType,
   } = props;
 
@@ -49,11 +38,6 @@ function MappedHeatmapVis(props: Props) {
     setScaleType,
     invertColorMap,
   } = useHeatmapConfig((state) => state, shallow);
-
-  const value = useDatasetValue(dataset, dimMapping);
-
-  const title = useDatasetValue(titleDataset) || getDatasetLabel(dataset);
-  const axisMapping = useAxisMapping(axisDatasets, axisScaleTypes);
 
   const [slicedDims, slicedMapping] = useMemo(
     () => [

--- a/src/h5web/vis-packs/core/hooks.ts
+++ b/src/h5web/vis-packs/core/hooks.ts
@@ -18,10 +18,15 @@ import { AxisScale, ScaleType } from './models';
 import { ProviderContext } from '../../providers/context';
 import type { Dataset, Value } from '../../providers/models';
 
-export function useDatasetValue<D extends Dataset | undefined>(
+export function useDatasetValue<D extends Dataset>(
   dataset: D,
   dimMapping?: DimensionMapping
-): D extends Dataset ? Value<D> : undefined;
+): Value<D>;
+
+export function useDatasetValue<D extends Dataset>(
+  dataset: D | undefined,
+  dimMapping?: DimensionMapping
+): Value<D> | undefined;
 
 export function useDatasetValue(
   dataset: Dataset | undefined,

--- a/src/h5web/vis-packs/core/line/MappedLineVis.tsx
+++ b/src/h5web/vis-packs/core/line/MappedLineVis.tsx
@@ -2,8 +2,6 @@ import { useEffect } from 'react';
 import shallow from 'zustand/shallow';
 import LineVis from './LineVis';
 import {
-  useDatasetValue,
-  useDatasetValues,
   useCombinedDomain,
   useMappedArrays,
   useMappedArray,
@@ -11,44 +9,34 @@ import {
   useDomains,
 } from '../hooks';
 import { useLineConfig } from './config';
-import type { ScaleType } from '../models';
+import type { AxisMapping, ScaleType } from '../models';
 import type { DimensionMapping } from '../../../dimension-mapper/models';
-import type {
-  Dataset,
-  NumArrayDataset,
-  ScalarShape,
-  StringType,
-} from '../../../providers/models';
-import { useAxisMapping } from '../../nexus/hooks';
-import type { AxisDatasetMapping } from '../../nexus/models';
 
 type HookArgs = [number[], DimensionMapping, boolean];
 
 interface Props {
-  valueDataset: NumArrayDataset;
+  value: number[];
   valueLabel?: string;
   valueScaleType?: ScaleType;
-  errorsDataset?: NumArrayDataset;
-  auxDatasets?: NumArrayDataset[];
+  errors?: number[];
+  auxiliaries?: number[][];
   dims: number[];
   dimMapping: DimensionMapping;
-  titleDataset?: Dataset<ScalarShape, StringType>;
-  axisDatasets?: AxisDatasetMapping;
-  axisScaleTypes?: ScaleType[];
+  axisMapping?: AxisMapping;
+  title: string;
 }
 
 function MappedLineVis(props: Props) {
   const {
-    valueDataset,
+    value,
     valueLabel,
     valueScaleType,
-    errorsDataset,
-    auxDatasets = [],
+    errors,
+    auxiliaries = [],
     dims,
     dimMapping,
-    titleDataset,
-    axisDatasets = [],
-    axisScaleTypes,
+    axisMapping = [],
+    title,
   } = props;
 
   const {
@@ -65,19 +53,9 @@ function MappedLineVis(props: Props) {
   } = useLineConfig((state) => state, shallow);
 
   const hookArgs: HookArgs = [dims, dimMapping, autoScale];
-
-  const value = useDatasetValue(valueDataset);
   const [dataArray, dataForDomain] = useMappedArray(value, ...hookArgs);
-
-  const errors = useDatasetValue(errorsDataset);
   const [errorArray, errorsForDomain] = useMappedArray(errors, ...hookArgs);
-
-  const auxiliaries = Object.values(useDatasetValues(auxDatasets));
   const [auxArrays, auxForDomain] = useMappedArrays(auxiliaries, ...hookArgs);
-
-  const title =
-    useDatasetValue(titleDataset) || valueLabel || valueDataset.name;
-  const axisMapping = useAxisMapping(axisDatasets, axisScaleTypes);
 
   const dataDomain = useDomain(
     dataForDomain,

--- a/src/h5web/vis-packs/core/matrix/MappedMatrixVis.tsx
+++ b/src/h5web/vis-packs/core/matrix/MappedMatrixVis.tsx
@@ -1,24 +1,21 @@
 import { useMemo } from 'react';
 import MatrixVis from './MatrixVis';
-import { useDatasetValue, useMappedArray } from '../hooks';
+import { useMappedArray } from '../hooks';
 import type { DimensionMapping } from '../../../dimension-mapper/models';
-import type { Dataset, ArrayShape } from '../../../providers/models';
+import type { Primitive } from '../../../providers/models';
 import { isAxis } from '../../../dimension-mapper/utils';
 import type { PrintableType } from '../models';
-import { format } from 'd3-format';
-import { isComplexArray } from '../../../guards';
-import { renderComplex } from '../../../metadata-viewer/utils';
 
 interface Props {
-  dataset: Dataset<ArrayShape, PrintableType>;
+  value: Primitive<PrintableType>[];
   dims: number[];
   dimMapping: DimensionMapping;
+  formatter: (value: Primitive<PrintableType>) => string;
+  cellWidth: number;
 }
 
 function MappedMatrixVis(props: Props) {
-  const { dataset, dims, dimMapping } = props;
-
-  const value = useDatasetValue(dataset, dimMapping);
+  const { value, dims, dimMapping, formatter, cellWidth } = props;
 
   const [slicedDims, slicedMapping] = useMemo(
     () => [
@@ -30,25 +27,11 @@ function MappedMatrixVis(props: Props) {
 
   const [mappedArray] = useMappedArray(value, slicedDims, slicedMapping);
 
-  if (isComplexArray(dataset.type, mappedArray)) {
-    return (
-      <MatrixVis
-        dataArray={mappedArray}
-        formatter={(dataValue) => renderComplex(dataValue, '.2e')}
-        cellWidth={232} // To accommodate the longer complex numbers
-      />
-    );
-  }
-
   return (
     <MatrixVis
       dataArray={mappedArray}
-      formatter={(dataValue) => {
-        return typeof dataValue === 'number'
-          ? format('.3e')(dataValue)
-          : dataValue.toString();
-      }}
-      cellWidth={116}
+      formatter={formatter}
+      cellWidth={cellWidth}
     />
   );
 }

--- a/src/h5web/vis-packs/core/matrix/MatrixVis.tsx
+++ b/src/h5web/vis-packs/core/matrix/MatrixVis.tsx
@@ -11,13 +11,13 @@ import type { PrintableType } from '../models';
 
 const CELL_HEIGHT = 32;
 
-interface Props<T> {
-  dataArray: NdArray<T>;
-  formatter: (value: T) => string;
+interface Props {
+  dataArray: NdArray<Primitive<PrintableType>>;
+  formatter: (value: Primitive<PrintableType>) => string;
   cellWidth: number;
 }
 
-function MatrixVis<T extends Primitive<PrintableType>>(props: Props<T>) {
+function MatrixVis(props: Props) {
   const { dataArray, formatter, cellWidth } = props;
   const dims = dataArray.shape;
 

--- a/src/h5web/vis-packs/core/matrix/utils.ts
+++ b/src/h5web/vis-packs/core/matrix/utils.ts
@@ -1,0 +1,23 @@
+import { hasComplexType, hasNumericType } from '../../../guards';
+import { renderComplex } from '../../../metadata-viewer/utils';
+import type {
+  ArrayShape,
+  Dataset,
+  H5WebComplex,
+} from '../../../providers/models';
+import type { PrintableType, ValueFormatter } from '../models';
+import { formatNumber } from '../utils';
+
+export function getFormatter(
+  dataset: Dataset<ArrayShape, PrintableType>
+): ValueFormatter<PrintableType> {
+  if (hasComplexType(dataset)) {
+    return (val) => renderComplex(val as H5WebComplex, '.2e');
+  }
+
+  if (hasNumericType(dataset)) {
+    return (val) => formatNumber(val as number);
+  }
+
+  return (val) => (val as string).toString();
+}

--- a/src/h5web/vis-packs/core/models.ts
+++ b/src/h5web/vis-packs/core/models.ts
@@ -4,6 +4,8 @@ import type {
   StringType,
   BooleanType,
   ComplexType,
+  DType,
+  Primitive,
 } from '../../providers/models';
 
 export enum ScaleType {
@@ -78,3 +80,5 @@ export type PrintableType =
   | NumericType
   | ComplexType
   | StringType;
+
+export type ValueFormatter<T extends DType> = (val: Primitive<T>) => string;

--- a/src/h5web/vis-packs/core/scalar/ScalarVis.tsx
+++ b/src/h5web/vis-packs/core/scalar/ScalarVis.tsx
@@ -2,12 +2,12 @@ import type { Primitive } from '../../../providers/models';
 import type { PrintableType } from '../models';
 import styles from './ScalarVis.module.css';
 
-interface Props<T extends Primitive<PrintableType> = Primitive<PrintableType>> {
-  value: T;
-  formatter: (value: T) => string;
+interface Props {
+  value: Primitive<PrintableType>;
+  formatter: (value: Primitive<PrintableType>) => string;
 }
 
-function ScalarVis<T extends Primitive<PrintableType>>(props: Props<T>) {
+function ScalarVis(props: Props) {
   const { value, formatter } = props;
   return <div className={styles.scalar}>{formatter(value)}</div>;
 }

--- a/src/h5web/vis-packs/core/scalar/utils.ts
+++ b/src/h5web/vis-packs/core/scalar/utils.ts
@@ -1,0 +1,18 @@
+import { hasComplexType } from '../../../guards';
+import type {
+  ArrayShape,
+  Dataset,
+  H5WebComplex,
+} from '../../../providers/models';
+import { formatComplex } from '../../../utils';
+import type { PrintableType, ValueFormatter } from '../models';
+
+export function getFormatter(
+  dataset: Dataset<ArrayShape, PrintableType>
+): ValueFormatter<PrintableType> {
+  if (hasComplexType(dataset)) {
+    return (val) => formatComplex(val as H5WebComplex);
+  }
+
+  return (val) => (val as number | string | boolean).toString();
+}

--- a/src/h5web/vis-packs/core/utils.ts
+++ b/src/h5web/vis-packs/core/utils.ts
@@ -23,7 +23,8 @@ import {
 import { assertDataLength, isDefined } from '../../guards';
 import { isAxis } from '../../dimension-mapper/utils';
 
-const TICK_FORMAT = format('0');
+const formatTick = format('0');
+export const formatNumber = format('.3e');
 
 export const DEFAULT_DOMAIN: Domain = [0.1, 1];
 
@@ -258,20 +259,20 @@ export function getTickFormatter(
   scaleType: ScaleType
 ): (val: number | { valueOf(): number }) => string {
   if (scaleType !== ScaleType.Log) {
-    return TICK_FORMAT;
+    return formatTick;
   }
 
   // If available size allows for all log ticks to be rendered without overlap, use default formatter
   const [min, max] = domain[0] > 0 ? domain : [-domain[1], -[domain[0]]];
   const threshold = adaptedLogTicksThreshold(availableSize);
   if (max / min < 10 ** threshold) {
-    return TICK_FORMAT;
+    return formatTick;
   }
 
   // Otherwise, use formatter that hides non-exact powers of 10
   return (val) => {
     const loggedVal = Math.log10(Math.abs(val.valueOf()));
-    return loggedVal === Math.floor(loggedVal) ? TICK_FORMAT(val) : ''; // eslint-disable-line new-cap
+    return loggedVal === Math.floor(loggedVal) ? formatTick(val) : '';
   };
 }
 

--- a/src/h5web/vis-packs/nexus/NxValuesFetcher.tsx
+++ b/src/h5web/vis-packs/nexus/NxValuesFetcher.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from 'react';
+import type { DimensionMapping } from '../../dimension-mapper/models';
+import { useDatasetValue, useDatasetValues } from '../core/hooks';
+import { useAxisMapping } from './hooks';
+import type { NxData, NxValues } from './models';
+
+interface Props {
+  nxData: NxData;
+  dimMapping?: DimensionMapping; // for slice-by-slice fetching
+  render: (val: NxValues) => ReactNode;
+}
+
+function NxValuesFetcher(props: Props) {
+  const { nxData, dimMapping, render } = props;
+  const {
+    signalDataset,
+    errorsDataset,
+    axisDatasets,
+    auxDatasets,
+    titleDataset,
+    silxStyle,
+  } = nxData;
+
+  const signal = useDatasetValue(signalDataset, dimMapping);
+  const errors = useDatasetValue(errorsDataset);
+  const axisMapping = useAxisMapping(axisDatasets, silxStyle.axisScaleTypes);
+  const auxiliaries = Object.values(useDatasetValues(auxDatasets));
+  const title = useDatasetValue(titleDataset);
+
+  return <>{render({ signal, errors, axisMapping, auxiliaries, title })}</>;
+}
+
+export default NxValuesFetcher;

--- a/src/h5web/vis-packs/nexus/containers/NxComplexContainer.tsx
+++ b/src/h5web/vis-packs/nexus/containers/NxComplexContainer.tsx
@@ -1,14 +1,13 @@
-import { Suspense, useContext } from 'react';
 import { assertComplexType, assertGroup, assertMinDims } from '../../../guards';
 import type { VisContainerProps } from '../../models';
 import { useNxData } from '../hooks';
 import { useDimMappingState } from '../../hooks';
-import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
-import ValueLoader from '../../../visualizer/ValueLoader';
-import { ErrorBoundary } from 'react-error-boundary';
-import ErrorFallback from '../../../visualizer/ErrorFallback';
-import { ProviderContext } from '../../../providers/context';
 import MappedComplexVis from '../../core/complex/MappedComplexVis';
+import VisBoundary from '../../core/VisBoundary';
+import NxValuesFetcher from '../NxValuesFetcher';
+import type { H5WebComplex } from '../../../providers/models';
+import { getDatasetLabel } from '../utils';
+import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 
 function NxComplexContainer(props: VisContainerProps) {
   const { entity } = props;
@@ -16,15 +15,12 @@ function NxComplexContainer(props: VisContainerProps) {
 
   const nxData = useNxData(entity);
 
-  const { signalDataset, titleDataset, axisDatasets, silxStyle } = nxData;
-  const { axisScaleTypes, signalScaleType } = silxStyle;
+  const { signalDataset, silxStyle } = nxData;
   assertComplexType(signalDataset);
   assertMinDims(signalDataset, 2);
 
   const { shape: dims } = signalDataset;
   const [dimMapping, setDimMapping] = useDimMappingState(dims, 2);
-
-  const { valuesStore } = useContext(ProviderContext);
 
   return (
     <>
@@ -33,23 +29,25 @@ function NxComplexContainer(props: VisContainerProps) {
         mapperState={dimMapping}
         onChange={setDimMapping}
       />
-      <ErrorBoundary
-        resetKeys={[dimMapping]}
-        FallbackComponent={ErrorFallback}
-        onError={() => valuesStore.evictCancelled()}
-      >
-        <Suspense fallback={<ValueLoader />}>
-          <MappedComplexVis
-            dataset={signalDataset}
-            dims={dims}
-            dimMapping={dimMapping}
-            axisDatasets={axisDatasets}
-            titleDataset={titleDataset}
-            colorScaleType={signalScaleType}
-            axisScaleTypes={axisScaleTypes}
-          />
-        </Suspense>
-      </ErrorBoundary>
+      <VisBoundary resetKey={dimMapping}>
+        <NxValuesFetcher
+          nxData={nxData}
+          dimMapping={dimMapping}
+          render={(nxValues) => {
+            const { signal, axisMapping, title } = nxValues;
+            return (
+              <MappedComplexVis
+                value={signal as H5WebComplex[]}
+                dims={dims}
+                dimMapping={dimMapping}
+                axisMapping={axisMapping}
+                title={title || getDatasetLabel(signalDataset)}
+                colorScaleType={silxStyle.signalScaleType}
+              />
+            );
+          }}
+        />
+      </VisBoundary>
     </>
   );
 }

--- a/src/h5web/vis-packs/nexus/containers/NxImageContainer.tsx
+++ b/src/h5web/vis-packs/nexus/containers/NxImageContainer.tsx
@@ -1,14 +1,12 @@
-import { Suspense, useContext } from 'react';
 import { assertGroup, assertMinDims, assertNumericType } from '../../../guards';
 import type { VisContainerProps } from '../../models';
 import MappedHeatmapVis from '../../core/heatmap/MappedHeatmapVis';
 import { useNxData } from '../hooks';
 import { useDimMappingState } from '../../hooks';
+import VisBoundary from '../../core/VisBoundary';
+import NxValuesFetcher from '../NxValuesFetcher';
+import { getDatasetLabel } from '../utils';
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
-import ValueLoader from '../../../visualizer/ValueLoader';
-import { ErrorBoundary } from 'react-error-boundary';
-import ErrorFallback from '../../../visualizer/ErrorFallback';
-import { ProviderContext } from '../../../providers/context';
 
 function NxImageContainer(props: VisContainerProps) {
   const { entity } = props;
@@ -16,15 +14,12 @@ function NxImageContainer(props: VisContainerProps) {
 
   const nxData = useNxData(entity);
 
-  const { signalDataset, titleDataset, axisDatasets, silxStyle } = nxData;
-  const { axisScaleTypes, signalScaleType } = silxStyle;
+  const { signalDataset, silxStyle } = nxData;
   assertNumericType(signalDataset);
   assertMinDims(signalDataset, 2);
 
   const { shape: dims } = signalDataset;
   const [dimMapping, setDimMapping] = useDimMappingState(dims, 2);
-
-  const { valuesStore } = useContext(ProviderContext);
 
   return (
     <>
@@ -33,23 +28,25 @@ function NxImageContainer(props: VisContainerProps) {
         mapperState={dimMapping}
         onChange={setDimMapping}
       />
-      <ErrorBoundary
-        resetKeys={[dimMapping]}
-        FallbackComponent={ErrorFallback}
-        onError={() => valuesStore.evictCancelled()}
-      >
-        <Suspense fallback={<ValueLoader />}>
-          <MappedHeatmapVis
-            dataset={signalDataset}
-            dims={dims}
-            dimMapping={dimMapping}
-            axisDatasets={axisDatasets}
-            titleDataset={titleDataset}
-            colorScaleType={signalScaleType}
-            axisScaleTypes={axisScaleTypes}
-          />
-        </Suspense>
-      </ErrorBoundary>
+      <VisBoundary resetKey={dimMapping}>
+        <NxValuesFetcher
+          nxData={nxData}
+          dimMapping={dimMapping}
+          render={(nxValues) => {
+            const { signal, axisMapping, title } = nxValues;
+            return (
+              <MappedHeatmapVis
+                value={signal as number[]}
+                dims={dims}
+                dimMapping={dimMapping}
+                axisMapping={axisMapping}
+                title={title || getDatasetLabel(signalDataset)}
+                colorScaleType={silxStyle.signalScaleType}
+              />
+            );
+          }}
+        />
+      </VisBoundary>
     </>
   );
 }

--- a/src/h5web/vis-packs/nexus/models.ts
+++ b/src/h5web/vis-packs/nexus/models.ts
@@ -2,12 +2,13 @@ import type {
   ArrayShape,
   ComplexType,
   Dataset,
+  H5WebComplex,
   NumArrayDataset,
   NumericType,
   ScalarShape,
   StringType,
 } from '../../providers/models';
-import type { ScaleType } from '../core/models';
+import type { AxisMapping, ScaleType } from '../core/models';
 
 export type NxAttribute =
   | 'NX_class'
@@ -28,10 +29,18 @@ export enum NxInterpretation {
 export interface NxData {
   signalDataset: Dataset<ArrayShape, NumericType | ComplexType>;
   errorsDataset?: NumArrayDataset;
-  titleDataset?: Dataset<ScalarShape, StringType>;
   axisDatasets: AxisDatasetMapping;
-  silxStyle: SilxStyle;
   auxDatasets: NumArrayDataset[];
+  titleDataset?: Dataset<ScalarShape, StringType>;
+  silxStyle: SilxStyle;
+}
+
+export interface NxValues {
+  signal: (number | H5WebComplex)[];
+  errors?: number[];
+  axisMapping: AxisMapping;
+  auxiliaries?: number[][];
+  title?: string;
 }
 
 export type AxisDatasetMapping = (NumArrayDataset | undefined)[];

--- a/src/h5web/visualizer/Visualizer.tsx
+++ b/src/h5web/visualizer/Visualizer.tsx
@@ -1,13 +1,8 @@
-import { Suspense, useContext } from 'react';
-import { ErrorBoundary } from 'react-error-boundary';
 import Profiler from '../Profiler';
 import type { Entity } from '../providers/models';
-import ErrorFallback from './ErrorFallback';
 import type { VisDef } from '../vis-packs/models';
-import ValueLoader from './ValueLoader';
 import VisSelector from './VisSelector';
 import styles from './Visualizer.module.css';
-import { ProviderContext } from '../providers/context';
 
 interface Props<T extends VisDef> {
   entity: Entity;
@@ -18,7 +13,6 @@ interface Props<T extends VisDef> {
 
 function Visualizer<T extends VisDef>(props: Props<T>) {
   const { entity, activeVis, supportedVis, onActiveVisChange } = props;
-  const { valuesStore } = useContext(ProviderContext);
 
   if (!activeVis) {
     return (
@@ -42,17 +36,9 @@ function Visualizer<T extends VisDef>(props: Props<T>) {
       </div>
 
       <div className={styles.displayArea}>
-        <ErrorBoundary
-          resetKeys={[entity.path]}
-          FallbackComponent={ErrorFallback}
-          onError={() => valuesStore.evictCancelled()}
-        >
-          <Suspense fallback={<ValueLoader />}>
-            <Profiler id={activeVis.name}>
-              <Container key={entity.path} entity={entity} />
-            </Profiler>
-          </Suspense>
-        </ErrorBoundary>
+        <Profiler id={activeVis.name}>
+          <Container key={entity.path} entity={entity} />
+        </Profiler>
       </div>
     </div>
   );


### PR DESCRIPTION
First, I created a `VisBoundary` component to hold the `ErrorBoundary` and `Suspense` logic of the vis containers. I did not end up moving the `DimensionMapper` into this component, as keeping the mapper in the containers means I could use `VisBoundary` in the `RawVisContainer` and `ScalarVisContainer` and remove `ErrorBoundary` and `Suspense` from `Visualizer`.

Second, I moved all the data fetching (`useDatasetValue(s)`) out of the mapped visualizations and inside two new components: `ValueFetcher` and `NxValuesFetcher`. I used the [render props](https://reactjs.org/docs/render-props.html) pattern, as it is much clearer than my previous state-based solution.

Third, I refactored the way we pass formatters to `ScalarVis` and `MatrixVis`. Instead of having a guard and an early return in the mapped vis components, I decided to make use of simple type casting.

Fourth, I ran `ts-prune` to remove unused exports, notably in `guards.ts`.

---

### What's next

- Move prefetching to `NxValuesFetcher` so retrying a cancelled NeXus visualization doesn't lead to a refetching waterfall.
- _[Can wait]_ Review current solution for complex visualizations (containers, mapped vis, typings, etc.)
- _[Can wait]_ Review mapped vis components to see if anything else can be abstracted out of them.