### PR TITLE
Support providing multiple auxiliary curve colors

### DIFF
--- a/src/h5web/vis-packs/core/line/LineVis.tsx
+++ b/src/h5web/vis-packs/core/line/LineVis.tsx
@@ -13,6 +13,10 @@ import { assertDataLength, assertDefined } from '../../../guards';
 import { useTooltipFormatters } from './hooks';
 import { useCSSCustomProperties } from '../hooks';
 
+const DEFAULT_CURVE_COLOR = 'midnightblue';
+const DEFAULT_AUX_COLORS =
+  'orangered, forestgreen, crimson, mediumslateblue, sienna';
+
 interface Props {
   dataArray: NdArray;
   domain: Domain | undefined;
@@ -75,9 +79,14 @@ function LineVis(props: Props) {
   );
 
   const {
-    colors: [curveColor, auxColor],
+    colors: [curveColor, rawAuxColor],
     refCallback: rootRef,
   } = useCSSCustomProperties('--h5w-line--color', '--h5w-line--colorAux');
+
+  // Support comma-separated list of auxiliary colors
+  const auxColors = (rawAuxColor || DEFAULT_AUX_COLORS)
+    .split(',')
+    .map((col) => col.trim());
 
   return (
     <figure ref={rootRef} className={styles.root} aria-labelledby="vis-title">
@@ -104,7 +113,7 @@ function LineVis(props: Props) {
           ordinates={dataArray.data as number[]}
           errors={errorsArray && (errorsArray.data as number[])}
           showErrors={showErrors}
-          color={curveColor || 'midnightblue'}
+          color={curveColor || DEFAULT_CURVE_COLOR}
           curveType={curveType}
         />
         {auxArrays.map((array, i) => (
@@ -112,7 +121,7 @@ function LineVis(props: Props) {
             key={i} // eslint-disable-line react/no-array-index-key
             abscissas={abscissas}
             ordinates={array.data as number[]}
-            color={auxColor || 'cornflowerblue'}
+            color={auxColors[i < auxColors.length ? i : auxColors.length - 1]}
             curveType={curveType}
           />
         ))}

--- a/src/stories/Customization.stories.mdx
+++ b/src/stories/Customization.stories.mdx
@@ -77,10 +77,10 @@ as you see fit. For instance, if you'd like to change the color of the curve of 
 
 #### Line
 
-| Name                   | Default          | Description                             |
-| ---------------------- | ---------------- | --------------------------------------- |
-| `--h5w-line--color`    | `midnightblue`   | Color of main curve and error bars/caps |
-| `--h5w-line--colorAux` | `cornflowerblue` | Color of auxiliary curves               |
+| Name                   | Default                                                    | Description                                                                                                                                                                        |
+| ---------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--h5w‑line‑‑color`    | `midnightblue`                                             | Color of main curve and error bars/caps                                                                                                                                            |
+| `--h5w‑line‑‑colorAux` | `orangered, forestgreen, crimson, mediumslateblue, sienna` | Color(s) of auxiliary curves. Accepts a comma-separated list of colors. If the number of colours is lower than the number of auxiliary curves, the last color in the list is used. |
 
 #### Heatmap
 


### PR DESCRIPTION
`--h5w-line-auxColor` now accepts a comma-separated list of colours. If there are more auxiliary curves than colours, then the extra curves receive the last colour in the list.

Here is what the new default auxiliary colors look like:

![image](https://user-images.githubusercontent.com/2936402/118953828-7753a680-b95d-11eb-9fc6-acf89715cc92.png)

They are similar to Matplotlib's colors: https://matplotlib.org/stable/_images/dflt_style_changes-1.png.