### PR TITLE
Make copy path button more "catchable"

### DIFF
--- a/packages/app/src/breadcrumbs/BreadcrumbsBar.module.css
+++ b/packages/app/src/breadcrumbs/BreadcrumbsBar.module.css
@@ -15,7 +15,7 @@
   min-width: 0;
   margin-top: 0;
   margin-bottom: 0;
-  padding: 0 1rem;
+  padding: 0 0 0 1rem;
   font-size: inherit;
   font-weight: inherit;
   line-height: 1.3; /* fix cropping of glyphs */
@@ -34,6 +34,7 @@
 .crumbButton[data-current] {
   flex: none; /* never shrink current breadcrumb */
   font-weight: 600;
+  padding-right: 1rem;
 }
 
 .crumbButton:hover {
@@ -55,8 +56,8 @@
   position: absolute;
   display: none;
   font-size: 0.9rem;
-  top: 50%;
-  right: -0.125rem;
+  top: calc(50% - 0.125rem);
+  right: 0.875rem;
   margin: 1px 0;
   transform: translate(100%, -50%);
 }


### PR DESCRIPTION
As I wanted to copy the path by clicking on the copy icon, I realized that the icon was quite shy:

![Peek 2021-11-03 16-24](https://user-images.githubusercontent.com/42204205/140090684-39e52766-dcf6-4e71-a950-a056f1f83e09.gif)

I changed the CSS a bit so that the icon is included in the crumb and is more easily "catchable"

_PS: Yes, I know I could click directly on the crumb but my brain forced me to click on the icon_
