### PR TITLE
Show error instead of blank screen when file is not found

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -22,49 +22,51 @@ function App() {
 
   return (
     <ReflexContainer className={styles.root} orientation="vertical">
-      <ReflexElement
-        className={styles.explorer}
-        style={{ display: isExplorerOpen ? undefined : 'none' }}
-        flex={25}
-        minSize={150}
-      >
-        <Explorer selectedPath={selectedPath} onSelect={setSelectedPath} />
-      </ReflexElement>
+      <ErrorBoundary FallbackComponent={ErrorFallback}>
+        <ReflexElement
+          className={styles.explorer}
+          style={{ display: isExplorerOpen ? undefined : 'none' }}
+          flex={25}
+          minSize={150}
+        >
+          <Explorer selectedPath={selectedPath} onSelect={setSelectedPath} />
+        </ReflexElement>
 
-      <ReflexSplitter
-        className={styles.splitter}
-        style={{ display: isExplorerOpen ? undefined : 'none' }}
-      />
-
-      <ReflexElement className={styles.mainArea} flex={75} minSize={500}>
-        <BreadcrumbsBar
-          path={selectedPath}
-          isExplorerOpen={isExplorerOpen}
-          isInspecting={isInspecting}
-          onToggleExplorer={() => setExplorerOpen(!isExplorerOpen)}
-          onChangeInspecting={setInspecting}
-          onSelectPath={setSelectedPath}
+        <ReflexSplitter
+          className={styles.splitter}
+          style={{ display: isExplorerOpen ? undefined : 'none' }}
         />
-        <VisConfigProvider>
-          <ErrorBoundary
-            resetKeys={[selectedPath, isInspecting]}
-            FallbackComponent={ErrorFallback}
-          >
-            <Suspense
-              fallback={<LoadingFallback isInspecting={isInspecting} />}
+
+        <ReflexElement className={styles.mainArea} flex={75} minSize={500}>
+          <BreadcrumbsBar
+            path={selectedPath}
+            isExplorerOpen={isExplorerOpen}
+            isInspecting={isInspecting}
+            onToggleExplorer={() => setExplorerOpen(!isExplorerOpen)}
+            onChangeInspecting={setInspecting}
+            onSelectPath={setSelectedPath}
+          />
+          <VisConfigProvider>
+            <ErrorBoundary
+              resetKeys={[selectedPath, isInspecting]}
+              FallbackComponent={ErrorFallback}
             >
-              {isInspecting ? (
-                <MetadataViewer
-                  path={selectedPath}
-                  onSelectPath={setSelectedPath}
-                />
-              ) : (
-                <VisPackChooser path={selectedPath} />
-              )}
-            </Suspense>
-          </ErrorBoundary>
-        </VisConfigProvider>
-      </ReflexElement>
+              <Suspense
+                fallback={<LoadingFallback isInspecting={isInspecting} />}
+              >
+                {isInspecting ? (
+                  <MetadataViewer
+                    path={selectedPath}
+                    onSelectPath={setSelectedPath}
+                  />
+                ) : (
+                  <VisPackChooser path={selectedPath} />
+                )}
+              </Suspense>
+            </ErrorBoundary>
+          </VisConfigProvider>
+        </ReflexElement>
+      </ErrorBoundary>
     </ReflexContainer>
   );
 }

--- a/packages/app/src/explorer/EntityList.tsx
+++ b/packages/app/src/explorer/EntityList.tsx
@@ -1,7 +1,12 @@
-import { assertGroupWithChildren, buildEntityPath } from '@h5web/shared';
+import {
+  assertGroupWithChildren,
+  buildEntityPath,
+  handleError,
+} from '@h5web/shared';
 import { useContext } from 'react';
 
 import { ProviderContext } from '../providers/context';
+import { ProviderError } from '../providers/models';
 import EntityItem from './EntityItem';
 import styles from './Explorer.module.css';
 
