### PR TITLE
Enforce stricter types for groups with/without children

### DIFF
--- a/src/h5web/explorer/EntityList.tsx
+++ b/src/h5web/explorer/EntityList.tsx
@@ -2,7 +2,7 @@ import { useContext } from 'react';
 import styles from './Explorer.module.css';
 import { ProviderContext } from '../providers/context';
 import EntityItem from './EntityItem';
-import { assertGroup } from '../guards';
+import { assertGroupWithChildren } from '../guards';
 import { buildEntityPath } from '../utils';
 
 interface Props {
@@ -17,7 +17,7 @@ function EntityList(props: Props) {
 
   const { entitiesStore } = useContext(ProviderContext);
   const group = entitiesStore.get(parentPath);
-  assertGroup(group);
+  assertGroupWithChildren(group);
 
   if (group.children.length === 0) {
     return null;

--- a/src/h5web/guards.ts
+++ b/src/h5web/guards.ts
@@ -16,6 +16,7 @@ import {
   ComplexType,
   ComplexArray,
   H5WebComplex,
+  GroupWithChildren,
 } from './providers/models';
 import type { PrintableType } from './vis-packs/core/models';
 import { toArray } from './vis-packs/core/utils';
@@ -50,6 +51,10 @@ export function assertArray<T>(val: unknown): asserts val is T[] {
 
 export function isGroup(entity: Entity): entity is Group {
   return entity.kind === EntityKind.Group;
+}
+
+export function hasChildren(group: Group): group is GroupWithChildren {
+  return 'children' in group;
 }
 
 export function isDataset(entity: Entity): entity is Dataset {
@@ -146,12 +151,11 @@ export function assertDataset(
   }
 }
 
-export function assertGroup(
-  entity: Entity,
-  message = 'Expected group'
-): asserts entity is Group {
-  if (!isGroup(entity)) {
-    throw new Error(message);
+export function assertGroupWithChildren(
+  entity: Entity
+): asserts entity is GroupWithChildren {
+  if (!isGroup(entity) || !hasChildren(entity)) {
+    throw new Error('Expected group with children');
   }
 }
 

--- a/src/h5web/providers/Provider.tsx
+++ b/src/h5web/providers/Provider.tsx
@@ -3,7 +3,7 @@ import { createFetchStore } from 'react-suspense-fetch';
 import { ProviderContext } from './context';
 import type { ProviderApi } from './api';
 import type { Entity } from './models';
-import { isGroup } from '../guards';
+import { assertGroupWithChildren, isGroup } from '../guards';
 
 interface Props {
   api: ProviderApi;
@@ -24,12 +24,15 @@ function Provider(props: Props) {
       const entity = await api.getEntity(path);
 
       if (isGroup(entity)) {
+        // Make sure `getEntity` doesn't return groups without `children` proprety
+        assertGroupWithChildren(entity);
+
         // Cache non-group children (datasets, datatypes and links)
-        entity.children.forEach((child) => {
-          if (!isGroup(child)) {
+        entity.children
+          .filter((child) => !isGroup(child))
+          .forEach((child) => {
             childCache.set(child.path, child);
-          }
-        });
+          });
       }
 
       return entity;

--- a/src/h5web/providers/mock/metadata-utils.ts
+++ b/src/h5web/providers/mock/metadata-utils.ts
@@ -17,9 +17,10 @@ import {
   CompoundType,
   LinkClass,
   UnresolvedEntity,
+  GroupWithChildren,
 } from '../models';
 import type { NxInterpretation, SilxStyle } from '../../vis-packs/nexus/models';
-import { isGroup } from '../../guards';
+import { isGroup, hasChildren } from '../../guards';
 import { buildEntityPath } from '../../utils';
 import type { MockDataset, MockValueId } from './models';
 import { mockValues } from './values';
@@ -123,11 +124,14 @@ type EntityOpts = Partial<Pick<Entity, 'attributes' | 'link'>>;
 type GroupOpts = EntityOpts & { isRoot?: boolean; children?: Entity[] };
 type DatasetOpts = EntityOpts & { valueId?: MockValueId };
 
-function prefixChildrenPaths(group: Group, parentPath: string): void {
+function prefixChildrenPaths(
+  group: GroupWithChildren,
+  parentPath: string
+): void {
   group.children.forEach((c) => {
     c.path = buildEntityPath(parentPath, c.path.slice(1));
 
-    if (isGroup(c)) {
+    if (isGroup(c) && hasChildren(c)) {
       prefixChildrenPaths(c, parentPath);
     }
   });
@@ -137,11 +141,11 @@ export function makeGroup(
   name: string,
   children: Entity[] = [],
   opts: Omit<GroupOpts, 'children'> = {}
-): Group {
+): GroupWithChildren {
   const { attributes = [], link, isRoot = false } = opts;
   const path = isRoot ? '/' : `/${name}`;
 
-  const group: Group = {
+  const group: GroupWithChildren = {
     name,
     path,
     kind: EntityKind.Group,

--- a/src/h5web/providers/mock/utils.ts
+++ b/src/h5web/providers/mock/utils.ts
@@ -6,6 +6,7 @@ import {
   assertArrayShape,
   isDataset,
   isGroup,
+  hasChildren,
 } from '../../guards';
 import { getChildEntity } from '../../utils';
 import { Entity, ProviderError } from '../models';
@@ -34,7 +35,7 @@ export function findMockEntity(path: string): Entity {
   const pathSegments = path.slice(1).split('/');
   const entity = pathSegments.reduce<Entity | undefined>(
     (parentEntity, currSegment) => {
-      return parentEntity && isGroup(parentEntity)
+      return parentEntity && isGroup(parentEntity) && hasChildren(parentEntity)
         ? getChildEntity(parentEntity, currSegment)
         : undefined;
     },

--- a/src/h5web/providers/models.ts
+++ b/src/h5web/providers/models.ts
@@ -28,6 +28,9 @@ export interface Entity {
 
 export interface Group extends Entity {
   kind: EntityKind.Group;
+}
+
+export interface GroupWithChildren extends Group {
   children: Entity[];
 }
 

--- a/src/h5web/utils.ts
+++ b/src/h5web/utils.ts
@@ -1,5 +1,9 @@
 import { format } from 'd3-format';
-import type { Entity, Group, H5WebComplex } from './providers/models';
+import type {
+  Entity,
+  GroupWithChildren,
+  H5WebComplex,
+} from './providers/models';
 import type { ImageAttribute } from './vis-packs/core/models';
 import type { NxAttribute } from './vis-packs/nexus/models';
 
@@ -23,7 +27,7 @@ export function formatComplex(value: H5WebComplex, specifier = '') {
 }
 
 export function getChildEntity(
-  group: Group,
+  group: GroupWithChildren,
   entityName: string
 ): Entity | undefined {
   return group.children.find((child) => child.name === entityName);

--- a/src/h5web/vis-packs/nexus/containers/NxComplexImageContainer.tsx
+++ b/src/h5web/vis-packs/nexus/containers/NxComplexImageContainer.tsx
@@ -1,4 +1,8 @@
-import { assertComplexType, assertGroup, assertMinDims } from '../../../guards';
+import {
+  assertComplexType,
+  assertGroupWithChildren,
+  assertMinDims,
+} from '../../../guards';
 import type { VisContainerProps } from '../../models';
 import { useDimMappingState } from '../../hooks';
 import MappedComplexVis from '../../core/complex/MappedComplexVis';
@@ -10,7 +14,7 @@ import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 
 function NxComplexImageContainer(props: VisContainerProps) {
   const { entity } = props;
-  assertGroup(entity);
+  assertGroupWithChildren(entity);
 
   const nxData = getNxData(entity);
   const { signalDataset, silxStyle } = nxData;

--- a/src/h5web/vis-packs/nexus/containers/NxComplexSpectrumContainer.tsx
+++ b/src/h5web/vis-packs/nexus/containers/NxComplexSpectrumContainer.tsx
@@ -1,4 +1,4 @@
-import { assertGroup } from '../../../guards';
+import { assertGroupWithChildren } from '../../../guards';
 import type { VisContainerProps } from '../../models';
 import { useDimMappingState } from '../../hooks';
 import { getNxData, getDatasetLabel } from '../utils';
@@ -10,7 +10,7 @@ import { assertComplexNxData } from '../guards';
 
 function NxComplexSpectrumContainer(props: VisContainerProps) {
   const { entity } = props;
-  assertGroup(entity);
+  assertGroupWithChildren(entity);
 
   const nxData = getNxData(entity);
   assertComplexNxData(nxData);

--- a/src/h5web/vis-packs/nexus/containers/NxImageContainer.tsx
+++ b/src/h5web/vis-packs/nexus/containers/NxImageContainer.tsx
@@ -1,4 +1,8 @@
-import { assertGroup, assertMinDims, assertNumericType } from '../../../guards';
+import {
+  assertGroupWithChildren,
+  assertMinDims,
+  assertNumericType,
+} from '../../../guards';
 import type { VisContainerProps } from '../../models';
 import MappedHeatmapVis from '../../core/heatmap/MappedHeatmapVis';
 import { useDimMappingState } from '../../hooks';
@@ -9,7 +13,7 @@ import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 
 function NxImageContainer(props: VisContainerProps) {
   const { entity } = props;
-  assertGroup(entity);
+  assertGroupWithChildren(entity);
 
   const nxData = getNxData(entity);
   const { signalDataset, silxStyle } = nxData;

--- a/src/h5web/vis-packs/nexus/containers/NxRgbContainer.tsx
+++ b/src/h5web/vis-packs/nexus/containers/NxRgbContainer.tsx
@@ -1,4 +1,8 @@
-import { assertGroup, assertNumDims, assertNumericType } from '../../../guards';
+import {
+  assertGroupWithChildren,
+  assertNumDims,
+  assertNumericType,
+} from '../../../guards';
 import type { VisContainerProps } from '../../models';
 import VisBoundary from '../../core/VisBoundary';
 import NxValuesFetcher from '../NxValuesFetcher';
@@ -10,7 +14,7 @@ import shallow from 'zustand/shallow';
 
 function NxRgbContainer(props: VisContainerProps) {
   const { entity } = props;
-  assertGroup(entity);
+  assertGroupWithChildren(entity);
 
   const nxData = getNxData(entity);
   const { signalDataset } = nxData;

--- a/src/h5web/vis-packs/nexus/containers/NxSpectrumContainer.tsx
+++ b/src/h5web/vis-packs/nexus/containers/NxSpectrumContainer.tsx
@@ -1,5 +1,5 @@
 import { isEqual } from 'lodash';
-import { assertGroup } from '../../../guards';
+import { assertGroupWithChildren } from '../../../guards';
 import MappedLineVis from '../../core/line/MappedLineVis';
 import type { VisContainerProps } from '../../models';
 import { useDimMappingState } from '../../hooks';
@@ -11,7 +11,7 @@ import { assertNumericNxData } from '../guards';
 
 function NxSpectrumContainer(props: VisContainerProps) {
   const { entity } = props;
-  assertGroup(entity);
+  assertGroupWithChildren(entity);
 
   const nxData = getNxData(entity);
   assertNumericNxData(nxData);

--- a/src/h5web/vis-packs/nexus/pack-utils.ts
+++ b/src/h5web/vis-packs/nexus/pack-utils.ts
@@ -1,5 +1,6 @@
 import type { FetchStore } from 'react-suspense-fetch';
 import {
+  assertGroupWithChildren,
   assertStr,
   hasComplexType,
   hasMinDims,
@@ -41,6 +42,7 @@ export function getSupportedVis(entity: Entity): VisDef | undefined {
     return undefined;
   }
 
+  assertGroupWithChildren(entity);
   const dataset = findSignalDataset(entity);
   const isCplx = hasComplexType(dataset);
   const interpretation = getAttributeValue(dataset, 'interpretation');

--- a/src/h5web/vis-packs/nexus/utils.ts
+++ b/src/h5web/vis-packs/nexus/utils.ts
@@ -7,6 +7,7 @@ import type {
   ComplexType,
   ScalarShape,
   StringType,
+  GroupWithChildren,
 } from '../../providers/models';
 import {
   assertDefined,
@@ -49,7 +50,7 @@ export function assertNxDataGroup(group: Group) {
 }
 
 export function findSignalDataset(
-  group: Group
+  group: GroupWithChildren
 ): Dataset<ArrayShape, NumericType | ComplexType> {
   const signal = getAttributeValue(group, 'signal');
   assertDefined(signal, "Expected 'signal' attribute");
@@ -65,7 +66,7 @@ export function findSignalDataset(
 }
 
 function findErrorsDataset(
-  group: Group,
+  group: GroupWithChildren,
   signalName: string
 ): NumArrayDataset | undefined {
   const dataset =
@@ -83,7 +84,7 @@ function findErrorsDataset(
 }
 
 function findAssociatedDatasets(
-  group: Group,
+  group: GroupWithChildren,
   type: 'axes' | 'auxiliary_signals'
 ): (NumArrayDataset | undefined)[] {
   const dsetList = getAttributeValue(group, type) || [];
@@ -106,7 +107,7 @@ function findAssociatedDatasets(
 }
 
 function findTitleDataset(
-  group: Group
+  group: GroupWithChildren
 ): Dataset<ScalarShape, StringType> | undefined {
   const dataset = getChildEntity(group, 'title');
   if (!dataset) {
@@ -149,7 +150,7 @@ export function getSilxStyle(group: Group): SilxStyle {
   }
 }
 
-export function getNxData(group: Group): NxData {
+export function getNxData(group: GroupWithChildren): NxData {
   assertNxDataGroup(group);
   const signalDataset = findSignalDataset(group);
   const errorsDataset = findErrorsDataset(group, signalDataset.name);


### PR DESCRIPTION
Something I'd been meaning to do for a while.

- When a group is fetched directly with `api.getEntity('/path/to/group')`, its children are also fetched. The group entity must therefore include a `children` array (which may be empty if the group doesn't actually have children).
- When fetching a group's children, if a child group is encountered, then this child group's own children are _not_ fetched. The child group entity must therefore _not_ include a `children` array.

This PR aims at making this behaviour clearer in the codebase by enforcing stricter type checking when accessing the `children` property of a group. It also adds runtime type checking, notably after `api.getEntity` to make sure provider APIs never return a group without a `children` property. Additionally, providers can now create groups with or without children instead of being forced to initialise groups with empty `children` arrays.