### PR TITLE
Transform `null` in `NaN` in h5grove and Jupyter providers

### DIFF
--- a/src/h5web/providers/h5grove/h5grove-api.ts
+++ b/src/h5web/providers/h5grove/h5grove-api.ts
@@ -23,6 +23,7 @@ import {
   flattenValue,
   handleAxiosError,
   encodeQueryParams,
+  transformNullInNaN,
 } from '../utils';
 import { buildEntityPath } from '../../utils';
 
@@ -31,7 +32,10 @@ export class H5GroveApi extends ProviderApi {
 
   /* API compatible with h5grove@0.0.4 */
   public constructor(url: string, filepath: string) {
-    super(filepath, { baseURL: url });
+    super(filepath, {
+      baseURL: url,
+      transformResponse: transformNullInNaN,
+    });
   }
 
   public async getEntity(path: string): Promise<Entity> {

--- a/src/h5web/providers/jupyter/jupyter-api.ts
+++ b/src/h5web/providers/jupyter/jupyter-api.ts
@@ -17,7 +17,7 @@ import type {
   JupyterAttribute,
 } from './models';
 import { assertDataset } from '../../guards';
-import { convertDtype, flattenValue } from '../utils';
+import { convertDtype, flattenValue, transformNullInNaN } from '../utils';
 import { buildEntityPath } from '../../utils';
 
 export class JupyterStableApi extends ProviderApi {
@@ -25,7 +25,10 @@ export class JupyterStableApi extends ProviderApi {
 
   /* API compatible with jupyterlab_hdf v0.6.0 */
   public constructor(url: string, filepath: string) {
-    super(filepath, { baseURL: `${url}/hdf` });
+    super(filepath, {
+      baseURL: `${url}/hdf`,
+      transformResponse: transformNullInNaN,
+    });
   }
 
   public async getEntity(path: string): Promise<Entity> {

--- a/src/h5web/providers/utils.ts
+++ b/src/h5web/providers/utils.ts
@@ -112,3 +112,13 @@ export async function handleAxiosError<T>(
 export function encodeQueryParams(params: Record<string, string>) {
   return new URLSearchParams(params).toString();
 }
+
+export function transformNullInNaN(data: unknown) {
+  if (typeof data !== 'string') {
+    return data;
+  }
+
+  return JSON.parse(data, (key, value) =>
+    value !== null ? value : Number.NaN
+  );
+}


### PR DESCRIPTION
Fixes Jupyter/h5grove issues reported in https://github.com/silx-kit/h5web/issues/641#issuecomment-894235661:
> :x: The `null` value gets interpreted as `0` in most numeric contexts: value display in the tooltip, domain computation, colormap mapping, `MatrixVis`...
> :x:  Sole exception of the rule above: `ScalarVis` throws with `val is null`