### PR TITLE
Do not support NaN in domain computation and shaders

### DIFF
--- a/src/h5web/vis-packs/core/heatmap/HeatmapMesh.tsx
+++ b/src/h5web/vis-packs/core/heatmap/HeatmapMesh.tsx
@@ -193,8 +193,9 @@ function HeatmapMesh(props: Props) {
 
       void main() {
         float value = texture2D(data, coords).r;
+        bool isNotFinite = isnan(value) || isinf(value);
 
-        if (!isSupported(value)) {
+        if (isNotFinite || !isSupported(value)) {
           gl_FragColor = nanColor;
         } else {
           gl_FragColor = texture2D(colorMap, vec2(scale(value), 0.5));

--- a/src/h5web/vis-packs/core/utils.test.ts
+++ b/src/h5web/vis-packs/core/utils.test.ts
@@ -13,6 +13,7 @@ import { Domain, ScaleType } from './models';
 
 const MAX = Number.MAX_VALUE / 2;
 const POS_MIN = Number.MIN_VALUE;
+const { NaN: NAN, POSITIVE_INFINITY: INFINITY } = Number;
 
 describe('computeCanvasSize', () => {
   describe('with aspect ratio > 1', () => {
@@ -75,6 +76,16 @@ describe('getDomain', () => {
 
   it('should return `undefined` if data is empty', () => {
     const domain = getDomain([]);
+    expect(domain).toBeUndefined();
+  });
+
+  it('should ignore NaN and Infinity', () => {
+    const domain = getDomain([2, NAN, 10, INFINITY, 2, -1]);
+    expect(domain).toEqual([-1, 10]);
+  });
+
+  it('should return `undefined` if data contains only NaN and Infinity', () => {
+    const domain = getDomain([NAN, NAN, -INFINITY, INFINITY]);
     expect(domain).toBeUndefined();
   });
 

--- a/src/h5web/vis-packs/core/utils.ts
+++ b/src/h5web/vis-packs/core/utils.ts
@@ -94,20 +94,23 @@ export function getBounds(
   const values = toArray(valuesArray);
   const errors = errorArray && toArray(errorArray);
 
-  if (values.length === 0) {
-    return undefined;
-  }
-
-  return values.reduce<Bounds>(
+  const bounds = values.reduce<Bounds>(
     (acc, val, i) => {
+      // Ignore NaN and Infinity from the bounds computation
+      if (!Number.isFinite(val)) {
+        return acc;
+      }
       const newBounds = getNewBounds(acc, val);
       const err = errors && errors[i];
       return err
         ? getNewBounds(getNewBounds(newBounds, val - err), val + err)
         : newBounds;
     },
-    { min: values[0], max: values[0], positiveMin: Infinity }
+    { min: Infinity, max: -Infinity, positiveMin: Infinity }
   );
+
+  // Return undefined if min is Infinity (values is empty or contains only NaN/Infinity)
+  return Number.isFinite(bounds.min) ? bounds : undefined;
 }
 
 export function getDomain(


### PR DESCRIPTION
Fixes HSDS issues reported in https://github.com/silx-kit/h5web/issues/641#issuecomment-894235661:
> :x: LineVis show a blank canvas even for slices containing only valid values
> :x: Computation of the domain in the HeatmapVis yields NaN or Infinity values

Also pixels with `NaN` are not considered as unsupported in `HeatmapVis`:
![image](https://user-images.githubusercontent.com/42204205/128518771-459cca32-6318-43de-91af-172280d1882f.png)