### PR TITLE
Add support for custom tooltips

### DIFF
--- a/src/h5web/toolbar/controls/DomainSlider/BoundEditor.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/BoundEditor.tsx
@@ -6,7 +6,7 @@ import {
   useState,
 } from 'react';
 import { FiCheck, FiSlash } from 'react-icons/fi';
-import { formatPreciseValue } from '../../../utils';
+import { formatBoundInput } from '../../../utils';
 import type { Bound } from '../../../vis-packs/core/models';
 import { clampBound } from '../../../vis-packs/core/utils';
 import styles from './BoundEditor.module.css';
@@ -34,7 +34,7 @@ const BoundEditor = forwardRef<Handle, Props>((props, ref) => {
 
   function cancel() {
     onEditToggle(false);
-    setInputValue(formatPreciseValue(value));
+    setInputValue(formatBoundInput(value));
   }
 
   /* Expose `cancel` function to parent component through ref handle so that
@@ -42,7 +42,7 @@ const BoundEditor = forwardRef<Handle, Props>((props, ref) => {
   useImperativeHandle(ref, () => ({ cancel }));
 
   useEffect(() => {
-    setInputValue(formatPreciseValue(value));
+    setInputValue(formatBoundInput(value));
   }, [value, setInputValue]);
 
   useEffect(() => {
@@ -71,7 +71,7 @@ const BoundEditor = forwardRef<Handle, Props>((props, ref) => {
           : clampBound(parsedValue);
 
         // Clean up input in case value hasn't changed (since `useEffect` won't be triggered)
-        setInputValue(formatPreciseValue(newValue));
+        setInputValue(formatBoundInput(newValue));
 
         onChange(newValue);
         onEditToggle(false);

--- a/src/h5web/toolbar/controls/DomainSlider/DomainTooltip.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/DomainTooltip.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useImperativeHandle, useRef } from 'react';
 import type { Domain } from '../../../../packages/lib';
-import { formatValue } from '../../../utils';
+import { formatBound } from '../../../utils';
 import { DomainError, DomainErrors } from '../../../vis-packs/core/models';
 import ToggleBtn from '../ToggleBtn';
 import BoundEditor, { BoundEditorHandle } from './BoundEditor';
@@ -100,11 +100,11 @@ const DomainTooltip = forwardRef<Handle, Props>((props, ref) => {
           <span>
             [{' '}
             <abbr title={dataDomain[0].toString()}>
-              {formatValue(dataDomain[0])}
+              {formatBound(dataDomain[0])}
             </abbr>{' '}
             ,{' '}
             <abbr title={dataDomain[1].toString()}>
-              {formatValue(dataDomain[1])}
+              {formatBound(dataDomain[1])}
             </abbr>{' '}
             ]
           </span>

--- a/src/h5web/utils.ts
+++ b/src/h5web/utils.ts
@@ -7,13 +7,16 @@ import type {
 import type { ImageAttribute } from './vis-packs/core/models';
 import type { NxAttribute } from './vis-packs/nexus/models';
 
-export const formatValue = format('.3~e');
-export const formatPreciseValue = format('.5~e');
+export const formatTick = format('.5~g');
+export const formatBound = format('.3~e');
+export const formatBoundInput = format('.5~e');
+export const formatTooltipVal = format('.5~g');
+export const formatTooltipErr = format('.3~g');
 export const formatMatrixValue = format('.3e');
 export const formatMatrixComplex = createComplexFormatter('.2e', true);
 export const formatScalarComplex = createComplexFormatter('.12~g');
 
-export function createComplexFormatter(specifier: string, full = false) {
+function createComplexFormatter(specifier: string, full = false) {
   const formatVal = format(specifier);
 
   return (value: H5WebComplex) => {

--- a/src/h5web/vis-packs/core/heatmap/ColorBar.tsx
+++ b/src/h5web/vis-packs/core/heatmap/ColorBar.tsx
@@ -5,7 +5,7 @@ import styles from './ColorBar.module.css';
 import { getInterpolator, getLinearGradient } from './utils';
 import type { ScaleType, Domain } from '../models';
 import type { ColorMap } from './models';
-import { formatValue } from '../../../utils';
+import { formatBound } from '../../../utils';
 import Tick from '../shared/Tick';
 
 interface Props {
@@ -48,10 +48,10 @@ function ColorBar(props: Props) {
       {withBounds && (
         <>
           <p className={styles.minBound}>
-            {isEmptyDomain ? '−∞' : formatValue(domain[0])}
+            {isEmptyDomain ? '−∞' : formatBound(domain[0])}
           </p>
           <p className={styles.maxBound}>
-            {isEmptyDomain ? '+∞' : formatValue(domain[1])}
+            {isEmptyDomain ? '+∞' : formatBound(domain[1])}
           </p>
         </>
       )}

--- a/src/h5web/vis-packs/core/heatmap/HeatmapVis.module.css
+++ b/src/h5web/vis-packs/core/heatmap/HeatmapVis.module.css
@@ -5,3 +5,9 @@
   min-height: 0;
   margin: 0;
 }
+
+.tooltipValue {
+  font-weight: 600;
+  margin-top: 0.25rem;
+  font-size: 1.125em;
+}

--- a/src/h5web/vis-packs/core/heatmap/hooks.ts
+++ b/src/h5web/vis-packs/core/heatmap/hooks.ts
@@ -1,33 +1,6 @@
-import { format } from 'd3-format';
-import type { NdArray } from 'ndarray';
 import { createMemo } from 'react-use';
-import { useValueToIndexScale } from '../hooks';
-import type { TooltipIndexFormatter, TooltipValueFormatter } from '../models';
 import { getVisDomain, getSafeDomain, getAxisValues } from './utils';
 
 export const useVisDomain = createMemo(getVisDomain);
 export const useSafeDomain = createMemo(getSafeDomain);
 export const useAxisValues = createMemo(getAxisValues);
-
-export function useTooltipFormatters(
-  abscissas: number[],
-  ordinates: number[],
-  abscissaLabel: string | undefined,
-  ordinateLabel: string | undefined,
-  dataArray: NdArray
-): {
-  formatIndex: TooltipIndexFormatter;
-  formatValue: TooltipValueFormatter;
-} {
-  const abscissaToIndex = useValueToIndexScale(abscissas);
-  const ordinateToIndex = useValueToIndexScale(ordinates);
-
-  return {
-    formatIndex: ([x, y]) =>
-      `${abscissaLabel || 'x'}=${abscissas[abscissaToIndex(x)]}, ` +
-      `${ordinateLabel || 'y'}=${ordinates[ordinateToIndex(y)]}`,
-
-    formatValue: ([x, y]) =>
-      format('.3')(dataArray.get(ordinateToIndex(y), abscissaToIndex(x))),
-  };
-}

--- a/src/h5web/vis-packs/core/heatmap/models.ts
+++ b/src/h5web/vis-packs/core/heatmap/models.ts
@@ -10,3 +10,12 @@ export type D3Interpolator = (t: number) => string;
 export type ColorMap = keyof typeof INTERPOLATORS;
 
 export type Layout = 'contain' | 'cover' | 'fill';
+
+export interface TooltipData {
+  abscissa: number;
+  ordinate: number;
+  xi: number;
+  yi: number;
+  x: number;
+  y: number;
+}

--- a/src/h5web/vis-packs/core/line/LineVis.module.css
+++ b/src/h5web/vis-packs/core/line/LineVis.module.css
@@ -5,3 +5,12 @@
   min-height: 0;
   margin: 1rem;
 }
+
+.tooltipValue {
+  margin-top: 0.25rem;
+}
+
+.tooltipValue > strong {
+  font-weight: 600;
+  font-size: 1.125em;
+}

--- a/src/h5web/vis-packs/core/line/hooks.ts
+++ b/src/h5web/vis-packs/core/line/hooks.ts
@@ -1,9 +1,5 @@
-import { format } from 'd3-format';
-import type { NdArray } from 'ndarray';
 import { useMemo } from 'react';
 import { Vector3 } from 'three';
-import { useValueToIndexScale } from '../hooks';
-import type { TooltipIndexFormatter, TooltipValueFormatter } from '../models';
 import { useAxisSystemContext } from '../shared/AxisSystemContext';
 
 const CAMERA_FAR = 1000; // R3F's default
@@ -57,35 +53,4 @@ export function useCanvasPoints(
 
     return { data: dataPoints, bars: errorBarSegments, caps: errorCapPoints };
   }, [abscissaScale, abscissas, errors, ordinateScale, ordinates]);
-}
-
-export function useTooltipFormatters(
-  abscissas: number[],
-  abscissaLabel: string | undefined,
-  dataArray: NdArray,
-  errorsArray: NdArray | undefined
-): {
-  formatIndex: TooltipIndexFormatter;
-  formatValue: TooltipValueFormatter;
-} {
-  const abscissaToIndex = useValueToIndexScale(abscissas, true);
-
-  return {
-    formatIndex: ([x]) =>
-      `${abscissaLabel || 'x'}=${format('0')(abscissas[abscissaToIndex(x)])}`,
-
-    formatValue: ([x]) => {
-      const index = abscissaToIndex(x);
-      const value = dataArray.get(index);
-
-      if (value === undefined) {
-        return undefined;
-      }
-
-      const error = errorsArray && errorsArray.get(index);
-      return error
-        ? `${format('.3f')(value)} ±${format('.3f')(error)}`
-        : `${format('.3f')(value)}`;
-    },
-  };
 }

--- a/src/h5web/vis-packs/core/line/models.ts
+++ b/src/h5web/vis-packs/core/line/models.ts
@@ -15,3 +15,9 @@ export const GLYPH_URLS = {
   Square: squareURL,
   Cap: capURL,
 };
+
+export interface TooltipData {
+  abscissa: number;
+  xi: number;
+  x: number;
+}

--- a/src/h5web/vis-packs/core/models.ts
+++ b/src/h5web/vis-packs/core/models.ts
@@ -74,8 +74,6 @@ export interface Bounds {
 }
 
 export type Coords = [number, number];
-export type TooltipIndexFormatter = (t: Coords) => string;
-export type TooltipValueFormatter = (t: Coords) => string | undefined;
 
 export type PrintableType =
   | BooleanType

--- a/src/h5web/vis-packs/core/shared/TooltipMesh.module.css
+++ b/src/h5web/vis-packs/core/shared/TooltipMesh.module.css
@@ -15,10 +15,3 @@
   stroke-width: var(--h5w-tooltip-guide--width, 1.5);
   stroke-opacity: var(--h5w-tooltip-guide--opacity, 0.5);
 }
-
-.tooltipValue {
-  display: block;
-  font-weight: 600;
-  margin-top: 0.25rem;
-  font-size: 1.125em;
-}

--- a/src/h5web/vis-packs/core/shared/TooltipMesh.tsx
+++ b/src/h5web/vis-packs/core/shared/TooltipMesh.tsx
@@ -1,26 +1,21 @@
-import { useCallback } from 'react';
+import { ReactElement, useCallback } from 'react';
 import { useThree } from '@react-three/fiber';
 import { TooltipWithBounds, useTooltip } from '@visx/tooltip';
 import { Line } from '@visx/shape';
 import Html from './Html';
 import styles from './TooltipMesh.module.css';
 import type { ThreeEvent } from '@react-three/fiber/dist/declarations/src/core/events';
-import type {
-  Coords,
-  TooltipIndexFormatter,
-  TooltipValueFormatter,
-} from '../models';
+import type { Coords } from '../models';
 import { useAxisSystemContext } from './AxisSystemContext';
 import VisMesh from './VisMesh';
 
 interface Props {
-  formatIndex: TooltipIndexFormatter;
-  formatValue: TooltipValueFormatter;
   guides?: 'horizontal' | 'vertical' | 'both';
+  renderTooltip: (x: number, y: number) => ReactElement | undefined;
 }
 
 function TooltipMesh(props: Props) {
-  const { formatIndex, formatValue, guides } = props;
+  const { guides, renderTooltip } = props;
 
   const camera = useThree((state) => state.camera);
   const { width, height } = useThree((state) => state.size);
@@ -71,7 +66,7 @@ function TooltipMesh(props: Props) {
     [height, onPointerMove, width]
   );
 
-  const value = tooltipData && formatValue(tooltipData);
+  const content = tooltipData && renderTooltip(...tooltipData);
 
   return (
     <>
@@ -79,7 +74,7 @@ function TooltipMesh(props: Props) {
         <meshBasicMaterial opacity={0} transparent />
       </VisMesh>
       <Html style={{ width, height }}>
-        {tooltipOpen && tooltipData && value && (
+        {tooltipOpen && content && (
           <>
             <TooltipWithBounds
               key={Math.random()}
@@ -89,8 +84,7 @@ function TooltipMesh(props: Props) {
               unstyled
               applyPositionStyle
             >
-              {formatIndex(tooltipData)}
-              <span className={styles.tooltipValue}>{value}</span>
+              {content}
             </TooltipWithBounds>
             {guides && (
               <svg className={styles.guides}>

--- a/src/h5web/vis-packs/core/utils.ts
+++ b/src/h5web/vis-packs/core/utils.ts
@@ -5,7 +5,6 @@ import {
   PickD3Scale,
 } from '@visx/scale';
 import { tickStep, range } from 'd3-array';
-import { format } from 'd3-format';
 import ndarray, { NdArray } from 'ndarray';
 import { assign } from 'ndarray-ops';
 import { isNumber } from 'lodash';
@@ -21,13 +20,10 @@ import {
 } from './models';
 import { assertDataLength, isDefined } from '../../guards';
 import { isAxis } from '../../dimension-mapper/utils';
-import { getAttributeValue } from '../../utils';
+import { formatTick, getAttributeValue } from '../../utils';
 import type { Dataset } from '../../providers/models';
 import { H5WEB_SCALES } from './scales';
 import { clamp } from 'three/src/math/MathUtils';
-
-const formatTick = format('0');
-export const formatNumber = format('.3e');
 
 export const DEFAULT_DOMAIN: Domain = [0.1, 1];
 

--- a/src/stories/HeatmapVisDisplay.stories.tsx
+++ b/src/stories/HeatmapVisDisplay.stories.tsx
@@ -7,6 +7,7 @@ import {
   getMockDataArray,
   Annotation,
 } from '../packages/lib';
+import { formatTooltipVal } from '../h5web/utils';
 
 const dataArray = getMockDataArray('/nD_datasets/twoD');
 const domain = getDomain(dataArray.data);
@@ -39,6 +40,31 @@ NoGrid.args = {
   dataArray,
   domain,
   showGrid: false,
+};
+
+export const CustomTooltip = Template.bind({});
+CustomTooltip.args = {
+  dataArray,
+  domain,
+  abscissaParams: {
+    value: Array.from({ length: dataArray.shape[1] }, (_, i) => 100 + 10 * i),
+  },
+  ordinateParams: {
+    value: Array.from({ length: dataArray.shape[0] }, (_, i) => -5 + 0.5 * i),
+  },
+  renderTooltip: (data) => {
+    const { abscissa, ordinate, xi, yi, x, y } = data;
+    return (
+      <>
+        <div>
+          <strong>{`value = ${dataArray.get(yi, xi)}`}</strong>
+        </div>
+        <div>{`abscissa = ${abscissa}, ordinate = ${ordinate}`}</div>
+        <div>{`xi = ${xi}, yi = ${yi}`}</div>
+        <div>{`x = ${formatTooltipVal(x)}, y=${formatTooltipVal(y)}`}</div>
+      </>
+    );
+  },
 };
 
 export const WheelCapture = Template.bind({});

--- a/src/stories/LineVisDisplay.stories.tsx
+++ b/src/stories/LineVisDisplay.stories.tsx
@@ -8,6 +8,7 @@ import {
   getMockDataArray,
   Annotation,
 } from '../packages/lib';
+import { formatTooltipVal } from '../h5web/utils';
 
 const dataArray = getMockDataArray('/nD_datasets/oneD_linear');
 const domain = getDomain(dataArray.data);
@@ -34,6 +35,28 @@ NoGrid.args = {
   dataArray,
   domain,
   showGrid: false,
+};
+
+export const CustomTooltip = Template.bind({});
+CustomTooltip.args = {
+  dataArray,
+  domain,
+  abscissaParams: {
+    value: Array.from({ length: dataArray.size }, (_, i) => -10 + 0.5 * i),
+  },
+  renderTooltip: (data) => {
+    const { abscissa, xi, x } = data;
+    return (
+      <>
+        <div>
+          <strong>{`value = ${dataArray.get(xi)}`}</strong>
+        </div>
+        <div>{`abscissa = ${abscissa}`}</div>
+        <div>{`xi = ${xi}`}</div>
+        <div>{`x = ${formatTooltipVal(x)}`}</div>
+      </>
+    );
+  },
 };
 
 export const WithTitle = Template.bind({});

--- a/src/stories/VisCanvasInteraction.stories.tsx
+++ b/src/stories/VisCanvasInteraction.stories.tsx
@@ -1,13 +1,8 @@
 import type { Meta, Story } from '@storybook/react';
 import VisCanvasStoriesConfig from './VisCanvas.stories';
 import { PanZoomMesh, TooltipMesh, VisCanvas } from '../packages/lib';
-import { format } from 'd3-format';
-import type { Coords } from '../h5web/vis-packs/core/models';
 import type { TooltipMeshProps } from '../h5web/vis-packs/core/shared/TooltipMesh';
-
-const formatCoord = format('.3');
-const formatIndex = ([x, y]: Coords) =>
-  `x=${formatCoord(x)} y=${formatCoord(y)}`;
+import { formatTooltipVal } from '../h5web/utils';
 
 interface TemplateProps {
   panZoom?: boolean;
@@ -26,9 +21,15 @@ const Template: Story<TemplateProps> = (args) => {
       {panZoom && <PanZoomMesh />}
       {tooltipValue && (
         <TooltipMesh
-          formatIndex={formatIndex}
-          formatValue={() => tooltipValue}
           guides={guides}
+          renderTooltip={(x, y) => (
+            <>
+              {`x=${formatTooltipVal(x)}, y=${formatTooltipVal(y)}`}
+              <div>
+                <strong>{tooltipValue}</strong>
+              </div>
+            </>
+          )}
         />
       )}
     </VisCanvas>


### PR DESCRIPTION
`HeatmapVis` and `LineVis` both accept a `renderTooltip` function that receives the tooltip's current coordinates, indices and abscissa/ordinate values. This allows the content of the tooltip to be customised (fix #757).

![Screenshot from 2021-07-22 13-45-36](https://user-images.githubusercontent.com/2936402/126634283-3dee12c7-f4dc-40c7-a8db-25ec754deb91.png)

![Screenshot from 2021-07-22 13-46-09](https://user-images.githubusercontent.com/2936402/126634289-5abee5c1-7a46-475e-ab8f-2d9151f84c31.png)
