### PR TITLE
Add package.json exports for stylesheets in app package

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,6 @@
   - [Icon set](#icon-set)
 - [Build](#build)
   - [Use built packages in demos](#use-built-packages-in-demos)
-  - [Use built packages in other local apps](#use-built-packages-in-other-local-apps)
 - [Code quality](#code-quality)
   - [Fixing and formatting](#fixing-and-formatting)
   - [Editor integration](#editor-integration)

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -40,3 +40,11 @@ function MyApp() {
 
 export default MyApp;
 ```
+
+> If your bundler supports it (e.g. webpack 5), you may be able to shorten the
+> stylesheet import paths as follows:
+>
+> ```ts
+> import '@h5web/app/style-lib.css';
+> import '@h5web/app/style.css';
+> ```

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -19,6 +19,10 @@
     "module": "dist/index.js",
     "types": "dist/index.d.ts",
     "exports": {
+      "./dist/style-lib.css": "./dist/style-lib.css",
+      "./style-lib.css": "./dist/style-lib.css",
+      "./dist/style.css": "./dist/style.css",
+      "./style.css": "./dist/style.css",
       ".": {
         "require": "./dist/index.cjs",
         "import": "./dist/index.js"


### PR DESCRIPTION
Fix #832 

We had problems testing yesterday because we forgot to run `pnpm packages && pnpm packages:dts`, so VSCode couldn't find the type declarations.

That being said, we cannot test the new exports in the demo because CRA still uses webpack 4, which doesn't look at the `exports` field in `package.json`. This feature is supported only by webpack 5. So we'll have to publish a beta to try it out.