### PR TITLE
Make histogram extension match the slider extension

### DIFF
--- a/src/h5web/toolbar/controls/DomainSlider/DataHistogram.module.css
+++ b/src/h5web/toolbar/controls/DomainSlider/DataHistogram.module.css
@@ -1,0 +1,15 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 2em;
+}
+
+.svg {
+  overflow: visible;
+  background-color: var(--h5w-domainSlider-histogram--bgColor, white);
+}
+
+.bar {
+  fill: var(--h5w-domainSlider-histogram-bar--color, royalblue);
+}

--- a/src/h5web/toolbar/controls/DomainSlider/DataHistogram.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/DataHistogram.tsx
@@ -1,43 +1,54 @@
 import { AxisBottom, AxisLeft } from '@visx/axis';
 import { scaleLinear } from '@visx/scale';
 import { useDomain } from '../../../vis-packs/core/hooks';
-import type { Size } from '../../../vis-packs/core/models';
+import type { ScaleType, Size, Domain } from '../../../vis-packs/core/models';
+import { H5WEB_SCALES } from '../../../vis-packs/core/scales';
 import styles from './DataHistogram.module.css';
 
 interface Props {
   bins: number[];
   data: number[];
   size: Size | undefined;
+  scaleType: ScaleType;
+  sliderDomain: Domain;
 }
 
 function DataHistogram(props: Props) {
-  const { data, bins, size = { width: 0, height: 0 } } = props;
+  const {
+    data,
+    bins,
+    scaleType,
+    sliderDomain,
+    size = { width: 0, height: 0 },
+  } = props;
   const { height, width } = size;
 
-  const domain = useDomain(data);
+  const histDomain = useDomain(data);
 
-  const xScale = scaleLinear({
-    domain: [bins[0], bins[bins.length - 1]],
+  const xScale = H5WEB_SCALES[scaleType].createScale({
+    domain: sliderDomain,
     range: [0, width],
   });
   const yScale = scaleLinear({
-    domain: domain ? [0, domain[1]] : undefined,
+    domain: histDomain ? [0, histDomain[1]] : undefined,
     range: [0, height],
   });
 
   return (
     <div className={styles.container}>
       <svg width={width} height={height} className={styles.svg}>
-        {data.map((d, i) => (
-          <rect
-            className={styles.bar}
-            key={i} // eslint-disable-line react/no-array-index-key
-            x={xScale(bins[i])}
-            y={height - yScale(d)}
-            width={xScale(bins[i + 1]) - xScale(bins[i])}
-            height={yScale(d)}
-          />
-        ))}
+        <svg width={width} height={height}>
+          {data.map((d, i) => (
+            <rect
+              className={styles.bar}
+              key={i} // eslint-disable-line react/no-array-index-key
+              x={xScale(bins[i])}
+              y={height - yScale(d)}
+              width={xScale(bins[i + 1]) - xScale(bins[i])}
+              height={yScale(d)}
+            />
+          ))}
+        </svg>
 
         <AxisBottom top={height} scale={xScale} />
         <AxisLeft scale={yScale.range([height, 0])} />

--- a/src/h5web/toolbar/controls/DomainSlider/DataHistogram.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/DataHistogram.tsx
@@ -1,0 +1,49 @@
+import { AxisBottom, AxisLeft } from '@visx/axis';
+import { scaleLinear } from '@visx/scale';
+import { useDomain } from '../../../vis-packs/core/hooks';
+import type { Size } from '../../../vis-packs/core/models';
+import styles from './DataHistogram.module.css';
+
+interface Props {
+  bins: number[];
+  data: number[];
+  size: Size | undefined;
+}
+
+function DataHistogram(props: Props) {
+  const { data, bins, size = { width: 0, height: 0 } } = props;
+  const { height, width } = size;
+
+  const domain = useDomain(data);
+
+  const xScale = scaleLinear({
+    domain: [bins[0], bins[bins.length - 1]],
+    range: [0, width],
+  });
+  const yScale = scaleLinear({
+    domain: domain ? [0, domain[1]] : undefined,
+    range: [0, height],
+  });
+
+  return (
+    <div className={styles.container}>
+      <svg width={width} height={height} className={styles.svg}>
+        {data.map((d, i) => (
+          <rect
+            className={styles.bar}
+            key={i} // eslint-disable-line react/no-array-index-key
+            x={xScale(bins[i])}
+            y={height - yScale(d)}
+            width={xScale(bins[i + 1]) - xScale(bins[i])}
+            height={yScale(d)}
+          />
+        ))}
+
+        <AxisBottom top={height} scale={xScale} />
+        <AxisLeft scale={yScale.range([height, 0])} />
+      </svg>
+    </div>
+  );
+}
+
+export default DataHistogram;

--- a/src/h5web/toolbar/controls/DomainSlider/DataHistogram.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/DataHistogram.tsx
@@ -3,6 +3,8 @@ import { scaleLinear } from '@visx/scale';
 import { useDomain } from '../../../vis-packs/core/hooks';
 import type { ScaleType, Size, Domain } from '../../../vis-packs/core/models';
 import { H5WEB_SCALES } from '../../../vis-packs/core/scales';
+import Tick from '../../../vis-packs/core/shared/Tick';
+import { adaptedNumTicks } from '../../../vis-packs/core/utils';
 import styles from './DataHistogram.module.css';
 
 interface Props {
@@ -50,8 +52,21 @@ function DataHistogram(props: Props) {
           ))}
         </svg>
 
-        <AxisBottom top={height} scale={xScale} />
-        <AxisLeft scale={yScale.range([height, 0])} />
+        <AxisBottom
+          top={height}
+          scale={xScale}
+          numTicks={adaptedNumTicks(width)}
+          tickClassName={styles.tick}
+          tickComponent={Tick}
+          tickFormat={xScale.tickFormat(adaptedNumTicks(width), '.3~g')}
+        />
+        <AxisLeft
+          scale={yScale.range([height, 0])}
+          numTicks={adaptedNumTicks(height)}
+          tickClassName={styles.tick}
+          tickComponent={Tick}
+          tickFormat={yScale.tickFormat(adaptedNumTicks(height), '.3~g')}
+        />
       </svg>
     </div>
   );

--- a/src/h5web/toolbar/controls/DomainSlider/DomainSlider.module.css
+++ b/src/h5web/toolbar/controls/DomainSlider/DomainSlider.module.css
@@ -1,6 +1,7 @@
 .root {
   position: relative;
   display: flex;
+  justify-content: center;
   padding: 0 0.375rem;
   margin-right: -0.375rem;
 }

--- a/src/h5web/toolbar/controls/DomainSlider/DomainSlider.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/DomainSlider.tsx
@@ -136,6 +136,7 @@ function DomainSlider(props: Props) {
         onChangeMin={(val) => onCustomDomainChange([val, customDomain[1]])}
         onChangeMax={(val) => onCustomDomainChange([customDomain[0], val])}
         onSwap={() => onCustomDomainChange([customDomain[1], customDomain[0]])}
+        scaleType={scaleType}
         histogram={histogram}
       />
     </div>

--- a/src/h5web/toolbar/controls/DomainSlider/DomainSlider.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/DomainSlider.tsx
@@ -3,6 +3,7 @@ import styles from './DomainSlider.module.css';
 import type {
   CustomDomain,
   Domain,
+  HistogramData,
   ScaleType,
 } from '../../../vis-packs/core/models';
 import ToggleBtn from '../ToggleBtn';
@@ -23,11 +24,12 @@ interface Props {
   customDomain: CustomDomain;
   scaleType: ScaleType;
   onCustomDomainChange: (domain: CustomDomain) => void;
+  histogram?: HistogramData;
 }
 
 function DomainSlider(props: Props) {
   const { dataDomain, customDomain, scaleType } = props;
-  const { onCustomDomainChange } = props;
+  const { onCustomDomainChange, histogram } = props;
 
   const visDomain = useVisDomain(customDomain, dataDomain);
   const [safeDomain, errors] = useSafeDomain(visDomain, dataDomain, scaleType);
@@ -134,9 +136,11 @@ function DomainSlider(props: Props) {
         onChangeMin={(val) => onCustomDomainChange([val, customDomain[1]])}
         onChangeMax={(val) => onCustomDomainChange([customDomain[0], val])}
         onSwap={() => onCustomDomainChange([customDomain[1], customDomain[0]])}
+        histogram={histogram}
       />
     </div>
   );
 }
 
+export type { Props as DomainSliderProps };
 export default DomainSlider;

--- a/src/h5web/toolbar/controls/DomainSlider/DomainTooltip.module.css
+++ b/src/h5web/toolbar/controls/DomainSlider/DomainTooltip.module.css
@@ -12,13 +12,15 @@
 .tooltipInner {
   composes: popupInner from '../../Toolbar.module.css';
   padding: 1rem 0.375rem 1rem 0.75rem;
+  display: flex;
+  align-items: center;
 }
 
-.tooltipInner > p {
+.tooltipControls > p {
   margin-bottom: 0.75rem;
 }
 
-.tooltipInner > p:last-child {
+.tooltipControls > p:last-child {
   margin-bottom: 0;
 }
 

--- a/src/h5web/toolbar/controls/DomainSlider/DomainTooltip.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/DomainTooltip.tsx
@@ -1,9 +1,15 @@
 import { forwardRef, useImperativeHandle, useRef } from 'react';
+import { useMeasure } from 'react-use';
 import type { Domain } from '../../../../packages/lib';
 import { formatBound } from '../../../utils';
-import { DomainError, DomainErrors } from '../../../vis-packs/core/models';
+import {
+  DomainError,
+  DomainErrors,
+  HistogramData,
+} from '../../../vis-packs/core/models';
 import ToggleBtn from '../ToggleBtn';
 import BoundEditor, { BoundEditorHandle } from './BoundEditor';
+import DataHistogram from './DataHistogram';
 import styles from './DomainTooltip.module.css';
 import ErrorMessage from './ErrorMessage';
 
@@ -24,6 +30,7 @@ interface Props {
   onChangeMin: (val: number) => void;
   onChangeMax: (val: number) => void;
   onSwap: () => void;
+  histogram?: HistogramData;
 }
 
 interface Handle {
@@ -31,7 +38,7 @@ interface Handle {
 }
 
 const DomainTooltip = forwardRef<Handle, Props>((props, ref) => {
-  const { id, open, sliderDomain, dataDomain, errors } = props;
+  const { id, open, sliderDomain, dataDomain, errors, histogram } = props;
   const { isAutoMin, isAutoMax, isEditingMin, isEditingMax } = props;
   const {
     onAutoMinToggle,
@@ -46,6 +53,8 @@ const DomainTooltip = forwardRef<Handle, Props>((props, ref) => {
   const { minGreater, minError, maxError } = errors;
   const minEditorRef = useRef<BoundEditorHandle>(null);
   const maxEditorRef = useRef<BoundEditorHandle>(null);
+
+  const [controlsRef, controlsSize] = useMeasure<HTMLDivElement>();
 
   /* Expose `cancelEditing` function to parent component through ref handle so that
      editing can be cancelled when the user closes the domain tooltip. */
@@ -65,66 +74,74 @@ const DomainTooltip = forwardRef<Handle, Props>((props, ref) => {
       hidden={!open}
     >
       <div className={styles.tooltipInner}>
-        {minGreater && (
-          <ErrorMessage
-            error={DomainError.MinGreater}
-            showSwapBtn={!isAutoMin && !isAutoMax}
-            onSwap={onSwap}
+        {histogram && (
+          <DataHistogram
+            bins={histogram.bins}
+            data={histogram.data}
+            size={controlsSize}
           />
         )}
-
-        <BoundEditor
-          ref={minEditorRef}
-          bound="min"
-          value={sliderDomain[0]}
-          isEditing={isEditingMin}
-          hasError={minGreater || !!minError}
-          onEditToggle={onEditMin}
-          onChange={onChangeMin}
-        />
-        {minError && <ErrorMessage error={minError} />}
-
-        <BoundEditor
-          ref={maxEditorRef}
-          bound="max"
-          value={sliderDomain[1]}
-          isEditing={isEditingMax}
-          hasError={minGreater || !!maxError}
-          onEditToggle={onEditMax}
-          onChange={onChangeMax}
-        />
-        {maxError && <ErrorMessage error={maxError} />}
-
-        <p className={styles.dataRange}>
-          Data range{' '}
-          <span>
-            [{' '}
-            <abbr title={dataDomain[0].toString()}>
-              {formatBound(dataDomain[0])}
-            </abbr>{' '}
-            ,{' '}
-            <abbr title={dataDomain[1].toString()}>
-              {formatBound(dataDomain[1])}
-            </abbr>{' '}
-            ]
-          </span>
-        </p>
-
-        <p className={styles.autoscale}>
-          Autoscale{' '}
-          <ToggleBtn
-            label="Min"
-            raised
-            value={isAutoMin}
-            onToggle={onAutoMinToggle}
+        <div ref={controlsRef} className={styles.tooltipControls}>
+          {minGreater && (
+            <ErrorMessage
+              error={DomainError.MinGreater}
+              showSwapBtn={!isAutoMin && !isAutoMax}
+              onSwap={onSwap}
+            />
+          )}
+          <BoundEditor
+            ref={minEditorRef}
+            bound="min"
+            value={sliderDomain[0]}
+            isEditing={isEditingMin}
+            hasError={minGreater || !!minError}
+            onEditToggle={onEditMin}
+            onChange={onChangeMin}
           />
-          <ToggleBtn
-            label="Max"
-            raised
-            value={isAutoMax}
-            onToggle={onAutoMaxToggle}
+          {minError && <ErrorMessage error={minError} />}
+
+          <BoundEditor
+            ref={maxEditorRef}
+            bound="max"
+            value={sliderDomain[1]}
+            isEditing={isEditingMax}
+            hasError={minGreater || !!maxError}
+            onEditToggle={onEditMax}
+            onChange={onChangeMax}
           />
-        </p>
+          {maxError && <ErrorMessage error={maxError} />}
+
+          <p className={styles.dataRange}>
+            Data range{' '}
+            <span>
+              [{' '}
+              <abbr title={dataDomain[0].toString()}>
+                {formatBound(dataDomain[0])}
+              </abbr>{' '}
+              ,{' '}
+              <abbr title={dataDomain[1].toString()}>
+                {formatBound(dataDomain[1])}
+              </abbr>{' '}
+              ]
+            </span>
+          </p>
+
+          <p className={styles.autoscale}>
+            Autoscale{' '}
+            <ToggleBtn
+              label="Min"
+              raised
+              value={isAutoMin}
+              onToggle={onAutoMinToggle}
+            />
+            <ToggleBtn
+              label="Max"
+              raised
+              value={isAutoMax}
+              onToggle={onAutoMaxToggle}
+            />
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/src/h5web/toolbar/controls/DomainSlider/DomainTooltip.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/DomainTooltip.tsx
@@ -6,6 +6,7 @@ import {
   DomainError,
   DomainErrors,
   HistogramData,
+  ScaleType,
 } from '../../../vis-packs/core/models';
 import ToggleBtn from '../ToggleBtn';
 import BoundEditor, { BoundEditorHandle } from './BoundEditor';
@@ -30,6 +31,7 @@ interface Props {
   onChangeMin: (val: number) => void;
   onChangeMax: (val: number) => void;
   onSwap: () => void;
+  scaleType: ScaleType;
   histogram?: HistogramData;
 }
 
@@ -38,7 +40,8 @@ interface Handle {
 }
 
 const DomainTooltip = forwardRef<Handle, Props>((props, ref) => {
-  const { id, open, sliderDomain, dataDomain, errors, histogram } = props;
+  const { id, open, sliderDomain, dataDomain, errors, histogram, scaleType } =
+    props;
   const { isAutoMin, isAutoMax, isEditingMin, isEditingMax } = props;
   const {
     onAutoMinToggle,
@@ -78,6 +81,8 @@ const DomainTooltip = forwardRef<Handle, Props>((props, ref) => {
           <DataHistogram
             bins={histogram.bins}
             data={histogram.data}
+            scaleType={scaleType}
+            sliderDomain={sliderDomain}
             size={controlsSize}
           />
         )}

--- a/src/h5web/vis-packs/core/models.ts
+++ b/src/h5web/vis-packs/core/models.ts
@@ -84,3 +84,8 @@ export type PrintableType =
 export type ValueFormatter<T extends DType> = (val: Primitive<T>) => string;
 
 export type ImageAttribute = 'CLASS' | 'IMAGE_SUBCLASS';
+
+export interface HistogramData {
+  data: number[];
+  bins: number[];
+}

--- a/src/stories/Customization.stories.mdx
+++ b/src/stories/Customization.stories.mdx
@@ -164,3 +164,5 @@ as you see fit. For instance, if you'd like to change the color of the curve of 
 | `--h5w-domainSlider-boundInput-focus--shadowColor`   | `royalblue`                | Box shadow color of bound inputs on focus      |
 | `--h5w-domainSlider-boundInput-editing--bgColor`     | `white`                    | Background color of bound inputs when editing  |
 | `--h5w-domainSlider-boundInput-editing--borderColor` | `royalblue`                | Border color of bound inputs when editing      |
+| `--h5w-domainSlider-histogram-bar--color`            | `royalblue`                | Fill color of histogram bars                   |
+| `--h5w-domainSlider-histogram-bgColor`               | `white`                    | Background color of histogram                  |

--- a/src/stories/DomainSlider.stories.tsx
+++ b/src/stories/DomainSlider.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import { CustomDomain, DomainSlider, ScaleType } from '../packages/lib';
+import type { DomainSliderProps } from '../h5web/toolbar/controls/DomainSlider/DomainSlider';
+import { useState } from 'react';
+
+const Template: Story<Omit<DomainSliderProps, 'onCustomDomainChange'>> = (
+  args
+) => {
+  const { customDomain: initialDomain = [null, null], ...otherArgs } = args;
+  const [domain, setDomain] = useState<CustomDomain>(initialDomain);
+
+  return (
+    <DomainSlider
+      customDomain={domain}
+      onCustomDomainChange={setDomain}
+      {...otherArgs}
+    />
+  );
+};
+
+export const Default = Template.bind({});
+
+Default.args = {
+  dataDomain: [-95, 400],
+  scaleType: ScaleType.Linear,
+};
+
+export const WithError = Template.bind({});
+
+WithError.args = {
+  dataDomain: [-95, 400],
+  customDomain: [20, 10], // Putting a higher min
+  scaleType: ScaleType.Linear,
+};
+
+export const Histogram = Template.bind({});
+
+Histogram.args = {
+  ...Default.args,
+  histogram: {
+    data: [100, 166, 130, 92, 76, 68, 60, 52, 50, 26],
+    bins: [-95, -45.5, 4, 53.5, 103, 152.5, 202, 251.5, 301, 350.5, 400],
+  },
+};
+
+export default {
+  title: 'Building Blocks/DomainSlider',
+  component: DomainSlider,
+  parameters: {
+    controls: { exclude: ['customDomain', 'onCustomDomainChange'] },
+  },
+  argTypes: {
+    scaleType: {
+      control: {
+        type: 'inline-radio',
+        options: [ScaleType.Linear, ScaleType.SymLog],
+      },
+    },
+  },
+} as Meta;

--- a/src/styles/vars.css
+++ b/src/styles/vars.css
@@ -41,4 +41,5 @@
   --h5w-selector-label--color: var(--secondary-dark);
   --h5w-selector-option-hover--bgColor: var(--secondary-light-bg);
   --h5w-selector-option-selected--bgColor: var(--secondary-light);
+  --h5w-domainSlider-histogram-bar--color: var(--secondary-dark);
 }


### PR DESCRIPTION
Second step of #758 

Also accounts for `scaleType`

### Slider domain bigger than data domain
![image](https://user-images.githubusercontent.com/42204205/127976972-437e35cd-989f-4f91-a8aa-f1483bedf514.png)

### Slider domain smaller than data domain
![image](https://user-images.githubusercontent.com/42204205/127977105-e20cc8db-c5eb-4819-b6ae-b2abdfe5b2fb.png)

### Symlog scale
![image](https://user-images.githubusercontent.com/42204205/127977254-a991528d-2cd4-4ca7-8665-5969b99fd2be.png)

Ticks are not great in the last case. <s>I will try to reuse our `Axis` components in a future PR.</s> Done in a522f25f9086ee6a3690ddb06dda4c47cf634005.

![image](https://user-images.githubusercontent.com/42204205/127980317-34fcdc81-75a5-4504-8b4d-ac480b4a3a25.png)


