### PR TITLE
Fetch `NX_class` on demand when checking if entity is `NXdata` group

### DIFF
--- a/packages/app/src/__tests__/NexusPack.test.tsx
+++ b/packages/app/src/__tests__/NexusPack.test.tsx
@@ -116,30 +116,35 @@ test('visualize NXentry group with implicit default child NXdata group', async (
   expect(tabs[0]).toHaveTextContent(NexusVis.NxSpectrum);
 });
 
-test('show error when encountering malformed NeXus metadata', async () => {
+test('show error when `default` entity is not found', async () => {
   await renderApp();
 
   const errorSpy = mockConsoleMethod('error');
-  await selectExplorerNode('nexus_malformed');
-  expect(await screen.findByText("Expected 'signal' attribute")).toBeVisible(); // `nexus_malformed` resolves to implicit default child `no_signal`
-
-  await selectExplorerNode('default_not_string');
-  expect(
-    await screen.findByText("Expected 'default' attribute to be a string")
-  ).toBeVisible();
-
-  await selectExplorerNode('default_not_found');
+  await selectExplorerNode('nexus_malformed/default_not_found');
   expect(await screen.findByText('No entity found at /test')).toBeVisible();
 
-  await selectExplorerNode('no_signal');
-  expect(await screen.findByText("Expected 'signal' attribute")).toBeVisible();
+  expect(errorSpy).toHaveBeenCalledTimes(2); // React logs two stack traces
+});
 
-  await selectExplorerNode('signal_not_found');
+test('show error when `signal` entity is not found', async () => {
+  await renderApp();
+
+  const errorSpy = mockConsoleMethod('error');
+  await selectExplorerNode('nexus_malformed/signal_not_found');
   expect(
     await screen.findByText('Expected "unknown" signal entity to exist')
   ).toBeVisible();
 
-  expect(errorSpy).toHaveBeenCalledTimes(10); // React logs two stack traces per error
+  expect(errorSpy).toHaveBeenCalledTimes(2); // React logs two stack traces
+});
+
+test('show fallback message when NXdata group has no `signal` attribute', async () => {
+  await renderApp();
+  await selectExplorerNode('nexus_malformed/no_signal');
+
+  expect(
+    await screen.findByText('No visualization available for this entity.')
+  ).toBeInTheDocument();
 });
 
 test('cancel and retry slow fetch of NxSpectrum', async () => {

--- a/packages/app/src/explorer/utils.ts
+++ b/packages/app/src/explorer/utils.ts
@@ -1,14 +1,14 @@
-import type { AttributeValues, Entity } from '@h5web/shared';
+import type { Entity } from '@h5web/shared';
 import { isGroup, assertStr } from '@h5web/shared';
-import type { FetchStore } from 'react-suspense-fetch';
 
+import type { AttrValuesStore } from '../providers/context';
 import { hasAttribute } from '../utils';
 
 const SUPPORTED_NX_CLASSES = new Set(['NXdata', 'NXentry', 'NXprocess']);
 
 export function needsNxBadge(
   entity: Entity,
-  attrValuesStore: FetchStore<AttributeValues, Entity>
+  attrValuesStore: AttrValuesStore
 ): boolean {
   if (!isGroup(entity)) {
     return false;
@@ -19,9 +19,7 @@ export function needsNxBadge(
   }
 
   if (hasAttribute(entity, 'NX_class')) {
-    const attrValues = attrValuesStore.get(entity);
-    const nxClass = attrValues?.NX_class;
-
+    const nxClass = attrValuesStore.getSingle(entity, 'NX_class');
     assertStr(nxClass);
     return SUPPORTED_NX_CLASSES.has(nxClass);
   }

--- a/packages/app/src/explorer/utils.ts
+++ b/packages/app/src/explorer/utils.ts
@@ -18,8 +18,8 @@ export function needsNxBadge(
     return true;
   }
 
-  if (hasAttribute(entity, 'NX_class')) {
-    const nxClass = attrValuesStore.getSingle(entity, 'NX_class');
+  const nxClass = attrValuesStore.getSingle(entity, 'NX_class');
+  if (nxClass) {
     assertStr(nxClass);
     return SUPPORTED_NX_CLASSES.has(nxClass);
   }

--- a/packages/app/src/providers/Provider.tsx
+++ b/packages/app/src/providers/Provider.tsx
@@ -4,6 +4,9 @@ import type { ReactNode } from 'react';
 import { useMemo } from 'react';
 import { createFetchStore } from 'react-suspense-fetch';
 
+import { hasAttribute } from '../utils';
+import type { ImageAttribute } from '../vis-packs/core/models';
+import type { NxAttribute } from '../vis-packs/nexus/models';
 import type { ProviderApi } from './api';
 import { ProviderContext } from './context';
 
@@ -64,7 +67,17 @@ function Provider(props: Props) {
 
   const filepathMembers = api.filepath.split('/');
 
-  const attrValuesStore = createFetchStore(api.getAttrValues.bind(api));
+  const attrValuesStore = useMemo(() => {
+    const store = createFetchStore(api.getAttrValues.bind(api));
+
+    return Object.assign(store, {
+      getSingle: (entity: Entity, attrName: NxAttribute | ImageAttribute) => {
+        return hasAttribute(entity, attrName)
+          ? attrValuesStore.get(entity)[attrName]
+          : undefined;
+      },
+    });
+  }, [api]);
 
   return (
     <ProviderContext.Provider

--- a/packages/app/src/providers/context.ts
+++ b/packages/app/src/providers/context.ts
@@ -2,6 +2,8 @@ import type { AttributeValues, Entity } from '@h5web/shared';
 import { createContext } from 'react';
 import type { FetchStore } from 'react-suspense-fetch';
 
+import type { ImageAttribute } from '../vis-packs/core/models';
+import type { NxAttribute } from '../vis-packs/nexus/models';
 import type { ValuesStoreParams } from './models';
 
 interface ValuesStore extends FetchStore<unknown, ValuesStoreParams> {
@@ -9,12 +11,19 @@ interface ValuesStore extends FetchStore<unknown, ValuesStoreParams> {
   evictCancelled: () => void;
 }
 
+export interface AttrValuesStore extends FetchStore<AttributeValues, Entity> {
+  getSingle: (
+    entity: Entity,
+    attrName: NxAttribute | ImageAttribute
+  ) => unknown | undefined;
+}
+
 interface Context {
   filepath: string;
   filename: string;
   entitiesStore: FetchStore<Entity, string>;
   valuesStore: ValuesStore;
-  attrValuesStore: FetchStore<AttributeValues, Entity>;
+  attrValuesStore: AttrValuesStore;
 }
 
 export const ProviderContext = createContext({} as Context);

--- a/packages/app/src/vis-packs/nexus/containers/NxComplexImageContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxComplexImageContainer.tsx
@@ -6,13 +6,14 @@ import VisBoundary from '../../VisBoundary';
 import MappedComplexVis from '../../core/complex/MappedComplexVis';
 import type { VisContainerProps } from '../../models';
 import NxValuesFetcher from '../NxValuesFetcher';
-import { getNxData, getDatasetLabel, assertComplexSignal } from '../utils';
+import { useNxData } from '../hooks';
+import { getDatasetLabel, assertComplexSignal } from '../utils';
 
 function NxComplexImageContainer(props: VisContainerProps) {
   const { entity } = props;
   assertGroupWithChildren(entity);
 
-  const nxData = getNxData(entity);
+  const nxData = useNxData(entity);
   assertComplexSignal(nxData);
 
   const { signalDataset, silxStyle } = nxData;

--- a/packages/app/src/vis-packs/nexus/containers/NxComplexSpectrumContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxComplexSpectrumContainer.tsx
@@ -7,13 +7,14 @@ import MappedComplexLineVis from '../../core/complex/MappedComplexLineVis';
 import type { VisContainerProps } from '../../models';
 import NxValuesFetcher from '../NxValuesFetcher';
 import { assertComplexNxData } from '../guards';
-import { getNxData, getDatasetLabel } from '../utils';
+import { useNxData } from '../hooks';
+import { getDatasetLabel } from '../utils';
 
 function NxComplexSpectrumContainer(props: VisContainerProps) {
   const { entity } = props;
   assertGroupWithChildren(entity);
 
-  const nxData = getNxData(entity);
+  const nxData = useNxData(entity);
   assertComplexNxData(nxData);
   const { signalDataset, silxStyle } = nxData;
 

--- a/packages/app/src/vis-packs/nexus/containers/NxImageContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxImageContainer.tsx
@@ -6,13 +6,14 @@ import VisBoundary from '../../VisBoundary';
 import MappedHeatmapVis from '../../core/heatmap/MappedHeatmapVis';
 import type { VisContainerProps } from '../../models';
 import NxValuesFetcher from '../NxValuesFetcher';
-import { getNxData, getDatasetLabel, assertNumericSignal } from '../utils';
+import { useNxData } from '../hooks';
+import { getDatasetLabel, assertNumericSignal } from '../utils';
 
 function NxImageContainer(props: VisContainerProps) {
   const { entity } = props;
   assertGroupWithChildren(entity);
 
-  const nxData = getNxData(entity);
+  const nxData = useNxData(entity);
   assertNumericSignal(nxData);
 
   const { signalDataset, silxStyle } = nxData;

--- a/packages/app/src/vis-packs/nexus/containers/NxRgbContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxRgbContainer.tsx
@@ -10,13 +10,14 @@ import VisBoundary from '../../VisBoundary';
 import { useRgbVisConfig } from '../../core/rgb/config';
 import type { VisContainerProps } from '../../models';
 import NxValuesFetcher from '../NxValuesFetcher';
-import { getNxData, getDatasetLabel, assertNumericSignal } from '../utils';
+import { useNxData } from '../hooks';
+import { getDatasetLabel, assertNumericSignal } from '../utils';
 
 function NxRgbContainer(props: VisContainerProps) {
   const { entity } = props;
   assertGroupWithChildren(entity);
 
-  const nxData = getNxData(entity);
+  const nxData = useNxData(entity);
   assertNumericSignal(nxData);
 
   const { signalDataset } = nxData;

--- a/packages/app/src/vis-packs/nexus/containers/NxSpectrumContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxSpectrumContainer.tsx
@@ -8,13 +8,14 @@ import MappedLineVis from '../../core/line/MappedLineVis';
 import type { VisContainerProps } from '../../models';
 import NxValuesFetcher from '../NxValuesFetcher';
 import { assertNumericNxData } from '../guards';
-import { getNxData, getDatasetLabel } from '../utils';
+import { useNxData } from '../hooks';
+import { getDatasetLabel } from '../utils';
 
 function NxSpectrumContainer(props: VisContainerProps) {
   const { entity } = props;
   assertGroupWithChildren(entity);
 
-  const nxData = getNxData(entity);
+  const nxData = useNxData(entity);
   assertNumericNxData(nxData);
   const { signalDataset, errorsDataset, silxStyle } = nxData;
 

--- a/packages/app/src/vis-packs/nexus/hooks.ts
+++ b/packages/app/src/vis-packs/nexus/hooks.ts
@@ -1,10 +1,38 @@
-import type { ScaleType } from '@h5web/shared';
+import type { GroupWithChildren, ScaleType } from '@h5web/shared';
 import { isDefined } from '@h5web/shared';
+import { useContext } from 'react';
 
+import { ProviderContext } from '../../providers/context';
 import { useDatasetValues } from '../core/hooks';
 import type { AxisMapping } from '../core/models';
-import type { AxisDatasetMapping } from './models';
-import { getDatasetLabel } from './utils';
+import type { AxisDatasetMapping, NxData } from './models';
+import {
+  assertNxDataGroup,
+  findAssociatedDatasets,
+  findErrorsDataset,
+  findSignalDataset,
+  findTitleDataset,
+  getDatasetLabel,
+  getSilxStyle,
+} from './utils';
+
+export function useNxData(group: GroupWithChildren): NxData {
+  const { attrValuesStore } = useContext(ProviderContext);
+
+  assertNxDataGroup(group, attrValuesStore);
+  const signalDataset = findSignalDataset(group);
+  const errorsDataset = findErrorsDataset(group, signalDataset.name);
+  const auxDatasets = findAssociatedDatasets(group, 'auxiliary_signals');
+
+  return {
+    signalDataset,
+    errorsDataset,
+    axisDatasets: findAssociatedDatasets(group, 'axes'),
+    titleDataset: findTitleDataset(group),
+    silxStyle: getSilxStyle(group),
+    auxDatasets: auxDatasets.filter(isDefined),
+  };
+}
 
 export function useAxisMapping(
   mapping: AxisDatasetMapping,

--- a/packages/app/src/visualizer/utils.ts
+++ b/packages/app/src/visualizer/utils.ts
@@ -1,4 +1,4 @@
-import type { AttributeValues, Entity } from '@h5web/shared';
+import type { Entity } from '@h5web/shared';
 import {
   assertGroupWithChildren,
   hasComplexType,
@@ -10,8 +10,8 @@ import {
   buildEntityPath,
   NxInterpretation,
 } from '@h5web/shared';
-import type { FetchStore } from 'react-suspense-fetch';
 
+import type { AttrValuesStore } from '../providers/context';
 import type { CoreVisDef } from '../vis-packs/core/visualizations';
 import { Vis, CORE_VIS } from '../vis-packs/core/visualizations';
 import type { VisDef } from '../vis-packs/models';
@@ -25,7 +25,7 @@ import { NexusVis, NEXUS_VIS } from '../vis-packs/nexus/visualizations';
 export function resolvePath(
   path: string,
   getEntity: (path: string) => Entity,
-  attrValueStore: FetchStore<AttributeValues, Entity>
+  attrValueStore: AttrValuesStore
 ): { entity: Entity; supportedVis: VisDef[] } | undefined {
   const entity = getEntity(path);
 
@@ -44,7 +44,7 @@ export function resolvePath(
 
 function findSupportedVis(
   entity: Entity,
-  attrValueStore: FetchStore<AttributeValues, Entity>
+  attrValueStore: AttrValuesStore
 ): VisDef[] {
   const nxVis = getSupportedNxVis(entity, attrValueStore);
   if (nxVis) {
@@ -56,7 +56,7 @@ function findSupportedVis(
 
 function getNxDefaultPath(
   entity: Entity,
-  attrValueStore: FetchStore<AttributeValues, Entity>
+  attrValueStore: AttrValuesStore
 ): string | undefined {
   if (!isGroup(entity)) {
     return undefined;
@@ -88,7 +88,7 @@ function getSupportedCoreVis(entity: Entity): CoreVisDef[] {
 
 function getSupportedNxVis(
   entity: Entity,
-  attrValueStore: FetchStore<AttributeValues, Entity>
+  attrValueStore: AttrValuesStore
 ): VisDef | undefined {
   if (!isGroup(entity) || !isNxDataGroup(entity)) {
     return undefined;

--- a/packages/app/src/visualizer/utils.ts
+++ b/packages/app/src/visualizer/utils.ts
@@ -90,7 +90,7 @@ function getSupportedNxVis(
   entity: Entity,
   attrValueStore: AttrValuesStore
 ): VisDef | undefined {
-  if (!isGroup(entity) || !isNxDataGroup(entity)) {
+  if (!isGroup(entity) || !isNxDataGroup(entity, attrValueStore)) {
     return undefined;
   }
 

--- a/packages/shared/src/mock/metadata.ts
+++ b/packages/shared/src/mock/metadata.ts
@@ -15,7 +15,6 @@ import {
   complexType,
   makeScalarDataset,
   makeDataset,
-  makeScalarAttr,
   withImageAttributes,
 } from './metadata-utils';
 
@@ -171,9 +170,6 @@ export const mockMetadata = makeNxGroup(mockFilepath, 'NXroot', {
       ],
     }),
     makeGroup('nexus_malformed', [
-      makeGroup('default_not_string', [], {
-        attributes: [makeScalarAttr('default', intType, 42)],
-      }),
       makeGroup('default_not_found', [], {
         attributes: [makeStrAttr('default', '/test')],
       }),


### PR DESCRIPTION
Part of #807 

I add a new `attrValuesStore.getSingle()` method that allows retrieving the value of a specific attribute. It still fetches the values of all the attributes, but it returns only the value of the attribute we're interested in. Moreover, the fetch only happens if we know that the attribute exists.

Also, as per our discussion in the meeting this morning, I know consider that a group without a `signal` attribute is _not_ an `NXdata` group. I even check this first, before the value of the `NX_class`, so that we don't bother fetching the attribute values at all if the entity has no `signal` attribute. As a result of this change, if an entity has an `NXdata` class but no `signal` attribute, we no longer show the "Expected `signal` attribute` error -- we show the "no vis" fallback message instead.