### PR TITLE
Encode query params with axios

### DIFF
--- a/src/h5web/providers/Provider.tsx
+++ b/src/h5web/providers/Provider.tsx
@@ -51,8 +51,8 @@ function Provider(props: Props) {
     return Object.assign(store, {
       cancelOngoing: () => api.cancelValueRequests(),
       evictCancelled: () => {
-        api.cancelledValueRequests.forEach(({ params }) => {
-          valuesStore.evict(params);
+        api.cancelledValueRequests.forEach(({ storeParams }) => {
+          valuesStore.evict(storeParams);
         });
         api.cancelledValueRequests.clear();
       },

--- a/src/h5web/providers/context.ts
+++ b/src/h5web/providers/context.ts
@@ -1,8 +1,8 @@
 import { createContext } from 'react';
-import type { Entity, ValueRequestParams } from './models';
+import type { Entity, ValuesStoreParams } from './models';
 import type { FetchStore } from 'react-suspense-fetch';
 
-interface ValuesStore extends FetchStore<unknown, ValueRequestParams> {
+interface ValuesStore extends FetchStore<unknown, ValuesStoreParams> {
   cancelOngoing: () => void;
   evictCancelled: () => void;
 }

--- a/src/h5web/providers/hsds/hsds-api.ts
+++ b/src/h5web/providers/hsds/hsds-api.ts
@@ -13,7 +13,7 @@ import type {
   HsdsId,
 } from './models';
 import {
-  ValueRequestParams,
+  ValuesStoreParams,
   Dataset,
   Datatype,
   Entity,
@@ -104,7 +104,7 @@ export class HsdsApi extends ProviderApi {
     return entity;
   }
 
-  public async getValue(params: ValueRequestParams): Promise<unknown> {
+  public async getValue(params: ValuesStoreParams): Promise<unknown> {
     const { path } = params;
 
     const entity = await this.getEntity(path);
@@ -173,12 +173,13 @@ export class HsdsApi extends ProviderApi {
 
   private async fetchValue(
     entityId: HsdsId,
-    params: ValueRequestParams
+    params: ValuesStoreParams
   ): Promise<unknown> {
-    const { selection = '' } = params;
+    const { selection } = params;
     const { data } = await this.cancellableFetchValue<HsdsValueResponse>(
-      `/datasets/${entityId}/value${selection && `?select=[${selection}]`}`,
-      params
+      `/datasets/${entityId}/value`,
+      params,
+      { select: selection && `[${selection}]` }
     );
     return data.value;
   }

--- a/src/h5web/providers/jupyter/jupyter-api.ts
+++ b/src/h5web/providers/jupyter/jupyter-api.ts
@@ -1,5 +1,5 @@
 import {
-  ValueRequestParams,
+  ValuesStoreParams,
   Dataset,
   Entity,
   EntityKind,
@@ -33,7 +33,7 @@ export class JupyterStableApi extends ProviderApi {
     return this.processEntityResponse(path, response);
   }
 
-  public async getValue(params: ValueRequestParams): Promise<unknown> {
+  public async getValue(params: ValuesStoreParams): Promise<unknown> {
     const { path, selection } = params;
     const [value, entity] = await Promise.all([
       this.fetchData(params),
@@ -47,7 +47,8 @@ export class JupyterStableApi extends ProviderApi {
 
   protected async fetchEntity(path: string): Promise<JupyterEntityResponse> {
     const { data } = await this.client.get<JupyterEntityResponse>(
-      `/meta/${this.filepath}?uri=${path}`
+      `/meta/${this.filepath}`,
+      { params: { uri: path } }
     );
     return data;
   }
@@ -63,7 +64,8 @@ export class JupyterStableApi extends ProviderApi {
     }
 
     const { data } = await this.client.get<JupyterAttrValuesResponse>(
-      `/attrs/${this.filepath}?uri=${path}`
+      `/attrs/${this.filepath}`,
+      { params: { uri: path } }
     );
 
     this.attrValuesCache.set(path, data);
@@ -71,12 +73,13 @@ export class JupyterStableApi extends ProviderApi {
   }
 
   protected async fetchData(
-    params: ValueRequestParams
+    params: ValuesStoreParams
   ): Promise<JupyterDataResponse> {
-    const { path, selection = '' } = params;
+    const { path, selection } = params;
     const { data } = await this.cancellableFetchValue<JupyterDataResponse>(
-      `/data/${this.filepath}?uri=${path}${selection && `&ixstr=${selection}`}`,
-      params
+      `/data/${this.filepath}`,
+      params,
+      { uri: path, ixstr: selection }
     );
     return data;
   }

--- a/src/h5web/providers/mock/mock-api.ts
+++ b/src/h5web/providers/mock/mock-api.ts
@@ -7,7 +7,7 @@ import {
 } from '../../guards';
 import { applyMapping } from '../../vis-packs/core/utils';
 import { ProviderApi } from '../api';
-import type { ValueRequestParams, Entity, Primitive } from '../models';
+import type { ValuesStoreParams, Entity, Primitive } from '../models';
 import { mockFilepath } from './metadata';
 import { assertMockDataset, findMockEntity } from './utils';
 
@@ -28,7 +28,7 @@ export class MockApi extends ProviderApi {
     return findMockEntity(path);
   }
 
-  public async getValue(params: ValueRequestParams): Promise<unknown> {
+  public async getValue(params: ValuesStoreParams): Promise<unknown> {
     const { path, selection } = params;
 
     if (path.includes('error_value')) {
@@ -64,9 +64,9 @@ export class MockApi extends ProviderApi {
     return mappedArray.data;
   }
 
-  private async cancellableDelay(params: ValueRequestParams) {
+  private async cancellableDelay(storeParams: ValuesStoreParams) {
     const cancelSource = axios.CancelToken.source();
-    const request = { params, cancelSource };
+    const request = { storeParams, cancelSource };
     this.valueRequests.add(request);
 
     try {

--- a/src/h5web/providers/models.ts
+++ b/src/h5web/providers/models.ts
@@ -1,6 +1,6 @@
-export interface ValueRequestParams {
+export interface ValuesStoreParams {
   path: string;
-  selection?: string;
+  selection?: string | undefined;
 }
 
 export enum ProviderError {

--- a/src/h5web/providers/utils.test.ts
+++ b/src/h5web/providers/utils.test.ts
@@ -1,5 +1,5 @@
 import { Endianness, DTypeClass } from './models';
-import { convertDtype, encodeQueryParams } from './utils';
+import { convertDtype } from './utils';
 
 describe('convertDtype', () => {
   it('should convert integer dtypes', () => {
@@ -73,19 +73,5 @@ describe('convertDtype', () => {
 
   it('should handle unknown type', () => {
     expect(convertDtype('>notAType')).toEqual({ class: DTypeClass.Unknown });
-  });
-});
-
-describe('encodeQueryParams', () => {
-  it('should convert a record into a query string', () => {
-    expect(encodeQueryParams({ file: 'a_file.h5', format: 'json' })).toEqual(
-      'file=a_file.h5&format=json'
-    );
-  });
-
-  it('should encode special characters', () => {
-    expect(encodeQueryParams({ file: 'a+file.h5', path: '/' })).toEqual(
-      'file=a%2Bfile.h5&path=%2F'
-    );
   });
 });

--- a/src/h5web/providers/utils.ts
+++ b/src/h5web/providers/utils.ts
@@ -108,7 +108,3 @@ export async function handleAxiosError<T>(
     throw error;
   }
 }
-
-export function encodeQueryParams(params: Record<string, string>) {
-  return new URLSearchParams(params).toString();
-}


### PR DESCRIPTION
Common encoding issues (such as not including `undefined` fields) were not solved by #774. Using axios avoid reimplementing fixes for such issues.

Also, the encoding was extended to all providers and not solely `h5grove`.