### PR TITLE
Refactor formatting of complex numbers

### DIFF
--- a/src/h5web/metadata-viewer/utils.ts
+++ b/src/h5web/metadata-viewer/utils.ts
@@ -6,7 +6,7 @@ import {
   H5WebComplex,
   Shape,
 } from '../providers/models';
-import { formatComplex } from '../utils';
+import { formatScalarComplex } from '../utils';
 
 export function renderShape(shape: Shape): string {
   if (shape === null) {
@@ -38,12 +38,9 @@ export function renderType(type: DType): string {
   return type.class;
 }
 
-export function renderComplex(
-  complex: H5WebComplex | ComplexArray,
-  specifier?: string
-): string {
+export function renderComplex(complex: H5WebComplex | ComplexArray): string {
   if (isH5WebComplex(complex)) {
-    return formatComplex(complex, specifier);
+    return formatScalarComplex(complex);
   }
 
   return `[ ${complex.map((c) => renderComplex(c)).join(', ')} ]`;

--- a/src/h5web/utils.ts
+++ b/src/h5web/utils.ts
@@ -9,21 +9,27 @@ import type { NxAttribute } from './vis-packs/nexus/models';
 
 export const formatValue = format('.3~e');
 export const formatPreciseValue = format('.5~e');
-export function formatComplex(value: H5WebComplex, specifier = '') {
-  const [real, imag] = value;
-  const formatFunction = format(specifier);
+export const formatMatrixValue = format('.3e');
+export const formatMatrixComplex = createComplexFormatter('.2e', true);
+export const formatScalarComplex = createComplexFormatter('.12~g');
 
-  if (imag === 0) {
-    return `${formatFunction(real)}`;
-  }
+export function createComplexFormatter(specifier: string, full = false) {
+  const formatVal = format(specifier);
 
-  if (real === 0) {
-    return `${formatFunction(imag)}ⅈ`;
-  }
+  return (value: H5WebComplex) => {
+    const [real, imag] = value;
 
-  return `${formatFunction(real)}${
-    Math.sign(imag) === 1 ? ' + ' : ' − '
-  }${formatFunction(Math.abs(imag))}ⅈ`;
+    if (imag === 0 && !full) {
+      return `${formatVal(real)}`;
+    }
+
+    if (real === 0 && !full) {
+      return `${formatVal(imag)} i`;
+    }
+
+    const sign = Math.sign(imag) >= 0 ? ' + ' : ' − ';
+    return `${formatVal(real)}${sign}${formatVal(Math.abs(imag))} i`;
+  };
 }
 
 export function getChildEntity(

--- a/src/h5web/vis-packs/core/matrix/MatrixVis.module.css
+++ b/src/h5web/vis-packs/core/matrix/MatrixVis.module.css
@@ -14,8 +14,7 @@
 .cell {
   display: flex;
   align-items: center;
-  justify-content: right;
-  padding-right: 0.25rem;
+  justify-content: center;
   background-color: var(--h5w-matrix-cell--bgColor, transparent);
 }
 

--- a/src/h5web/vis-packs/core/matrix/utils.ts
+++ b/src/h5web/vis-packs/core/matrix/utils.ts
@@ -1,24 +1,23 @@
 import type { NdArray } from 'ndarray';
 import { hasComplexType, hasNumericType } from '../../../guards';
-import { renderComplex } from '../../../metadata-viewer/utils';
 import type {
   ArrayShape,
   Dataset,
   H5WebComplex,
   Primitive,
 } from '../../../providers/models';
+import { formatMatrixComplex, formatMatrixValue } from '../../../utils';
 import type { PrintableType, ValueFormatter } from '../models';
-import { formatNumber } from '../utils';
 
 export function getFormatter(
   dataset: Dataset<ArrayShape, PrintableType>
 ): ValueFormatter<PrintableType> {
   if (hasComplexType(dataset)) {
-    return (val) => renderComplex(val as H5WebComplex, '.2e');
+    return (val) => formatMatrixComplex(val as H5WebComplex);
   }
 
   if (hasNumericType(dataset)) {
-    return (val) => formatNumber(val as number);
+    return (val) => formatMatrixValue(val as number);
   }
 
   return (val) => (val as string).toString();

--- a/src/h5web/vis-packs/core/scalar/utils.ts
+++ b/src/h5web/vis-packs/core/scalar/utils.ts
@@ -4,14 +4,14 @@ import type {
   Dataset,
   H5WebComplex,
 } from '../../../providers/models';
-import { formatComplex } from '../../../utils';
+import { formatScalarComplex } from '../../../utils';
 import type { PrintableType, ValueFormatter } from '../models';
 
 export function getFormatter(
   dataset: Dataset<ArrayShape, PrintableType>
 ): ValueFormatter<PrintableType> {
   if (hasComplexType(dataset)) {
-    return (val) => formatComplex(val as H5WebComplex);
+    return (val) => formatScalarComplex(val as H5WebComplex);
   }
 
   return (val) => (val as number | string | boolean).toString();

--- a/src/stories/MatrixVis.stories.tsx
+++ b/src/stories/MatrixVis.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import type { H5WebComplex } from '../h5web/providers/models';
-import { formatNumber } from '../h5web/vis-packs/core/utils';
+import { formatMatrixComplex, formatMatrixValue } from '../h5web/utils';
 import { getMockDataArray, MatrixVis, MatrixVisProps } from '../packages/lib';
 import FillHeight from './decorators/FillHeight';
 
@@ -10,16 +10,16 @@ export const Default = Template.bind({});
 
 Default.args = {
   dataArray: getMockDataArray('/nD_datasets/twoD'),
-  formatter: (val) => formatNumber(val as number),
-  cellWidth: 100,
+  formatter: (val) => formatMatrixValue(val as number),
+  cellWidth: 116,
 };
 
 export const Complex = Template.bind({});
 
 Complex.args = {
   dataArray: getMockDataArray<H5WebComplex>('/nD_datasets/twoD_cplx'),
-  formatter: (val) => `real = ${formatNumber((val as H5WebComplex)[0])}`,
-  cellWidth: 180,
+  formatter: (val) => formatMatrixComplex(val as H5WebComplex),
+  cellWidth: 232,
 };
 
 export default {


### PR DESCRIPTION
I got side-tracked working on the tooltip. 😄 I was trying to collocate all the D3 formatters in `h5web/utils` so we could have the format specifiers all in one place and keep our sanity.

Here, I do so for the complex formatters used by the scalar vis, matrix vis and metadata viewer. I refactor the code that creates these formatters so we no longer have to pass specifiers around multiple functions.

I also did the following to improve the display of the matrix vis:

- I replaced the fancy `i` for imaginary numbers with a simple `i` with a space before it. The fancy `i` just looked off. I find the normal `i` works better, especially with that extra space to give it some breathing room.
- I centered the values inside the cells of the Matrix vis, since the formatters (and monospace font) guarantee that they will always take the same amount of space).
- ... except when the real/imag part is equal to 0 and not displayed. So I fixed this by always displaying the real/imag part even when equal to 0 (in the matrix vis only). I think it makes the values more readable as a result, but let me know what you think.

![image](https://user-images.githubusercontent.com/2936402/126503072-2597dab6-4090-44cc-96ed-34fdf52d13d1.png)

For reference, here is what complex numbers look like now in the scalar vis and the metadata viewer:

![image](https://user-images.githubusercontent.com/2936402/126503025-92da65da-98c5-4107-9c64-149aa569693e.png)

![image](https://user-images.githubusercontent.com/2936402/126502981-52992701-9f3e-41c0-9e00-e317d5c24c6d.png)
