### PR TITLE
Add thin axis line when grid is not displayed

### DIFF
--- a/src/h5web/vis-packs/core/shared/Axis.tsx
+++ b/src/h5web/vis-packs/core/shared/Axis.tsx
@@ -12,7 +12,6 @@ import {
 import Tick from './Tick';
 
 const AXIS_PROPS: Partial<SharedAxisProps<AxisScale>> = {
-  hideAxisLine: true,
   labelClassName: styles.label,
   labelProps: {}, // remove any styling props from parent `svg` element
   tickClassName: styles.tick,
@@ -61,6 +60,7 @@ function Axis(props: Props) {
           tickFormat={getTickFormatter(domain, axisLength, scaleType)}
           label={label}
           labelOffset={type === 'abscissa' ? 28 : 42}
+          hideAxisLine={showGrid}
           {...ticksProp}
           {...AXIS_PROPS}
         />

--- a/src/h5web/vis-packs/core/shared/AxisSystem.module.css
+++ b/src/h5web/vis-packs/core/shared/AxisSystem.module.css
@@ -28,6 +28,11 @@
   grid-area: axis-grid;
 }
 
+.axis > g > line {
+  stroke: var(--h5w-grid--color, gray);
+  stroke-opacity: var(--h5w-grid--opacity, 0.33);
+}
+
 .tick > line {
   stroke: var(--h5w-ticks--color, gray);
 }


### PR DESCRIPTION
Fix #692 

![image](https://user-images.githubusercontent.com/42204205/122028799-a8908c80-cdcc-11eb-90b3-b721a726c0a8.png)
