### PR TITLE
Fix controls jumping in/out of overflow menu and refactor controls measuring flow

### DIFF
--- a/src/h5web/toolbar/MeasuredControl.tsx
+++ b/src/h5web/toolbar/MeasuredControl.tsx
@@ -4,23 +4,29 @@ import styles from './Toolbar.module.css';
 
 interface Props {
   children: ReactElement;
+  knownWidth: number | undefined;
   onMeasure: (width: number) => void;
 }
 
 function MeasuredControl(props: Props) {
-  const { children: child, onMeasure } = props;
+  const { children: child, knownWidth, onMeasure } = props;
 
   return (
     <Measure
       onResize={({ entry }: { entry?: DOMRect }) => {
-        if (entry) {
+        if (entry && entry.width !== knownWidth) {
           onMeasure(entry.width);
         }
       }}
     >
       {({ measureRef }) => (
-        <div ref={measureRef} className={styles.control}>
-          {child}
+        <div
+          className={styles.controlWrapper}
+          data-measured={knownWidth !== undefined} // hide control until measured for the first time
+        >
+          <div ref={measureRef} className={styles.control}>
+            {child}
+          </div>
         </div>
       )}
     </Measure>

--- a/src/h5web/toolbar/MeasuredControl.tsx
+++ b/src/h5web/toolbar/MeasuredControl.tsx
@@ -14,7 +14,7 @@ function MeasuredControl(props: Props) {
   return (
     <Measure
       onResize={({ entry }: { entry?: DOMRect }) => {
-        if (entry && entry.width !== knownWidth) {
+        if (entry && entry.width > (knownWidth || 0)) {
           onMeasure(entry.width);
         }
       }}

--- a/src/h5web/toolbar/Toolbar.module.css
+++ b/src/h5web/toolbar/Toolbar.module.css
@@ -15,21 +15,18 @@
   min-width: 0;
 }
 
-.controlsInner {
-  display: flex;
-}
-
-.control {
-  display: flex;
-}
-
-.controlsInner[data-all-measured='false'] {
+.controlWrapper[data-measured='false'] {
   position: relative;
   overflow: hidden; /* hide controls while they are being measured */
 }
 
-.controlsInner[data-all-measured='false'] > .control {
+.controlWrapper[data-measured='false'] > .control {
   position: absolute;
+}
+
+.controlWrapper,
+.control {
+  display: flex;
 }
 
 .sep {


### PR DESCRIPTION
The controls have a tendency to jump in and out of the overflow menu when switching back and forth between a shorter and longer option in a selector control - e.g. between "Log" and "Square root" in a scale selector. This shifts the position of the controls in the toolbar (including the one being interacted with), which can be annoying:

![jump1](https://user-images.githubusercontent.com/2936402/129551874-cd7857c1-5f31-405d-9980-78a8741e1675.gif)

**This PR fixes this issue by storing only the largest known width of each control.** This is done by ignoring new measurements of a control if they are shorter than the measurement already present in the state.

This change has the side-effect of decreasing **by half** the number of renders of the `Toolbar` used in `HeatmapToolbar`. Indeed, until now, we weren't checking if a measured width had changed before updating the state, which was triggering a lot of unnecessary renders when the domain slider appeared for the first time.

The result is that overflowing controls jump into the overflow menu but don't come out of it again:

![jump3](https://user-images.githubusercontent.com/2936402/129566915-31a75d18-2761-47a6-9ea0-c6e0afb0d36b.gif)

---

The above fix is actually the second commit of the PR. The first commit is a refactoring that consists in moving the logic of showing/hiding controls from `Toolbar` to `MeasuredControl` so that each control is shown/hidden independently from all the others while it is being measured for the first time.

Apart from hugely simplifying the logic in `Toolbar` by removing the need for an `allMeasured` boolean, it also means that we no longer re-hide all the controls when the domain slider appears for the first time (i.e. when the domain is computed, after all the other controls have already been measured). This should improve the perceived rendering time of the toolbar by a few milliseconds (which is a little bit noticeable when switching between the line and heatmap vis).