### PR TITLE
Prevent HTML annotations from overflowing canvas

### DIFF
--- a/src/h5web/vis-packs/core/heatmap/HeatmapVis.tsx
+++ b/src/h5web/vis-packs/core/heatmap/HeatmapVis.tsx
@@ -94,8 +94,8 @@ function HeatmapVis(props: Props) {
           flip: flipYAxis,
         }}
       >
-        <TooltipMesh {...tooltipFormatters} guides="both" />
         <PanZoomMesh />
+        <TooltipMesh {...tooltipFormatters} guides="both" />
         <HeatmapMesh
           rows={rows}
           cols={cols}

--- a/src/h5web/vis-packs/core/line/LineVis.tsx
+++ b/src/h5web/vis-packs/core/line/LineVis.tsx
@@ -108,8 +108,8 @@ function LineVis(props: Props) {
           label: ordinateLabel,
         }}
       >
-        <TooltipMesh {...tooltipFormatters} guides="vertical" />
         <PanZoomMesh />
+        <TooltipMesh {...tooltipFormatters} guides="vertical" />
         <DataCurve
           abscissas={abscissas}
           ordinates={dataArray.data as number[]}

--- a/src/h5web/vis-packs/core/shared/Annotation.tsx
+++ b/src/h5web/vis-packs/core/shared/Annotation.tsx
@@ -1,4 +1,4 @@
-import type { HTMLAttributes } from 'react';
+import type { CSSProperties, HTMLAttributes } from 'react';
 import { useAxisSystemContext } from './AxisSystemContext';
 import Html from './Html';
 
@@ -7,22 +7,21 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
   y: number;
   z?: number;
   scaleOnZoom?: boolean;
+  style?: CSSProperties;
 }
 
 function Annotation(props: Props) {
-  const { x, y, z = 1, scaleOnZoom, children, ...divProps } = props;
+  const { x, y, z = 1, scaleOnZoom, style, children, ...divProps } = props;
   const { abscissaScale, ordinateScale } = useAxisSystemContext();
 
   return (
     <Html
-      groupProps={{
-        position: [abscissaScale(x), ordinateScale(y), z],
-      }}
+      groupProps={{ position: [abscissaScale(x), ordinateScale(y), z] }}
       followCamera
       scaleOnZoom={scaleOnZoom}
       {...divProps}
     >
-      {children}
+      <div style={style}>{children}</div>
     </Html>
   );
 }

--- a/src/stories/HeatmapVis.stories.tsx
+++ b/src/stories/HeatmapVis.stories.tsx
@@ -165,8 +165,8 @@ WithAlphaArray.args = {
 
 export const WithAnnotation: Story<HeatmapVisProps> = (args) => (
   <HeatmapVis {...args}>
-    <Annotation x={30} y={18} style={{ width: '200px' }}>
-      <p style={{ color: 'white' }}>An annotation</p>
+    <Annotation x={30} y={18} style={{ width: '200px', color: 'white' }}>
+      An annotation
     </Annotation>
   </HeatmapVis>
 );

--- a/src/stories/LineVisDisplay.stories.tsx
+++ b/src/stories/LineVisDisplay.stories.tsx
@@ -67,8 +67,8 @@ WithTitle.args = {
 
 export const WithAnnotation: Story<LineVisProps> = (args) => (
   <LineVis {...args}>
-    <Annotation x={30} y={10} style={{ width: '200px' }}>
-      <p>A simple line</p>
+    <Annotation x={30} y={10} style={{ width: '100px' }}>
+      a very simple line
     </Annotation>
   </LineVis>
 );


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2936402/123757403-3c2e8680-d8be-11eb-8ff8-ef822ed02c61.png)

Big refactoring, but worth it, I think. It's no longer the outer element that is transformed around the canvas, but the inner element. The outer element now takes the whole size of the canvas, which means it now has to have the `pointer-events: none`. This revealed an event propagation regression with the tooltip, which was easily fixed. Most importantly, I find that it makes the roles of all the `useLayoutEffect`, `useEffect` and `useFrame` hooks a lot clearer (as demonstrated by the fact that we no longer need to disable ESLint because of missing hook dependencies).