### PR TITLE
Fetch only slice for LineVis of huge datasets

### DIFF
--- a/packages/app/src/vis-packs/core/LimitedValueFetcher.tsx
+++ b/packages/app/src/vis-packs/core/LimitedValueFetcher.tsx
@@ -1,0 +1,33 @@
+import type {
+  ArrayShape,
+  ComplexType,
+  Dataset,
+  NumericType,
+  Value,
+} from '@h5web/shared';
+import type { ReactNode } from 'react';
+
+import type { DimensionMapping } from '../../dimension-mapper/models';
+import { useDatasetValue } from './hooks';
+import { getValueSize } from './utils';
+
+const MAX_SIZE = 64_000_000;
+
+interface Props<D extends Dataset> {
+  dataset: D;
+  dimMapping: DimensionMapping;
+  render: (val: Value<D>, isSlice?: boolean) => ReactNode;
+}
+
+function LimitedValueFetcher<
+  D extends Dataset<ArrayShape, NumericType> | Dataset<ArrayShape, ComplexType>
+>(props: Props<D>) {
+  const { dataset, dimMapping, render } = props;
+
+  const fetchSlice = getValueSize(dataset) >= MAX_SIZE;
+
+  const value = useDatasetValue(dataset, fetchSlice ? dimMapping : undefined);
+  return <>{render(value, fetchSlice)}</>;
+}
+
+export default LimitedValueFetcher;

--- a/packages/app/src/vis-packs/core/complex/ComplexLineVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/complex/ComplexLineVisContainer.tsx
@@ -8,7 +8,7 @@ import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useDimMappingState } from '../../../dimension-mapper/hooks';
 import VisBoundary from '../../VisBoundary';
 import type { VisContainerProps } from '../../models';
