### PR TITLE
Bring H5Grove API in line with Jupyter API

### DIFF
--- a/src/h5web/providers/h5grove/models.ts
+++ b/src/h5web/providers/h5grove/models.ts
@@ -1,10 +1,6 @@
 import type { EntityKind } from '../models';
 
-export type H5GroveAttrResponse = Record<string, unknown>;
-
-export type H5GroveDataResponse = unknown;
-
-export interface H5GroveMetaResponse {
+export interface H5GroveEntityResponse {
   name: string;
   type:
     | EntityKind.Dataset
@@ -12,34 +8,36 @@ export interface H5GroveMetaResponse {
     | 'externalLink'
     | 'softLink'
     | 'other';
+  attributes: H5GroveAttribute[];
 }
 
-export interface H5GroveSoftLinkMetaResponse extends H5GroveMetaResponse {
+export interface H5GroveSoftLinkResponse extends H5GroveEntityResponse {
   target_path: string;
   type: 'softLink';
 }
 
-export interface H5GroveExternalLinkMetaResponse extends H5GroveMetaResponse {
+export interface H5GroveExternalLinkResponse extends H5GroveEntityResponse {
   target_file: string;
   target_path: string;
   type: 'externalLink';
 }
 
-interface H5GroveAttrMetadata {
+export interface H5GroveDatasetReponse extends H5GroveEntityResponse {
+  type: EntityKind.Dataset;
+  dtype: string;
+  shape: number[];
+}
+
+export interface H5GroveGroupResponse extends H5GroveEntityResponse {
+  type: EntityKind.Group;
+  children?: H5GroveEntityResponse[];
+}
+
+export interface H5GroveAttribute {
   dtype: string;
   name: string;
   shape: number[];
 }
 
-export interface H5GroveDatasetMetaReponse extends H5GroveMetaResponse {
-  attributes: H5GroveAttrMetadata[];
-  dtype: string;
-  shape: number[];
-  type: EntityKind.Dataset;
-}
-
-export interface H5GroveGroupMetaResponse extends H5GroveMetaResponse {
-  attributes: H5GroveAttrMetadata[];
-  children: H5GroveMetaResponse[];
-  type: EntityKind.Group;
-}
+export type H5GroveAttrValuesResponse = Record<string, unknown>;
+export type H5GroveDataResponse = unknown;

--- a/src/h5web/providers/h5grove/utils.ts
+++ b/src/h5web/providers/h5grove/utils.ts
@@ -1,17 +1,18 @@
 import { EntityKind } from '../models';
 import type {
-  H5GroveMetaResponse,
-  H5GroveDatasetMetaReponse,
-  H5GroveGroupMetaResponse,
+  H5GroveEntityResponse,
+  H5GroveDatasetReponse,
+  H5GroveGroupResponse,
 } from './models';
 
 export function isGroupResponse(
-  response: H5GroveMetaResponse
-): response is H5GroveGroupMetaResponse {
+  response: H5GroveEntityResponse
+): response is H5GroveGroupResponse {
   return response.type === EntityKind.Group;
 }
+
 export function isDatasetResponse(
-  response: H5GroveMetaResponse
-): response is H5GroveDatasetMetaReponse {
+  response: H5GroveEntityResponse
+): response is H5GroveDatasetReponse {
   return response.type === EntityKind.Dataset;
 }

--- a/src/h5web/providers/jupyter/jupyter-api.ts
+++ b/src/h5web/providers/jupyter/jupyter-api.ts
@@ -23,7 +23,7 @@ import { buildEntityPath } from '../../utils';
 export class JupyterStableApi extends ProviderApi {
   protected attrValuesCache = new Map<string, JupyterAttrValuesResponse>();
 
-  /* API compatible with jupyterlab_hdf v0.7.0 */
+  /* API compatible with jupyterlab_hdf v0.6.0 */
   public constructor(url: string, filepath: string) {
     super(filepath, { baseURL: `${url}/hdf` });
   }


### PR DESCRIPTION
- Add attributes values cache.
- Prevent re-fetching children metadata in `processEntity`.
- Rename types and methods.

The code is now practically the same in both providers, which is a great sign. 😄 Now we can focus on improving H5Grove by transferring flat, binary arrays with support for NaN/Infinity.