### PR TITLE
Upgrade @types/ndarray

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "@types/d3-scale-chromatic": "^3.0.0",
         "@types/jest": "^26.0.23",
         "@types/lodash": "^4.14.170",
-        "@types/ndarray": "^1.0.9",
+        "@types/ndarray": "^1.0.10",
         "@types/node": "^15.12.5",
         "@types/react": "^17.0.11",
         "@types/react-aria-menubutton": "^6.2.7",
@@ -6772,9 +6772,9 @@
       "dev": true
     },
     "node_modules/@types/ndarray": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/ndarray/-/ndarray-1.0.9.tgz",
-      "integrity": "sha512-/JhpsxXBJ7ThPzzirBvqQoUlau+aKBlRqPQDwW985ee85o+g4DtsOeeq/XNZLIXNwy7BxP09reSKTSKn7q8Bdw==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@types/ndarray/-/ndarray-1.0.10.tgz",
+      "integrity": "sha512-UMQxmWA9V0hHqMntIItRVVc6sHmut9E4tBIv811EBPucuyMbAG70KgEdrhnEoD5L3BrLTpnWiCSxQA1HnXfXbw==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -37499,9 +37499,9 @@
       "dev": true
     },
     "@types/ndarray": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/ndarray/-/ndarray-1.0.9.tgz",
-      "integrity": "sha512-/JhpsxXBJ7ThPzzirBvqQoUlau+aKBlRqPQDwW985ee85o+g4DtsOeeq/XNZLIXNwy7BxP09reSKTSKn7q8Bdw==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@types/ndarray/-/ndarray-1.0.10.tgz",
+      "integrity": "sha512-UMQxmWA9V0hHqMntIItRVVc6sHmut9E4tBIv811EBPucuyMbAG70KgEdrhnEoD5L3BrLTpnWiCSxQA1HnXfXbw==",
       "dev": true
     },
     "@types/node": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@types/d3-scale-chromatic": "^3.0.0",
     "@types/jest": "^26.0.23",
     "@types/lodash": "^4.14.170",
-    "@types/ndarray": "^1.0.9",
+    "@types/ndarray": "^1.0.10",
     "@types/node": "^15.12.5",
     "@types/react": "^17.0.11",
     "@types/react-aria-menubutton": "^6.2.7",

