### PR TITLE
Fix empty toolbar on some renders

### DIFF
--- a/src/h5web/toolbar/HeatmapToolbar.tsx
+++ b/src/h5web/toolbar/HeatmapToolbar.tsx
@@ -29,16 +29,18 @@ function HeatmapToolbar() {
 
   return (
     <Toolbar>
-      {dataDomain && (
+      {dataDomain ? (
         <DomainSlider
           dataDomain={dataDomain}
           customDomain={customDomain}
           scaleType={scaleType}
           onCustomDomainChange={setCustomDomain}
         />
+      ) : (
+        <div />
       )}
 
-      {dataDomain && <Separator />}
+      {dataDomain ? <Separator /> : <div />}
 
       <ColorMapSelector
         value={colorMap}


### PR DESCRIPTION
The problem is that we store measured widths against children indices, so the fact that the domain slider and its separator are not rendered right away causes issues... In some cases, the toolbar remains blank thinking some of the children have not yet been measured... I spent ages on this and couldn't find any better solution. Reverting to using `keys` is no better unless we want to force users to specify a `key` on every control....