### PR TITLE
Fix ignored selection in h5grove fetchData

### DIFF
--- a/packages/app/src/providers/h5grove/h5grove-api.ts
+++ b/packages/app/src/providers/h5grove/h5grove-api.ts
@@ -126,7 +126,7 @@ export class H5GroveApi extends ProviderApi {
     const { data } = await this.cancellableFetchValue<H5GroveDataResponse>(
       `/data/`,
       params,
-      { path: params.dataset.path }
+      { path: params.dataset.path, selection: params.selection }
     );
     return data;
   }


### PR DESCRIPTION
This made the HeatmapVis crash for arrays where the binary fetching is not supported (e.g. `int64` dtype)