### PR TITLE
Read CSS custom property in `LineVis` instead of `DataCurve`

### DIFF
--- a/src/h5web/vis-packs/core/hooks.ts
+++ b/src/h5web/vis-packs/core/hooks.ts
@@ -1,5 +1,12 @@
 import type { NdArray } from 'ndarray';
-import { useContext, useEffect, useMemo, useState } from 'react';
+import {
+  RefCallback,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { createMemo } from 'react-use';
 import { useFrame, useThree } from '@react-three/fiber';
 import type { DimensionMapping } from '../../dimension-mapper/models';
@@ -173,3 +180,23 @@ export function useMappedArrays(
 }
 
 export const useValueToIndexScale = createMemo(getValueToIndexScale);
+
+export function useCSSCustomProperties(...names: string[]): {
+  colors: string[];
+  refCallback: RefCallback<HTMLElement>;
+} {
+  const [styles, setStyles] = useState<CSSStyleDeclaration>();
+
+  // https://reactjs.org/docs/hooks-faq.html#how-can-i-measure-a-dom-node
+  const refCallback: RefCallback<HTMLElement> = useCallback(
+    (elem) => setStyles(elem ? window.getComputedStyle(elem) : undefined),
+    [setStyles]
+  );
+
+  return {
+    colors: names.map((name) => {
+      return styles ? styles.getPropertyValue(name).trim() : 'transparent';
+    }),
+    refCallback,
+  };
+}

--- a/src/h5web/vis-packs/core/line/DataCurve.tsx
+++ b/src/h5web/vis-packs/core/line/DataCurve.tsx
@@ -24,7 +24,7 @@ interface Props {
   ordinates: number[];
   errors?: number[];
   showErrors?: boolean;
-  color?: string;
+  color: string;
   curveType?: CurveType;
 }
 
@@ -34,7 +34,7 @@ function DataCurve(props: Props) {
     ordinates,
     errors,
     showErrors,
-    color = '--secondary-dark',
+    color,
     curveType = CurveType.LineOnly,
   } = props;
 
@@ -50,24 +50,19 @@ function DataCurve(props: Props) {
   const showLine = curveType !== CurveType.GlyphsOnly;
   const showGlyphs = curveType !== CurveType.LineOnly;
 
-  const { domElement } = useThree((state) => state.gl);
-  const curveColor = color.startsWith('--')
-    ? window.getComputedStyle(domElement).getPropertyValue(color).trim()
-    : color;
-
   return (
     <Suspense fallback={null}>
       <line_ visible={showLine} geometry={dataGeometry}>
-        <lineBasicMaterial color={curveColor} linewidth={2} />
+        <lineBasicMaterial color={color} linewidth={2} />
       </line_>
       <points visible={showGlyphs} geometry={dataGeometry}>
-        <GlyphMaterial color={curveColor} size={6} />
+        <GlyphMaterial color={color} size={6} />
       </points>
       {showErrors && errors && (
         <ErrorBars
           barsSegments={points.bars}
           capsPoints={points.caps}
-          color={curveColor}
+          color={color}
         />
       )}
     </Suspense>

--- a/src/h5web/vis-packs/core/line/LineVis.module.css
+++ b/src/h5web/vis-packs/core/line/LineVis.module.css
@@ -5,8 +5,3 @@
   min-height: 0;
   margin: 1rem;
 }
-
-.root canvas {
-  /* This sets the default color of the line */
-  color: var(--secondary-dark);
-}

--- a/src/h5web/vis-packs/core/line/LineVis.tsx
+++ b/src/h5web/vis-packs/core/line/LineVis.tsx
@@ -11,6 +11,7 @@ import { CurveType } from './models';
 import { getDomain, extendDomain, DEFAULT_DOMAIN } from '../utils';
 import { assertDataLength, assertDefined } from '../../../guards';
 import { useTooltipFormatters } from './hooks';
+import { useCSSCustomProperties } from '../hooks';
 
 interface Props {
   dataArray: NdArray;
@@ -73,8 +74,13 @@ function LineVis(props: Props) {
     errorsArray
   );
 
+  const {
+    colors: [curveColor, auxColor],
+    refCallback: rootRef,
+  } = useCSSCustomProperties('--secondary-dark', '--secondary');
+
   return (
-    <figure className={styles.root} aria-labelledby="vis-title">
+    <figure ref={rootRef} className={styles.root} aria-labelledby="vis-title">
       <VisCanvas
         canvasTitle={title}
         abscissaConfig={{
@@ -94,19 +100,20 @@ function LineVis(props: Props) {
         <TooltipMesh {...tooltipFormatters} guides="vertical" />
         <PanZoomMesh />
         <DataCurve
-          curveType={curveType}
           abscissas={abscissas}
           ordinates={dataArray.data as number[]}
           errors={errorsArray && (errorsArray.data as number[])}
           showErrors={showErrors}
+          color={curveColor}
+          curveType={curveType}
         />
         {auxArrays.map((array, i) => (
           <DataCurve
             key={i} // eslint-disable-line react/no-array-index-key
-            color="--secondary"
-            curveType={curveType}
             abscissas={abscissas}
             ordinates={array.data as number[]}
+            color={auxColor}
+            curveType={curveType}
           />
         ))}
       </VisCanvas>


### PR DESCRIPTION
This relates to #631 and #555.

`DataCurve` no longer relies on H5Web's CSS custom properties. The `color` prop is now expected to be a valid color string. I've kept a default value for convenience, but I've chosen `black`. (If we add a `bgColor` prop to the canvas as per https://github.com/silx-kit/h5web/issues/555#issuecomment-821144768, we can use `white` as default.)

The CSS custom properties are now read by `LineVis` on the root `figure` element via a `ref` (instead of on the `canvas` element via `useThree`).