### PR TITLE
Add optional histogram to DomainSlider in the tooltip

### DIFF
--- a/src/h5web/toolbar/controls/DomainSlider/DomainSlider.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/DomainSlider.tsx
@@ -3,6 +3,7 @@ import styles from './DomainSlider.module.css';
 import type {
   CustomDomain,
   Domain,
+  HistogramData,
   ScaleType,
 } from '../../../vis-packs/core/models';
 import ToggleBtn from '../ToggleBtn';
@@ -23,11 +24,12 @@ interface Props {
   customDomain: CustomDomain;
   scaleType: ScaleType;
   onCustomDomainChange: (domain: CustomDomain) => void;
+  histogram?: HistogramData;
 }
 
 function DomainSlider(props: Props) {
   const { dataDomain, customDomain, scaleType } = props;
-  const { onCustomDomainChange } = props;
+  const { onCustomDomainChange, histogram } = props;
 
   const visDomain = useVisDomain(customDomain, dataDomain);
   const [safeDomain, errors] = useSafeDomain(visDomain, dataDomain, scaleType);
@@ -134,9 +136,11 @@ function DomainSlider(props: Props) {
         onChangeMin={(val) => onCustomDomainChange([val, customDomain[1]])}
         onChangeMax={(val) => onCustomDomainChange([customDomain[0], val])}
         onSwap={() => onCustomDomainChange([customDomain[1], customDomain[0]])}
+        histogram={histogram}
       />
     </div>
   );
 }
 
+export type { Props as DomainSliderProps };
 export default DomainSlider;

--- a/src/h5web/toolbar/controls/DomainSlider/DomainTooltip.module.css
+++ b/src/h5web/toolbar/controls/DomainSlider/DomainTooltip.module.css
@@ -12,13 +12,15 @@
 .tooltipInner {
   composes: popupInner from '../../Toolbar.module.css';
   padding: 1rem 0.375rem 1rem 0.75rem;
+  display: flex;
+  align-items: center;
 }
 
