### PR TITLE
Show file name instead of file path in headings

### DIFF
--- a/src/h5web/breadcrumbs/Breadcrumbs.tsx
+++ b/src/h5web/breadcrumbs/Breadcrumbs.tsx
@@ -8,20 +8,20 @@ import CopyableCrumb from './CopyableCrumb';
 interface Props {
   path: string;
   onSelect: (path: string) => void;
-  showFilepath: boolean;
+  showFilename: boolean;
 }
 
 function Breadcrumbs(props: Props) {
-  const { path, onSelect, showFilepath } = props;
+  const { path, onSelect, showFilename } = props;
 
   assertAbsolutePath(path);
-  const { filepath } = useContext(ProviderContext);
+  const { filename } = useContext(ProviderContext);
 
   if (path === '/') {
     return (
       <h1 className={styles.breadCrumbs}>
         <span className={styles.crumb} data-current>
-          {filepath}
+          {filename}
         </span>
       </h1>
     );
@@ -32,7 +32,7 @@ function Breadcrumbs(props: Props) {
 
   return (
     <h1 className={styles.breadCrumbs}>
-      {showFilepath && <Crumb name={filepath} onClick={() => onSelect('/')} />}
+      {showFilename && <Crumb name={filename} onClick={() => onSelect('/')} />}
       {crumbs.slice(0, -1).map((crumb, i) => {
         const crumbPath = `/${crumbs.slice(0, i + 1).join('/')}`;
         return (

--- a/src/h5web/breadcrumbs/BreadcrumbsBar.tsx
+++ b/src/h5web/breadcrumbs/BreadcrumbsBar.tsx
@@ -36,7 +36,7 @@ function BreadcrumbsBar(props: Props) {
       <Breadcrumbs
         path={path}
         onSelect={onSelectPath}
-        showFilepath={!isExplorerOpen}
+        showFilename={!isExplorerOpen}
       />
 
       <ToggleGroup

--- a/src/h5web/explorer/Explorer.tsx
+++ b/src/h5web/explorer/Explorer.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 function Explorer(props: Props) {
   const { selectedPath, onSelect } = props;
-  const { filepath } = useContext(ProviderContext);
+  const { filename } = useContext(ProviderContext);
 
   return (
     <div className={styles.explorer} role="tree">
@@ -23,7 +23,7 @@ function Explorer(props: Props) {
         onClick={() => onSelect('/')}
       >
         <FiFileText className={styles.fileIcon} />
-        {filepath}
+        {filename}
       </button>
 
       <Suspense

--- a/src/h5web/metadata-viewer/EntityTable.tsx
+++ b/src/h5web/metadata-viewer/EntityTable.tsx
@@ -14,7 +14,7 @@ interface Props {
 function EntityTable(props: Props) {
   const { entity } = props;
   const { name, path, kind } = entity;
-  const { filepath } = useContext(ProviderContext);
+  const { filename } = useContext(ProviderContext);
 
   return (
     <table className={styles.table}>
@@ -32,7 +32,7 @@ function EntityTable(props: Props) {
         </tr>
         <tr>
           <th scope="row">Name</th>
-          <td>{path === '/' ? filepath : name}</td>
+          <td>{path === '/' ? filename : name}</td>
         </tr>
         {(isDataset(entity) || isDatatype(entity)) && (
           <tr>

--- a/src/h5web/providers/Provider.tsx
+++ b/src/h5web/providers/Provider.tsx
@@ -56,10 +56,12 @@ function Provider(props: Props) {
     });
   }, [api]);
 
+  const filepathMembers = api.filepath.split('/');
+
   return (
     <ProviderContext.Provider
       value={{
-        filepath: api.filepath,
+        filename: filepathMembers[filepathMembers.length - 1],
         entitiesStore,
         valuesStore,
       }}

--- a/src/h5web/providers/context.ts
+++ b/src/h5web/providers/context.ts
@@ -8,7 +8,7 @@ interface ValuesStore extends FetchStore<unknown, ValueRequestParams> {
 }
 
 interface Context {
-  filepath: string;
+  filename: string;
   entitiesStore: FetchStore<Entity, string>;
   valuesStore: ValuesStore;
 }


### PR DESCRIPTION
With https://github.com/silx-kit/jupyterlab-h5web/issues/37 next release, the filepaths in h5web can be absolute and therefore quite lengthy. I think it would be prettier to show only the filename and not the full path, which is the point of this PR.

**Before:**
![image](https://user-images.githubusercontent.com/42204205/123263996-df1b8500-d4f9-11eb-99b2-30e820c5ac1d.png)

**After:**
![image](https://user-images.githubusercontent.com/42204205/123264294-2e61b580-d4fa-11eb-8bc9-28817df40597.png)