@@ -14,9 +19,14 @@ interface Props {
 
 function EntityList(props: Props) {
   const { level, parentPath, selectedPath, onSelect } = props;
+  const { filepath, entitiesStore } = useContext(ProviderContext);
 
-  const { entitiesStore } = useContext(ProviderContext);
-  const group = entitiesStore.get(parentPath);
+  const group = handleError(
+    () => entitiesStore.get(parentPath),
+    ProviderError.FileNotFound,
+    `File not found: '${filepath}'`
+  );
+
   assertGroupWithChildren(group);
 
   if (group.children.length === 0) {

--- a/packages/app/src/metadata-viewer/MetadataViewer.tsx
+++ b/packages/app/src/metadata-viewer/MetadataViewer.tsx
@@ -18,7 +18,7 @@ function MetadataViewer(props: Props) {
 
   const entity = handleError(
     () => entitiesStore.get(path),
-    ProviderError.NotFound,
+    ProviderError.EntityNotFound,
     `No entity found at ${path}`
   );
 

--- a/packages/app/src/providers/hsds/hsds-api.ts
+++ b/packages/app/src/providers/hsds/hsds-api.ts
@@ -17,6 +17,7 @@ import {
 import { ProviderApi } from '../api';
 import type { ValuesStoreParams } from '../models';
 import { ProviderError } from '../models';
+import { handleAxiosError } from '../utils';
 import type {
   HsdsDatasetResponse,
   HsdsDatatypeResponse,
@@ -95,7 +96,7 @@ export class HsdsApi extends ProviderApi {
 
     const childName = path.slice(path.lastIndexOf('/') + 1);
     const child = getChildEntity(parentGroup, childName);
-    assertDefined(child, ProviderError.NotFound);
+    assertDefined(child, ProviderError.EntityNotFound);
     assertHsdsEntity(child);
 
     const entity = isHsdsGroup(child)
@@ -125,7 +126,10 @@ export class HsdsApi extends ProviderApi {
   }
 
   private async fetchRootId(): Promise<HsdsId> {
-    const { data } = await this.client.get<HsdsRootResponse>('/');
+    const { data } = await handleAxiosError(
+      () => this.client.get<HsdsRootResponse>('/'),
+      (status) => (status === 400 ? ProviderError.FileNotFound : undefined)
+    );
     return data.root;
   }
 

--- a/packages/app/src/providers/mock/mock-api.ts
+++ b/packages/app/src/providers/mock/mock-api.ts
@@ -31,7 +31,7 @@ export class MockApi extends ProviderApi {
     }
 
     const entity = findMockEntity(path);
-    assertDefined(entity, ProviderError.NotFound);
+    assertDefined(entity, ProviderError.EntityNotFound);
     return entity;
   }
 
@@ -44,7 +44,7 @@ export class MockApi extends ProviderApi {
     }
 
     const dataset = findMockEntity(path);
-    assertDefined(dataset, ProviderError.NotFound);
+    assertDefined(dataset, ProviderError.EntityNotFound);
     assertMockDataset(dataset);
 
     if (path.includes('slow')) {

--- a/packages/app/src/providers/models.ts
+++ b/packages/app/src/providers/models.ts
@@ -4,6 +4,7 @@ export interface ValuesStoreParams {
 }
 
 export enum ProviderError {
-  NotFound = 'Entity not found',
+  FileNotFound = 'File not found',
+  EntityNotFound = 'Entity not found',
   Cancelled = 'Request cancelled',
 }

--- a/packages/app/src/vis-packs/VisPackChooser.tsx
+++ b/packages/app/src/vis-packs/VisPackChooser.tsx
@@ -24,7 +24,7 @@ function VisPackChooser(props: Props) {
 
   const entity = handleError(
     () => entitiesStore.get(path),
-    ProviderError.NotFound,
+    ProviderError.EntityNotFound,
     `No entity found at ${path}`
   );
 

--- a/packages/app/src/vis-packs/nexus/pack-utils.ts
+++ b/packages/app/src/vis-packs/nexus/pack-utils.ts
@@ -34,7 +34,7 @@ export function getDefaultEntity(
 
   const defaultEntity = handleError(
     () => entitiesStore.get(path),
-    ProviderError.NotFound,
+    ProviderError.EntityNotFound,
     `No entity found at NeXus default path "${path}"`
   );
 


### PR DESCRIPTION
Fix #826 

When the explorer fails to get an entity because the server can't find the requested file (or domain for HSDS), we used to see a blank screen. Now we see this:

![image](https://user-images.githubusercontent.com/2936402/139077888-62e00920-95cc-4518-9fb0-82ef7be95bce.png)