### PR TITLE
Allow Html to scale according to the camera zoom

### DIFF
--- a/src/h5web/vis-packs/core/shared/Html.tsx
+++ b/src/h5web/vis-packs/core/shared/Html.tsx
@@ -17,6 +17,7 @@ const v1 = new Vector3();
 export interface HtmlProps extends HTMLAttributes<HTMLDivElement> {
   groupProps?: GroupProps;
   followCamera?: boolean;
+  scaleOnZoom?: boolean;
 }
 
 const Html = forwardRef<HTMLDivElement, HtmlProps>((props, ref) => {
@@ -25,6 +26,7 @@ const Html = forwardRef<HTMLDivElement, HtmlProps>((props, ref) => {
     style,
     children,
     followCamera,
+    scaleOnZoom,
     groupProps = {},
     ...divProps
   } = props;
@@ -49,7 +51,8 @@ const Html = forwardRef<HTMLDivElement, HtmlProps>((props, ref) => {
       -(objectPos.y * heightHalf) + heightHalf,
     ];
 
-    el.style.transform = `translate3d(${pos[0]}px,${pos[1]}px,0)`;
+    el.style.transform = `translate3d(${pos[0]}px,${pos[1]}px,0)
+    scale(${scaleOnZoom ? camera.zoom : 1})`;
   }
 
   useLayoutEffect(() => {

--- a/src/stories/HeatmapVis.stories.tsx
+++ b/src/stories/HeatmapVis.stories.tsx
@@ -168,6 +168,7 @@ export const WithOverlay: Story<HeatmapVisProps> = (args) => (
     <Html
       groupProps={{ position: [100, 200, 0] }}
       followCamera
+      scaleOnZoom
       style={{ width: '200px' }}
     >
       <p style={{ color: 'white' }}>An annotation</p>


### PR DESCRIPTION
Follow-up of #695 

Simplified version of the [scaling of drei's Html](https://github.com/pmndrs/drei/blob/v6.0.3/src/web/Html.tsx#L269) as we only support Orthographic Camera.