### PR TITLE
SqrtScale: use positive min rather than 0 when domain crosses 0

### DIFF
--- a/src/h5web/vis-packs/core/complex/utils.ts
+++ b/src/h5web/vis-packs/core/complex/utils.ts
@@ -6,6 +6,7 @@ const INITIAL_BOUNDS: Bounds = {
   min: Infinity,
   max: -Infinity,
   positiveMin: Infinity,
+  strictPositiveMin: Infinity,
 };
 
 export function getPhaseAmplitudeValues(mappedValues: H5WebComplex[]): {

--- a/src/h5web/vis-packs/core/models.ts
+++ b/src/h5web/vis-packs/core/models.ts
@@ -88,6 +88,7 @@ export interface Bounds {
   min: number;
   max: number;
   positiveMin: number;
+  strictPositiveMin: number;
 }
 
 export type Coords = [number, number];

--- a/src/h5web/vis-packs/core/utils.test.ts
+++ b/src/h5web/vis-packs/core/utils.test.ts
@@ -95,7 +95,7 @@ describe('getDomain', () => {
       expect(domain).toEqual([-10, -1]);
     });
 
-    it('should clamp domain min to first positive value when domain crosses zero', () => {
+    it('should clamp domain min to first strict positive value when domain crosses zero', () => {
       const domain = getDomain([2, 0, 10, 5, 2, -1], ScaleType.Log);
       expect(domain).toEqual([2, 10]);
     });
@@ -103,6 +103,26 @@ describe('getDomain', () => {
     it('should return `undefined` if domain is not supported', () => {
       const domain = getDomain([-2, 0, -10, -5, -2, -1], ScaleType.Log);
       expect(domain).toBeUndefined();
+    });
+  });
+
+  describe('with sqrt scale', () => {
+    it('should support negative domain', () => {
+      const domain = getDomain([-2, -10, -5, -2, -1], ScaleType.Sqrt);
+      expect(domain).toEqual([-10, -1]);
+    });
+
+    it('should support negative domain including 0', () => {
+      const domain = getDomain([-2, 0, -10, -5, -2, -1], ScaleType.Sqrt);
+      expect(domain).toEqual([-10, 0]);
+    });
+
+    it('should clamp domain min to first positive value when domain crosses zero', () => {
+      const domain = getDomain([2, 0, 10, 5, 2, -1], ScaleType.Sqrt);
+      expect(domain).toEqual([0, 10]);
+
+      const domain2 = getDomain([2, 10, 5, 2, -1], ScaleType.Sqrt);
+      expect(domain2).toEqual([2, 10]);
     });
   });
 });


### PR DESCRIPTION
Fix #789 