### PR TITLE
Improve error message when entity is not found with H5Grove

### DIFF
--- a/src/h5web/providers/h5grove/h5grove-api.ts
+++ b/src/h5web/providers/h5grove/h5grove-api.ts
@@ -7,6 +7,7 @@ import {
   Attribute,
   Group,
   UnresolvedEntity,
+  ProviderError,
 } from '../models';
 import { ProviderApi } from '../api';
 import { isDatasetResponse, isGroupResponse } from './utils';
@@ -17,7 +18,7 @@ import type {
   H5GroveAttribute,
 } from './models';
 import { assertDataset } from '../../guards';
-import { convertDtype, flattenValue } from '../utils';
+import { convertDtype, flattenValue, handleAxiosError } from '../utils';
 import { buildEntityPath } from '../../utils';
 
 export class H5GroveApi extends ProviderApi {
@@ -46,8 +47,13 @@ export class H5GroveApi extends ProviderApi {
   }
 
   private async fetchEntity(path: string): Promise<H5GroveEntityResponse> {
-    const { data } = await this.client.get<H5GroveEntityResponse>(
-      `/meta/?file=${this.filepath}&path=${path}`
+    const { data } = await handleAxiosError(
+      () =>
+        this.client.get<H5GroveEntityResponse>(
+          `/meta/?file=${this.filepath}&path=${path}`
+        ),
+      404,
+      ProviderError.NotFound
     );
     return data;
   }

--- a/src/h5web/providers/utils.ts
+++ b/src/h5web/providers/utils.ts
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import { hasArrayShape } from '../guards';
 import { Dataset, DType, DTypeClass, Endianness } from './models';
 
@@ -90,4 +91,20 @@ export function flattenValue(
   const slicedDims = selection?.split(',').filter((s) => s.includes(':'));
   const dims = slicedDims || entity.shape;
   return (value as unknown[]).flat(dims.length - 1);
+}
+
+export async function handleAxiosError<T>(
+  func: () => Promise<T>,
+  status: number,
+  errToThrow: string
+): Promise<T> {
+  try {
+    return await func();
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error) && error.response?.status === status) {
+      throw new Error(errToThrow);
+    }
+
+    throw error;
+  }
 }


### PR DESCRIPTION
See https://github.com/silx-kit/h5web/issues/618#issuecomment-875431360 and https://github.com/silx-kit/h5grove/issues/24

This can be merged before or after the latest version of H5Grove is deployed, it doesn't matter.