### PR TITLE
Fetch attribute values on demand for NX badges in explorer

### DIFF
--- a/packages/app/src/explorer/EntityItem.tsx
+++ b/packages/app/src/explorer/EntityItem.tsx
@@ -3,12 +3,13 @@ import type { Entity } from '@h5web/shared';
 import { useToggle } from '@react-hookz/web';
 import type { CSSProperties } from 'react';
 import { Suspense, useEffect } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { FiRefreshCw } from 'react-icons/fi';
 
 import EntityList from './EntityList';
 import styles from './Explorer.module.css';
 import Icon from './Icon';
-import { isNxGroup } from './utils';
+import NxBadge from './NxBadge';
 
 interface Props {
   path: string;
@@ -57,11 +58,12 @@ function EntityItem(props: Props) {
       >
         <Icon entity={entity} isExpanded={isExpanded} />
         <span className={styles.name}>{entity.name}</span>
-        {isNxGroup(entity) && (
-          <span className={styles.nx} aria-label=" (NeXus group)">
-            NX
-          </span>
-        )}
+
+        <ErrorBoundary fallback={<> </>}>
+          <Suspense fallback={null}>
+            <NxBadge entity={entity} />
+          </Suspense>
+        </ErrorBoundary>
       </button>
 
       {isGroup(entity) && isExpanded && (

--- a/packages/app/src/explorer/NxBadge.tsx
+++ b/packages/app/src/explorer/NxBadge.tsx
@@ -1,0 +1,30 @@
+import type { Entity } from '@h5web/shared';
+import { useContext } from 'react';
+
+import { ProviderContext } from '../providers/context';
+import styles from './Explorer.module.css';
+import { needsNxBadge } from './utils';
+
+interface Props {
+  entity: Entity;
+}
+
+function NxBadge(props: Props) {
+  const { entity } = props;
+  const { attrValuesStore } = useContext(ProviderContext);
+
+  if (!needsNxBadge(entity, attrValuesStore)) {
+    return null;
+  }
+
+  return (
+    <>
+      {' '}
+      <span className={styles.nx} aria-label="(NeXus group)">
+        NX
+      </span>
+    </>
+  );
+}
+
+export default NxBadge;

--- a/packages/app/src/explorer/utils.ts
+++ b/packages/app/src/explorer/utils.ts
@@ -1,11 +1,15 @@
-import type { Entity } from '@h5web/shared';
-import { assertStr, isGroup } from '@h5web/shared';
+import type { AttributeValues, Entity } from '@h5web/shared';
+import { isGroup, assertStr } from '@h5web/shared';
+import type { FetchStore } from 'react-suspense-fetch';
 
-import { getAttributeValue, hasAttribute } from '../utils';
+import { hasAttribute } from '../utils';
 
 const SUPPORTED_NX_CLASSES = new Set(['NXdata', 'NXentry', 'NXprocess']);
 
-export function isNxGroup(entity: Entity): boolean {
+export function needsNxBadge(
+  entity: Entity,
+  attrValuesStore: FetchStore<AttributeValues, Entity>
+): boolean {
   if (!isGroup(entity)) {
     return false;
   }
@@ -15,7 +19,9 @@ export function isNxGroup(entity: Entity): boolean {
   }
 
   if (hasAttribute(entity, 'NX_class')) {
-    const nxClass = getAttributeValue(entity, 'NX_class');
+    const attrValues = attrValuesStore.get(entity);
+    const nxClass = attrValues?.NX_class;
+
     assertStr(nxClass);
     return SUPPORTED_NX_CLASSES.has(nxClass);
   }


### PR DESCRIPTION
Part of #807 

Here I'm dealing with the NX badge case. I introduce an `NxBadge` component that I wrap with error/suspense boundaries. I give these boudaries empty fallbacks so that the NX badges load silently, and also fail silently in the event of network errors.

For the moment, it's difficult to see whether our NX badge heuristics lead to an appropriate number of requests. We'll have to wait until we no longer fetch any attribute values ahead of time before we can tweak things.