### PR TITLE
Add RgbImageVis for RGB Image of HDF5 spec

### DIFF
--- a/src/h5web/guards.ts
+++ b/src/h5web/guards.ts
@@ -16,6 +16,7 @@ import {
   ComplexType,
   ComplexArray,
   H5WebComplex,
+  IntegerType,
 } from './providers/models';
 import type { PrintableType } from './vis-packs/core/models';
 import { toArray } from './vis-packs/core/utils';
@@ -129,6 +130,16 @@ export function hasNumericType<S extends Shape>(
   return isNumericType(dataset.type);
 }
 
+function isIntegerType(type: DType): type is IntegerType {
+  return [DTypeClass.Integer, DTypeClass.Unsigned].includes(type.class);
+}
+
+export function hasIntegerType<S extends Shape>(
+  dataset: Dataset<S>
+): dataset is Dataset<S, IntegerType> {
+  return isIntegerType(dataset.type);
+}
+
 export function isAbsolutePath(path: string) {
   return path.startsWith('/');
 }
@@ -181,6 +192,15 @@ export function assertMinDims(dataset: Dataset<ArrayShape>, min: number) {
   }
 }
 
+export function assertNumDims(
+  dataset: Dataset<ArrayShape>,
+  expectedNum: number
+) {
+  if (dataset.shape.length !== expectedNum) {
+    throw new Error(`Expected dataset with ${expectedNum} dimensions`);
+  }
+}
+
 export function assertPrintableType<S extends Shape>(
   dataset: Dataset<S>
 ): asserts dataset is Dataset<S, PrintableType> {
@@ -207,6 +227,14 @@ export function assertNumericType<S extends Shape>(
 ): asserts dataset is Dataset<S, NumericType> {
   if (!hasNumericType(dataset)) {
     throw new Error('Expected dataset to have numeric type');
+  }
+}
+
+export function assertIntegerType<S extends Shape>(
+  dataset: Dataset<S>
+): asserts dataset is Dataset<S, IntegerType> {
+  if (!hasIntegerType(dataset)) {
+    throw new Error('Expected dataset to have integer type');
   }
 }
 

--- a/src/h5web/providers/models.ts
+++ b/src/h5web/providers/models.ts
@@ -109,9 +109,13 @@ export interface BooleanType {
 }
 
 export interface NumericType {
-  class: DTypeClass.Integer | DTypeClass.Float | DTypeClass.Unsigned;
+  class: DTypeClass.Integer | DTypeClass.Unsigned | DTypeClass.Float;
   size: number;
   endianness?: Endianness;
+}
+
+export interface IntegerType extends NumericType {
+  class: DTypeClass.Integer | DTypeClass.Unsigned;
 }
 
 export interface ComplexType {

--- a/src/h5web/toolbar/RgbVisToolbar.tsx
+++ b/src/h5web/toolbar/RgbVisToolbar.tsx
@@ -1,0 +1,28 @@
+import { MdAspectRatio } from 'react-icons/md';
+import ToggleBtn from './controls/ToggleBtn';
+import Toolbar from './Toolbar';
+import shallow from 'zustand/shallow';
+import GridToggler from './controls/GridToggler';
+import { useRgbVisConfig } from '../vis-packs/core/rgb/config';
+
+function RgbVisToolbar() {
+  const { layout, setLayout, showGrid, toggleGrid } = useRgbVisConfig(
+    (state) => state,
+    shallow
+  );
+
+  return (
+    <Toolbar>
+      <ToggleBtn
+        label="Keep ratio"
+        icon={MdAspectRatio}
+        value={layout === 'cover'}
+        onToggle={() => setLayout(layout === 'cover' ? 'fill' : 'cover')}
+      />
+
+      <GridToggler value={showGrid} onToggle={toggleGrid} />
+    </Toolbar>
+  );
+}
+
+export default RgbVisToolbar;

--- a/src/h5web/utils.test.ts
+++ b/src/h5web/utils.test.ts
@@ -1,9 +1,11 @@
 import {
   intType,
   makeGroup,
+  makeNxAxesAttr,
   makeScalarDataset,
+  makeStrAttr,
 } from './providers/mock/metadata-utils';
-import { buildEntityPath, getChildEntity } from './utils';
+import { buildEntityPath, getAttributeValue, getChildEntity } from './utils';
 
 describe('getChildEntity', () => {
   const dataset = makeScalarDataset('dataset', intType);
@@ -30,5 +32,25 @@ describe('buildEntityPath', () => {
   it('should build absolute path with relative path', () => {
     expect(buildEntityPath('/', 'group/dataset')).toBe('/group/dataset');
     expect(buildEntityPath('/foo', 'group/dataset')).toBe('/foo/group/dataset');
+  });
+});
+
+describe('getAttributeValue', () => {
+  const group = makeGroup('group', [], {
+    attributes: [
+      makeStrAttr('signal', 'my_signal'),
+      makeNxAxesAttr(['X']),
+      makeStrAttr('CLASS', 'IMAGE'),
+    ],
+  });
+
+  it("should return an attribute's value", () => {
+    expect(getAttributeValue(group, 'signal')).toBe('my_signal');
+    expect(getAttributeValue(group, 'axes')).toEqual(['X']);
+    expect(getAttributeValue(group, 'CLASS')).toEqual('IMAGE');
+  });
+
+  it("should return `undefined` if attribute doesn't exist", () => {
+    expect(getAttributeValue(group, 'NX_class')).toBeUndefined();
   });
 });

--- a/src/h5web/utils.ts
+++ b/src/h5web/utils.ts
@@ -1,5 +1,6 @@
 import { format } from 'd3-format';
 import type { Entity, Group, H5WebComplex } from './providers/models';
+import type { NxAttribute } from './vis-packs/nexus/models';
 
 export const formatValue = format('.3~e');
 export const formatPreciseValue = format('.5~e');
@@ -49,4 +50,11 @@ export function handleError<T>(
 
     throw error;
   }
+}
+
+export function getAttributeValue(
+  entity: Entity,
+  attributeName: NxAttribute | 'CLASS'
+): unknown {
+  return entity.attributes?.find((attr) => attr.name === attributeName)?.value;
 }

--- a/src/h5web/vis-packs/VisPackChooser.tsx
+++ b/src/h5web/vis-packs/VisPackChooser.tsx
@@ -1,10 +1,9 @@
 import { useContext } from 'react';
 import { ProviderContext } from '../providers/context';
 import { ProviderError } from '../providers/models';
-import { handleError } from '../utils';
+import { getAttributeValue, handleError } from '../utils';
 import CorePack from './core/CorePack';
 import NexusPack from './nexus/NexusPack';
-import { getAttributeValue } from './nexus/utils';
 
 interface Props {
   path: string;

--- a/src/h5web/vis-packs/core/VisBoundary.tsx
+++ b/src/h5web/vis-packs/core/VisBoundary.tsx
@@ -5,7 +5,7 @@ import ErrorFallback from '../../visualizer/ErrorFallback';
 import ValueLoader from '../../visualizer/ValueLoader';
 
 interface Props {
-  resetKey: unknown;
+  resetKey?: unknown;
   loadingMessage?: string;
   children: ReactNode;
 }

--- a/src/h5web/vis-packs/core/containers/RgbVisContainer.tsx
+++ b/src/h5web/vis-packs/core/containers/RgbVisContainer.tsx
@@ -1,0 +1,45 @@
+import {
+  assertDataset,
+  assertArrayShape,
+  assertIntegerType,
+  assertNumDims,
+} from '../../../guards';
+import type { VisContainerProps } from '../../models';
+import VisBoundary from '../VisBoundary';
+import ValueFetcher from '../ValueFetcher';
+import RgbVis from '../rgb/RgbVis';
+import { useRgbVisConfig } from '../rgb/config';
+import shallow from 'zustand/shallow';
+
+function RgbVisContainer(props: VisContainerProps) {
+  const { entity } = props;
+  assertDataset(entity);
+  assertArrayShape(entity);
+  assertNumDims(entity, 3);
+  assertIntegerType(entity);
+
+  const { shape: dims } = entity;
+
+  const { showGrid, layout } = useRgbVisConfig((state) => state, shallow);
+
+  return (
+    <VisBoundary loadingMessage="Loading image">
+      <ValueFetcher
+        dataset={entity}
+        render={(value) => {
+          return (
+            <RgbVis
+              value={value}
+              dims={dims}
+              title={entity.name}
+              showGrid={showGrid}
+              layout={layout}
+            />
+          );
+        }}
+      />
+    </VisBoundary>
+  );
+}
+
+export default RgbVisContainer;

--- a/src/h5web/vis-packs/core/heatmap/HeatmapMesh.tsx
+++ b/src/h5web/vis-packs/core/heatmap/HeatmapMesh.tsx
@@ -85,7 +85,6 @@ function HeatmapMesh(props: Props) {
   const shader = {
     uniforms: {
       data: { value: dataTexture },
-      originY: { value: ordinateConfig.flip ? 1 : 0 },
       withAlpha: { value: alphaValues ? 1 : 0 },
       alpha: { value: alphaTexture },
       colorMap: { value: colorMapTexture },
@@ -99,10 +98,9 @@ function HeatmapMesh(props: Props) {
     },
     vertexShader: `
       varying vec2 coords;
-      uniform float originY;
 
       void main() {
-        coords = vec2(uv[0], abs(uv[1] - originY));
+        coords = uv;
         gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
       }
     `,
@@ -155,7 +153,7 @@ function HeatmapMesh(props: Props) {
   };
 
   return (
-    <VisMesh>
+    <VisMesh scale={[1, ordinateConfig.flip ? -1 : 1, 1]}>
       <shaderMaterial args={[shader]} />
     </VisMesh>
   );

--- a/src/h5web/vis-packs/core/rgb/RgbVis.tsx
+++ b/src/h5web/vis-packs/core/rgb/RgbVis.tsx
@@ -1,0 +1,73 @@
+import { ReactNode, useMemo } from 'react';
+import styles from '../heatmap/HeatmapVis.module.css';
+import PanZoomMesh from '../shared/PanZoomMesh';
+import VisCanvas from '../shared/VisCanvas';
+import type { Layout } from '../heatmap/models';
+import { DataTexture, RGBFormat, UnsignedByteType } from 'three';
+import VisMesh from '../shared/VisMesh';
+
+interface Props {
+  value: number[];
+  dims: number[];
+  layout?: Layout;
+  showGrid?: boolean;
+  title?: string;
+  children?: ReactNode;
+}
+
+function RgbVis(props: Props) {
+  const {
+    value,
+    dims,
+    layout = 'cover',
+    showGrid = false,
+    title,
+    children,
+  } = props;
+
+  const [rows, cols] = dims;
+
+  const texture = useMemo(() => {
+    return new DataTexture(
+      Uint8Array.from(value),
+      cols,
+      rows,
+      RGBFormat,
+      UnsignedByteType
+    );
+  }, [cols, rows, value]);
+
+  return (
+    <figure
+      className={styles.root}
+      aria-labelledby="vis-title"
+      data-keep-canvas-colors
+    >
+      <VisCanvas
+        title={title}
+        aspectRatio={layout === 'contain' ? cols / rows : undefined}
+        visRatio={layout === 'cover' ? cols / rows : undefined}
+        abscissaConfig={{
+          visDomain: [0, cols],
+          showGrid,
+          isIndexAxis: true,
+        }}
+        ordinateConfig={{
+          visDomain: [0, rows],
+          showGrid,
+          isIndexAxis: true,
+          flip: true,
+        }}
+      >
+        <PanZoomMesh />
+        <VisMesh scale={[1, -1, 1]}>
+          <meshBasicMaterial map={texture} />
+        </VisMesh>
+        {children}
+      </VisCanvas>
+    </figure>
+  );
+}
+
+export type { Props as RgbVisProps };
+export default RgbVis;

--- a/src/h5web/vis-packs/core/rgb/config.tsx
+++ b/src/h5web/vis-packs/core/rgb/config.tsx
@@ -1,0 +1,46 @@
+import create from 'zustand';
+import { persist } from 'zustand/middleware';
+import type { Layout } from '../heatmap/models';
+import { useState } from 'react';
+import type { ConfigProviderProps } from '../../models';
+import createContext from 'zustand/context';
+
+interface RgbVisConfig {
+  showGrid: boolean;
+  toggleGrid: () => void;
+
+  layout: Layout;
+  setLayout: (layout: Layout) => void;
+}
+
+function initialiseStore() {
+  return create<RgbVisConfig>(
+    persist(
+      (set) => ({
+        showGrid: false,
+        toggleGrid: () => set((state) => ({ showGrid: !state.showGrid })),
+
+        layout: 'cover',
+        setLayout: (layout: Layout) => set({ layout }),
+      }),
+      {
+        name: 'h5web:image',
+        whitelist: ['showGrid', 'layout'],
+        version: 1,
+      }
+    )
+  );
+}
+
+const { Provider, useStore } = createContext<RgbVisConfig>();
+export const useRgbVisConfig = useStore;
+
+// https://github.com/pmndrs/zustand/issues/128#issuecomment-673398578
+export function RgbVisConfigProvider(props: ConfigProviderProps) {
+  const { children } = props;
+
+  // https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
+  const [store] = useState(() => initialiseStore());
+
+  return <Provider initialStore={store}>{children}</Provider>;
+}

--- a/src/h5web/vis-packs/core/visualizations.test.ts
+++ b/src/h5web/vis-packs/core/visualizations.test.ts
@@ -9,6 +9,7 @@ import {
   complexType,
   makeScalarDataset,
   unsignedType,
+  makeStrAttr,
 } from '../../providers/mock/metadata-utils';
 
 const datasetIntScalar = makeScalarDataset('dataset_int', intType);
@@ -27,6 +28,20 @@ const datasetCplx2D = makeDataset('dataset_cplx_2d', complexType, [2, 2]);
 const datasetStr2D = makeDataset('dataset_str_2d', stringType, [5, 3]);
 const datasetFlt3D = makeDataset('dataset_flt_3d', intType, [5, 3, 1]);
 const datasetCplx3D = makeDataset('dataset_cplx_3d', complexType, [5, 2, 2]);
+const imageDataset = makeDataset('image_dataset', intType, [256, 256, 3], {
+  attributes: [makeStrAttr('CLASS', 'IMAGE')],
+});
+const scalarImageDataset = makeScalarDataset('image_dataset', intType, {
+  attributes: [makeStrAttr('CLASS', 'IMAGE')],
+});
+const floatImageDataset = makeDataset(
+  'image_dataset',
+  floatType,
+  [256, 256, 3],
+  {
+    attributes: [makeStrAttr('CLASS', 'IMAGE')],
+  }
+);
 
 describe('Raw', () => {
   const { supportsDataset } = CORE_VIS.Raw;
@@ -160,5 +175,21 @@ describe('Complex Line', () => {
 
   it('should not support dataset with non-array shape', () => {
     expect(supportsDataset(datasetCplxScalar)).toBe(false);
+  });
+});
+
+describe('RGB', () => {
+  const { supportsDataset } = CORE_VIS.RGB;
+
+  it('should support array dataset with IMAGE attribute and integer type', () => {
+    expect(supportsDataset(imageDataset)).toBe(true);
+  });
+
+  it('should not support dataset with non-integer type', () => {
+    expect(supportsDataset(floatImageDataset)).toBe(false);
+  });
+
+  it('should not support dataset with non-array shape', () => {
+    expect(supportsDataset(scalarImageDataset)).toBe(false);
   });
 });

--- a/src/h5web/vis-packs/core/visualizations.ts
+++ b/src/h5web/vis-packs/core/visualizations.ts
@@ -1,4 +1,11 @@
-import { FiCode, FiGrid, FiActivity, FiMap, FiCpu } from 'react-icons/fi';
+import {
+  FiCode,
+  FiGrid,
+  FiActivity,
+  FiMap,
+  FiCpu,
+  FiImage,
+} from 'react-icons/fi';
 import LineToolbar from '../../toolbar/LineToolbar';
 import HeatmapToolbar from '../../toolbar/HeatmapToolbar';
 import type { Dataset } from '../../providers/models';
@@ -10,6 +17,7 @@ import {
   hasMinDims,
   hasNonNullShape,
   hasComplexType,
+  hasIntegerType,
 } from '../../guards';
 import {
   RawVisContainer,
@@ -27,6 +35,10 @@ import { ComplexConfigProvider } from './complex/config';
 import ComplexLineVisContainer from './containers/ComplexLineVisContainer';
 import ComplexLineToolbar from '../../toolbar/ComplexLineToolbar';
 import { ComplexLineConfigProvider } from './complex/lineConfig';
+import RgbVisContainer from './containers/RgbVisContainer';
+import { RgbVisConfigProvider } from './rgb/config';
+import RgbVisToolbar from '../../toolbar/RgbVisToolbar';
+import { getAttributeValue } from '../../utils';
 
 export enum Vis {
   Raw = 'Raw',
@@ -36,6 +48,7 @@ export enum Vis {
   Heatmap = 'Heatmap',
   Complex = 'Complex',
   ComplexLine = 'ComplexLine',
+  RGB = 'RGB',
 }
 
 export interface CoreVisDef extends VisDef {
@@ -116,6 +129,24 @@ export const CORE_VIS: Record<Vis, CoreVisDef> = {
         hasComplexType(dataset) &&
         hasArrayShape(dataset) &&
         hasMinDims(dataset, 2)
+      );
+    },
+  },
+
+  [Vis.RGB]: {
+    name: Vis.RGB,
+    Icon: FiImage,
+    Toolbar: RgbVisToolbar,
+    Container: RgbVisContainer,
+    ConfigProvider: RgbVisConfigProvider,
+    supportsDataset: (dataset) => {
+      const classAttr = getAttributeValue(dataset, 'CLASS');
+      return (
+        typeof classAttr === 'string' &&
+        classAttr === 'IMAGE' &&
+        hasArrayShape(dataset) &&
+        dataset.shape.length === 3 &&
+        hasIntegerType(dataset)
       );
     },
   },

--- a/src/h5web/vis-packs/nexus/pack-utils.ts
+++ b/src/h5web/vis-packs/nexus/pack-utils.ts
@@ -1,10 +1,10 @@
 import type { FetchStore } from 'react-suspense-fetch';
 import { assertStr, hasComplexType, hasMinDims, isGroup } from '../../guards';
 import { Entity, ProviderError } from '../../providers/models';
-import { buildEntityPath, handleError } from '../../utils';
+import { buildEntityPath, getAttributeValue, handleError } from '../../utils';
 import type { VisDef } from '../models';
 import { NxInterpretation } from './models';
-import { findSignalDataset, getAttributeValue, isNxDataGroup } from './utils';
+import { findSignalDataset, isNxDataGroup } from './utils';
 import { NexusVis, NEXUS_VIS } from './visualizations';
 
 export function getDefaultEntity(

--- a/src/h5web/vis-packs/nexus/utils.test.ts
+++ b/src/h5web/vis-packs/nexus/utils.test.ts
@@ -7,31 +7,10 @@ import {
   makeIntAttr,
   makeSilxStyleAttr,
   makeScalarDataset,
-  makeNxAxesAttr,
 } from '../../providers/mock/metadata-utils';
 import { mockConsoleMethod } from '../../test-utils';
 import { ScaleType } from '../core/models';
-import {
-  findSignalDataset,
-  getAttributeValue,
-  getDatasetLabel,
-  getSilxStyle,
-} from './utils';
-
-describe('getAttributeValue', () => {
-  const group = makeGroup('group', [], {
-    attributes: [makeStrAttr('signal', 'my_signal'), makeNxAxesAttr(['X'])],
-  });
-
-  it("should return an attribute's value", () => {
-    expect(getAttributeValue(group, 'signal')).toBe('my_signal');
-    expect(getAttributeValue(group, 'axes')).toEqual(['X']);
-  });
-
-  it("should return `undefined` if attribute doesn't exist", () => {
-    expect(getAttributeValue(group, 'NX_class')).toBeUndefined();
-  });
-});
+import { findSignalDataset, getDatasetLabel, getSilxStyle } from './utils';
 
 describe('findSignalDataset', () => {
   it("should return dataset named 'signal'", () => {

--- a/src/h5web/vis-packs/nexus/utils.ts
+++ b/src/h5web/vis-packs/nexus/utils.ts
@@ -1,6 +1,5 @@
 import type {
   Group,
-  Entity,
   Dataset,
   NumArrayDataset,
   NumericType,
@@ -21,16 +20,9 @@ import {
   assertArray,
   isDefined,
 } from '../../guards';
-import type { NxAttribute, NxData, SilxStyle } from './models';
+import type { NxData, SilxStyle } from './models';
 import { isScaleType } from '../core/utils';
-import { getChildEntity } from '../../utils';
-
-export function getAttributeValue(
-  entity: Entity,
-  attributeName: NxAttribute
-): unknown {
-  return entity.attributes?.find((attr) => attr.name === attributeName)?.value;
-}
+import { getAttributeValue, getChildEntity } from '../../utils';
 
 export function getDatasetLabel(dataset: Dataset): string {
   const longName = getAttributeValue(dataset, 'long_name');


### PR DESCRIPTION
Work towards #649 :see_no_evil: 

![image](https://user-images.githubusercontent.com/42204205/123222813-9c918280-d4d0-11eb-9d34-59993572ad80.png)

For now, works only for RGB images and only datasets with 3 dimensions, integers dtype and a `CLASS=IMAGE` attribute are interpreted as such.

Future PRs will widen the support but supporting the full specification is out of scope in my opinion.
