### PR TITLE
Remove global utility classes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@
 - [Continuous deployment](#continuous-deployment)
 - [NPM packages](#npm-packages-)
   - [Release process](#release-process)
-  - [Local testing](#local-testing)
+  - [Build and test locally](#build-and-test-locally)
 - [Icon set](#icon-set)
 
 ## Quick start 🚀

--- a/packages/webpack.config.js
+++ b/packages/webpack.config.js
@@ -83,6 +83,12 @@ function getConfig(pkg) {
         ],
       }),
     ],
+    stats: {
+      excludeAssets: /\.d\.ts$/u, // hide emitted type definitions
+      modules: false, // don't log individual modules
+      children: false, // hide `MiniCssExtractPlugin` logs
+    },
+    performance: { hints: false }, // hide max asset size warnings
   };
 }
 

--- a/src/h5web/breadcrumbs/BreadcrumbsBar.module.css
+++ b/src/h5web/breadcrumbs/BreadcrumbsBar.module.css
@@ -22,7 +22,7 @@
 }
 
 .crumbButton {
-  composes: btn-clean from global;
+  composes: btnClean from '../utils.module.css';
   position: relative;
   display: flex;
   align-items: center;

--- a/src/h5web/explorer/Explorer.module.css
+++ b/src/h5web/explorer/Explorer.module.css
@@ -15,7 +15,7 @@
 }
 
 .btn {
-  composes: btn-clean from global;
+  composes: btnClean from '../utils.module.css';
   display: block;
   width: 100%;
   padding: 0.25rem 1rem 0.25rem calc(0.25rem + (var(--level) + 1) * 0.75rem);

--- a/src/h5web/metadata-viewer/MetadataViewer.module.css
+++ b/src/h5web/metadata-viewer/MetadataViewer.module.css
@@ -57,7 +57,7 @@
 }
 
 .attrValueBtn {
-  composes: btn-clean from global;
+  composes: btnClean from '../utils.module.css';
   display: flex;
   align-items: center;
   font-weight: 600;

--- a/src/h5web/toolbar/Toolbar.module.css
+++ b/src/h5web/toolbar/Toolbar.module.css
@@ -36,7 +36,7 @@
 }
 
 .btn {
-  composes: btn-clean from global;
+  composes: btnClean from '../utils.module.css';
   display: flex;
   align-items: center;
   padding: 0 0.25rem;

--- a/src/h5web/toolbar/controls/ColorMapSelector/ColorMapSelector.module.css
+++ b/src/h5web/toolbar/controls/ColorMapSelector/ColorMapSelector.module.css
@@ -3,7 +3,6 @@
 }
 
 .gradient {
-  composes: no-invert from global;
   position: relative;
   top: 1px;
   width: 2rem;

--- a/src/h5web/toolbar/controls/ColorMapSelector/ColorMapSelector.tsx
+++ b/src/h5web/toolbar/controls/ColorMapSelector/ColorMapSelector.tsx
@@ -14,7 +14,11 @@ function ColorMapOption(props: { option: ColorMap }) {
   return (
     <>
       {option}
-      <div className={styles.gradient} style={{ backgroundImage }} />
+      <div
+        className={styles.gradient}
+        style={{ backgroundImage }}
+        data-keep-colors
+      />
     </>
   );
 }

--- a/src/h5web/toolbar/controls/DomainSlider/DomainTooltip.module.css
+++ b/src/h5web/toolbar/controls/DomainSlider/DomainTooltip.module.css
@@ -43,7 +43,7 @@
 }
 
 .actionBtn {
-  composes: btn-clean from global;
+  composes: btnClean from '../../../utils.module.css';
   display: flex;
   align-items: center;
   padding: 0.25rem;

--- a/src/h5web/utils.module.css
+++ b/src/h5web/utils.module.css
@@ -1,0 +1,28 @@
+.btnClean {
+  margin: 0;
+  padding: 0;
+  background: none;
+  border: none;
+  font: inherit;
+  color: inherit;
+  line-height: inherit;
+  text-align: left;
+  white-space: normal;
+  cursor: pointer;
+}
+
+.btnClean:disabled,
+.btnClean[aria-disabled='true'] {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.btnLink {
+  composes: btnClean;
+  padding: 0.25rem 0.5rem;
+  font-weight: 600;
+}
+
+.btnLink:hover {
+  text-decoration: underline;
+}

--- a/src/h5web/vis-packs/core/heatmap/ColorBar.module.css
+++ b/src/h5web/vis-packs/core/heatmap/ColorBar.module.css
@@ -28,7 +28,6 @@
 }
 
 .gradient {
-  composes: no-invert from global;
   flex: 1 1 0%;
   background-repeat: no-repeat; /* fix subtle bug where gradient is repeated over 1px */
 }

--- a/src/h5web/vis-packs/core/heatmap/ColorBar.tsx
+++ b/src/h5web/vis-packs/core/heatmap/ColorBar.tsx
@@ -58,6 +58,7 @@ function ColorBar(props: Props) {
       >
         <div
           className={styles.gradient}
+          data-keep-colors
           style={{
             backgroundImage: getLinearGradient(
               getInterpolator(colorMap, invertColorMap),

--- a/src/h5web/vis-packs/core/heatmap/HeatmapVis.tsx
+++ b/src/h5web/vis-packs/core/heatmap/HeatmapVis.tsx
@@ -67,7 +67,11 @@ function HeatmapVis(props: Props) {
   );
 
   return (
-    <figure className={styles.root} aria-labelledby="vis-title">
+    <figure
+      className={styles.root}
+      aria-labelledby="vis-title"
+      data-keep-canvas-colors
+    >
       <VisCanvas
         abscissaConfig={{
           domain: abscissaDomain,

--- a/src/h5web/vis-packs/core/matrix/MatrixVis.module.css
+++ b/src/h5web/vis-packs/core/matrix/MatrixVis.module.css
@@ -74,7 +74,7 @@
 }
 
 .anchorBtn {
-  composes: btn-clean from global;
+  composes: btnClean from '../../../utils.module.css';
   flex: 1 1 0%;
   display: flex;
   align-items: center;

--- a/src/h5web/vis-packs/core/shared/VisCanvas.module.css
+++ b/src/h5web/vis-packs/core/shared/VisCanvas.module.css
@@ -13,7 +13,6 @@
 
 /* R3F's root element */
 .canvasWrapper {
-  composes: no-invert-canvas from global;
   overflow: visible !important; /* show child axis grid, which is bigger than canvas */
   background-color: var(--h5w-canvas--bgColor, transparent);
 }

--- a/src/h5web/visualizer/ValueLoader.module.css
+++ b/src/h5web/visualizer/ValueLoader.module.css
@@ -7,7 +7,7 @@
 }
 
 .cancelBtn {
-  composes: btn-clean btn-link from global;
+  composes: btnLink from '../utils.module.css';
 }
 
 .grid {

--- a/src/h5web/visualizer/VisSelector.module.css
+++ b/src/h5web/visualizer/VisSelector.module.css
@@ -4,7 +4,7 @@
 }
 
 .btn {
-  composes: btn-clean from global;
+  composes: btnClean from '../utils.module.css';
   display: flex;
   align-items: center;
   padding: 0.375rem 1rem;

--- a/src/h5web/visualizer/Visualizer.module.css
+++ b/src/h5web/visualizer/Visualizer.module.css
@@ -35,5 +35,5 @@
 }
 
 .retryBtn {
-  composes: btn-clean btn-link from global;
+  composes: btnLink from '../utils.module.css';
 }

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -57,34 +57,6 @@ abbr[title] {
 [tabindex='-1']:focus:not(:focus-visible) {
   outline: 0 !important;
 }
-.btn-clean {
-  margin: 0;
-  padding: 0;
-  background: none;
-  border: none;
-  font: inherit;
-  color: inherit;
-  line-height: inherit;
-  text-align: left;
-  white-space: normal;
-  cursor: pointer;
-}
-
-.btn-clean:disabled,
-.btn-clean[aria-disabled='true'] {
-  opacity: 0.5;
-  pointer-events: none;
-}
-
-.btn-link {
-  composes: btn-clean from global;
-  padding: 0.25rem 0.5rem;
-  font-weight: 600;
-}
-
-.btn-link:hover {
-  text-decoration: underline;
-}
 
 .reflex-splitter {
   width: 5px !important;
@@ -116,11 +88,8 @@ abbr[title] {
     --btn-shadow-darker-color: #fff;
   }
 
-  .no-invert {
-    filter: invert(); /* invert back to normal colors */
-  }
-
-  .no-invert-canvas > canvas {
+  [data-keep-colors],
+  [data-keep-canvas-colors] canvas {
     filter: invert(); /* invert back to normal colors */
   }
 }


### PR DESCRIPTION
Global utility classes are problematic when importing components in other apps. They require importing global CSS, which isn't ideal in terms of namespacing and developer experience.

We had four global utility classes: `btn-clean`, `btn-link`, `no-invert` and `no-invert-canvas`. For the first two, I move them into a CSS module: `src/h5web/utils.module.css` so they become locally scoped. For the last two, since `jupyterlab-h5web` has to be able to write selectors targeting them, they cannot be locally scoped -- so instead of moving them into a CSS module, I replace them with `data-` attributes: `data-keep-colors` and `data-keep-canvas-colors`.