### PR TITLE
Use `userEvent.keyboard` instead of `pressKey`

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -60,7 +60,7 @@
     "@testing-library/dom": "8.7.1",
     "@testing-library/jest-dom": "5.14.1",
     "@testing-library/react": "12.1.2",
-    "@testing-library/user-event": "13.2.1",
+    "@testing-library/user-event": "13.5.0",
     "@types/lodash": "4.14.175",
     "@types/ndarray": "1.0.10",
     "@types/react": "17.0.19",

--- a/packages/app/src/__tests__/DomainSlider.test.tsx
+++ b/packages/app/src/__tests__/DomainSlider.test.tsx
@@ -1,7 +1,7 @@
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { pressKey, renderApp, selectExplorerNode } from '../test-utils';
+import { renderApp, selectExplorerNode } from '../test-utils';
 
 test('show slider with two thumbs', async () => {
   await renderApp(); // default NeXus group renders heatmap and therefore domain slider
@@ -32,7 +32,7 @@ test('show tooltip on hover', async () => {
   expect(tooltip).not.toBeVisible();
 
   userEvent.hover(editBtn);
-  pressKey('Escape');
+  userEvent.keyboard('{Escape}');
   expect(tooltip).not.toBeVisible();
 });
 
@@ -68,12 +68,12 @@ test('update domain when moving thumbs (with keyboard)', async () => {
 
   // Move min thumb one step to the left with keyboard
   minThumb.focus();
-  pressKey('ArrowLeft'); // `userEvent.keyboard('{ArrowLeft}');` causes `act` warnings
+  userEvent.keyboard('{ArrowLeft}');
   expect(minInput).toHaveValue('−1.04671e+2');
   expect(within(visArea).getByText('−1.047e+2')).toBeInTheDocument();
 
   // Move thumb five steps to the left (in a single press)
-  pressKey('ArrowLeft', 5); // https://github.com/testing-library/user-event/issues/618
+  userEvent.keyboard('{ArrowLeft>5/}'); // press key and hold for 5 keydown events, then release
   expect(minInput).toHaveValue('−2.30818e+2');
   expect(within(visArea).getByText('−2.308e+2')).toBeInTheDocument();
 
@@ -85,12 +85,12 @@ test('update domain when moving thumbs (with keyboard)', async () => {
   maxThumb.focus();
 
   // Jump ten steps to the left
-  pressKey('PageDown');
+  userEvent.keyboard('{PageDown}');
   expect(maxInput).toHaveValue('5.72182e+1');
   expect(within(visArea).getByText('5.722e+1')).toBeInTheDocument();
 
   // Jump ten steps to the right
-  pressKey('PageUp');
+  userEvent.keyboard('{PageUp}');
   expect(maxInput).toHaveValue('2.52142e+2'); // not back to 4e+2 because of domain extension behaviour
   expect(within(visArea).getByText('2.521e+2')).toBeInTheDocument();
 
@@ -170,7 +170,7 @@ test('clamp domain in symlog scale', async () => {
   expect(maxThumb).toHaveAttribute('aria-valuenow', '100');
 
   maxThumb.focus();
-  pressKey('ArrowLeft');
+  userEvent.keyboard('{ArrowLeft}');
   expect(maxInput).toHaveValue('5.40006e+301');
   expect(maxThumb).toHaveAttribute('aria-valuenow', '99'); // does not jump back to 81
 
@@ -206,7 +206,7 @@ test('control min/max autoscale behaviour', async () => {
 
   // Moving min thumb disables min autoscale
   minThumb.focus();
-  pressKey('ArrowRight');
+  userEvent.keyboard('{ArrowRight}');
   expect(minBtn).toHaveAttribute('aria-pressed', 'false');
   expect(maxBtn).toHaveAttribute('aria-pressed', 'true'); // unaffected
 
@@ -244,14 +244,14 @@ test('handle empty domain', async () => {
 
   // Check that pearling works (i.e. that one thumb can push the other)
   maxThumb.focus();
-  pressKey('ArrowLeft');
+  userEvent.keyboard('{ArrowLeft}');
   expect(minInput).toHaveValue('3.97453e+2');
   expect(maxInput).toHaveValue('3.97453e+2');
   expect(minThumb).toHaveAttribute('aria-valuenow', '58'); // thumbs stay in the middle
   expect(maxThumb).toHaveAttribute('aria-valuenow', '58');
 
   // Ensure thumbs can be separated again
-  pressKey('ArrowRight');
+  userEvent.keyboard('{ArrowRight}');
   expect(maxInput).toHaveValue('3.99891e+2');
   expect(minThumb).toHaveAttribute('aria-valuenow', '20');
   expect(maxThumb).toHaveAttribute('aria-valuenow', '81');

--- a/packages/app/src/test-utils.tsx
+++ b/packages/app/src/test-utils.tsx
@@ -41,16 +41,6 @@ export async function selectVisTab(name: Vis): Promise<void> {
   userEvent.click(await screen.findByRole('tab', { name }));
 }
 
-export function pressKey(key: string, downCount = 1) {
-  const elem = document.activeElement || document.body; // https://testing-library.com/docs/guide-events#keydown
-
-  for (let i = 0; i < downCount; i++) {
-    fireEvent.keyDown(elem, { key });
-  }
-
-  fireEvent.keyUp(elem, { key });
-}
-
 /**
  * Mock console method in test.
  * Mocks are automatically restored after every test, but to restore

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,7 +160,7 @@ importers:
       '@testing-library/dom': 8.7.1
       '@testing-library/jest-dom': 5.14.1
       '@testing-library/react': 12.1.2
-      '@testing-library/user-event': 13.2.1
+      '@testing-library/user-event': 13.5.0
       '@types/lodash': 4.14.175
       '@types/ndarray': 1.0.10
       '@types/react': 17.0.19
@@ -207,7 +207,7 @@ importers:
       '@testing-library/dom': 8.7.1
       '@testing-library/jest-dom': 5.14.1
       '@testing-library/react': 12.1.2_react-dom@17.0.2+react@17.0.2
-      '@testing-library/user-event': 13.2.1_@testing-library+dom@8.7.1
+      '@testing-library/user-event': 13.5.0_@testing-library+dom@8.7.1
       '@types/lodash': 4.14.175
       '@types/ndarray': 1.0.10
       '@types/react': 17.0.19
@@ -7049,8 +7049,8 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: true
 
-  /@testing-library/user-event/13.2.1_@testing-library+dom@8.7.1:
-    resolution: {integrity: sha512-cczlgVl+krjOb3j1625usarNEibI0IFRJrSWX9UsJ1HKYFgCQv9Nb7QAipUDXl3Xdz8NDTsiS78eAkPSxlzTlw==}
+  /@testing-library/user-event/13.5.0_@testing-library+dom@8.7.1:
+    resolution: {integrity: sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==}
     engines: {node: '>=10', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'


### PR DESCRIPTION
... now that `userEvent.keyboard` no longer triggers `act` warnings and that it supports holding a key pressed to trigger multiple `keydown` events: https://github.com/testing-library/user-event/releases/tag/v13.5.0 (somebody implemented my feature request: https://github.com/testing-library/user-event/issues/618! :tada:)