### PR TITLE
Make `Html` move according to camera

### DIFF
--- a/src/h5web/vis-packs/core/shared/PanZoomMesh.tsx
+++ b/src/h5web/vis-packs/core/shared/PanZoomMesh.tsx
@@ -28,6 +28,7 @@ function PanZoomMesh() {
         position.z
       );
 
+      camera.updateMatrixWorld();
       invalidate();
     },
     [camera, height, invalidate, width]

--- a/src/stories/HeatmapVis.stories.tsx
+++ b/src/stories/HeatmapVis.stories.tsx
@@ -165,8 +165,12 @@ WithAlphaArray.args = {
 
 export const WithOverlay: Story<HeatmapVisProps> = (args) => (
   <HeatmapVis {...args}>
-    <Html>
-      <p style={{ marginTop: '2%', marginLeft: '2%' }}>Keep this in view !</p>
+    <Html
+      groupProps={{ position: [100, 200, 0] }}
+      followCamera
+      style={{ width: '200px' }}
+    >
+      <p style={{ color: 'white' }}>An annotation</p>
     </Html>
   </HeatmapVis>
 );


### PR DESCRIPTION
Implements `calculatePosition` from https://github.com/pmndrs/drei/blob/v6.0.3/src/web/Html.tsx

This is a prop that can be overridden which is needed for `AxisSystem` and `Tooltip` that should not move.