### PR TITLE
Let providers throw user-facing errors

### DIFF
--- a/packages/app/src/ErrorFallback.tsx
+++ b/packages/app/src/ErrorFallback.tsx
@@ -1,7 +1,7 @@
 import type { FallbackProps } from 'react-error-boundary';
 
 import styles from './App.module.css';
-import { ProviderError } from './providers/models';
+import { CANCELLED_ERROR_MSG } from './providers/utils';
 
 function ErrorFallback(props: FallbackProps) {
   const { error, resetErrorBoundary } = props;
@@ -9,7 +9,7 @@ function ErrorFallback(props: FallbackProps) {
   return (
     <p className={styles.error}>
       {error.message}
-      {error.message === ProviderError.Cancelled && (
+      {error.message === CANCELLED_ERROR_MSG && (
         <>
           <span>–</span>
           <button

--- a/packages/app/src/explorer/EntityList.tsx
+++ b/packages/app/src/explorer/EntityList.tsx
@@ -1,12 +1,7 @@
-import {
-  assertGroupWithChildren,
-  buildEntityPath,
-  handleError,
-} from '@h5web/shared';
+import { assertGroupWithChildren, buildEntityPath } from '@h5web/shared';
 import { useContext } from 'react';
 
 import { ProviderContext } from '../providers/context';
-import { ProviderError } from '../providers/models';
 import EntityItem from './EntityItem';
 import styles from './Explorer.module.css';
 
@@ -19,14 +14,9 @@ interface Props {
 
 function EntityList(props: Props) {
   const { level, parentPath, selectedPath, onSelect } = props;
-  const { filepath, entitiesStore } = useContext(ProviderContext);
 
-  const group = handleError(
-    () => entitiesStore.get(parentPath),
-    ProviderError.FileNotFound,
-    `File not found: '${filepath}'`
-  );
-
+  const { entitiesStore } = useContext(ProviderContext);
+  const group = entitiesStore.get(parentPath);
   assertGroupWithChildren(group);
 
   if (group.children.length === 0) {

--- a/packages/app/src/explorer/utils.ts
+++ b/packages/app/src/explorer/utils.ts
@@ -1,7 +1,7 @@
 import type { Entity } from '@h5web/shared';
 import { isGroup, assertStr } from '@h5web/shared';
 
-import type { AttrValuesStore } from '../providers/context';
+import type { AttrValuesStore } from '../providers/models';
 import { hasAttribute } from '../utils';
 
 const SUPPORTED_NX_CLASSES = new Set(['NXdata', 'NXentry', 'NXprocess']);

--- a/packages/app/src/metadata-viewer/MetadataViewer.tsx
+++ b/packages/app/src/metadata-viewer/MetadataViewer.tsx
@@ -1,15 +1,9 @@
-import {
-  buildEntityPath,
-  EntityKind,
-  handleError,
-  isAbsolutePath,
-} from '@h5web/shared';
+import { buildEntityPath, EntityKind, isAbsolutePath } from '@h5web/shared';
 import { capitalize } from 'lodash';
 import { Suspense, memo, useContext } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
 import { ProviderContext } from '../providers/context';
-import { ProviderError } from '../providers/models';
 import AttrErrorFallback from './AttrErrorFallback';
 import AttrValueLoader from './AttrValueLoader';
 import AttributesInfo from './AttributesInfo';
@@ -24,13 +18,9 @@ interface Props {
 
 function MetadataViewer(props: Props) {
   const { path, onSelectPath } = props;
-  const { entitiesStore } = useContext(ProviderContext);
 
-  const entity = handleError(
-    () => entitiesStore.get(path),
-    ProviderError.EntityNotFound,
-    `No entity found at ${path}`
-  );
+  const { entitiesStore } = useContext(ProviderContext);
+  const entity = entitiesStore.get(path);
 
   const { kind, attributes } = entity;
   const title = kind === EntityKind.Unresolved ? 'Entity' : capitalize(kind);

--- a/packages/app/src/providers/api.ts
+++ b/packages/app/src/providers/api.ts
@@ -9,7 +9,7 @@ import type {
 import axios from 'axios';
 
 import type { ValuesStoreParams } from './models';
-import { ProviderError } from './models';
+import { CANCELLED_ERROR_MSG } from './utils';
 
 interface ValueRequest {
   storeParams: ValuesStoreParams;
@@ -31,7 +31,7 @@ export abstract class ProviderApi {
   public cancelValueRequests(): void {
     // Cancel every active value request
     this.valueRequests.forEach((request) => {
-      request.cancelSource.cancel(ProviderError.Cancelled);
+      request.cancelSource.cancel(CANCELLED_ERROR_MSG);
 
       // Save request so params can later be evicted from the values store (cf. `Provider.tsx`)
       this.cancelledValueRequests.add(request);

--- a/packages/app/src/providers/context.ts
+++ b/packages/app/src/providers/context.ts
@@ -1,27 +1,11 @@
-import type { AttributeValues, Entity } from '@h5web/shared';
 import { createContext } from 'react';
-import type { FetchStore } from 'react-suspense-fetch';
 
-import type { ImageAttribute } from '../vis-packs/core/models';
-import type { NxAttribute } from '../vis-packs/nexus/models';
-import type { ValuesStoreParams } from './models';
-
-interface ValuesStore extends FetchStore<unknown, ValuesStoreParams> {
-  cancelOngoing: () => void;
-  evictCancelled: () => void;
-}
-
-export interface AttrValuesStore extends FetchStore<AttributeValues, Entity> {
-  getSingle: (
-    entity: Entity,
-    attrName: NxAttribute | ImageAttribute
-  ) => unknown | undefined;
-}
+import type { AttrValuesStore, EntitiesStore, ValuesStore } from './models';
 
 interface Context {
   filepath: string;
   filename: string;
-  entitiesStore: FetchStore<Entity, string>;
+  entitiesStore: EntitiesStore;
   valuesStore: ValuesStore;
   attrValuesStore: AttrValuesStore;
 }

--- a/packages/app/src/providers/h5grove/h5grove-api.ts
+++ b/packages/app/src/providers/h5grove/h5grove-api.ts
@@ -25,7 +25,6 @@ import type {
   H5GroveEntityResponse,
 } from './models';
 import {
-  getMatchingProviderError,
   isDatasetResponse,
   isGroupResponse,
   typedArrayFromDType,
@@ -81,7 +80,17 @@ export class H5GroveApi extends ProviderApi {
           return undefined;
         }
 
-        return getMatchingProviderError(errorData);
+        if (errorData.includes('File not found')) {
+          return `File not found: '${this.filepath}'`;
+        }
+        if (errorData.includes('not a valid path')) {
+          return `No entity found at ${path}`;
+        }
+        if (errorData.includes('Cannot resolve')) {
+          return `Could not resolve soft link at ${path}`;
+        }
+
+        return undefined;
       }
     );
     return data;

--- a/packages/app/src/providers/h5grove/utils.ts
+++ b/packages/app/src/providers/h5grove/utils.ts
@@ -1,7 +1,6 @@
 import type { DType } from '@h5web/shared';
 import { DTypeClass, EntityKind, isNumericType } from '@h5web/shared';
 
-import { ProviderError } from '../models';
 import type {
   H5GroveDatasetReponse,
   H5GroveEntityResponse,
@@ -63,22 +62,6 @@ export function typedArrayFromDType(dtype: DType) {
       case 64:
         return Float64Array;
     }
-  }
-
-  return undefined;
-}
-
-export function getMatchingProviderError(
-  errorData: string
-): ProviderError | undefined {
-  if (errorData.includes('File not found')) {
-    return ProviderError.FileNotFound;
-  }
-  if (errorData.includes('not a valid path')) {
-    return ProviderError.EntityNotFound;
-  }
-  if (errorData.includes('Cannot resolve')) {
-    return ProviderError.UnresolvableLink;
   }
 
   return undefined;

--- a/packages/app/src/providers/hsds/hsds-api.ts
+++ b/packages/app/src/providers/hsds/hsds-api.ts
@@ -17,7 +17,6 @@ import {
 
 import { ProviderApi } from '../api';
 import type { ValuesStoreParams } from '../models';
-import { ProviderError } from '../models';
 import { flattenValue, handleAxiosError } from '../utils';
 import type {
   HsdsDatasetResponse,
@@ -104,7 +103,7 @@ export class HsdsApi extends ProviderApi {
 
     const childName = path.slice(path.lastIndexOf('/') + 1);
     const child = getChildEntity(parentGroup, childName);
-    assertDefined(child, ProviderError.EntityNotFound);
+    assertDefined(child, `No entity found at ${path}`);
     assertHsdsEntity(child);
 
     const entity = isHsdsGroup(child)
@@ -147,7 +146,8 @@ export class HsdsApi extends ProviderApi {
   private async fetchRootId(): Promise<HsdsId> {
     const { data } = await handleAxiosError(
       () => this.client.get<HsdsRootResponse>('/'),
-      (status) => (status === 400 ? ProviderError.FileNotFound : undefined)
+      (status) =>
+        status === 400 ? `File not found: ${this.filepath}` : undefined
     );
     return data.root;
   }

--- a/packages/app/src/providers/mock/mock-api.ts
+++ b/packages/app/src/providers/mock/mock-api.ts
@@ -14,7 +14,6 @@ import ndarray from 'ndarray';
 
 import { applyMapping } from '../../vis-packs/core/utils';
 import { ProviderApi } from '../api';
-import { ProviderError } from '../models';
 import type { ValuesStoreParams } from '../models';
 
 const SLOW_TIMEOUT = 3000;
@@ -32,7 +31,7 @@ export class MockApi extends ProviderApi {
     }
 
     const entity = findMockEntity(path);
-    assertDefined(entity, ProviderError.EntityNotFound);
+    assertDefined(entity, `No entity found at ${path}`);
     return entity;
   }
 

--- a/packages/app/src/providers/models.ts
+++ b/packages/app/src/providers/models.ts
@@ -1,13 +1,30 @@
-import type { ArrayShape, Dataset, ScalarShape } from '@h5web/shared';
+import type {
+  AttributeValues,
+  Entity,
+  ArrayShape,
+  Dataset,
+  ScalarShape,
+} from '@h5web/shared';
+import type { FetchStore } from 'react-suspense-fetch';
+
+import type { ImageAttribute } from '../vis-packs/core/models';
+import type { NxAttribute } from '../vis-packs/nexus/models';
+
+export type EntitiesStore = FetchStore<Entity, string>;
+
+export interface ValuesStore extends FetchStore<unknown, ValuesStoreParams> {
+  cancelOngoing: () => void;
+  evictCancelled: () => void;
+}
 
 export interface ValuesStoreParams {
   dataset: Dataset<ScalarShape | ArrayShape>;
   selection?: string | undefined;
 }
 
-export enum ProviderError {
-  FileNotFound = 'File not found',
-  EntityNotFound = 'Entity not found',
-  UnresolvableLink = 'Cannot resolve soft link',
-  Cancelled = 'Request cancelled',
+export interface AttrValuesStore extends FetchStore<AttributeValues, Entity> {
+  getSingle: (
+    entity: Entity,
+    attrName: NxAttribute | ImageAttribute
+  ) => unknown | undefined;
 }

--- a/packages/app/src/providers/utils.ts
+++ b/packages/app/src/providers/utils.ts
@@ -2,7 +2,7 @@ import type { ArrayShape, Dataset, DType } from '@h5web/shared';
 import { Endianness, DTypeClass, assertArray } from '@h5web/shared';
 import axios from 'axios';
 
-import type { ProviderError } from './models';
+export const CANCELLED_ERROR_MSG = 'Request cancelled';
 
 // https://numpy.org/doc/stable/reference/generated/numpy.dtype.byteorder.html#numpy.dtype.byteorder
 const ENDIANNESS_MAPPING: Record<string, Endianness> = {
@@ -94,10 +94,7 @@ export function flattenValue(
 
 export async function handleAxiosError<T>(
   func: () => Promise<T>,
-  getErrorToThrow: (
-    status: number,
-    errorData: unknown
-  ) => ProviderError | undefined
+  getErrorToThrow: (status: number, errorData: unknown) => string | undefined
 ): Promise<T> {
   try {
     return await func();

--- a/packages/app/src/vis-packs/core/visualizations.test.ts
+++ b/packages/app/src/vis-packs/core/visualizations.test.ts
@@ -13,7 +13,7 @@ import {
   withImageAttributes,
 } from '@h5web/shared/src/mock/metadata-utils';
 
-import type { AttrValuesStore } from '../../providers/context';
+import type { AttrValuesStore } from '../../providers/models';
 import { CORE_VIS } from './visualizations';
 
 const mockStore = {

--- a/packages/app/src/vis-packs/core/visualizations.ts
+++ b/packages/app/src/vis-packs/core/visualizations.ts
@@ -17,7 +17,7 @@ import {
   FiImage,
 } from 'react-icons/fi';
 
-import type { AttrValuesStore } from '../../providers/context';
+import type { AttrValuesStore } from '../../providers/models';
 import type { VisDef } from '../models';
 import {
   MatrixConfigProvider,

--- a/packages/app/src/vis-packs/nexus/utils.ts
+++ b/packages/app/src/vis-packs/nexus/utils.ts
@@ -24,7 +24,7 @@ import type {
   NumArrayDataset,
 } from '@h5web/shared';
 
-import type { AttrValuesStore } from '../../providers/context';
+import type { AttrValuesStore } from '../../providers/models';
 import { hasAttribute } from '../../utils';
 import type { NxData, SilxStyle } from './models';
 

--- a/packages/app/src/visualizer/Visualizer.tsx
+++ b/packages/app/src/visualizer/Visualizer.tsx
@@ -1,9 +1,6 @@
-import type { Entity } from '@h5web/shared';
-import { handleError } from '@h5web/shared';
 import { useContext } from 'react';
 
 import { ProviderContext } from '../providers/context';
-import { ProviderError } from '../providers/models';
 import VisManager from './VisManager';
 import styles from './Visualizer.module.css';
 import { resolvePath } from './utils';
@@ -16,16 +13,7 @@ function Visualizer(props: Props) {
   const { path } = props;
 
   const { entitiesStore, attrValuesStore } = useContext(ProviderContext);
-
-  function getEntity(entityPath: string): Entity {
-    return handleError(
-      () => entitiesStore.get(entityPath),
-      ProviderError.EntityNotFound,
-      `No entity found at ${entityPath}`
-    );
-  }
-
-  const resolution = resolvePath(path, getEntity, attrValuesStore);
+  const resolution = resolvePath(path, entitiesStore, attrValuesStore);
 
   if (!resolution) {
     return (

--- a/packages/app/src/visualizer/utils.ts
+++ b/packages/app/src/visualizer/utils.ts
@@ -11,7 +11,7 @@ import {
   NxInterpretation,
 } from '@h5web/shared';
 
-import type { AttrValuesStore } from '../providers/context';
+import type { AttrValuesStore, EntitiesStore } from '../providers/models';
 import { hasAttribute } from '../utils';
 import type { CoreVisDef } from '../vis-packs/core/visualizations';
 import { Vis, CORE_VIS } from '../vis-packs/core/visualizations';
@@ -21,10 +21,10 @@ import { NexusVis, NEXUS_VIS } from '../vis-packs/nexus/visualizations';
 
 export function resolvePath(
   path: string,
-  getEntity: (path: string) => Entity,
+  entitiesStore: EntitiesStore,
   attrValueStore: AttrValuesStore
 ): { entity: Entity; supportedVis: VisDef[] } | undefined {
-  const entity = getEntity(path);
+  const entity = entitiesStore.get(path);
 
   const supportedVis = findSupportedVis(entity, attrValueStore);
   if (supportedVis.length > 0) {
@@ -33,7 +33,7 @@ export function resolvePath(
 
   const nxDefaultPath = getNxDefaultPath(entity, attrValueStore);
   if (nxDefaultPath) {
-    return resolvePath(nxDefaultPath, getEntity, attrValueStore);
+    return resolvePath(nxDefaultPath, entitiesStore, attrValueStore);
   }
 
   return undefined;

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -55,22 +55,6 @@ export function buildEntityPath(
   return `${prefix}/${entityNameOrRelativePath}`;
 }
 
-export function handleError<T>(
-  func: () => T,
-  errToCatch: string,
-  errToThrow: string
-): T {
-  try {
-    return func();
-  } catch (error) {
-    if (error instanceof Error && error.message === errToCatch) {
-      throw new Error(errToThrow);
-    }
-
-    throw error;
-  }
-}
-
 export function createArrayFromView<T>(view: NdArray<T[]>): NdArray<T[]> {
   const array = ndarray<T[]>([], view.shape);
   assign(array, view);


### PR DESCRIPTION
This simplifies things a bit. We no longer have to wrap `entitiesStore.get()` with `handleError`, or create a `getEntity` function in `Visualizer` to pass to `resolvePath`.