### PR TITLE
Allow passing custom query params to H5GroveProvider

### DIFF
--- a/apps/demo/src/H5GroveApp.tsx
+++ b/apps/demo/src/H5GroveApp.tsx
@@ -6,10 +6,14 @@ const FILEPATH = process.env.REACT_APP_H5GROVE_FALLBACK_FILEPATH || '';
 
 function H5GroveApp() {
   const query = new URLSearchParams(useLocation().search);
-  const filepath = query.get('file');
+  const filepath = query.get('file') || FILEPATH;
 
   return (
-    <H5GroveProvider url={URL} filepath={filepath || FILEPATH}>
+    <H5GroveProvider
+      url={URL}
+      filepath={filepath}
+      axiosParams={{ file: filepath }}
+    >
       <App />
     </H5GroveProvider>
   );

--- a/apps/demo/src/HsdsApp.tsx
+++ b/apps/demo/src/HsdsApp.tsx
@@ -8,14 +8,14 @@ const FILEPATH = process.env.REACT_APP_HSDS_FALLBACK_FILEPATH || '';
 
 function HsdsApp() {
   const query = new URLSearchParams(useLocation().search);
-  const filepath = query.get('file');
+  const filepath = query.get('file') || FILEPATH;
 
   return (
     <HsdsProvider
       url={URL}
       username={USERNAME}
       password={PASSWORD}
-      filepath={filepath || FILEPATH}
+      filepath={filepath}
     >
       <App />
     </HsdsProvider>

--- a/packages/app/src/providers/h5grove/H5GroveProvider.tsx
+++ b/packages/app/src/providers/h5grove/H5GroveProvider.tsx
@@ -7,12 +7,17 @@ import { H5GroveApi } from './h5grove-api';
 interface Props {
   url: string;
   filepath: string;
+  axiosParams?: Record<string, string>;
   children: ReactNode;
 }
 
 function H5GroveProvider(props: Props) {
-  const { url, filepath, children } = props;
-  const api = useMemo(() => new H5GroveApi(url, filepath), [filepath, url]);
+  const { url, filepath, axiosParams, children } = props;
+
+  const api = useMemo(
+    () => new H5GroveApi(url, filepath, axiosParams),
+    [filepath, url, axiosParams]
+  );
 
   return <Provider api={api}>{children}</Provider>;
 }

--- a/packages/app/src/providers/h5grove/h5grove-api.ts
+++ b/packages/app/src/providers/h5grove/h5grove-api.ts
@@ -35,8 +35,15 @@ export class H5GroveApi extends ProviderApi {
   protected attrValuesCache = new Map<string, H5GroveAttrValuesResponse>();
 
   /* API compatible with h5grove@0.0.9 */
-  public constructor(url: string, filepath: string) {
-    super(filepath, { baseURL: url, params: { file: filepath } });
+  public constructor(
+    url: string,
+    filepath: string,
+    axiosParams?: Record<string, string>
+  ) {
+    super(filepath, {
+      baseURL: url,
+      params: axiosParams || { file: filepath },
+    });
   }
 
   public async getEntity(path: string): Promise<Entity> {

--- a/packages/app/src/providers/h5grove/h5grove-api.ts
+++ b/packages/app/src/providers/h5grove/h5grove-api.ts
@@ -42,7 +42,7 @@ export class H5GroveApi extends ProviderApi {
   ) {
     super(filepath, {
       baseURL: url,
-      params: axiosParams || { file: filepath },
+      params: axiosParams,
     });
   }
 


### PR DESCRIPTION
Developing our own provider outside of the h5web monorepo is quite challenging, as most of the required components, models and utilities are not exposed. Since the change to `H5GroveProvider` required to make the future H5Viewer work is very small, I decided to set up a small testing app here as a proof of concept. Once this is confirmed to work, we can remove the test app and merge this PR. We'll then be able to use the `H5GroveProvider` directly in https://gitlab.esrf.fr/ui/h5web-viewer

---

### ~Testing workflow~ (outdated, test app now removed)

1. Set the `REACT_APP_H5VIEWER_URL` env var to the URL provided by @antolinos in the chat, and then start the dev server.
2. Visit the data portal test URL, also provided by @antolinos, making sure to pass the following query param: `h5viewerURL=http://localhost:3000/h5viewer`
3. Log in, expand a dataset, select the `Files` tab, and click on the "eye" icon next to one of the files.
4. This should open http://localhost:3000/h5viewer?sessionId=foo&datafileId=bar
5. H5Viewer requires the filename to be passed as well, so until it is passed by the data portal, add `&file=foo` to the URL.
6. If the H5Grove testing server set up by @antolinos is up, the viewer should be working.