### PR TITLE
Add Annotation component and allow children in LineVis

### DIFF
--- a/src/h5web/vis-packs/core/line/LineVis.tsx
+++ b/src/h5web/vis-packs/core/line/LineVis.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { ReactNode, useMemo } from 'react';
 import type { NdArray } from 'ndarray';
 import { range } from 'd3-array';
 import styles from './LineVis.module.css';
@@ -35,6 +35,7 @@ interface Props {
   errorsArray?: NdArray;
   showErrors?: boolean;
   auxArrays?: NdArray[];
+  children?: ReactNode;
 }
 
 function LineVis(props: Props) {
@@ -50,6 +51,7 @@ function LineVis(props: Props) {
     errorsArray,
     showErrors = false,
     auxArrays = [],
+    children,
   } = props;
 
   const {
@@ -139,6 +141,7 @@ function LineVis(props: Props) {
               curveType={curveType}
             />
           ))}
+          {children}
         </AxisSystem>
       </VisCanvas>
     </figure>

--- a/src/h5web/vis-packs/core/shared/Annotation.tsx
+++ b/src/h5web/vis-packs/core/shared/Annotation.tsx
@@ -1,0 +1,31 @@
+import { HTMLAttributes, useContext } from 'react';
+import AxisSystemContext from './AxisSystemContext';
+import Html from './Html';
+
+interface Props extends HTMLAttributes<HTMLDivElement> {
+  x: number;
+  y: number;
+  z?: number;
+  scaleOnZoom?: boolean;
+}
+
+function Annotation(props: Props) {
+  const { x, y, z = 1, scaleOnZoom, children, ...divProps } = props;
+
+  const { abscissaScale, ordinateScale } = useContext(AxisSystemContext);
+
+  return (
+    <Html
+      groupProps={{
+        position: [abscissaScale(x), ordinateScale(y), z],
+      }}
+      followCamera
+      scaleOnZoom={scaleOnZoom}
+      {...divProps}
+    >
+      {children}
+    </Html>
+  );
+}
+
+export default Annotation;

--- a/src/packages/lib.ts
+++ b/src/packages/lib.ts
@@ -26,6 +26,7 @@ export { default as HeatmapMeshMaterial } from '../h5web/vis-packs/core/heatmap/
 export { default as DataCurve } from '../h5web/vis-packs/core/line/DataCurve';
 export type { AxisSystemProps } from '../h5web/vis-packs/core/shared/AxisSystem';
 export { default as Html } from '../h5web/vis-packs/core/shared/Html';
+export { default as Annotation } from '../h5web/vis-packs/core/shared/Annotation';
 
 // Utilities
 export {

--- a/src/stories/HeatmapVis.stories.tsx
+++ b/src/stories/HeatmapVis.stories.tsx
@@ -7,7 +7,7 @@ import {
   getDomain,
   getMockDataArray,
   INTERPOLATORS,
-  Html,
+  Annotation,
 } from '../packages/lib';
 import ndarray from 'ndarray';
 
@@ -163,20 +163,15 @@ WithAlphaArray.args = {
   alphaDomain,
 };
 
-export const WithOverlay: Story<HeatmapVisProps> = (args) => (
+export const WithAnnotation: Story<HeatmapVisProps> = (args) => (
   <HeatmapVis {...args}>
-    <Html
-      groupProps={{ position: [100, 200, 0] }}
-      followCamera
-      scaleOnZoom
-      style={{ width: '200px' }}
-    >
+    <Annotation x={30} y={18} style={{ width: '200px' }}>
       <p style={{ color: 'white' }}>An annotation</p>
-    </Html>
+    </Annotation>
   </HeatmapVis>
 );
 
-WithOverlay.args = {
+WithAnnotation.args = {
   dataArray,
   domain,
 };

--- a/src/stories/LineVisDisplay.stories.tsx
+++ b/src/stories/LineVisDisplay.stories.tsx
@@ -6,6 +6,7 @@ import {
   CurveType,
   getDomain,
   getMockDataArray,
+  Annotation,
 } from '../packages/lib';
 
 const dataArray = getMockDataArray('/nD_datasets/oneD_linear');
@@ -62,6 +63,19 @@ WithTitle.args = {
   dataArray,
   domain,
   title: 'A simple curve',
+};
+
+export const WithAnnotation: Story<LineVisProps> = (args) => (
+  <LineVis {...args}>
+    <Annotation x={30} y={10} style={{ width: '200px' }}>
+      <p>A simple line</p>
+    </Annotation>
+  </LineVis>
+);
+
+WithAnnotation.args = {
+  dataArray,
+  domain,
 };
 
 export default {


### PR DESCRIPTION
`Annotation` is a simple wrapper around `Html` that takes vis coordinates instead of canvas coordinates. 