### PR TITLE
Fetch numeric arrays with binary in h5grove

### DIFF
--- a/packages/app/src/providers/api.ts
+++ b/packages/app/src/providers/api.ts
@@ -4,6 +4,7 @@ import type {
   AxiosRequestConfig,
   AxiosResponse,
   CancelTokenSource,
+  ResponseType,
 } from 'axios';
 import axios from 'axios';
 
@@ -42,7 +43,8 @@ export abstract class ProviderApi {
   protected async cancellableFetchValue<T>(
     endpoint: string,
     storeParams: ValuesStoreParams,
-    queryParams?: Record<string, string | undefined>
+    queryParams?: Record<string, string | undefined>,
+    responseType?: ResponseType
   ): Promise<AxiosResponse<T>> {
     const cancelSource = axios.CancelToken.source();
     const request = { storeParams, cancelSource };
@@ -53,6 +55,7 @@ export abstract class ProviderApi {
       return await this.client.get<T>(endpoint, {
         cancelToken,
         params: queryParams || storeParams,
+        responseType,
       });
     } finally {
       // Remove cancellation source when request fulfills

--- a/packages/app/src/providers/h5grove/utils.ts
+++ b/packages/app/src/providers/h5grove/utils.ts
@@ -1,8 +1,9 @@
-import { EntityKind } from '@h5web/shared';
+import type { DType } from '@h5web/shared';
+import { DTypeClass, EntityKind, isNumericType } from '@h5web/shared';
 
 import type {
-  H5GroveEntityResponse,
   H5GroveDatasetReponse,
+  H5GroveEntityResponse,
   H5GroveGroupResponse,
 } from './models';
 
@@ -16,4 +17,52 @@ export function isDatasetResponse(
   response: H5GroveEntityResponse
 ): response is H5GroveDatasetReponse {
   return response.type === EntityKind.Dataset;
+}
+
+export function typedArrayFromDType(dtype: DType) {
+  /* Adapted from https://github.com/ludwigschubert/js-numpy-parser/blob/v1.2.3/src/main.js#L116 */
+  if (!isNumericType(dtype)) {
+    return undefined;
+  }
+
+  const { class: dtypeClass, size } = dtype;
+
+  if (dtypeClass === DTypeClass.Integer) {
+    switch (size) {
+      case 8:
+        return Int8Array;
+      case 16:
+        return Int16Array;
+      case 32:
+        return Int32Array;
+      case 64: // No support for 64-bit integer values in JS
+        return undefined;
+    }
+  }
+
+  if (dtypeClass === DTypeClass.Unsigned) {
+    switch (size) {
+      case 8:
+        return Uint8Array;
+      case 16:
+        return Uint16Array;
+      case 32:
+        return Uint32Array;
+      case 64: // No support for 64-bit unsigned integer values in JS
+        return undefined;
+    }
+  }
+
+  if (dtypeClass === DTypeClass.Float) {
+    switch (size) {
+      case 16: // No support for 16-bit floating values in JS
+        return undefined;
+      case 32:
+        return Float32Array;
+      case 64:
+        return Float64Array;
+    }
+  }
+
+  return undefined;
 }


### PR DESCRIPTION
Requires `h5grove>=0.0.9`

Fixes most issues of #641 for h5grove:
#### When fetching
- :heavy_check_mark: `NaN` and `(-)Infinity` values are conserved in the payload and interpreted as their JS counterpart in the Provider

#### When displaying
- :heavy_check_mark: The `LineVis` do not show points for these values
- :heavy_check_mark: `MatrixVis`, `ScalarVis` and the tooltip display the correct value `NaN`/`Infinity`
- :x: Attributes get still displayed as `null` as the binary format is only for dataset values