### PR TITLE
Cancel bound editors when closing domain tooltip

### DIFF
--- a/src/h5web/toolbar/controls/DomainSlider/BoundEditor.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/BoundEditor.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useRef, useState } from 'react';
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
 import { FiCheck, FiSlash } from 'react-icons/fi';
 import { formatPreciseValue } from '../../../utils';
 import type { Bound } from '../../../vis-packs/core/models';
@@ -14,13 +20,26 @@ interface Props {
   onChange: (val: number) => void;
 }
 
-function BoundEditor(props: Props) {
+interface Handle {
+  cancel: () => void;
+}
+
+const BoundEditor = forwardRef<Handle, Props>((props, ref) => {
   const { bound, value, isEditing, hasError, onEditToggle, onChange } = props;
 
   const id = `${bound}-bound`;
   const inputRef = useRef<HTMLInputElement>(null);
 
   const [inputValue, setInputValue] = useState('');
+
+  function cancel() {
+    onEditToggle(false);
+    setInputValue(formatPreciseValue(value));
+  }
+
+  /* Expose `cancel` function to parent component through ref handle so that
+    `inputValue` can be reset when the user closes the domain tooltip. */
+  useImperativeHandle(ref, () => ({ cancel }));
 
   useEffect(() => {
     setInputValue(formatPreciseValue(value));
@@ -92,15 +111,13 @@ function BoundEditor(props: Props) {
         type="button"
         disabled={!isEditing}
         aria-label={`Cancel ${bound}`}
-        onClick={() => {
-          onEditToggle(false);
-          setInputValue(formatPreciseValue(value));
-        }}
+        onClick={() => cancel()}
       >
         <FiSlash />
       </button>
     </form>
   );
-}
+});
 
+export type { Handle as BoundEditorHandle };
 export default BoundEditor;

--- a/src/h5web/toolbar/controls/DomainSlider/DomainSlider.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/DomainSlider.tsx
@@ -9,7 +9,7 @@ import ToggleBtn from '../ToggleBtn';
 import { FiEdit3 } from 'react-icons/fi';
 import { useClickAway, useKey } from 'react-use';
 import { useToggle } from '@react-hookz/web';
-import DomainTooltip from './DomainTooltip';
+import DomainTooltip, { DomainTooltipHandle } from './DomainTooltip';
 import ScaledSlider from './ScaledSlider';
 import {
   useSafeDomain,
@@ -51,10 +51,17 @@ function DomainSlider(props: Props) {
   }
 
   const rootRef = useRef(null);
-  useClickAway(rootRef, () => toggleEditing(false));
-  useKey('Escape', () => {
+  const tooltipRef = useRef<DomainTooltipHandle>(null);
+
+  useClickAway(rootRef, () => {
     toggleEditing(false);
+    tooltipRef.current?.cancelEditing();
+  });
+
+  useKey('Escape', () => {
     toggleHovered(false);
+    toggleEditing(false);
+    tooltipRef.current?.cancelEditing();
   });
 
   return (
@@ -96,6 +103,7 @@ function DomainSlider(props: Props) {
       />
 
       <DomainTooltip
+        ref={tooltipRef}
         id={TOOLTIP_ID}
         open={hovered || isEditing}
         sliderDomain={sliderDomain}


### PR DESCRIPTION
This PR fixes the following bug: 

1. Start editing min or max bound in domain tooltip.
2. Don't apply the edit -- instead, close the tooltip with Escape or by clicking outside of it.
3. Re-open the tooltip 👉 the field is no longer in edit mode and the edited value isn't applied, yet the field shows the edited value.