--- a/src/h5web/guards.ts
+++ b/src/h5web/guards.ts
@@ -239,8 +239,8 @@ export function assertAbsolutePath(path: string) {
 }
 
 export function assertDataLength(
-  arr: NdArray | number[] | undefined,
-  dataArray: NdArray | number[],
+  arr: NdArray<number[]> | number[] | undefined,
+  dataArray: NdArray<number[]> | number[],
   arrName: string
 ) {
   if (!arr) {

--- a/src/h5web/providers/mock/utils.ts
+++ b/src/h5web/providers/mock/utils.ts
@@ -46,7 +46,7 @@ export function findMockEntity(path: string): Entity {
   return entity;
 }
 
-export function getMockDataArray<T = number>(path: string): NdArray<T> {
+export function getMockDataArray<T = number>(path: string): NdArray<T[]> {
   const dataset = findMockEntity(path);
   assertMockDataset(dataset);
 

--- a/src/h5web/vis-packs/core/complex/hooks.ts
+++ b/src/h5web/vis-packs/core/complex/hooks.ts
@@ -7,18 +7,18 @@ import { DEFAULT_DOMAIN, getValidDomainForScale } from '../utils';
 import { getPhaseAmplitudeValues } from './utils';
 
 export function usePhaseAmplitudeArrays(
-  mappedArray: NdArray<H5WebComplex>,
+  mappedArray: NdArray<H5WebComplex[]>,
   scaleType: ScaleType = ScaleType.Linear
 ): {
-  phaseArray: NdArray;
+  phaseArray: NdArray<number[]>;
   phaseDomain: Domain;
-  amplitudeArray: NdArray;
+  amplitudeArray: NdArray<number[]>;
   amplitudeDomain: Domain;
 } {
   const [phaseArray, phaseBounds, amplitudeArray, amplitudeBounds] =
     useMemo(() => {
       const { phaseValues, phaseBounds, amplitudeValues, amplitudeBounds } =
-        getPhaseAmplitudeValues(mappedArray.data as H5WebComplex[]);
+        getPhaseAmplitudeValues(mappedArray.data);
 
       return [
         ndarray(phaseValues, mappedArray.shape),

--- a/src/h5web/vis-packs/core/heatmap/HeatmapVis.tsx
+++ b/src/h5web/vis-packs/core/heatmap/HeatmapVis.tsx
@@ -15,7 +15,7 @@ import { useDomain } from '../hooks';
 import HeatmapMesh from './HeatmapMesh';
 
 interface Props {
-  dataArray: NdArray;
+  dataArray: NdArray<number[]>;
   domain: Domain | undefined;
   colorMap?: ColorMap;
   scaleType?: ScaleType;
@@ -25,7 +25,7 @@ interface Props {
   invertColorMap?: boolean;
   abscissaParams?: AxisParams;
   ordinateParams?: AxisParams;
-  alphaArray?: NdArray;
+  alphaArray?: NdArray<number[]>;
   alphaDomain?: Domain;
   flipYAxis?: boolean;
   children?: ReactNode;
@@ -99,12 +99,12 @@ function HeatmapVis(props: Props) {
         <HeatmapMesh
           rows={rows}
           cols={cols}
-          values={dataArray.data as number[]}
+          values={dataArray.data}
           domain={domain}
           colorMap={colorMap}
           invertColorMap={invertColorMap}
           scaleType={scaleType}
-          alphaValues={alphaArray && (alphaArray.data as number[])}
+          alphaValues={alphaArray && alphaArray.data}
           alphaDomain={alphaDomain}
         />
         {children}

--- a/src/h5web/vis-packs/core/hooks.ts
+++ b/src/h5web/vis-packs/core/hooks.ts
@@ -72,16 +72,16 @@ const useBounds = createMemo(getBounds);
 const useValidDomainForScale = createMemo(getValidDomainForScale);
 
 export function useDomain(
-  valuesArray: NdArray | number[],
+  valuesArray: NdArray<number[]> | number[],
   scaleType: ScaleType = ScaleType.Linear,
-  errorArray?: NdArray | number[]
+  errorArray?: NdArray<number[]> | number[]
 ) {
   const bounds = useBounds(valuesArray, errorArray);
   return useValidDomainForScale(bounds, scaleType);
 }
 
 export function useDomains(
-  valuesArrays: (NdArray | number[])[],
+  valuesArrays: (NdArray<number[]> | number[])[],
   scaleType: ScaleType = ScaleType.Linear
 ) {
   const allBounds = useMemo(() => {
@@ -139,7 +139,9 @@ export function useMappedArray<T extends unknown[] | undefined>(
   dims: number[],
   mapping: DimensionMapping,
   autoScale?: boolean
-): T extends (infer U)[] ? [NdArray<U>, NdArray<U>] : [undefined, undefined];
+): T extends (infer U)[]
+  ? [NdArray<U[]>, NdArray<U[]>]
+  : [undefined, undefined];
 
 export function useMappedArray<T>(
   value: T[] | undefined,

--- a/src/h5web/vis-packs/core/line/LineVis.tsx
+++ b/src/h5web/vis-packs/core/line/LineVis.tsx
@@ -18,7 +18,7 @@ const DEFAULT_AUX_COLORS =
   'orangered, forestgreen, crimson, mediumslateblue, sienna';
 
 interface Props {
-  dataArray: NdArray;
+  dataArray: NdArray<number[]>;
   domain: Domain | undefined;
   scaleType?: ScaleType;
   curveType?: CurveType;
@@ -26,9 +26,9 @@ interface Props {
   abscissaParams?: AxisParams;
   ordinateLabel?: string;
   title?: string;
-  errorsArray?: NdArray;
+  errorsArray?: NdArray<number[]>;
   showErrors?: boolean;
-  auxArrays?: NdArray[];
+  auxArrays?: NdArray<number[]>[];
   children?: ReactNode;
 }
 
@@ -112,8 +112,8 @@ function LineVis(props: Props) {
         <TooltipMesh {...tooltipFormatters} guides="vertical" />
         <DataCurve
           abscissas={abscissas}
-          ordinates={dataArray.data as number[]}
-          errors={errorsArray && (errorsArray.data as number[])}
+          ordinates={dataArray.data}
+          errors={errorsArray && errorsArray.data}
           showErrors={showErrors}
           color={curveColor || DEFAULT_CURVE_COLOR}
           curveType={curveType}
@@ -122,7 +122,7 @@ function LineVis(props: Props) {
           <DataCurve
             key={i} // eslint-disable-line react/no-array-index-key
             abscissas={abscissas}
-            ordinates={array.data as number[]}
+            ordinates={array.data}
             color={auxColors[i < auxColors.length ? i : auxColors.length - 1]}
             curveType={curveType}
           />

--- a/src/h5web/vis-packs/core/matrix/MatrixVis.tsx
+++ b/src/h5web/vis-packs/core/matrix/MatrixVis.tsx
@@ -12,7 +12,7 @@ import type { PrintableType } from '../models';
 const CELL_HEIGHT = 32;
 
 interface Props {
-  dataArray: NdArray<Primitive<PrintableType>>;
+  dataArray: NdArray<Primitive<PrintableType>[]>;
   formatter: (value: Primitive<PrintableType>) => string;
   cellWidth: number;
 }

--- a/src/h5web/vis-packs/core/matrix/config.tsx
+++ b/src/h5web/vis-packs/core/matrix/config.tsx
@@ -6,8 +6,8 @@ import type { ConfigProviderProps } from '../../models';
 import type { PrintableType } from '../models';
 
 interface MatrixConfig {
-  currentSlice: NdArray<Primitive<PrintableType>> | undefined;
-  setCurrentSlice: (slice: NdArray<Primitive<PrintableType>>) => void;
+  currentSlice: NdArray<Primitive<PrintableType>[]> | undefined;
+  setCurrentSlice: (slice: NdArray<Primitive<PrintableType>[]>) => void;
 }
 
 function createStore() {

--- a/src/h5web/vis-packs/core/matrix/utils.ts
+++ b/src/h5web/vis-packs/core/matrix/utils.ts
@@ -24,7 +24,7 @@ export function getFormatter(
   return (val) => (val as string).toString();
 }
 
-export function sliceToCsv(slice: NdArray<Primitive<PrintableType>>): string {
+export function sliceToCsv(slice: NdArray<Primitive<PrintableType>[]>): string {
   let csv = '';
 
   if (slice.shape.length === 1) {

--- a/src/h5web/vis-packs/core/rgb/utils.ts
+++ b/src/h5web/vis-packs/core/rgb/utils.ts
@@ -6,5 +6,5 @@ export function flipLastDimension(value: number[], dims: number[]) {
   const steps = dims.map((_, index) => (index === dims.length - 1 ? -1 : 1));
 
   const flippedView = baseArray.step(...steps);
-  return createArrayFromView(flippedView).data as number[];
+  return createArrayFromView(flippedView).data;
 }

--- a/src/h5web/vis-packs/core/utils.ts
+++ b/src/h5web/vis-packs/core/utils.ts
@@ -94,13 +94,13 @@ export function getNewBounds(oldBounds: Bounds, value: number): Bounds {
   };
 }
 
-export function toArray(arr: NdArray | number[]): number[] {
-  return 'data' in arr ? (arr.data as number[]) : arr;
+export function toArray(arr: NdArray<number[]> | number[]): number[] {
+  return 'data' in arr ? arr.data : arr;
 }
 
 export function getBounds(
-  valuesArray: NdArray | number[],
-  errorArray?: NdArray | number[]
+  valuesArray: NdArray<number[]> | number[],
+  errorArray?: NdArray<number[]> | number[]
 ): Bounds | undefined {
   assertDataLength(errorArray, valuesArray, 'error');
 
@@ -124,9 +124,9 @@ export function getBounds(
 }
 
 export function getDomain(
-  valuesArray: NdArray | number[],
+  valuesArray: NdArray<number[]> | number[],
   scaleType: ScaleType = ScaleType.Linear,
-  errorArray?: NdArray | number[]
+  errorArray?: NdArray<number[]> | number[]
 ): Domain | undefined {
   const bounds = getBounds(valuesArray, errorArray);
 
@@ -134,7 +134,7 @@ export function getDomain(
 }
 
 export function getDomains(
-  arrays: (NdArray | number[])[],
+  arrays: (NdArray<number[]> | number[])[],
   scaleType: ScaleType = ScaleType.Linear
 ): (Domain | undefined)[] {
   return arrays.map((arr) => getDomain(arr, scaleType));
@@ -306,24 +306,24 @@ export function getCombinedDomain(
 export function getBaseArray<T extends unknown[] | undefined>(
   value: T,
   rawDims: number[]
-): T extends (infer U)[] ? NdArray<U> : undefined;
+): T extends (infer U)[] ? NdArray<U[]> : undefined;
 
 export function getBaseArray<T>(
   value: T[] | undefined,
   rawDims: number[]
-): NdArray<T> | undefined {
-  return value && ndarray<T>(value, rawDims);
+): NdArray<T[]> | undefined {
+  return value && ndarray(value, rawDims);
 }
 
-export function applyMapping<T extends NdArray<unknown> | undefined>(
+export function applyMapping<T extends NdArray<unknown[]> | undefined>(
   baseArray: T,
   mapping: (number | Axis | ':')[]
 ): T extends NdArray<infer U> ? NdArray<U> : undefined;
 
 export function applyMapping<T>(
-  baseArray: NdArray<T> | undefined,
+  baseArray: NdArray<T[]> | undefined,
   mapping: (number | Axis | ':')[]
-): NdArray<T> | undefined {
+): NdArray<T[]> | undefined {
   if (!baseArray) {
     return undefined;
   }
@@ -383,8 +383,8 @@ export function getAxisOffsets(
   };
 }
 
-export function createArrayFromView<T>(view: NdArray<T>): NdArray<T> {
-  const array = ndarray<T>([], view.shape);
+export function createArrayFromView<T>(view: NdArray<T[]>): NdArray<T[]> {
+  const array = ndarray<T[]>([], view.shape);
   assign(array, view);
 
   return array;

--- a/src/stories/GettingStarted.stories.mdx
+++ b/src/stories/GettingStarted.stories.mdx
@@ -39,7 +39,7 @@ The components are organised in three categories:
    const flatValues: number[] = values.flat(Infinity);
 
    // Convert to ndarray and get domain
-   const dataArray = ndarray<number>(flatValues, [2, 3]);
+   const dataArray = ndarray(flatValues, [2, 3]);
    const domain = getDomain(dataArray);
    ```
 

--- a/src/stories/HeatmapVis.stories.tsx
+++ b/src/stories/HeatmapVis.stories.tsx
@@ -12,7 +12,7 @@ import {
 import ndarray from 'ndarray';
 
 const dataArray = getMockDataArray('/nD_datasets/twoD');
-const dataValues = dataArray.data as number[];
+const { data: dataValues } = dataArray;
 const domain = getDomain(dataValues);
 const logSafeDomain = getDomain(dataValues, ScaleType.Log);
 

--- a/src/stories/LineVisDisplay.stories.tsx
+++ b/src/stories/LineVisDisplay.stories.tsx
@@ -10,7 +10,7 @@ import {
 } from '../packages/lib';
 
 const dataArray = getMockDataArray('/nD_datasets/oneD_linear');
-const domain = getDomain(dataArray.data as number[]);
+const domain = getDomain(dataArray.data);
 
 const Template: Story<LineVisProps> = (args) => <LineVis {...args} />;
 

--- a/src/stories/LineVisScales.stories.tsx
+++ b/src/stories/LineVisScales.stories.tsx
@@ -9,11 +9,11 @@ import {
 } from '../packages/lib';
 
 const dataArray = getMockDataArray('/nD_datasets/oneD_linear');
-const domain = getDomain(dataArray.data as number[]);
-const logSafeDomain = getDomain(dataArray.data as number[], ScaleType.Log);
+const domain = getDomain(dataArray.data);
+const logSafeDomain = getDomain(dataArray.data, ScaleType.Log);
 
 const dataArrayForXLog = getMockDataArray('/nexus_entry/log_spectrum/X_log');
-const domainForXLog = getDomain(dataArrayForXLog.data as number[]);
+const domainForXLog = getDomain(dataArrayForXLog.data);
 
 const Template: Story<LineVisProps> = (args) => <LineVis {...args} />;
 


### PR DESCRIPTION
I was able to merge https://github.com/DefinitelyTyped/DefinitelyTyped/pull/53728#issuecomment-878220724. Unfortunately, the PR did not receive any review from maintainers of `@types/ndarray` or `@types/numjs`. Let's hope people are happy with the changes once they upgrade...

Previously, `NdArray` or `NdArray<number>` meant that the underlying data could either be `number[]` or a typed array (`Float32Array` and the like), which is why we always had to cast: `myArr.data as number[]`.

The main change now is that the generic describes the exact type of the underlying data stored in the ndarray - e.g. `NdArray<number[]>` (note the `[]`), `NdArray<TypedArray>`, `NdArray<Float32Array>`, etc. With `NdArray<number[]>`, the type of `myArr.data` no longer includes typed arrays -- only `number[]` -- which means we can remove our type casts.

Note that we have to specify `NdArray<number[]>` because the default value for the generic is `Data<number>`, which replicates the old behaviour for backwards-compatibility.