### PR TITLE
Allow domain slider to be resized with CSS variables

### DIFF
--- a/src/h5web/toolbar/controls/DomainSlider/DomainSlider.module.css
+++ b/src/h5web/toolbar/controls/DomainSlider/DomainSlider.module.css
@@ -3,15 +3,16 @@
   display: flex;
   padding: 0 0.375rem;
   margin-right: -0.375rem;
-
-  --thumb-size: 1.375rem;
-  --thumb-size-auto: 1.25rem;
 }
 
 .slider {
   display: flex;
-  width: 8rem;
   margin-right: -0.25rem;
   font-size: 0.75rem;
   cursor: pointer;
+
+  --track-width: var(--h5w-domainSlider-track--width, 8rem);
+  --track-height: var(--h5w-domainSlider-track--height, 0.625rem);
+  --thumb-size: calc(var(--track-height) * 2.5);
+  --thumb-size-auto: calc(var(--thumb-size) * 0.9);
 }

--- a/src/h5web/toolbar/controls/DomainSlider/Track.module.css
+++ b/src/h5web/toolbar/controls/DomainSlider/Track.module.css
@@ -1,12 +1,13 @@
 .track {
   position: relative;
-  flex: 1 1 0%;
+  flex: none;
   align-self: center;
-  height: 0.5rem;
+  width: var(--track-width);
+  height: var(--track-height);
   margin: 0 calc(var(--thumb-size) / 2); /* make track end in middle of thumbs */
   background-color: var(--h5w-domainSlider-track--bgColor, lightgray);
   box-shadow: 1px 1px 2px inset var(--h5w-domainSlider-track--shadowColor, gray);
-  border-radius: 0.25rem;
+  border-radius: calc(var(--track-height) / 2);
   overflow: hidden; /* crop data track to root track's border radius */
 }
 

--- a/src/stories/Customization.stories.mdx
+++ b/src/stories/Customization.stories.mdx
@@ -150,6 +150,8 @@ as you see fit. For instance, if you'd like to change the color of the curve of 
 
 | Name                                                 | Default                    | Description                                    |
 | ---------------------------------------------------- | -------------------------- | ---------------------------------------------- |
+| `--h5w-domainSlider-track--width`                    | `8rem`                     | Width of track                                 |
+| `--h5w-domainSlider-track--height`                   | `0.625rem`                 | Height of track                                |
 | `--h5w-domainSlider-track--bgColor`                  | `gray`                     | Background color of track                      |
 | `--h5w-domainSlider-track--shadowColor`              | `gray`                     | Box shadow color of track                      |
 | `--h5w-domainSlider-dataTrack--bgColor`              | `royalblue`                | Background color of data track                 |


### PR DESCRIPTION
- I introduce two CSS variables to customize the width and height of the track.
- The width of the slider now depends on the width of the track and not the other way around. I've kept the same default width value in H5web, so because the track has some margin around it, it means the domain slider is now slightly larger in H5Web.
- To keep things looking right and avoid exposing too many customization variables, the size of the thumbs is now proportional to the height of the track.
- I've increased the height of the track in H5Web by 2px, as it is true that it was quite thin.

I'll post a Cypress diff here in a sec.