### PR TITLE
Encode query parameters in `H5GroveProvider`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "0.0.24",
+      "version": "0.0.25",
       "license": "MIT",
       "dependencies": {
         "@react-hookz/web": "^5.0.0",

--- a/src/h5web/providers/h5grove/h5grove-api.ts
+++ b/src/h5web/providers/h5grove/h5grove-api.ts
@@ -18,7 +18,12 @@ import type {
   H5GroveAttribute,
 } from './models';
 import { assertDataset } from '../../guards';
-import { convertDtype, flattenValue, handleAxiosError } from '../utils';
+import {
+  convertDtype,
+  flattenValue,
+  handleAxiosError,
+  encodeQueryParams,
+} from '../utils';
 import { buildEntityPath } from '../../utils';
 
 export class H5GroveApi extends ProviderApi {
@@ -50,7 +55,7 @@ export class H5GroveApi extends ProviderApi {
     const { data } = await handleAxiosError(
       () =>
         this.client.get<H5GroveEntityResponse>(
-          `/meta/?file=${this.filepath}&path=${path}`
+          `/meta/?${encodeQueryParams({ file: this.filepath, path })}`
         ),
       404,
       ProviderError.NotFound
@@ -69,7 +74,7 @@ export class H5GroveApi extends ProviderApi {
     }
 
     const { data } = await this.client.get<H5GroveAttrValuesResponse>(
-      `/attr/?file=${this.filepath}&path=${path}`
+      `/attr/?${encodeQueryParams({ file: this.filepath, path })}`
     );
 
     this.attrValuesCache.set(path, data);
@@ -79,11 +84,8 @@ export class H5GroveApi extends ProviderApi {
   private async fetchData(
     params: ValueRequestParams
   ): Promise<H5GroveDataResponse> {
-    const { path, selection = '' } = params;
     const { data } = await this.cancellableFetchValue<H5GroveDataResponse>(
-      `/data/?file=${this.filepath}&path=${path}${
-        selection && `&selection=${selection}`
-      }`,
+      `/data/?${encodeQueryParams({ file: this.filepath, ...params })}`,
       params
     );
     return data;

--- a/src/h5web/providers/utils.test.ts
+++ b/src/h5web/providers/utils.test.ts
@@ -1,5 +1,5 @@
 import { Endianness, DTypeClass } from './models';
-import { convertDtype } from './utils';
+import { convertDtype, encodeQueryParams } from './utils';
 
 describe('convertDtype', () => {
   it('should convert integer dtypes', () => {
@@ -73,5 +73,19 @@ describe('convertDtype', () => {
 
   it('should handle unknown type', () => {
     expect(convertDtype('>notAType')).toEqual({ class: DTypeClass.Unknown });
+  });
+});
+
+describe('encodeQueryParams', () => {
+  it('should convert a record into a query string', () => {
+    expect(encodeQueryParams({ file: 'a_file.h5', format: 'json' })).toEqual(
+      'file=a_file.h5&format=json'
+    );
+  });
+
+  it('should encode special characters', () => {
+    expect(encodeQueryParams({ file: 'a+file.h5', path: '/' })).toEqual(
+      'file=a%2Bfile.h5&path=%2F'
+    );
   });
 });

--- a/src/h5web/providers/utils.ts
+++ b/src/h5web/providers/utils.ts
@@ -108,3 +108,7 @@ export async function handleAxiosError<T>(
     throw error;
   }
 }
+
+export function encodeQueryParams(params: Record<string, string>) {
+  return new URLSearchParams(params).toString();
+}


### PR DESCRIPTION
To fix https://github.com/silx-kit/jupyterlab-h5web/issues/45

#### Previously
The raw URL `/meta/?file=stack+.h5&path=/` was unchanged. 

The `file` arg gets interpreted as  `stack .h5` by `h5grove`.

#### Now
The URL `/meta/?file=stack+.h5&path=/` gets encoded as `/meta/?file=stack%2B.h5&path=%2F`. 

The `file` arg gets interpreted as  `stack+.h5` by `h5grove`.