### PR TITLE
Simplify `getValue` signature to prepare for stricter typing

### DIFF
--- a/packages/app/src/providers/Provider.tsx
+++ b/packages/app/src/providers/Provider.tsx
@@ -47,7 +47,8 @@ function Provider(props: Props) {
   const valuesStore = useMemo(() => {
     const store = createFetchStore(api.getValue.bind(api), {
       type: 'Map',
-      areEqual: (a, b) => a.path === b.path && a.selection === b.selection,
+      areEqual: (a, b) =>
+        a.dataset.path === b.dataset.path && a.selection === b.selection,
     });
 
     return Object.assign(store, {

--- a/packages/app/src/providers/h5grove/h5grove-api.ts
+++ b/packages/app/src/providers/h5grove/h5grove-api.ts
@@ -9,10 +9,8 @@ import type {
 import {
   hasScalarShape,
   hasArrayShape,
-  assertDataset,
   buildEntityPath,
   EntityKind,
-  assertNonNullShape,
 } from '@h5web/shared';
 import { isString } from 'lodash';
 
@@ -48,21 +46,18 @@ export class H5GroveApi extends ProviderApi {
   public async getValue(
     params: ValuesStoreParams
   ): Promise<H5GroveDataResponse> {
-    const { path, selection } = params;
-    const entity = await this.getEntity(path);
-    assertDataset(entity);
-    assertNonNullShape(entity);
+    const { dataset, selection } = params;
 
-    const DTypedArray = typedArrayFromDType(entity.type);
+    const DTypedArray = typedArrayFromDType(dataset.type);
     if (DTypedArray) {
       const buffer = await this.fetchBinaryData(params);
       const array = new DTypedArray(buffer);
-      return hasScalarShape(entity) ? array[0] : [...array];
+      return hasScalarShape(dataset) ? array[0] : [...array];
     }
 
     const value = await this.fetchData(params);
-    return hasArrayShape(entity)
-      ? flattenValue(value, entity, selection)
+    return hasArrayShape(dataset)
+      ? flattenValue(value, dataset, selection)
       : value;
   }
 
@@ -128,7 +123,7 @@ export class H5GroveApi extends ProviderApi {
     const { data } = await this.cancellableFetchValue<ArrayBuffer>(
       '/data/',
       params,
-      { ...params, format: 'bin' },
+      { path: params.dataset.path, selection: params.selection, format: 'bin' },
       'arraybuffer'
     );
 

--- a/packages/app/src/providers/hsds/hsds-api.ts
+++ b/packages/app/src/providers/hsds/hsds-api.ts
@@ -33,7 +33,7 @@ import type {
   HsdsId,
 } from './models';
 import {
-  assertNonNullHsdsDataset,
+  assertHsdsDataset,
   isHsdsGroup,
   convertHsdsShape,
   convertHsdsType,
@@ -108,17 +108,15 @@ export class HsdsApi extends ProviderApi {
   }
 
   public async getValue(params: ValuesStoreParams): Promise<unknown> {
-    const { path } = params;
+    const { dataset } = params;
+    assertHsdsDataset(dataset);
 
-    const entity = await this.getEntity(path);
-    assertNonNullHsdsDataset(entity);
-
-    const value = await this.fetchValue(entity.id, params);
+    const value = await this.fetchValue(dataset.id, params);
 
     // https://github.com/HDFGroup/hsds/issues/88
     // HSDS does not reduce the number of dimensions when selecting indices
     // Therefore the flattening must be done on all dimensions regardless of the selection
-    return hasArrayShape(entity) ? flattenValue(value, entity) : value;
+    return hasArrayShape(dataset) ? flattenValue(value, dataset) : value;
   }
 
   private async fetchRootId(): Promise<HsdsId> {

--- a/packages/app/src/providers/hsds/utils.ts
+++ b/packages/app/src/providers/hsds/utils.ts
@@ -11,13 +11,7 @@ import type {
   ScalarShape,
   ArrayShape,
 } from '@h5web/shared';
-import {
-  isGroup,
-  isDataset,
-  DTypeClass,
-  Endianness,
-  hasNonNullShape,
-} from '@h5web/shared';
+import { isGroup, DTypeClass, Endianness } from '@h5web/shared';
 
 import type {
   HsdsType,
@@ -32,21 +26,17 @@ export function isHsdsGroup(entity: HsdsEntity): entity is HsdsEntity<Group> {
   return isGroup(entity);
 }
 
-function isHsdsDataset(entity: HsdsEntity): entity is HsdsEntity<Dataset> {
-  return isDataset(entity);
-}
-
 export function assertHsdsEntity(entity: Entity): asserts entity is HsdsEntity {
   if (!('id' in entity)) {
     throw new Error('Expected entity to be HSDS entity');
   }
 }
 
-export function assertNonNullHsdsDataset(
-  entity: HsdsEntity
-): asserts entity is HsdsEntity<Dataset<ScalarShape | ArrayShape>> {
-  if (!isHsdsDataset(entity) || !hasNonNullShape(entity)) {
-    throw new Error('Expected entity to be HSDS dataset with non-null shape');
+export function assertHsdsDataset(
+  dataset: Dataset<ScalarShape | ArrayShape>
+): asserts dataset is HsdsEntity<Dataset<ScalarShape | ArrayShape>> {
+  if (!('id' in dataset)) {
+    throw new Error('Expected entity to be HSDS dataset');
   }
 }
 

--- a/packages/app/src/providers/mock/mock-api.ts
+++ b/packages/app/src/providers/mock/mock-api.ts
@@ -36,21 +36,17 @@ export class MockApi extends ProviderApi {
   }
 
   public async getValue(params: ValuesStoreParams): Promise<unknown> {
-    const { path, selection } = params;
+    const { dataset, selection } = params;
 
-    if (path.includes('error_value')) {
-      // Throw error when fetching value with specific path
+    if (dataset.name === 'error_value') {
       throw new Error('error');
     }
 
-    const dataset = findMockEntity(path);
-    assertDefined(dataset, ProviderError.EntityNotFound);
-    assertMockDataset(dataset);
-
-    if (path.includes('slow')) {
+    if (dataset.name.startsWith('slow')) {
       await this.cancellableDelay(params);
     }
 
+    assertMockDataset(dataset);
     const { value: rawValue } = dataset;
     const value = hasArrayShape(dataset)
       ? (rawValue as unknown[]).flat(dataset.shape.length - 1)

--- a/packages/app/src/providers/models.ts
+++ b/packages/app/src/providers/models.ts
@@ -1,5 +1,7 @@
+import type { ArrayShape, Dataset, ScalarShape } from '@h5web/shared';
+
 export interface ValuesStoreParams {
-  path: string;
+  dataset: Dataset<ScalarShape | ArrayShape>;
   selection?: string | undefined;
 }
 

--- a/packages/app/src/vis-packs/core/hooks.ts
+++ b/packages/app/src/vis-packs/core/hooks.ts
@@ -1,5 +1,5 @@
 import { getCombinedDomain } from '@h5web/lib';
-import type { Dataset, Value } from '@h5web/shared';
+import type { ArrayShape, Dataset, ScalarShape, Value } from '@h5web/shared';
 import {
   isDefined,
   ScaleType,
@@ -18,12 +18,12 @@ import { ProviderContext } from '../../providers/context';
 import { applyMapping, getBaseArray, getSliceSelection } from './utils';
 
 export function usePrefetchValues(
-  datasets: (Dataset | undefined)[],
+  datasets: (Dataset<ScalarShape | ArrayShape> | undefined)[],
   dimMapping?: DimensionMapping
 ): void {
   const { valuesStore } = useContext(ProviderContext);
-  datasets.filter(isDefined).forEach(({ path }) => {
-    valuesStore.prefetch({ path, selection: getSliceSelection(dimMapping) });
+  datasets.filter(isDefined).forEach((dataset) => {
+    valuesStore.prefetch({ dataset, selection: getSliceSelection(dimMapping) });
   });
 }
 
@@ -52,7 +52,7 @@ export function useDatasetValue(
 
   // If `dimMapping` is not provided or has no slicing dimension, the entire dataset will be fetched
   const value = valuesStore.get({
-    path: dataset.path,
+    dataset,
     selection: getSliceSelection(dimMapping),
   });
 
@@ -71,11 +71,10 @@ export function useDatasetValues(datasets: Dataset[]): Record<string, unknown> {
     datasets.map((dataset) => {
       assertNonNullShape(dataset);
 
-      const { name, path } = dataset;
-      const value = valuesStore.get({ path });
+      const value = valuesStore.get({ dataset });
       assertDatasetValue(value, dataset);
 
-      return [name, value];
+      return [dataset.name, value];
     })
   );
 }


### PR DESCRIPTION
`getValue`'s `params` parameter now contains a complete `dataset` object instead of just a dataset `path`. This will allow me later to statically type the return value of `getValue` to `Value<D>` instead of `unknown`.