### PR TITLE
Consider domain of bins when computing domain of histogram x axis

### DIFF
--- a/src/h5web/toolbar/controls/DomainSlider/Histogram.tsx
+++ b/src/h5web/toolbar/controls/DomainSlider/Histogram.tsx
@@ -24,7 +24,8 @@ function Histogram(props: Props) {
   const { values, bins, scaleType, sliderDomain, dataDomain } = props;
   const { colorMap, invertColorMap } = props;
 
-  const binDomain = useCombinedDomain([sliderDomain, dataDomain]);
+  const binDomain = useDomain(bins);
+  const xDomain = useCombinedDomain([binDomain, sliderDomain, dataDomain]);
   const barDomain = useDomain(values);
   const yMax = barDomain ? barDomain[1] : DEFAULT_DOMAIN[1];
   const yMin = colorMap ? -yMax / 10 : 0;
@@ -38,7 +39,7 @@ function Histogram(props: Props) {
   const { width, height } = size;
 
   const xScale = H5WEB_SCALES[scaleType].createScale({
-    domain: binDomain,
+    domain: xDomain,
     range: [0, width],
   });
   const yScale = scaleLinear({

--- a/src/stories/DomainSlider.stories.tsx
+++ b/src/stories/DomainSlider.stories.tsx
@@ -44,6 +44,17 @@ Histogram.args = {
   },
 };
 
+export const HistogramBiggerThanDataDomain = Template.bind({});
+
+HistogramBiggerThanDataDomain.args = {
+  ...Default.args,
+  dataDomain: [100, 300],
+  histogram: {
+    values: [130, 92, 76, 68, 60, 52, 50, 26],
+    bins: [4, 53.5, 103, 152.5, 202, 251.5, 301, 350.5, 400],
+  },
+};
+
 export const HistogramWithColorMap = Template.bind({});
 
 HistogramWithColorMap.args = {


### PR DESCRIPTION
#### Problem

The domain of the histogram x axis is given by the combination of the slider domain and of the data domain. 
if the domain of bins is not contained in the slider domain or the data domain, the histogram can then overflow (reminder: the parent `svg` has `overflow: visible` to show the axes) :

![image](https://user-images.githubusercontent.com/42204205/131504896-df4e7b09-5aef-4aa8-87c2-63f9f5f30e3b.png)

Note that this occurs if the bin domain is not included in the data domain. This should not occur as normally, when computing a histogram of the data, the bins are spread along the data values. But this is not enforced in h5web.

#### What I could have done

I could have added a group with `clip-path="view-box"` as mentioned in https://github.com/silx-kit/h5web/pull/771#discussion_r685932539 to clip the overflowing histogram:

![image](https://user-images.githubusercontent.com/42204205/131505585-e329fc8c-3ccc-44f6-b18c-3e7d65df4db4.png)

But depending on the chosen data domain, the histogram can be really zoomed-in and is only discoverable by extending the slider domain. 

#### What this PR does instead

If we want the histogram to be relevant, I think it should to be **completely** visible at all times. I then combined the slider domain and the data domain with the bin domain to compute the x axis.

![image](https://user-images.githubusercontent.com/42204205/131506180-cc985a62-4c9b-4717-9676-3c9e491584c6.png)



