### PR TITLE
Add toolbar components to lib package and document

### DIFF
--- a/src/h5web/breadcrumbs/BreadcrumbsBar.tsx
+++ b/src/h5web/breadcrumbs/BreadcrumbsBar.tsx
@@ -30,7 +30,7 @@ function BreadcrumbsBar(props: Props) {
         icon={FiSidebar}
         iconOnly
         value={isExplorerOpen}
-        onChange={onToggleExplorer}
+        onToggle={onToggleExplorer}
       />
 
       <Breadcrumbs

--- a/src/h5web/toolbar/ComplexLineToolbar.tsx
+++ b/src/h5web/toolbar/ComplexLineToolbar.tsx
@@ -57,7 +57,7 @@ function ComplexLineToolbar() {
         label="Auto-scale"
         icon={MdDomain}
         value={autoScale}
-        onChange={toggleAutoScale}
+        onToggle={toggleAutoScale}
         disabled={isAutoScaleDisabled}
       />
 
@@ -71,7 +71,7 @@ function ComplexLineToolbar() {
           />
         )}
         value={!areErrorsDisabled && showErrors}
-        onChange={toggleErrors}
+        onToggle={toggleErrors}
         disabled={areErrorsDisabled}
       />
 
@@ -79,7 +79,7 @@ function ComplexLineToolbar() {
         label="Grid"
         icon={MdGridOn}
         value={showGrid}
-        onChange={toggleGrid}
+        onToggle={toggleGrid}
       />
 
       <Separator />

--- a/src/h5web/toolbar/ComplexToolbar.tsx
+++ b/src/h5web/toolbar/ComplexToolbar.tsx
@@ -63,13 +63,13 @@ function ComplexToolbar() {
         label="Keep ratio"
         icon={MdAspectRatio}
         value={keepAspectRatio}
-        onChange={toggleAspectRatio}
+        onToggle={toggleAspectRatio}
       />
       <ToggleBtn
         label="Grid"
         icon={MdGridOn}
         value={showGrid}
-        onChange={toggleGrid}
+        onToggle={toggleGrid}
       />
 
       <Separator />

--- a/src/h5web/toolbar/HeatmapToolbar.tsx
+++ b/src/h5web/toolbar/HeatmapToolbar.tsx
@@ -1,4 +1,4 @@
-import { MdAspectRatio, MdGridOn } from 'react-icons/md';
+import { MdAspectRatio } from 'react-icons/md';
 import ToggleBtn from './controls/ToggleBtn';
 import { useHeatmapConfig } from '../vis-packs/core/heatmap/config';
 import DomainSlider from './controls/DomainSlider/DomainSlider';
@@ -8,6 +8,7 @@ import Toolbar from './Toolbar';
 import ColorMapSelector from './controls/ColorMapSelector/ColorMapSelector';
 import ScaleSelector from './controls/ScaleSelector/ScaleSelector';
 import shallow from 'zustand/shallow';
+import GridToggler from './controls/GridToggler';
 
 function HeatmapToolbar() {
   const {
@@ -56,14 +57,9 @@ function HeatmapToolbar() {
         label="Keep ratio"
         icon={MdAspectRatio}
         value={keepAspectRatio}
-        onChange={toggleAspectRatio}
+        onToggle={toggleAspectRatio}
       />
-      <ToggleBtn
-        label="Grid"
-        icon={MdGridOn}
-        value={showGrid}
-        onChange={toggleGrid}
-      />
+      <GridToggler value={showGrid} onToggle={toggleGrid} />
 
       <Separator />
 

--- a/src/h5web/toolbar/LineToolbar.tsx
+++ b/src/h5web/toolbar/LineToolbar.tsx
@@ -46,7 +46,7 @@ function LineToolbar() {
         label="Auto-scale"
         icon={MdDomain}
         value={autoScale}
-        onChange={toggleAutoScale}
+        onToggle={toggleAutoScale}
         disabled={isAutoScaleDisabled}
       />
 
@@ -60,7 +60,7 @@ function LineToolbar() {
           />
         )}
         value={!areErrorsDisabled && showErrors}
-        onChange={toggleErrors}
+        onToggle={toggleErrors}
         disabled={areErrorsDisabled}
       />
 
@@ -68,7 +68,7 @@ function LineToolbar() {
         label="Grid"
         icon={MdGridOn}
         value={showGrid}
-        onChange={toggleGrid}
+        onToggle={toggleGrid}
       />
 
       <Separator />

--- a/src/h5web/toolbar/controls/ColorMapSelector/ColorMapSelector.tsx
+++ b/src/h5web/toolbar/controls/ColorMapSelector/ColorMapSelector.tsx
@@ -46,7 +46,7 @@ function ColorMapSelector(props: Props) {
         label="Invert"
         icon={FiShuffle}
         value={invert}
-        onChange={onInversionChange}
+        onToggle={onInversionChange}
       />
     </div>
   );

--- a/src/h5web/toolbar/controls/DomainSlider/DomainSlider.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/DomainSlider.tsx
@@ -99,7 +99,7 @@ function DomainSlider(props: Props) {
         aria-controls={TOOLTIP_ID}
         icon={FiEdit3}
         value={isEditing}
-        onChange={() => toggleEditing(!isEditing)}
+        onToggle={() => toggleEditing(!isEditing)}
       />
 
       <DomainTooltip

--- a/src/h5web/toolbar/controls/DomainSlider/DomainTooltip.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/DomainTooltip.tsx
@@ -116,13 +116,13 @@ const DomainTooltip = forwardRef<Handle, Props>((props, ref) => {
             label="Min"
             raised
             value={isAutoMin}
-            onChange={onAutoMinToggle}
+            onToggle={onAutoMinToggle}
           />
           <ToggleBtn
             label="Max"
             raised
             value={isAutoMax}
-            onChange={onAutoMaxToggle}
+            onToggle={onAutoMaxToggle}
           />
         </p>
       </div>

--- a/src/h5web/toolbar/controls/GridToggler.tsx
+++ b/src/h5web/toolbar/controls/GridToggler.tsx
@@ -1,0 +1,17 @@
+import { MdGridOn } from 'react-icons/md';
+import ToggleBtn from './ToggleBtn';
+
+interface Props {
+  value: boolean;
+  onToggle: () => void;
+}
+
+function GridToggler(props: Props) {
+  const { value, onToggle } = props;
+
+  return (
+    <ToggleBtn label="Grid" icon={MdGridOn} value={value} onToggle={onToggle} />
+  );
+}
+
+export default GridToggler;

--- a/src/h5web/toolbar/controls/ToggleBtn.tsx
+++ b/src/h5web/toolbar/controls/ToggleBtn.tsx
@@ -9,7 +9,7 @@ interface Props extends AriaAttributes {
   small?: boolean;
   raised?: boolean;
   value: boolean;
-  onChange: () => void;
+  onToggle: () => void;
   disabled?: boolean;
 }
 
@@ -21,7 +21,7 @@ function ToggleBtn(props: Props) {
     small,
     raised,
     value,
-    onChange,
+    onToggle,
     disabled,
     ...ariaAttrs
   } = props;
@@ -30,7 +30,7 @@ function ToggleBtn(props: Props) {
     <button
       className={styles.btn}
       type="button"
-      onClick={onChange}
+      onClick={() => onToggle()}
       disabled={disabled}
       data-small={small || undefined}
       data-raised={raised || undefined}

--- a/src/packages/lib.ts
+++ b/src/packages/lib.ts
@@ -6,6 +6,16 @@ export type { MatrixVisProps } from '../h5web/vis-packs/core/matrix/MatrixVis';
 export type { LineVisProps } from '../h5web/vis-packs/core/line/LineVis';
 export type { HeatmapVisProps } from '../h5web/vis-packs/core/heatmap/HeatmapVis';
 
+// Toolbar and controls
+export { default as Toolbar } from '../h5web/toolbar/Toolbar';
+export { default as Separator } from '../h5web/toolbar/Separator';
+export { default as ToggleBtn } from '../h5web/toolbar/controls/ToggleBtn';
+export { default as ToggleGroup } from '../h5web/toolbar/controls/ToggleGroup';
+export { default as DomainSlider } from '../h5web/toolbar/controls/DomainSlider/DomainSlider';
+export { default as ColorMapSelector } from '../h5web/toolbar/controls/ColorMapSelector/ColorMapSelector';
+export { default as ScaleSelector } from '../h5web/toolbar/controls/ScaleSelector/ScaleSelector';
+export { default as GridToggler } from '../h5web/toolbar/controls/GridToggler';
+
 // Building blocks
 export { default as VisCanvas } from '../h5web/vis-packs/core/shared/VisCanvas';
 export { default as PanZoomMesh } from '../h5web/vis-packs/core/shared/PanZoomMesh';
@@ -32,12 +42,22 @@ export {
 
 export { getLinearGradient } from '../h5web/vis-packs/core/heatmap/utils';
 
+export {
+  useVisDomain,
+  useSafeDomain,
+} from '../h5web/vis-packs/core/heatmap/hooks';
+
 // Models
 export { INTERPOLATORS } from '../h5web/vis-packs/core/heatmap/interpolators';
 export { ScaleType } from '../h5web/vis-packs/core/models';
 export { CurveType } from '../h5web/vis-packs/core/line/models';
 
-export type { Domain, Size, AxisConfig } from '../h5web/vis-packs/core/models';
+export type {
+  Domain,
+  CustomDomain,
+  Size,
+  AxisConfig,
+} from '../h5web/vis-packs/core/models';
 
 export type {
   Dims,

--- a/src/stories/GettingStarted.stories.mdx
+++ b/src/stories/GettingStarted.stories.mdx
@@ -7,10 +7,11 @@
 
 The **H5Web Component Library** provides data visualization components and utilities from H5Web for use in other front-end web applications.
 
-The components are organised in two categories:
+The components are organised in three categories:
 
 - 🎨 **Visualizations**: the top-level visualization components — i.e. the components you will most likely need.
 - 🧱 **Building Blocks**: the low-level components used by the visualization components — for advanced uses only.
+- 🧰 **Toolbar**: the responsive toolbar and toolbar controls.
 
 ## Getting started
 

--- a/src/stories/Toolbar.stories.tsx
+++ b/src/stories/Toolbar.stories.tsx
@@ -1,0 +1,132 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { Title, Primary } from '@storybook/addon-docs/blocks';
+import type { Story } from '@storybook/react';
+import { useState } from 'react';
+import { useToggle } from '@react-hookz/web';
+import { FiTarget } from 'react-icons/fi';
+import {
+  ScaleType,
+  Toolbar,
+  DomainSlider,
+  ColorMapSelector,
+  ScaleSelector,
+  Separator,
+  ColorMap,
+  GridToggler,
+  ToggleGroup,
+  ToggleBtn,
+  CustomDomain,
+} from '../packages/lib';
+
+const Template: Story<{ narrow?: boolean }> = ({ narrow }) => {
+  const [customDomain, setCustomDomain] = useState<CustomDomain>([null, null]);
+  const [colorMap, setColorMap] = useState<ColorMap>('Viridis');
+  const [invertColorMap, toggleColorMapInversion] = useToggle();
+  const [scaleType, setScaleType] = useState(ScaleType.Linear);
+  const [showGrid, toggleGrid] = useToggle();
+  const [withTest, toggleTest] = useToggle(true);
+  const [foo, setFoo] = useState('bar');
+
+  const allStates = {
+    customDomain,
+    colorMap,
+    invertColorMap,
+    scaleType,
+    showGrid,
+    withTest,
+    foo,
+  };
+
+  return (
+    <>
+      <div
+        style={{
+          display: 'flex',
+          maxWidth: narrow ? '30rem' : undefined,
+          height: '2.5rem',
+          marginLeft: 'auto',
+          backgroundColor: 'var(--primary-bg)',
+        }}
+      >
+        <Toolbar>
+          <DomainSlider
+            dataDomain={[1, 100]}
+            customDomain={customDomain}
+            scaleType={scaleType}
+            onCustomDomainChange={setCustomDomain}
+          />
+
+          <Separator />
+          <ColorMapSelector
+            value={colorMap}
+            onValueChange={setColorMap}
+            invert={invertColorMap}
+            onInversionChange={toggleColorMapInversion}
+          />
+
+          <Separator />
+          <ScaleSelector value={scaleType} onScaleChange={setScaleType} />
+
+          <Separator />
+          <GridToggler value={showGrid} onToggle={toggleGrid} />
+          <ToggleBtn
+            label="Test"
+            iconOnly
+            icon={FiTarget}
+            value={withTest}
+            onToggle={toggleTest}
+          />
+
+          <Separator />
+          <ToggleGroup
+            role="radiogroup"
+            ariaLabel="Foo"
+            value={foo}
+            onChange={setFoo}
+          >
+            <ToggleGroup.Btn label="Bar" value="bar" />
+            <ToggleGroup.Btn label="Baz" value="baz" />
+          </ToggleGroup>
+        </Toolbar>
+      </div>
+
+      <pre style={{ padding: '0 1.5rem' }}>
+        State = {JSON.stringify(allStates, null, 2)}
+      </pre>
+    </>
+  );
+};
+
+export const Default = Template.bind({});
+
+export const Responsive = Template.bind({});
+Responsive.args = { narrow: true };
+
+export default {
+  title: 'Toolbar/Toolbar',
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      source: { type: 'code' },
+      page: () => (
+        <>
+          <Title />
+          <p>
+            The source code of the <em>Default</em> story demonstrates a basic
+            use of the <code>Toolbar</code> component and associated toolbar
+            controls. To reveal the code, click on <em>Show code</em> below the
+            preview.
+          </p>
+          <p>
+            The following toolbar controls are available:{' '}
+            <code>DomainSlider</code>, <code>ColorMapSelector</code>,{' '}
+            <code>ScaleSelector</code>, <code>GridToggler</code>, and the
+            generic controls <code>ToggleBtn</code>, <code>ToggleGroup</code>{' '}
+            and <code>ToggleGroup.Btn</code>.
+          </p>
+          <Primary />
+        </>
+      ),
+    },
+  },
+};


### PR DESCRIPTION
- Add `Toolbar` and the main controls to `@h5web/lib`, as well as a couple more hooks and models.
- Create `GridToggler` control and expose to `@h5web/lib`.
- Document toolbar usage in storybook.
- Rename prop `onChange` of `ToggleBtn` to `onToggle`.