-.tooltipInner > p {
+.tooltipControls > p {
   margin-bottom: 0.75rem;
 }
 
-.tooltipInner > p:last-child {
+.tooltipControls > p:last-child {
   margin-bottom: 0;
 }
 

--- a/src/h5web/toolbar/controls/DomainSlider/DomainTooltip.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/DomainTooltip.tsx
@@ -1,9 +1,14 @@
 import { forwardRef, useImperativeHandle, useRef } from 'react';
 import type { Domain } from '../../../../packages/lib';
 import { formatBound } from '../../../utils';
-import { DomainError, DomainErrors } from '../../../vis-packs/core/models';
+import {
+  DomainError,
+  DomainErrors,
+  HistogramData,
+} from '../../../vis-packs/core/models';
 import ToggleBtn from '../ToggleBtn';
 import BoundEditor, { BoundEditorHandle } from './BoundEditor';
+import Histogram from './Histogram';
 import styles from './DomainTooltip.module.css';
 import ErrorMessage from './ErrorMessage';
 
@@ -24,6 +29,7 @@ interface Props {
   onChangeMin: (val: number) => void;
   onChangeMax: (val: number) => void;
   onSwap: () => void;
+  histogram?: HistogramData;
 }
 
 interface Handle {
@@ -31,7 +37,7 @@ interface Handle {
 }
 
 const DomainTooltip = forwardRef<Handle, Props>((props, ref) => {
-  const { id, open, sliderDomain, dataDomain, errors } = props;
+  const { id, open, sliderDomain, dataDomain, errors, histogram } = props;
   const { isAutoMin, isAutoMax, isEditingMin, isEditingMax } = props;
   const {
     onAutoMinToggle,
@@ -65,66 +71,68 @@ const DomainTooltip = forwardRef<Handle, Props>((props, ref) => {
       hidden={!open}
     >
       <div className={styles.tooltipInner}>
-        {minGreater && (
-          <ErrorMessage
-            error={DomainError.MinGreater}
-            showSwapBtn={!isAutoMin && !isAutoMax}
-            onSwap={onSwap}
+        {histogram && <Histogram {...histogram} />}
+        <div className={styles.tooltipControls}>
+          {minGreater && (
+            <ErrorMessage
+              error={DomainError.MinGreater}
+              showSwapBtn={!isAutoMin && !isAutoMax}
+              onSwap={onSwap}
+            />
+          )}
+          <BoundEditor
+            ref={minEditorRef}
+            bound="min"
+            value={sliderDomain[0]}
+            isEditing={isEditingMin}
+            hasError={minGreater || !!minError}
+            onEditToggle={onEditMin}
+            onChange={onChangeMin}
           />
-        )}
+          {minError && <ErrorMessage error={minError} />}
 
-        <BoundEditor
-          ref={minEditorRef}
-          bound="min"
-          value={sliderDomain[0]}
-          isEditing={isEditingMin}
-          hasError={minGreater || !!minError}
-          onEditToggle={onEditMin}
-          onChange={onChangeMin}
-        />
-        {minError && <ErrorMessage error={minError} />}
-
-        <BoundEditor
-          ref={maxEditorRef}
-          bound="max"
-          value={sliderDomain[1]}
-          isEditing={isEditingMax}
-          hasError={minGreater || !!maxError}
-          onEditToggle={onEditMax}
-          onChange={onChangeMax}
-        />
-        {maxError && <ErrorMessage error={maxError} />}
-
-        <p className={styles.dataRange}>
-          Data range{' '}
-          <span>
-            [{' '}
-            <abbr title={dataDomain[0].toString()}>
-              {formatBound(dataDomain[0])}
-            </abbr>{' '}
-            ,{' '}
-            <abbr title={dataDomain[1].toString()}>
-              {formatBound(dataDomain[1])}
-            </abbr>{' '}
-            ]
-          </span>
-        </p>
-
-        <p className={styles.autoscale}>
-          Autoscale{' '}
-          <ToggleBtn
-            label="Min"
-            raised
-            value={isAutoMin}
-            onToggle={onAutoMinToggle}
+          <BoundEditor
+            ref={maxEditorRef}
+            bound="max"
+            value={sliderDomain[1]}
+            isEditing={isEditingMax}
+            hasError={minGreater || !!maxError}
+            onEditToggle={onEditMax}
+            onChange={onChangeMax}
           />
-          <ToggleBtn
-            label="Max"
-            raised
-            value={isAutoMax}
-            onToggle={onAutoMaxToggle}
-          />
-        </p>
+          {maxError && <ErrorMessage error={maxError} />}
+
+          <p className={styles.dataRange}>
+            Data range{' '}
+            <span>
+              [{' '}
+              <abbr title={dataDomain[0].toString()}>
+                {formatBound(dataDomain[0])}
+              </abbr>{' '}
+              ,{' '}
+              <abbr title={dataDomain[1].toString()}>
+                {formatBound(dataDomain[1])}
+              </abbr>{' '}
+              ]
+            </span>
+          </p>
+
+          <p className={styles.autoscale}>
+            Autoscale{' '}
+            <ToggleBtn
+              label="Min"
+              raised
+              value={isAutoMin}
+              onToggle={onAutoMinToggle}
+            />
+            <ToggleBtn
+              label="Max"
+              raised
+              value={isAutoMax}
+              onToggle={onAutoMaxToggle}
+            />
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/src/h5web/toolbar/controls/DomainSlider/Histogram.module.css
+++ b/src/h5web/toolbar/controls/DomainSlider/Histogram.module.css
@@ -1,0 +1,18 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  width: 20rem;
+  height: 10rem;
+  padding-left: 2rem;
+  padding-bottom: 1rem;
+  padding-right: 1rem;
+}
+
+.histogram {
+  overflow: visible;
+  background-color: var(--h5w-domainSlider-histogram--bgColor, white);
+}
+
+.bar {
+  fill: var(--h5w-domainSlider-histogram--color, royalblue);
+}

--- a/src/h5web/toolbar/controls/DomainSlider/Histogram.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/Histogram.tsx
@@ -1,0 +1,53 @@
+import { useMeasure } from '@react-hookz/web';
+import { AxisBottom, AxisLeft } from '@visx/axis';
+import { scaleLinear } from '@visx/scale';
+import { useDomain } from '../../../vis-packs/core/hooks';
+import type { HistogramData } from '../../../vis-packs/core/models';
+import Tick from '../../../vis-packs/core/shared/Tick';
+import { DEFAULT_DOMAIN } from '../../../vis-packs/core/utils';
+import styles from './Histogram.module.css';
+
+function Histogram(props: HistogramData) {
+  const { data, bins } = props;
+
+  const domain = useDomain(data);
+
+  const [size, ref] = useMeasure<HTMLDivElement>();
+
+  if (!size) {
+    return <div ref={ref} className={styles.container} />;
+  }
+
+  const { width, height } = size;
+
+  const xScale = scaleLinear({
+    domain: [bins[0], bins[bins.length - 1]],
+    range: [0, width],
+  });
+  const yScale = scaleLinear({
+    domain: domain ? [0, domain[1]] : DEFAULT_DOMAIN,
+    range: [0, height],
+  });
+
+  return (
+    <div ref={ref} className={styles.container}>
+      <svg width="100%" height="100%" className={styles.histogram}>
+        {data.map((d, i) => (
+          <rect
+            className={styles.bar}
+            key={i} // eslint-disable-line react/no-array-index-key
+            x={xScale(bins[i])}
+            y={height - yScale(d)}
+            width={xScale(bins[i + 1]) - xScale(bins[i]) + 0.5} // +0.5 removes the small gap between bars
+            height={yScale(d)}
+          />
+        ))}
+
+        <AxisBottom top={height} scale={xScale} tickComponent={Tick} />
+        <AxisLeft scale={yScale.range([height, 0])} tickComponent={Tick} />
+      </svg>
+    </div>
+  );
+}
+
+export default Histogram;

--- a/src/h5web/vis-packs/core/models.ts
+++ b/src/h5web/vis-packs/core/models.ts
@@ -84,3 +84,8 @@ export type PrintableType =
 export type ValueFormatter<T extends DType> = (val: Primitive<T>) => string;
 
 export type ImageAttribute = 'CLASS' | 'IMAGE_SUBCLASS';
+
+export interface HistogramData {
+  data: number[];
+  bins: number[];
+}

--- a/src/stories/Customization.stories.mdx
+++ b/src/stories/Customization.stories.mdx
@@ -164,3 +164,5 @@ as you see fit. For instance, if you'd like to change the color of the curve of 
 | `--h5w-domainSlider-boundInput-focus--shadowColor`   | `royalblue`                | Box shadow color of bound inputs on focus      |
 | `--h5w-domainSlider-boundInput-editing--bgColor`     | `white`                    | Background color of bound inputs when editing  |
 | `--h5w-domainSlider-boundInput-editing--borderColor` | `royalblue`                | Border color of bound inputs when editing      |
+| `--h5w-domainSlider-histogram--color`                | `royalblue`                | Fill color of histogram bars                   |
+| `--h5w-domainSlider-histogram-bgColor`               | `white`                    | Background color of histogram                  |

--- a/src/stories/DomainSlider.stories.tsx
+++ b/src/stories/DomainSlider.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import { CustomDomain, DomainSlider, ScaleType } from '../packages/lib';
+import type { DomainSliderProps } from '../h5web/toolbar/controls/DomainSlider/DomainSlider';
+import { useState } from 'react';
+import Center from './decorators/Center';
+
+const Template: Story<Omit<DomainSliderProps, 'onCustomDomainChange'>> = (
+  args
+) => {
+  const { customDomain: initialDomain = [null, null], ...otherArgs } = args;
+  const [domain, setDomain] = useState<CustomDomain>(initialDomain);
+
+  return (
+    <DomainSlider
+      customDomain={domain}
+      onCustomDomainChange={setDomain}
+      {...otherArgs}
+    />
+  );
+};
+
+export const Default = Template.bind({});
+
+Default.args = {
+  dataDomain: [-95, 400],
+  scaleType: ScaleType.Linear,
+};
+
+export const WithError = Template.bind({});
+
+WithError.args = {
+  dataDomain: [-95, 400],
+  customDomain: [20, 10], // Putting a higher min
+  scaleType: ScaleType.Linear,
+};
+
+export const Histogram = Template.bind({});
+
+Histogram.args = {
+  ...Default.args,
+  histogram: {
+    data: [100, 166, 130, 92, 76, 68, 60, 52, 50, 26],
+    bins: [-95, -45.5, 4, 53.5, 103, 152.5, 202, 251.5, 301, 350.5, 400],
+  },
+};
+
+export default {
+  title: 'Building Blocks/DomainSlider',
+  component: DomainSlider,
+  decorators: [Center],
+  parameters: {
+    controls: { exclude: ['customDomain', 'onCustomDomainChange'] },
+  },
+  argTypes: {
+    scaleType: {
+      control: {
+        type: 'inline-radio',
+        options: [ScaleType.Linear, ScaleType.SymLog],
+      },
+    },
+  },
+} as Meta;

--- a/src/stories/decorators/Center.tsx
+++ b/src/stories/decorators/Center.tsx
@@ -1,0 +1,11 @@
+import type { Story } from '@storybook/react';
+
+function Center(MyStory: Story) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center' }}>
+      <MyStory />
+    </div>
+  );
+}
+
+export default Center;

--- a/src/styles/vars.css
+++ b/src/styles/vars.css
@@ -41,4 +41,5 @@
   --h5w-selector-label--color: var(--secondary-dark);
   --h5w-selector-option-hover--bgColor: var(--secondary-light-bg);
   --h5w-selector-option-selected--bgColor: var(--secondary-light);
+  --h5w-domainSlider-histogram--color: var(--secondary-dark);
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/42204205/127637621-cb2a1785-3c4c-42bf-8097-715ee3f37210.png)

First step of #758.

The histogram is really basic for now: no interplay with the current scaleType nor the current slider domain. It simply displays what is given in the `histogram` prop of the `DomainSlider`