### PR TITLE
Implement Square root scale

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
   "jest": {
     "restoreMocks": true,
     "transformIgnorePatterns": [
-      "node_modules/(?!(d3-color|d3-format|d3-scale-chromatic)/)"
+      "node_modules/(?!(d3-color|d3-format|d3-scale-chromatic|three)/)"
     ]
   },
   "browserslist": {

--- a/src/h5web/toolbar/controls/DomainSlider/ErrorMessage.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/ErrorMessage.tsx
@@ -8,16 +8,16 @@ const ERRORS = {
     message: 'Min greater than max',
     fallback: 'data range',
   },
-  [DomainError.InvalidMinWithLog]: {
-    message: 'Custom min invalid with log scale',
+  [DomainError.InvalidMinWithScale]: {
+    message: 'Custom min invalid with this scale',
     fallback: 'data min',
   },
-  [DomainError.InvalidMaxWithLog]: {
-    message: 'Custom max invalid with log scale',
+  [DomainError.InvalidMaxWithScale]: {
+    message: 'Custom max invalid with this scale',
     fallback: 'data max',
   },
   [DomainError.CustomMaxFallback]: {
-    message: 'Custom min invalid with log scale',
+    message: 'Custom min invalid with this scale',
     fallback: 'custom max',
   },
 };

--- a/src/h5web/toolbar/controls/DomainSlider/ScaledSlider.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/ScaledSlider.tsx
@@ -1,7 +1,11 @@
 import { useState } from 'react';
 import { FiSkipBack, FiSkipForward } from 'react-icons/fi';
 import ReactSlider from 'react-slider';
-import { createAxisScale, extendDomain } from '../../../vis-packs/core/utils';
+import {
+  clampBound,
+  createAxisScale,
+  extendDomain,
+} from '../../../vis-packs/core/utils';
 import type {
   Domain,
   DomainErrors,
@@ -43,7 +47,7 @@ function ScaledSlider(props: Props) {
   const sliderExtent = extendDomain(safeVisDomain, EXTEND_FACTOR, scaleType);
   const scale = createAxisScale({
     type: scaleType,
-    domain: sliderExtent,
+    domain: sliderExtent.map((val) => clampBound(val)),
     range: SLIDER_RANGE,
     clamp: true,
   });

--- a/src/h5web/toolbar/controls/ScaleSelector/ScaleOption.tsx
+++ b/src/h5web/toolbar/controls/ScaleSelector/ScaleOption.tsx
@@ -1,28 +1,14 @@
-import type { IconType } from 'react-icons/lib';
-import { MdSort, MdFilterList } from 'react-icons/md';
-import { ScaleType } from '../../../vis-packs/core/models';
-import MdGraphicEqRotated from './MdGraphicEqRotated';
+import type { ScaleType } from '../../../vis-packs/core/models';
 import styles from '../../Toolbar.module.css';
-
-const ICONS: Record<ScaleType, IconType> = {
-  [ScaleType.Linear]: MdSort,
-  [ScaleType.Log]: MdFilterList,
-  [ScaleType.SymLog]: MdGraphicEqRotated,
-};
-
-const LABELS: Record<ScaleType, string> = {
-  [ScaleType.Linear]: 'Linear',
-  [ScaleType.Log]: 'Log',
-  [ScaleType.SymLog]: 'SymLog',
-};
+import { H5WEB_SCALES } from '../../../vis-packs/core/scales';
 
 function ScaleOption(props: { option: ScaleType }) {
   const { option } = props;
-  const Icon = ICONS[option];
+  const { Icon, label } = H5WEB_SCALES[option];
   return (
     <>
       <Icon className={styles.icon} />
-      {LABELS[option]}
+      {label}
     </>
   );
 }

--- a/src/h5web/toolbar/controls/ScaleSelector/SqrtIcon.tsx
+++ b/src/h5web/toolbar/controls/ScaleSelector/SqrtIcon.tsx
@@ -1,0 +1,25 @@
+/**
+ * Inspired by FiActivity
+ */
+import type { SVGProps } from 'react';
+
+function SqrtIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      stroke="currentColor"
+      fill="none"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      height="1em"
+      width="1em"
+      {...props}
+    >
+      <polyline points="2 12 6 12 9 21 15 3 19 3" />
+    </svg>
+  );
+}
+
+export default SqrtIcon;

--- a/src/h5web/vis-packs/core/models.ts
+++ b/src/h5web/vis-packs/core/models.ts
@@ -12,6 +12,7 @@ export enum ScaleType {
   Linear = 'linear',
   Log = 'log',
   SymLog = 'symlog',
+  Sqrt = 'sqrt',
 }
 
 export interface Size {
@@ -25,14 +26,14 @@ export type CustomDomain = [number | null, number | null]; // `null` for persist
 
 export interface DomainErrors {
   minGreater?: boolean;
-  minError?: DomainError.InvalidMinWithLog | DomainError.CustomMaxFallback;
-  maxError?: DomainError.InvalidMaxWithLog;
+  minError?: DomainError.InvalidMinWithScale | DomainError.CustomMaxFallback;
+  maxError?: DomainError.InvalidMaxWithScale;
 }
 
 export enum DomainError {
   MinGreater = 'min-greater',
-  InvalidMinWithLog = 'invalid-min-with-log',
-  InvalidMaxWithLog = 'invalid-max-with-log',
+  InvalidMinWithScale = 'invalid-min-with-scale',
+  InvalidMaxWithScale = 'invalid-max-with-scale',
   CustomMaxFallback = 'custom-max-fallback',
 }
 
@@ -46,7 +47,7 @@ export interface AxisConfig {
 }
 
 export type AxisScale = PickD3Scale<
-  ScaleType.Linear | ScaleType.Log | ScaleType.SymLog,
+  ScaleType.Linear | ScaleType.Log | ScaleType.SymLog | ScaleType.Sqrt,
   number,
   number
 >;

--- a/src/h5web/vis-packs/core/scales.ts
+++ b/src/h5web/vis-packs/core/scales.ts
@@ -1,0 +1,49 @@
+import {
+  scaleLinear,
+  scaleLog,
+  scaleSymlog,
+  scaleSqrt,
+  PickScaleConfig,
+} from '@visx/scale';
+import type { IconType } from 'react-icons/lib';
+import type { AxisScale } from './models';
+import { ScaleType } from './models';
+import { MdSort, MdFilterList } from 'react-icons/md';
+import SqrtIcon from '../../toolbar/controls/ScaleSelector/SqrtIcon';
+import MdGraphicEqRotated from '../../toolbar/controls/ScaleSelector/MdGraphicEqRotated';
+
+interface H5WebScale {
+  createScale: (
+    config: Omit<PickScaleConfig<ScaleType, number>, 'type'>
+  ) => AxisScale;
+  Icon: IconType;
+  label: string;
+  validMin: number;
+}
+
+export const H5WEB_SCALES: Record<ScaleType, H5WebScale> = {
+  [ScaleType.Linear]: {
+    createScale: (config) => scaleLinear<number>(config),
+    Icon: MdSort,
+    label: 'Linear',
+    validMin: -Infinity,
+  },
+  [ScaleType.Log]: {
+    createScale: (config) => scaleLog<number>(config),
+    Icon: MdFilterList,
+    label: 'Log',
+    validMin: Number.MIN_VALUE,
+  },
+  [ScaleType.SymLog]: {
+    createScale: (config) => scaleSymlog<number>(config),
+    Icon: MdGraphicEqRotated,
+    label: 'SymLog',
+    validMin: -Infinity,
+  },
+  [ScaleType.Sqrt]: {
+    createScale: (config) => scaleSqrt<number>(config),
+    Icon: SqrtIcon,
+    label: 'Square root',
+    validMin: 0,
+  },
+};


### PR DESCRIPTION
Fix #740 

This includes some refactorings. There was several problems with our implementation of scales:
1. **Adding a new scale requires to modify many files** as scale parameters (labels, icons, shaders...) are scattered
2. **The treatment of unsupported values is highly specific to the log** (i.e. supported value means `value > 0`) hampering the addition of scales with other supported values (namely, the square root that supports `value >= 0`) 
3. Combination of the two points above: **Treatment of unsupported values is scattered in many places**.

I address 1. by adding a single record `H5WEB_SCALES` that holds all the scale parameters and is indexed by the `scaleType`.

I address 2. by moving the `support` logic inside the record `H5WEB_SCALES`. I introduce `supportedDomain` which is the max extension supported domain and `supportsDomain` which tests if a domain is supported by the scale.

I address 3. by using the new `supportedDomain` and `supportsDomain` utilities in the appropriate functions: `clampBound`, `extendDomain` and `getValidDomainForScale`.

Adding the square root is then done by adding a new entry to `H5WEB_SCALES`.

