### PR TITLE
Show readable dtype in tooltip

### DIFF
--- a/packages/app/src/vis-packs/core/heatmap/HeatmapVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/HeatmapVisContainer.tsx
@@ -39,6 +39,7 @@ function HeatmapVisContainer(props: VisContainerProps) {
               dims={dims}
               dimMapping={dimMapping}
               title={entity.name}
+              dtype={entity.type}
             />
           )}
         />

--- a/packages/app/src/vis-packs/core/heatmap/MappedHeatmapVis.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/MappedHeatmapVis.tsx
@@ -1,5 +1,5 @@
 import { HeatmapVis } from '@h5web/lib';
-import type { ScaleType } from '@h5web/shared';
+import type { NumericType, ScaleType } from '@h5web/shared';
 import { useEffect } from 'react';
 import shallow from 'zustand/shallow';
 
@@ -17,6 +17,7 @@ interface Props {
   axisMapping?: AxisMapping;
   title: string;
   colorScaleType?: ScaleType;
+  dtype?: NumericType;
 }
 
 function MappedHeatmapVis(props: Props) {
@@ -26,6 +27,7 @@ function MappedHeatmapVis(props: Props) {
     dimMapping,
     axisMapping = [],
     title,
+    dtype,
     colorScaleType,
   } = props;
 
@@ -64,6 +66,7 @@ function MappedHeatmapVis(props: Props) {
     <HeatmapVis
       dataArray={dataArray}
       title={title}
+      dtype={dtype}
       domain={safeDomain}
       colorMap={colorMap}
       scaleType={scaleType}

--- a/packages/app/src/vis-packs/core/line/LineVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/line/LineVisContainer.tsx
@@ -39,6 +39,7 @@ function LineVisContainer(props: VisContainerProps) {
               dims={dims}
               dimMapping={dimMapping}
               title={entity.name}
+              dtype={entity.type}
             />
           )}
         />

--- a/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
+++ b/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
@@ -1,5 +1,5 @@
 import { LineVis } from '@h5web/lib';
-import type { ScaleType } from '@h5web/shared';
+import type { NumericType, ScaleType } from '@h5web/shared';
 import { useEffect } from 'react';
 import shallow from 'zustand/shallow';
 
@@ -26,6 +26,7 @@ interface Props {
   dimMapping: DimensionMapping;
   axisMapping?: AxisMapping;
   title: string;
+  dtype?: NumericType;
 }
 
 function MappedLineVis(props: Props) {
@@ -39,6 +40,7 @@ function MappedLineVis(props: Props) {
     dimMapping,
     axisMapping = [],
     title,
+    dtype,
   } = props;
 
   const {
@@ -103,6 +105,7 @@ function MappedLineVis(props: Props) {
       }}
       ordinateLabel={valueLabel}
       title={title}
+      dtype={dtype}
       errorsArray={errorArray}
       showErrors={showErrors}
       auxArrays={auxArrays}

--- a/packages/app/src/vis-packs/nexus/containers/NxImageContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxImageContainer.tsx
@@ -44,6 +44,7 @@ function NxImageContainer(props: VisContainerProps) {
                 axisMapping={axisMapping}
                 title={title}
                 colorScaleType={silxStyle.signalScaleType}
+                dtype={signalDataset.type}
               />
             );
           }}

--- a/packages/app/src/vis-packs/nexus/containers/NxSpectrumContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxSpectrumContainer.tsx
@@ -59,6 +59,7 @@ function NxSpectrumContainer(props: VisContainerProps) {
                 dimMapping={dimMapping}
                 axisMapping={axisMapping}
                 title={title}
+                dtype={signalDataset.type}
               />
             );
           }}

--- a/packages/lib/src/vis/heatmap/HeatmapVis.module.css
+++ b/packages/lib/src/vis/heatmap/HeatmapVis.module.css
@@ -7,7 +7,10 @@
 }
 
 .tooltipValue {
-  font-weight: 600;
   margin-top: 0.25rem;
+}
+
+.tooltipValue > strong {
+  font-weight: 600;
   font-size: 1.125em;
 }

--- a/packages/lib/src/vis/heatmap/HeatmapVis.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapVis.tsx
@@ -1,4 +1,4 @@
-import type { Domain } from '@h5web/shared';
+import type { Domain, NumericType } from '@h5web/shared';
 import { assertDefined, formatTooltipVal, ScaleType } from '@h5web/shared';
 import type { NdArray } from 'ndarray';
 import type { ReactElement, ReactNode } from 'react';
@@ -8,7 +8,7 @@ import type { VisScaleType, AxisParams } from '../models';
 import PanZoomMesh from '../shared/PanZoomMesh';
 import TooltipMesh from '../shared/TooltipMesh';
 import VisCanvas from '../shared/VisCanvas';
