### PR TITLE
Enforce non-null shape statically when fetching dataset value

### DIFF
--- a/packages/app/src/vis-packs/core/ValueFetcher.tsx
+++ b/packages/app/src/vis-packs/core/ValueFetcher.tsx
@@ -1,4 +1,4 @@
-import type { Dataset, Value } from '@h5web/shared';
+import type { ArrayShape, Dataset, ScalarShape, Value } from '@h5web/shared';
 import type { ReactNode } from 'react';
 
 import type { DimensionMapping } from '../../dimension-mapper/models';
@@ -10,7 +10,9 @@ interface Props<D extends Dataset> {
   render: (val: Value<D>) => ReactNode;
 }
 
-function ValueFetcher<D extends Dataset>(props: Props<D>) {
+function ValueFetcher<D extends Dataset<ArrayShape | ScalarShape>>(
+  props: Props<D>
+) {
   const { dataset, dimMapping, render } = props;
 
   const value = useDatasetValue(dataset, dimMapping);

--- a/packages/app/src/vis-packs/core/hooks.ts
+++ b/packages/app/src/vis-packs/core/hooks.ts
@@ -6,7 +6,6 @@ import {
   getBounds,
   getValidDomainForScale,
   assertDatasetValue,
-  assertNonNullShape,
 } from '@h5web/shared';
 import type { NdArray } from 'ndarray';
 import { useContext, useMemo } from 'react';
@@ -27,28 +26,25 @@ export function usePrefetchValues(
   });
 }
 
-export function useDatasetValue<D extends Dataset>(
+export function useDatasetValue<D extends Dataset<ArrayShape | ScalarShape>>(
   dataset: D,
   dimMapping?: DimensionMapping
 ): Value<D>;
 
-export function useDatasetValue<D extends Dataset>(
+export function useDatasetValue<D extends Dataset<ArrayShape | ScalarShape>>(
   dataset: D | undefined,
   dimMapping?: DimensionMapping
 ): Value<D> | undefined;
 
-export function useDatasetValue(
-  dataset: Dataset | undefined,
+export function useDatasetValue<D extends Dataset<ArrayShape | ScalarShape>>(
+  dataset: D | undefined,
   dimMapping?: DimensionMapping
-): unknown {
+): Value<D> | undefined {
   const { valuesStore } = useContext(ProviderContext);
 
   if (!dataset) {
     return undefined;
   }
-
-  // Dataset with null shape has no value to fetch
-  assertNonNullShape(dataset);
 
   // If `dimMapping` is not provided or has no slicing dimension, the entire dataset will be fetched
   const value = valuesStore.get({
@@ -60,17 +56,13 @@ export function useDatasetValue(
   return value;
 }
 
-export function useDatasetValues<D extends Dataset>(
+export function useDatasetValues<D extends Dataset<ArrayShape | ScalarShape>>(
   datasets: D[]
-): Record<string, Value<D>>;
-
-export function useDatasetValues(datasets: Dataset[]): Record<string, unknown> {
+): Record<string, Value<D>> {
   const { valuesStore } = useContext(ProviderContext);
 
   return Object.fromEntries(
     datasets.map((dataset) => {
-      assertNonNullShape(dataset);
-
       const value = valuesStore.get({ dataset });
       assertDatasetValue(value, dataset);
 


### PR DESCRIPTION
This is as far as I'll go.

I did a POC to try to go further (i.e. to move `assertDatasetValue` to the providers' `getValue` methods): https://github.com/silx-kit/h5web/compare/types...poc

However, it doesn't make the code any more statically safe -- it's still a runtime check, just at a different place, and the impact on the code is significant due to the `Context` boundary. So I'm not going to open a PR -- I just thought you might be interested in seeing how I managed to follow this person's advice to type the context with a generic: https://hipsterbrown.com/musings/musing/react-context-with-generics/