-import ValueFetcher from '../ValueFetcher';
+import LimitedValueFetcher from '../LimitedValueFetcher';
 import MappedComplexLineVis from './MappedComplexLineVis';
 
 function ComplexLineVisContainer(props: VisContainerProps) {
@@ -27,18 +27,17 @@ function ComplexLineVisContainer(props: VisContainerProps) {
         mapperState={dimMapping}
         onChange={setDimMapping}
       />
-      <VisBoundary
-        resetKey={dimMapping}
-        loadingMessage="Loading entire dataset"
-      >
-        <ValueFetcher
+      <VisBoundary resetKey={dimMapping} loadingMessage="Loading dataset">
+        <LimitedValueFetcher
           dataset={entity}
-          render={(value) => (
+          dimMapping={dimMapping}
+          render={(value, isSlice) => (
             <MappedComplexLineVis
               value={value}
               dims={dims}
               dimMapping={dimMapping}
               title={entity.name}
+              isValueSlice={isSlice}
             />
           )}
         />

--- a/packages/app/src/vis-packs/core/complex/MappedComplexLineVis.tsx
+++ b/packages/app/src/vis-packs/core/complex/MappedComplexLineVis.tsx
@@ -16,6 +16,7 @@ interface Props {
   dimMapping: DimensionMapping;
   axisMapping?: AxisMapping;
   title: string;
+  isValueSlice?: boolean;
 }
 
 function MappedComplexLineVis(props: Props) {

--- a/packages/app/src/vis-packs/core/line/LineVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/line/LineVisContainer.tsx
@@ -8,7 +8,7 @@ import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useDimMappingState } from '../../../dimension-mapper/hooks';
 import VisBoundary from '../../VisBoundary';
 import type { VisContainerProps } from '../../models';
-import ValueFetcher from '../ValueFetcher';
+import LimitedValueFetcher from '../LimitedValueFetcher';
 import MappedLineVis from './MappedLineVis';
 
 function LineVisContainer(props: VisContainerProps) {
@@ -27,18 +27,17 @@ function LineVisContainer(props: VisContainerProps) {
         mapperState={dimMapping}
         onChange={setDimMapping}
       />
-      <VisBoundary
-        resetKey={dimMapping}
-        loadingMessage="Loading entire dataset"
-      >
-        <ValueFetcher
+      <VisBoundary resetKey={dimMapping} loadingMessage="Loading dataset">
+        <LimitedValueFetcher
           dataset={entity}
-          render={(value) => (
+          dimMapping={dimMapping}
+          render={(value, isSlice) => (
             <MappedLineVis
               value={value}
               dims={dims}
               dimMapping={dimMapping}
               title={entity.name}
+              isValueSlice={isSlice}
             />
           )}
         />

--- a/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
+++ b/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
@@ -10,6 +10,7 @@ import {
   useMappedArray,
   useDomain,
   useDomains,
+  useSlicedDimsAndMapping,
 } from '../hooks';
 import type { AxisMapping } from '../models';
 import { useLineConfig } from './config';
@@ -26,6 +27,7 @@ interface Props {
   dimMapping: DimensionMapping;
   axisMapping?: AxisMapping;
   title: string;
+  isValueSlice?: boolean;
 }
 
 function MappedLineVis(props: Props) {
@@ -39,6 +41,7 @@ function MappedLineVis(props: Props) {
     dimMapping,
     axisMapping = [],
     title,
+    isValueSlice,
   } = props;
 
   const {
@@ -54,7 +57,12 @@ function MappedLineVis(props: Props) {
     disableErrors,
   } = useLineConfig((state) => state, shallow);
 
-  const hookArgs: HookArgs = [dims, dimMapping, autoScale];
+  const [slicedDims, slicedMapping] = useSlicedDimsAndMapping(dims, dimMapping);
+
+  const hookArgs: HookArgs = isValueSlice
+    ? [slicedDims, slicedMapping, autoScale]
+    : [dims, dimMapping, autoScale];
+
   const [dataArray, dataForDomain] = useMappedArray(value, ...hookArgs);
   const [errorArray, errorsForDomain] = useMappedArray(errors, ...hookArgs);
   const [auxArrays, auxForDomain] = useMappedArrays(auxiliaries, ...hookArgs);
@@ -85,9 +93,9 @@ function MappedLineVis(props: Props) {
   }, [disableErrors, errors]);
 
   useEffect(() => {
-    // Disable `autoScale` for 1D datasets (baseArray and dataArray are the same)
-    disableAutoScale(dims.length <= 1);
-  }, [dims, disableAutoScale]);
+    // Disable `autoScale` for 1D datasets (baseArray and dataArray are the same) or if the value is a slice
+    disableAutoScale(isValueSlice || dims.length <= 1);
+  }, [dims, disableAutoScale, isValueSlice]);
 
   return (
     <LineVis

--- a/packages/app/src/vis-packs/core/utils.ts
+++ b/packages/app/src/vis-packs/core/utils.ts
@@ -1,5 +1,11 @@
-import type { Domain } from '@h5web/shared';
-import { createArrayFromView } from '@h5web/shared';
+import type {
+  ArrayShape,
+  ComplexType,
+  Dataset,
+  Domain,
+  NumericType,
+} from '@h5web/shared';
+import { createArrayFromView, hasComplexType } from '@h5web/shared';
 import { isNumber } from 'lodash';
 import type { NdArray } from 'ndarray';
 import ndarray from 'ndarray';
@@ -56,4 +62,19 @@ export function getSliceSelection(
 
   // Create slice selection string from dim mapping - e.g. [0, 'y', 'x'] => "0,:,:"
   return dimMapping.map((dim) => (isAxis(dim) ? ':' : dim)).join(',');
+}
+
+export function getValueSize(
+  dataset: Dataset<ArrayShape, NumericType> | Dataset<ArrayShape, ComplexType>
+) {
+  if (hasComplexType(dataset)) {
+    const { type, shape } = dataset;
+    return (
+      shape.reduce((val, acc) => val * acc) *
+      (type.realType.size + type.imagType.size)
+    );
+  }
+
+  const { type, shape } = dataset;
+  return shape.reduce((val, acc) => val * acc) * type.size;
 }

--- a/packages/shared/src/models-hdf5.ts
+++ b/packages/shared/src/models-hdf5.ts
@@ -111,8 +111,8 @@ export interface NumericType {
 
 export interface ComplexType {
   class: DTypeClass.Complex;
-  realType: DType;
-  imagType: DType;
+  realType: NumericType;
+  imagType: NumericType;
 }
 
 export interface StringType {


### PR DESCRIPTION
A tentative to solve https://github.com/silx-kit/h5web/issues/616#issuecomment-964256705, open for discussion.

`LimitedValueFetcher` is a `ValueFetcher` that checks if the full dataset can be fetched. If not, it fetches the corresponding slice and passes a boolean to the render function to tell that only a slice was fetched. I make use of this boolean to know if autoscale should be disabled.

Note that because I added some code to compute the size of the value according to the dataset metadata, I had to ensure the fact that a complex dtype holds two numeric dtypes.

If we go this way, `LimitedValueFetcher` should also be used in `NxSpectrum` and `NxComplexSpectrum` vis.