-import { DEFAULT_DOMAIN } from '../utils';
+import { DEFAULT_DOMAIN, formatNumType } from '../utils';
 import ColorBar from './ColorBar';
 import HeatmapMesh from './HeatmapMesh';
 import styles from './HeatmapVis.module.css';
@@ -24,6 +24,7 @@ interface Props {
   layout?: Layout;
   showGrid?: boolean;
   title?: string;
+  dtype?: NumericType;
   invertColorMap?: boolean;
   abscissaParams?: AxisParams;
   ordinateParams?: AxisParams;
@@ -44,6 +45,7 @@ function HeatmapVis(props: Props) {
     showGrid = false,
     invertColorMap = false,
     title,
+    dtype,
     abscissaParams = {},
     ordinateParams = {},
     alphaArray,
@@ -107,7 +109,8 @@ function HeatmapVis(props: Props) {
                 {`${abscissaLabel ?? 'x'}=${formatTooltipVal(abscissa)}, `}
                 {`${ordinateLabel ?? 'y'}=${formatTooltipVal(ordinate)}`}
                 <div className={styles.tooltipValue}>
-                  {formatTooltipVal(dataArray.get(yi, xi))}
+                  <strong>{formatTooltipVal(dataArray.get(yi, xi))}</strong>
+                  {dtype && <em>{` (${formatNumType(dtype)})`}</em>}
                 </div>
               </>
             );

--- a/packages/lib/src/vis/line/LineVis.tsx
+++ b/packages/lib/src/vis/line/LineVis.tsx
@@ -1,4 +1,4 @@
-import type { Domain } from '@h5web/shared';
+import type { Domain, NumericType } from '@h5web/shared';
 import {
   assertDataLength,
   assertDefined,
@@ -20,7 +20,7 @@ import type { AxisParams } from '../models';
 import PanZoomMesh from '../shared/PanZoomMesh';
 import TooltipMesh from '../shared/TooltipMesh';
 import VisCanvas from '../shared/VisCanvas';
-import { extendDomain, DEFAULT_DOMAIN } from '../utils';
+import { extendDomain, DEFAULT_DOMAIN, formatNumType } from '../utils';
 import DataCurve from './DataCurve';
 import styles from './LineVis.module.css';
 import type { TooltipData } from './models';
@@ -39,6 +39,7 @@ interface Props {
   abscissaParams?: AxisParams;
   ordinateLabel?: string;
   title?: string;
+  dtype?: NumericType;
   errorsArray?: NdArray<number[]>;
   showErrors?: boolean;
   auxArrays?: NdArray<number[]>[];
@@ -56,6 +57,7 @@ function LineVis(props: Props) {
     abscissaParams = {},
     ordinateLabel,
     title,
+    dtype,
     errorsArray,
     showErrors = false,
     auxArrays = [],
@@ -134,6 +136,7 @@ function LineVis(props: Props) {
                 <div className={styles.tooltipValue}>
                   <strong>{formatTooltipVal(value)}</strong>
                   {error && ` ±${formatTooltipErr(error)}`}
+                  {dtype && <em>{` (${formatNumType(dtype)})`}</em>}
                 </div>
               </>
             );

--- a/packages/lib/src/vis/utils.ts
+++ b/packages/lib/src/vis/utils.ts
@@ -1,4 +1,4 @@
-import type { Domain } from '@h5web/shared';
+import type { Domain, NumericType } from '@h5web/shared';
 import {
   getValidDomainForScale,
   ScaleType,
@@ -6,6 +6,7 @@ import {
   formatTick,
   isScaleType,
   getBounds,
+  DTypeClass,
 } from '@h5web/shared';
 import { scaleLinear, scaleThreshold } from '@visx/scale';
 import { tickStep, range } from 'd3-array';
@@ -286,4 +287,14 @@ export function getAxisDomain(
   return isDescending(axisValues)
     ? [extendedDomain[1], extendedDomain[0]]
     : extendedDomain;
+}
+
+const TYPE_STRINGS: Record<NumericType['class'], string> = {
+  [DTypeClass.Integer]: 'int',
+  [DTypeClass.Unsigned]: 'uint',
+  [DTypeClass.Float]: 'float',
+};
+
+export function formatNumType(numType: NumericType): string {
+  return `${TYPE_STRINGS[numType.class]}${numType.size}`;
 }


### PR DESCRIPTION
Friday POC to fix #508, which has been open for a long time.

I pass the dataset type object (`NumericType`) from the container down to the visualization so it can be displayed in the tooltip, next to the hovered value. I let the tooltip's render prop convert the type to a readable string. It seems more straightforward, from a naming point of view, to do it this way than to format the readable string in the container and pass that down to the visualization.

I've only done `LineVisContainer` as a proof of concept for now:

![image](https://user-images.githubusercontent.com/2936402/143598451-b2f7c6f4-05bf-4938-b21c-9e59d8063165.png)

![image](https://user-images.githubusercontent.com/2936402/143598481-2c29eee8-d64e-4125-ab26-68e6889d73a2.png)
