### PR TITLE
Update h5grove API to pass filename as query arg

### DIFF
--- a/src/h5web/providers/h5grove/h5grove-api.ts
+++ b/src/h5web/providers/h5grove/h5grove-api.ts
@@ -19,7 +19,7 @@ import type {
 import { convertDtype, flattenValue } from '../utils';
 
 export class H5GroveApi extends ProviderApi {
-  /* API compatible with h5grove@0.0.1 */
+  /* API compatible with jupyterlab_h5web@e878351f5226fabc9cd14e8f0b774185ff8def45 */
   public constructor(url: string, filepath: string) {
     super(filepath, { baseURL: url });
   }
@@ -42,7 +42,7 @@ export class H5GroveApi extends ProviderApi {
 
   private async fetchAttributes(path: string): Promise<H5GroveAttrResponse> {
     const { data } = await this.client.get<H5GroveAttrResponse>(
-      `/attr/${this.filepath}?path=${path}`
+      `/attr/?file=${this.filepath}&path=${path}`
     );
     return data;
   }
@@ -52,7 +52,7 @@ export class H5GroveApi extends ProviderApi {
   ): Promise<H5GroveDataResponse> {
     const { path, selection = '' } = params;
     const { data } = await this.cancellableFetchValue<H5GroveDataResponse>(
-      `/data/${this.filepath}?path=${path}${
+      `/data/?file=${this.filepath}&path=${path}${
         selection && `&selection=${selection}`
       }`,
       params
@@ -62,7 +62,7 @@ export class H5GroveApi extends ProviderApi {
 
   private async fetchMetadata(path: string): Promise<H5GroveMetaResponse> {
     const { data } = await this.client.get<H5GroveMetaResponse>(
-      `/meta/${this.filepath}?path=${path}`
+      `/meta/?file=${this.filepath}&path=${path}`
     );
     return data;
   }


### PR DESCRIPTION
Technically, the API is meant to be compatible with `jupyterlab_h5web`'s backend that is based on `h5grove`... 

We could rename it into `JupyterlabH5Web` API but that's lengthier and we already have a `JupyterProvider` so we would need a **lot** of renames...