### PR TITLE
Prevent flickering of controls when switching scale type of Heatmap

### DIFF
--- a/src/h5web/toolbar/ComplexToolbar.tsx
+++ b/src/h5web/toolbar/ComplexToolbar.tsx
@@ -24,6 +24,7 @@ function ComplexToolbar() {
     colorMap,
     setColorMap,
     scaleType,
+    staleDomainScaleType,
     setScaleType,
     layout,
     setLayout,
@@ -41,7 +42,7 @@ function ComplexToolbar() {
           <DomainSlider
             dataDomain={dataDomain}
             customDomain={customDomain}
-            scaleType={scaleType}
+            scaleType={staleDomainScaleType || scaleType}
             onCustomDomainChange={setCustomDomain}
           />
           <Separator />

--- a/src/h5web/toolbar/HeatmapToolbar.tsx
+++ b/src/h5web/toolbar/HeatmapToolbar.tsx
@@ -20,6 +20,7 @@ function HeatmapToolbar() {
     colorMap,
     setColorMap,
     scaleType,
+    staleDomainScaleType,
     setScaleType,
     layout,
     setLayout,
@@ -38,7 +39,7 @@ function HeatmapToolbar() {
           <DomainSlider
             dataDomain={dataDomain}
             customDomain={customDomain}
-            scaleType={scaleType}
+            scaleType={staleDomainScaleType || scaleType}
             onCustomDomainChange={setCustomDomain}
           />
           <Separator />

--- a/src/h5web/vis-packs/core/complex/config.tsx
+++ b/src/h5web/vis-packs/core/complex/config.tsx
@@ -19,7 +19,7 @@ function createStore() {
       {
         name: 'h5web:complex',
         whitelist: ['visType'],
-        version: 1,
+        version: 2,
       }
     )
   );

--- a/src/h5web/vis-packs/core/complex/models.ts
+++ b/src/h5web/vis-packs/core/complex/models.ts
@@ -1,7 +1,7 @@
 export enum ComplexVisType {
   Phase = 'Phase',
   Amplitude = 'Amplitude',
-  PhaseAmplitude = 'Phase and amplitude',
+  PhaseAmplitude = 'Phase & Amp.',
 }
 
 export type ComplexLineVisType =

--- a/src/h5web/vis-packs/core/heatmap/config.tsx
+++ b/src/h5web/vis-packs/core/heatmap/config.tsx
@@ -19,6 +19,7 @@ interface HeatmapConfig {
   toggleColorMapInversion: () => void;
 
   scaleType: ScaleType;
+  staleDomainScaleType: ScaleType | undefined; // for domain slider, when `dataDomain` is being recomputed with new scale type
   setScaleType: (scaleType: ScaleType) => void;
 
   showGrid: boolean;
@@ -36,7 +37,9 @@ function createStore() {
     persist(
       (set, get) => ({
         dataDomain: undefined,
-        setDataDomain: (dataDomain: Domain) => set({ dataDomain }),
+        setDataDomain: (dataDomain: Domain) => {
+          set({ dataDomain, staleDomainScaleType: undefined });
+        },
 
         customDomain: [null, null],
         setCustomDomain: (customDomain: CustomDomain) => set({ customDomain }),
@@ -50,9 +53,11 @@ function createStore() {
         },
 
         scaleType: ScaleType.Linear,
+        staleDomainScaleType: undefined,
         setScaleType: (scaleType: ScaleType) => {
-          if (scaleType !== get().scaleType) {
-            set(() => ({ scaleType, dataDomain: undefined })); // clear `dataDomain` to avoid stale state
+          const prevScaleType = get().scaleType;
+          if (scaleType !== prevScaleType) {
+            set(() => ({ scaleType, staleDomainScaleType: prevScaleType }));
           }
         },
 


### PR DESCRIPTION
Another case of the toolbar controls moving in/out of the overflow menu occurs when changing the scale type on the heatmap/complex vis:

![jump2](https://user-images.githubusercontent.com/2936402/129583423-22788ae1-f496-45ce-8755-7ece7244743a.gif)

When I switch the `scaleType`, the `dataDomain` in the config store gets reset to `undefined`, which leads to the domain slider being unmounted in the toolbar. The space left by the slider is given to the "Screenshot" button, which was previously hidden in the overflow menu. When the `dataDomain` is recomputed and the `useEffect` that updates it in the store is called, the domain slider is re-mounted and the "Screenshot" button goes back in the overflow menu.

I scratched my head a lot to try to fix this in the toolbar (either in `Toolbar` or in `HeatmapToolbar`/`ComplexToolbar`), but it went nowhere. The problem is not with the toolbar, it is with resetting the `dataDomain` in the store. We've never really liked this solution anyway (at least I haven't), so I tried to find an alternative.

Turns out I found one, and I think it's actually pretty clean. The great part is that it's almost entirely contained within the config store of the Heatmap! Here is how the toolbar behaves after the fix (and the one from #785):

![jump4](https://user-images.githubusercontent.com/2936402/129585217-70e6f9eb-9a20-4657-90a1-2e6b347d0cf5.gif)

---

Another minor change: I've reworded "Phase and amplitude" to "Phase & Amp." to keep the selector to a reasonable size. Here is what the drop-down looks like with this change and the one from #784:

| Before #784 | Before this PR | Now |
| --- | --- | --- |
| ![image](https://user-images.githubusercontent.com/2936402/129586770-e0925359-9792-46d7-a49b-d753fb37443d.png) | ![image](https://user-images.githubusercontent.com/2936402/129586902-485fe465-ac88-4985-8aad-9564827ac70e.png) | ![image](https://user-images.githubusercontent.com/2936402/129586820-91e9839e-dfb3-40bf-9e21-62f4f6318b9a.png) |
| | ![image](https://user-images.githubusercontent.com/2936402/129586930-dfb54939-276d-44aa-b78c-52e4c6af6cec.png) | ![image](https://user-images.githubusercontent.com/2936402/129586984-8f8e18a1-0676-4342-be19-b920f70c3e39.png) |