### PR TITLE
Fix vis sizing feedback loop in some contexts

### DIFF
--- a/src/h5web/vis-packs/core/matrix/MatrixVis.module.css
+++ b/src/h5web/vis-packs/core/matrix/MatrixVis.module.css
@@ -1,10 +1,10 @@
 .wrapper {
+  position: relative;
   flex: 1 1 0%;
-  min-width: 0;
-  min-height: 0;
 }
 
 .grid {
+  position: absolute !important; /* prevent feedback loop with `useMeasure` on wrapper */
   color: var(--h5w-matrix--color, inherit);
   font-family: var(--h5w-matrix--fontFamily, monospace);
   font-size: var(--h5w-matrix--fontSize, inherit);

--- a/src/h5web/vis-packs/core/shared/VisCanvas.module.css
+++ b/src/h5web/vis-packs/core/shared/VisCanvas.module.css
@@ -1,14 +1,11 @@
 .visArea {
+  position: relative;
   flex: 1 1 0%;
-  min-width: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden; /* prevent overflow when keeping aspect ratio` */
+  overflow: hidden; /* prevent overflow when resizing */
 }
 
 .vis {
-  flex: none;
+  position: absolute; /* prevent feedback loop with `useMeasure` on wrapper */
 }
 
 /* R3F's root element */


### PR DESCRIPTION
This should fix the issue with long names on Jupyter Lab. The problem was actually caused by a feedback loop with the sizing of the visualizations. Taking the visualizations out of the flow with `position: absolute` seems to solve the issue.