### PR TITLE
Refactor Heatmap canvas domains computation

### DIFF
--- a/src/h5web/vis-packs/core/heatmap/HeatmapAxisSystem.tsx
+++ b/src/h5web/vis-packs/core/heatmap/HeatmapAxisSystem.tsx
@@ -1,8 +1,7 @@
 import type { ReactNode } from 'react';
-import { useThree } from '@react-three/fiber';
 import AxisSystem from '../shared/AxisSystem';
 import type { AxisOffsets, AxisConfig } from '../models';
-import { computeSameRatioDomains } from '../utils';
+import { useImageSize, useCanvasDomains } from './hooks';
 
 interface Props {
   axisOffsets: AxisOffsets;
@@ -16,21 +15,10 @@ interface Props {
 function HeatmapAxisSystem(props: Props) {
   const { abscissaConfig, ordinateConfig, imageRatio, ...forwardProps } = props;
 
-  const { width, height } = useThree((state) => state.size);
+  const imageSize = useImageSize(imageRatio);
 
-  if (!imageRatio) {
-    return (
-      <AxisSystem
-        abscissaConfig={abscissaConfig}
-        ordinateConfig={ordinateConfig}
-        {...forwardProps}
-      />
-    );
-  }
-
-  const [xAxisDomain, yAxisDomain] = computeSameRatioDomains(
-    width / height,
-    imageRatio,
+  const [xAxisDomain, yAxisDomain] = useCanvasDomains(
+    imageSize,
     abscissaConfig.domain,
     ordinateConfig.domain
   );

--- a/src/h5web/vis-packs/core/heatmap/hooks.ts
+++ b/src/h5web/vis-packs/core/heatmap/hooks.ts
@@ -1,8 +1,15 @@
+import { useThree } from '@react-three/fiber';
 import { format } from 'd3-format';
 import type { NdArray } from 'ndarray';
 import { createMemo } from 'react-use';
 import { useValueToIndexScale } from '../hooks';
-import type { TooltipIndexFormatter, TooltipValueFormatter } from '../models';
+import type {
+  Domain,
+  Size,
+  TooltipIndexFormatter,
+  TooltipValueFormatter,
+} from '../models';
+import { extendDomain } from '../utils';
 import { getVisDomain, getSafeDomain, getAxisValues } from './utils';
 
 export const useVisDomain = createMemo(getVisDomain);
@@ -30,4 +37,37 @@ export function useTooltipFormatters(
     formatValue: ([x, y]) =>
       format('.3')(dataArray.get(ordinateToIndex(y), abscissaToIndex(x))),
   };
+}
+
+export function useImageSize(imageRatio: number | undefined): Size {
+  const { width, height } = useThree((state) => state.size);
+
+  if (!imageRatio) {
+    return { width, height };
+  }
+
+  const canvasRatio = width / height;
+  const mismatch = canvasRatio / imageRatio;
+
+  return {
+    width: mismatch > 1 ? height * imageRatio : width,
+    height: mismatch > 1 ? height : width / imageRatio,
+  };
+}
+
+export function useCanvasDomains(
+  imageSize: Size,
+  abscissaDomain: Domain,
+  ordinateDomain: Domain
+): [Domain, Domain] {
+  const canvasSize = useThree((state) => state.size);
+
+  const widthRatio = canvasSize.width / imageSize.width;
+  const heightRatio = canvasSize.height / imageSize.height;
+
+  // `extendDomain(domain, factor)` actually extends  `domain` by `(1 + 2 * factor)`
+  return [
+    extendDomain(abscissaDomain, (widthRatio - 1) / 2),
+    extendDomain(ordinateDomain, (heightRatio - 1) / 2),
+  ];
 }

--- a/src/h5web/vis-packs/core/utils.ts
+++ b/src/h5web/vis-packs/core/utils.ts
@@ -369,23 +369,6 @@ export function getSliceSelection(
   return dimMapping.map((dim) => (isAxis(dim) ? ':' : dim)).join(',');
 }
 
-export function computeSameRatioDomains(
-  canvasRatio: number,
-  imageRatio: number,
-  abscissaDomain: Domain,
-  ordinateDomain: Domain
-): [Domain, Domain] {
-  const mismatch = canvasRatio / imageRatio; // ratio = width / height
-  if (mismatch > 1) {
-    // `canvasWidth` is relatively bigger than `imageWidth` => extend the abscissa domain by `mismatch` to make them match
-    // `extendDomain` relative extension is of `(1 + 2 * extendFactor)` so in this case, `extendFactor = (mismatch - 1) / 2`
-    return [extendDomain(abscissaDomain, (mismatch - 1) / 2), ordinateDomain];
-  }
-
-  // `canvasHeight` is relatively bigger than `imageHeight` => extend the ordinate domain by `1 / mismatch` to make them match
-  return [abscissaDomain, extendDomain(ordinateDomain, (1 / mismatch - 1) / 2)];
-}
-
 export function getAxisOffsets(
   hasLabel: Partial<Record<keyof AxisOffsets, boolean>> = {}
 ) {


### PR DESCRIPTION
As per our discussion on Friday, it makes more sense to compute the image's size directly from the ratios rather than from the axes scales and the abscissa/ordinate's min/max. As a first step towards this, I add a hook to compute the image's size, and I use this size to compute the canvas domains (previously "same-ratio domains").

The next step will be to find a way to pass down the image size to the Heatmap components (like `Mesh`), which may require another context. Alternative solutions include passing a prop called `visSize` or similar through `AxisSystemContext` that the Line components would just ignore ; or calling `useImageSize` again in the children (which would require passing them `imageRatio` as prop, which seems reasonable).