### PR TITLE
Add "Export" menu to toolbars with CSV/NPY/TIFF exports

### DIFF
--- a/packages/app/src/metadata-viewer/MetadataTable.tsx
+++ b/packages/app/src/metadata-viewer/MetadataTable.tsx
@@ -1,5 +1,6 @@
+import type { PropsWithChildren } from 'react';
+
 import styles from './MetadataViewer.module.css';
-import type { PropsWithChildren } from '.pnpm/@types+react@17.0.27/node_modules/@types/react';
 
 interface Props {
   title: string;

--- a/packages/app/src/providers/Provider.tsx
+++ b/packages/app/src/providers/Provider.tsx
@@ -90,7 +90,7 @@ function Provider(props: Props) {
         entitiesStore,
         valuesStore,
         attrValuesStore,
-        getTiffUrl: api.getTiffUrl?.bind(api),
+        getExportURL: api.getExportURL?.bind(api),
       }}
     >
       {children}

--- a/packages/app/src/providers/Provider.tsx
+++ b/packages/app/src/providers/Provider.tsx
@@ -90,6 +90,7 @@ function Provider(props: Props) {
         entitiesStore,
         valuesStore,
         attrValuesStore,
+        getTiffUrl: api.getTiffUrl?.bind(api),
       }}
     >
       {children}

--- a/packages/app/src/providers/api.ts
+++ b/packages/app/src/providers/api.ts
@@ -14,7 +14,7 @@ import type {
 } from 'axios';
 import axios from 'axios';
 
-import type { ValuesStoreParams } from './models';
+import type { ExportFormat, ValuesStoreParams } from './models';
 import { CANCELLED_ERROR_MSG } from './utils';
 
 interface ValueRequest {
@@ -34,10 +34,11 @@ export abstract class ProviderApi {
     this.client = axios.create(config);
   }
 
-  public getTiffUrl?(
+  public getExportURL?(
     dataset: Dataset<ArrayShape, NumericType>,
-    selection?: string | undefined
-  ): string | undefined;
+    selection: string | undefined,
+    format: ExportFormat
+  ): string | undefined; // `undefined` if format is not supported
 
   public cancelValueRequests(): void {
     // Cancel every active value request

--- a/packages/app/src/providers/api.ts
+++ b/packages/app/src/providers/api.ts
@@ -1,4 +1,10 @@
-import type { AttributeValues, Entity } from '@h5web/shared';
+import type {
+  ArrayShape,
+  AttributeValues,
+  Dataset,
+  Entity,
+  NumericType,
+} from '@h5web/shared';
 import type {
   AxiosInstance,
   AxiosRequestConfig,
@@ -27,6 +33,11 @@ export abstract class ProviderApi {
     this.filepath = filepath;
     this.client = axios.create(config);
   }
+
+  public getTiffUrl?(
+    dataset: Dataset<ArrayShape, NumericType>,
+    selection?: string | undefined
+  ): string | undefined;
 
   public cancelValueRequests(): void {
     // Cancel every active value request

--- a/packages/app/src/providers/context.ts
+++ b/packages/app/src/providers/context.ts
@@ -1,6 +1,6 @@
-import type { ArrayShape, Dataset, NumericType } from '@h5web/shared';
 import { createContext } from 'react';
 
+import type { ProviderApi } from './api';
 import type { AttrValuesStore, EntitiesStore, ValuesStore } from './models';
 
 interface Context {
@@ -9,10 +9,7 @@ interface Context {
   entitiesStore: EntitiesStore;
   valuesStore: ValuesStore;
   attrValuesStore: AttrValuesStore;
-  getTiffUrl?: (
-    dataset: Dataset<ArrayShape, NumericType>,
-    selection: string | undefined
-  ) => string | undefined;
+  getExportURL?: ProviderApi['getExportURL'];
 }
 
 export const ProviderContext = createContext({} as Context);

--- a/packages/app/src/providers/context.ts
+++ b/packages/app/src/providers/context.ts
@@ -1,3 +1,4 @@
+import type { ArrayShape, Dataset, NumericType } from '@h5web/shared';
 import { createContext } from 'react';
 
 import type { AttrValuesStore, EntitiesStore, ValuesStore } from './models';
@@ -8,6 +9,10 @@ interface Context {
   entitiesStore: EntitiesStore;
   valuesStore: ValuesStore;
   attrValuesStore: AttrValuesStore;
+  getTiffUrl?: (
+    dataset: Dataset<ArrayShape, NumericType>,
+    selection: string | undefined
+  ) => string | undefined;
 }
 
 export const ProviderContext = createContext({} as Context);

--- a/packages/app/src/providers/h5grove/h5grove-api.ts
+++ b/packages/app/src/providers/h5grove/h5grove-api.ts
@@ -33,7 +33,7 @@ import {
 } from './utils';
 
 export class H5GroveApi extends ProviderApi {
-  /* API compatible with h5grove@0.0.9 */
+  /* API compatible with h5grove@0.0.13 */
   public constructor(
     url: string,
     filepath: string,

--- a/packages/app/src/providers/h5grove/h5grove-api.ts
+++ b/packages/app/src/providers/h5grove/h5grove-api.ts
@@ -1,10 +1,12 @@
 import type {
+  ArrayShape,
   Attribute,
   AttributeValues,
   Dataset,
   Entity,
   Group,
   GroupWithChildren,
+  NumericType,
   UnresolvedEntity,
 } from '@h5web/shared';
 import {
@@ -69,6 +71,23 @@ export class H5GroveApi extends ProviderApi {
   public async getAttrValues(entity: Entity): Promise<AttributeValues> {
     const { path, attributes } = entity;
     return attributes.length > 0 ? this.fetchAttrValues(path) : {};
+  }
+
+  public getTiffUrl(
+    dataset: Dataset<ArrayShape, NumericType>,
+    selection: string | undefined
+  ): string | undefined {
+    const { baseURL, params } = this.client.defaults;
+
+    const searchParams = new URLSearchParams(params as Record<string, string>);
+    searchParams.set('path', dataset.path);
+    searchParams.set('format', 'tiff');
+
+    if (selection) {
+      searchParams.set('selection', selection);
+    }
+
+    return `${baseURL as string}/data/?${searchParams.toString()}`;
   }
 
   private async fetchEntity(path: string): Promise<H5GroveEntityResponse> {

--- a/packages/app/src/providers/h5grove/h5grove-api.ts
+++ b/packages/app/src/providers/h5grove/h5grove-api.ts
@@ -18,7 +18,7 @@ import {
 import { isString } from 'lodash';
 
 import { ProviderApi } from '../api';
-import type { ValuesStoreParams } from '../models';
+import type { ExportFormat, ValuesStoreParams } from '../models';
 import { convertDtype, flattenValue, handleAxiosError } from '../utils';
 import type {
   H5GroveAttribute,
@@ -73,15 +73,16 @@ export class H5GroveApi extends ProviderApi {
     return attributes.length > 0 ? this.fetchAttrValues(path) : {};
   }
 
-  public getTiffUrl(
+  public getExportURL(
     dataset: Dataset<ArrayShape, NumericType>,
-    selection: string | undefined
+    selection: string | undefined,
+    format: ExportFormat
   ): string | undefined {
     const { baseURL, params } = this.client.defaults;
 
     const searchParams = new URLSearchParams(params as Record<string, string>);
     searchParams.set('path', dataset.path);
-    searchParams.set('format', 'tiff');
+    searchParams.set('format', format);
 
     if (selection) {
       searchParams.set('selection', selection);

--- a/packages/app/src/providers/models.ts
+++ b/packages/app/src/providers/models.ts
@@ -28,3 +28,5 @@ export interface AttrValuesStore extends FetchStore<AttributeValues, Entity> {
     attrName: NxAttribute | ImageAttribute
   ) => unknown | undefined;
 }
+
+export type ExportFormat = 'csv' | 'npy' | 'tiff';

--- a/packages/app/src/vis-packs/core/heatmap/HeatmapToolbar.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/HeatmapToolbar.tsx
@@ -1,6 +1,6 @@
 import type { Domain } from '@h5web/lib';
 import {
-  DownloadBtn,
+  ExportMenu,
   ColorMapSelector,
   DomainSlider,
   FlipYAxisToggler,
@@ -14,12 +14,14 @@ import {
 } from '@h5web/lib';
 import type { ArrayShape, Dataset, NumericType } from '@h5web/shared';
 import { useEffect, useContext } from 'react';
-import { FiDownload } from 'react-icons/fi';
 import { MdAspectRatio } from 'react-icons/md';
 import shallow from 'zustand/shallow';
 
 import { ProviderContext } from '../../../providers/context';
+import type { ExportFormat } from '../../../providers/models';
 import { useHeatmapConfig } from './config';
+
+const EXPORT_FORMATS: ExportFormat[] = ['tiff', 'npy'];
 
 interface Props {
   dataset: Dataset<ArrayShape, NumericType>;
@@ -31,7 +33,7 @@ interface Props {
 function HeatmapToolbar(props: Props) {
   const { dataset, dataDomain, selection, initialScaleType } = props;
 
-  const { getTiffUrl } = useContext(ProviderContext);
+  const { getExportURL } = useContext(ProviderContext);
 
   const {
     customDomain,
@@ -101,14 +103,16 @@ function HeatmapToolbar(props: Props) {
 
       <Separator />
 
-      {getTiffUrl && (
-        <DownloadBtn
-          label="Export to TIFF"
-          icon={FiDownload}
-          filename="data.tiff"
-          getDownloadUrl={() => getTiffUrl(dataset, selection)}
+      {getExportURL && (
+        <ExportMenu
+          formats={EXPORT_FORMATS}
+          isSlice={selection !== undefined}
+          getFormatURL={(format: ExportFormat) =>
+            getExportURL(dataset, selection, format)
+          }
         />
       )}
+
       <SnapshotButton />
     </Toolbar>
   );

--- a/packages/app/src/vis-packs/core/heatmap/HeatmapToolbar.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/HeatmapToolbar.tsx
@@ -1,5 +1,6 @@
 import type { Domain } from '@h5web/lib';
 import {
+  DownloadBtn,
   ColorMapSelector,
   DomainSlider,
   FlipYAxisToggler,
@@ -11,19 +12,26 @@ import {
   ToggleBtn,
   Toolbar,
 } from '@h5web/lib';
-import { useEffect } from 'react';
+import type { ArrayShape, Dataset, NumericType } from '@h5web/shared';
+import { useEffect, useContext } from 'react';
+import { FiDownload } from 'react-icons/fi';
 import { MdAspectRatio } from 'react-icons/md';
 import shallow from 'zustand/shallow';
 
+import { ProviderContext } from '../../../providers/context';
 import { useHeatmapConfig } from './config';
 
 interface Props {
+  dataset: Dataset<ArrayShape, NumericType>;
   dataDomain: Domain;
+  selection: string | undefined;
   initialScaleType: ScaleType | undefined;
 }
 
 function HeatmapToolbar(props: Props) {
-  const { dataDomain, initialScaleType } = props;
+  const { dataset, dataDomain, selection, initialScaleType } = props;
+
+  const { getTiffUrl } = useContext(ProviderContext);
 
   const {
     customDomain,
@@ -93,6 +101,14 @@ function HeatmapToolbar(props: Props) {
 
       <Separator />
 
+      {getTiffUrl && (
+        <DownloadBtn
+          label="Export to TIFF"
+          icon={FiDownload}
+          filename="data.tiff"
+          getDownloadUrl={() => getTiffUrl(dataset, selection)}
+        />
+      )}
       <SnapshotButton />
     </Toolbar>
   );

--- a/packages/app/src/vis-packs/core/heatmap/HeatmapVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/HeatmapVisContainer.tsx
@@ -22,6 +22,7 @@ function HeatmapVisContainer(props: VisContainerProps) {
 
   const { shape: dims } = entity;
   const [dimMapping, setDimMapping] = useDimMappingState(dims, 2);
+  const selection = getSliceSelection(dimMapping);
 
   return (
     <>
@@ -33,14 +34,15 @@ function HeatmapVisContainer(props: VisContainerProps) {
       <VisBoundary resetKey={dimMapping} loadingMessage="Loading current slice">
         <ValueFetcher
           dataset={entity}
-          selection={getSliceSelection(dimMapping)}
+          selection={selection}
           render={(value) => (
             <MappedHeatmapVis
+              dataset={entity}
+              selection={selection}
               value={value}
               dims={dims}
               dimMapping={dimMapping}
               title={entity.name}
-              dtype={entity.type}
               toolbarContainer={toolbarContainer}
             />
           )}

--- a/packages/app/src/vis-packs/core/heatmap/MappedHeatmapVis.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/MappedHeatmapVis.tsx
@@ -1,5 +1,10 @@
 import { HeatmapVis } from '@h5web/lib';
-import type { NumericType, ScaleType } from '@h5web/shared';
+import type {
+  ArrayShape,
+  Dataset,
+  NumericType,
+  ScaleType,
+} from '@h5web/shared';
 import { createPortal } from 'react-dom';
 import shallow from 'zustand/shallow';
 
@@ -12,24 +17,26 @@ import { useHeatmapConfig } from './config';
 import { useSafeDomain, useVisDomain } from './hooks';
 
 interface Props {
+  dataset: Dataset<ArrayShape, NumericType>;
+  selection: string | undefined;
   value: number[];
   dims: number[];
   dimMapping: DimensionMapping;
   axisMapping?: AxisMapping;
   title: string;
   colorScaleType?: ScaleType;
-  dtype?: NumericType;
   toolbarContainer: HTMLDivElement | undefined;
 }
 
 function MappedHeatmapVis(props: Props) {
   const {
+    dataset,
+    selection,
     value,
     dims,
     dimMapping,
     axisMapping = [],
     title,
-    dtype,
     colorScaleType,
     toolbarContainer,
   } = props;
@@ -58,7 +65,9 @@ function MappedHeatmapVis(props: Props) {
       {toolbarContainer &&
         createPortal(
           <HeatmapToolbar
+            dataset={dataset}
             dataDomain={dataDomain}
+            selection={selection}
             initialScaleType={colorScaleType}
           />,
           toolbarContainer
@@ -67,7 +76,7 @@ function MappedHeatmapVis(props: Props) {
       <HeatmapVis
         dataArray={dataArray}
         title={title}
-        dtype={dtype}
+        dtype={dataset.type}
         domain={safeDomain}
         colorMap={colorMap}
         scaleType={scaleType}

--- a/packages/app/src/vis-packs/core/line/LineToolbar.tsx
+++ b/packages/app/src/vis-packs/core/line/LineToolbar.tsx
@@ -1,22 +1,29 @@
 import {
   CurveType,
+  ExportMenu,
   ScaleSelector,
   Separator,
   ToggleBtn,
   ToggleGroup,
   Toolbar,
 } from '@h5web/lib';
+import type { ArrayShape, Dataset, NumericType } from '@h5web/shared';
 import { ScaleType } from '@h5web/shared';
-import { useEffect } from 'react';
+import { useContext, useEffect } from 'react';
 import { FiItalic } from 'react-icons/fi';
 import { MdGridOn, MdDomain } from 'react-icons/md';
 import shallow from 'zustand/shallow';
 
+import { ProviderContext } from '../../../providers/context';
+import type { ExportFormat } from '../../../providers/models';
 import { useLineConfig } from './config';
 
 const SCALETYPE_OPTIONS = [ScaleType.Linear, ScaleType.Log, ScaleType.SymLog];
+const EXPORT_FORMATS: ExportFormat[] = ['npy', 'csv'];
 
 interface Props {
+  dataset?: Dataset<ArrayShape, NumericType>;
+  selection?: string | undefined;
   initialXScaleType: ScaleType | undefined;
   initialYScaleType: ScaleType | undefined;
   disableAutoScale: boolean;
@@ -25,11 +32,15 @@ interface Props {
 
 function LineToolbar(props: Props) {
   const {
+    dataset,
+    selection,
     initialXScaleType,
     initialYScaleType,
     disableAutoScale,
     disableErrors,
   } = props;
+
+  const { getExportURL } = useContext(ProviderContext);
 
   const {
     curveType,
@@ -118,6 +129,19 @@ function LineToolbar(props: Props) {
         <ToggleGroup.Btn label="Points" value={CurveType.GlyphsOnly} />
         <ToggleGroup.Btn label="Both" value={CurveType.LineAndGlyphs} />
       </ToggleGroup>
+
+      {getExportURL && dataset && (
+        <>
+          <Separator />
+          <ExportMenu
+            formats={EXPORT_FORMATS}
+            isSlice={selection !== undefined}
+            getFormatURL={(format: ExportFormat) =>
+              getExportURL(dataset, selection, format)
+            }
+          />
+        </>
+      )}
     </Toolbar>
   );
 }

--- a/packages/app/src/vis-packs/core/line/LineVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/line/LineVisContainer.tsx
@@ -23,6 +23,7 @@ function LineVisContainer(props: VisContainerProps) {
   const [dimMapping, setDimMapping] = useDimMappingState(dims, 1);
 
   const autoScale = useLineConfig((state) => state.autoScale);
+  const selection = autoScale ? getSliceSelection(dimMapping) : undefined;
 
   return (
     <>
@@ -39,14 +40,15 @@ function LineVisContainer(props: VisContainerProps) {
       >
         <ValueFetcher
           dataset={entity}
-          selection={autoScale ? getSliceSelection(dimMapping) : undefined}
+          selection={selection}
           render={(value) => (
             <MappedLineVis
+              dataset={entity}
+              selection={selection}
               value={value}
               dims={dims}
               dimMapping={dimMapping}
               title={entity.name}
-              dtype={entity.type}
               toolbarContainer={toolbarContainer}
             />
           )}

--- a/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
+++ b/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
@@ -1,5 +1,10 @@
 import { LineVis } from '@h5web/lib';
-import type { NumericType, ScaleType } from '@h5web/shared';
+import type {
+  ArrayShape,
+  Dataset,
+  NumericType,
+  ScaleType,
+} from '@h5web/shared';
 import { createPortal } from 'react-dom';
 import shallow from 'zustand/shallow';
 
@@ -19,6 +24,8 @@ import { useLineConfig } from './config';
 type HookArgs = [number[], DimensionMapping, boolean];
 
 interface Props {
+  dataset?: Dataset<ArrayShape, NumericType>;
+  selection?: string | undefined;
   value: number[];
   valueLabel?: string;
   valueScaleType?: ScaleType;
@@ -28,12 +35,13 @@ interface Props {
   dimMapping: DimensionMapping;
   axisMapping?: AxisMapping;
   title: string;
-  dtype?: NumericType;
   toolbarContainer?: HTMLDivElement | undefined;
 }
 
 function MappedLineVis(props: Props) {
   const {
+    dataset,
+    selection,
     value,
     valueLabel,
     valueScaleType,
@@ -43,7 +51,6 @@ function MappedLineVis(props: Props) {
     dimMapping,
     axisMapping = [],
     title,
-    dtype,
     toolbarContainer,
   } = props;
 
@@ -75,6 +82,8 @@ function MappedLineVis(props: Props) {
       {toolbarContainer &&
         createPortal(
           <LineToolbar
+            dataset={dataset}
+            selection={selection}
             initialXScaleType={mappedAbscissaParams?.scaleType}
             initialYScaleType={valueScaleType}
             disableAutoScale={dims.length <= 1} // with 1D datasets, `baseArray` and `dataArray` are the same so auto-scaling is implied
@@ -96,7 +105,7 @@ function MappedLineVis(props: Props) {
         }}
         ordinateLabel={valueLabel}
         title={title}
-        dtype={dtype}
+        dtype={dataset?.type}
         errorsArray={errorArray}
         showErrors={showErrors}
         auxArrays={auxArrays}

--- a/packages/app/src/vis-packs/core/matrix/MappedMatrixVis.tsx
+++ b/packages/app/src/vis-packs/core/matrix/MappedMatrixVis.tsx
@@ -1,5 +1,10 @@
 import { MatrixVis } from '@h5web/lib';
-import type { Primitive, PrintableType } from '@h5web/shared';
+import type {
+  ArrayShape,
+  Dataset,
+  Primitive,
+  PrintableType,
+} from '@h5web/shared';
 import { createPortal } from 'react-dom';
 
 import type { DimensionMapping } from '../../../dimension-mapper/models';
@@ -8,6 +13,8 @@ import MatrixToolbar from './MatrixToolbar';
 import { useMatrixVisConfig } from './config';
 
 interface Props {
+  dataset: Dataset<ArrayShape, PrintableType>;
+  selection: string | undefined;
   value: Primitive<PrintableType>[];
   dims: number[];
   dimMapping: DimensionMapping;
@@ -17,8 +24,16 @@ interface Props {
 }
 
 function MappedMatrixVis(props: Props) {
-  const { value, dims, dimMapping, formatter, cellWidth, toolbarContainer } =
-    props;
+  const {
+    dataset,
+    selection,
+    value,
+    dims,
+    dimMapping,
+    formatter,
+    cellWidth,
+    toolbarContainer,
+  } = props;
 
   const sticky = useMatrixVisConfig((state) => state.sticky);
 
@@ -29,7 +44,7 @@ function MappedMatrixVis(props: Props) {
     <>
       {toolbarContainer &&
         createPortal(
-          <MatrixToolbar currentSlice={mappedArray} />,
+          <MatrixToolbar dataset={dataset} selection={selection} />,
           toolbarContainer
         )}
 

--- a/packages/app/src/vis-packs/core/matrix/MatrixToolbar.tsx
+++ b/packages/app/src/vis-packs/core/matrix/MatrixToolbar.tsx
@@ -1,22 +1,25 @@
-import { DownloadBtn, Separator, ToggleBtn, Toolbar } from '@h5web/lib';
-import type { Primitive, PrintableType } from '@h5web/shared';
-import type { NdArray } from 'ndarray';
-import { FiAnchor, FiDownload } from 'react-icons/fi';
+import { Separator, ToggleBtn, Toolbar, ExportMenu } from '@h5web/lib';
+import type { ArrayShape, Dataset, PrintableType } from '@h5web/shared';
+import { hasNumericType } from '@h5web/shared';
+import { useContext } from 'react';
+import { FiAnchor } from 'react-icons/fi';
 
+import { ProviderContext } from '../../../providers/context';
+import type { ExportFormat } from '../../../providers/models';
 import { useMatrixVisConfig } from './config';
-import { sliceToCsv } from './utils';
+
+const EXPORT_FORMATS: ExportFormat[] = ['npy', 'csv'];
 
 interface Props {
-  currentSlice: NdArray<Primitive<PrintableType>[]> | undefined;
+  dataset: Dataset<ArrayShape, PrintableType>;
+  selection: string | undefined;
 }
 
 function MatrixToolbar(props: Props) {
-  const { currentSlice } = props;
-  const { sticky, toggleSticky } = useMatrixVisConfig();
+  const { dataset, selection } = props;
+  const { getExportURL } = useContext(ProviderContext);
 
-  if (currentSlice && currentSlice.shape.length > 2) {
-    throw new Error('Expected current slice to have at most two dimensions');
-  }
+  const { sticky, toggleSticky } = useMatrixVisConfig();
 
   return (
     <Toolbar>
@@ -27,20 +30,17 @@ function MatrixToolbar(props: Props) {
         onToggle={toggleSticky}
       />
 
-      <Separator />
-
-      {currentSlice && (
-        <DownloadBtn
-          icon={FiDownload}
-          label="CSV"
-          filename="export.csv"
-          getDownloadUrl={() => {
-            const data = sliceToCsv(currentSlice);
-            return URL.createObjectURL(
-              new Blob([data], { type: 'text/csv;charset=utf-8' })
-            );
-          }}
-        />
+      {getExportURL && hasNumericType(dataset) && (
+        <>
+          <Separator />
+          <ExportMenu
+            formats={EXPORT_FORMATS}
+            isSlice={selection !== undefined}
+            getFormatURL={(format: ExportFormat) =>
+              getExportURL(dataset, selection, format)
+            }
+          />
+        </>
       )}
     </Toolbar>
   );

--- a/packages/app/src/vis-packs/core/matrix/MatrixVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/matrix/MatrixVisContainer.tsx
@@ -23,6 +23,7 @@ function MatrixVisContainer(props: VisContainerProps) {
   const { shape: dims } = entity;
   const axesCount = Math.min(dims.length, 2);
   const [dimMapping, setDimMapping] = useDimMappingState(dims, axesCount);
+  const selection = getSliceSelection(dimMapping);
 
   const formatter = getFormatter(entity);
   const cellWidth = hasComplexType(entity) ? 232 : 116;
@@ -37,9 +38,11 @@ function MatrixVisContainer(props: VisContainerProps) {
       <VisBoundary resetKey={dimMapping} loadingMessage="Loading current slice">
         <ValueFetcher
           dataset={entity}
-          selection={getSliceSelection(dimMapping)}
+          selection={selection}
           render={(value) => (
             <MappedMatrixVis
+              dataset={entity}
+              selection={selection}
               value={value}
               dims={dims}
               dimMapping={dimMapping}

--- a/packages/app/src/vis-packs/core/matrix/utils.ts
+++ b/packages/app/src/vis-packs/core/matrix/utils.ts
@@ -3,7 +3,6 @@ import type {
   ArrayShape,
   PrintableType,
   H5WebComplex,
-  Primitive,
 } from '@h5web/shared';
 import {
   hasComplexType,
@@ -11,7 +10,6 @@ import {
   formatMatrixComplex,
   formatMatrixValue,
 } from '@h5web/shared';
-import type { NdArray } from 'ndarray';
 
 import type { ValueFormatter } from '../models';
 
@@ -27,30 +25,4 @@ export function getFormatter(
   }
 
   return (val) => (val as string).toString();
-}
-
-export function sliceToCsv(slice: NdArray<Primitive<PrintableType>[]>): string {
-  let csv = '';
-
-  if (slice.shape.length === 1) {
-    for (let i = 0; i < slice.shape[0]; i++) {
-      csv += `${slice.get(i).toString()}\n`; // complex numbers are stringifyied as two values
-    }
-
-    return csv;
-  }
-
-  if (slice.shape.length === 2) {
-    for (let i = 0; i < slice.shape[0]; i++) {
-      let line = '';
-      for (let j = 0; j < slice.shape[1]; j++) {
-        line += `${slice.get(i, j).toString()},`; // complex numbers are stringifyied as two values
-      }
-      csv += `${line.replace(/,$/u, '\n')}`;
-    }
-
-    return csv;
-  }
-
-  throw new Error('Expected at most 2 dimensions');
 }

--- a/packages/app/src/vis-packs/nexus/containers/NxImageContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxImageContainer.tsx
@@ -22,6 +22,7 @@ function NxImageContainer(props: VisContainerProps) {
 
   const { shape: dims } = signalDataset;
   const [dimMapping, setDimMapping] = useDimMappingState(dims, 2);
+  const selection = getSliceSelection(dimMapping);
 
   return (
     <>
@@ -33,19 +34,20 @@ function NxImageContainer(props: VisContainerProps) {
       <VisBoundary resetKey={dimMapping}>
         <NxValuesFetcher
           nxData={nxData}
-          selection={getSliceSelection(dimMapping)}
+          selection={selection}
           render={(nxValues) => {
             const { signal, axisMapping, title } = nxValues;
 
             return (
               <MappedHeatmapVis
+                dataset={signalDataset}
+                selection={selection}
                 value={signal}
                 dims={dims}
                 dimMapping={dimMapping}
                 axisMapping={axisMapping}
                 title={title}
                 colorScaleType={silxStyle.signalScaleType}
-                dtype={signalDataset.type}
                 toolbarContainer={toolbarContainer}
               />
             );

--- a/packages/app/src/vis-packs/nexus/containers/NxSpectrumContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxSpectrumContainer.tsx
@@ -31,6 +31,7 @@ function NxSpectrumContainer(props: VisContainerProps) {
   const [dimMapping, setDimMapping] = useDimMappingState(signalDims, 1);
 
   const autoScale = useLineConfig((state) => state.autoScale);
+  const selection = autoScale ? getSliceSelection(dimMapping) : undefined;
 
   return (
     <>
@@ -42,7 +43,7 @@ function NxSpectrumContainer(props: VisContainerProps) {
       <VisBoundary resetKey={dimMapping}>
         <NxValuesFetcher
           nxData={nxData}
-          selection={autoScale ? getSliceSelection(dimMapping) : undefined}
+          selection={selection}
           render={(nxValues) => {
             const {
               signal,
@@ -55,6 +56,8 @@ function NxSpectrumContainer(props: VisContainerProps) {
 
             return (
               <MappedLineVis
+                dataset={signalDataset}
+                selection={selection}
                 value={signal}
                 valueLabel={signalLabel}
                 valueScaleType={silxStyle.signalScaleType}
@@ -64,7 +67,6 @@ function NxSpectrumContainer(props: VisContainerProps) {
                 dimMapping={dimMapping}
                 axisMapping={axisMapping}
                 title={title}
-                dtype={signalDataset.type}
                 toolbarContainer={toolbarContainer}
               />
             );

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -22,6 +22,7 @@ export { default as ScaleSelector } from './toolbar/controls/ScaleSelector/Scale
 export { default as GridToggler } from './toolbar/controls/GridToggler';
 export { default as FlipYAxisToggler } from './toolbar/controls/FlipYAxisToggler';
 export { default as Selector } from './toolbar/controls/Selector/Selector';
+export { default as ExportMenu } from './toolbar/controls/ExportMenu';
 
 // Building blocks
 export { default as VisCanvas } from './vis/shared/VisCanvas';

--- a/packages/lib/src/toolbar/controls/DownloadBtn.tsx
+++ b/packages/lib/src/toolbar/controls/DownloadBtn.tsx
@@ -8,8 +8,8 @@ interface Props extends AriaAttributes {
   iconOnly?: boolean;
   // If specified, browser will prompt user to download the file instead of opening a new tab
   filename?: string;
-  // Invoked on click; must return URL to set as `href`, or `false` to do nothing
-  getDownloadUrl: () => string | false;
+  // Invoked on click; must return URL to set as `href`, or `undefined` to do nothing
+  getDownloadUrl: () => string | undefined;
 }
 
 function DownloadBtn(props: Props) {
@@ -33,7 +33,7 @@ function DownloadBtn(props: Props) {
       onClick={(evt) => {
         const url = getDownloadUrl();
 
-        if (url === false) {
+        if (url === undefined) {
           evt.preventDefault();
           return;
         }

--- a/packages/lib/src/toolbar/controls/ExportMenu.tsx
+++ b/packages/lib/src/toolbar/controls/ExportMenu.tsx
@@ -1,0 +1,60 @@
+import { isDefined } from '@h5web/shared';
+import { Button, Wrapper, Menu } from 'react-aria-menubutton';
+import { FiDownload } from 'react-icons/fi';
+import { MdArrowDropDown } from 'react-icons/md';
+
+import styles from './Selector/Selector.module.css';
+
+interface Props<F extends string> {
+  formats: F[];
+  isSlice: boolean;
+  getFormatURL: (format: F) => string | undefined; // `undefined` if format is not supported
+}
+
+function ExportMenu<F extends string>(props: Props<F>) {
+  const { formats, isSlice, getFormatURL } = props;
+
+  const urls = formats.map(getFormatURL);
+  const hasSupportedFormats = urls.some(isDefined);
+
+  return (
+    <Wrapper className={styles.wrapper}>
+      <Button
+        className={styles.btn}
+        tag="button"
+        disabled={!hasSupportedFormats}
+      >
+        <div className={styles.btnLike}>
+          <FiDownload className={styles.icon} />
+          <span className={styles.selectedOption}>
+            Export{isSlice && ' slice'}
+          </span>
+          <MdArrowDropDown className={styles.arrowIcon} />
+        </div>
+      </Button>
+      <Menu className={styles.menu}>
+        <div className={styles.list}>
+          {formats.map(
+            (format, index) =>
+              urls[index] && (
+                <a
+                  key={format}
+                  className={styles.linkOption}
+                  href={urls[index]}
+                  target="_blank"
+                  download={`data.${format}`}
+                  rel="noreferrer"
+                >
+                  <span
+                    className={styles.label}
+                  >{`Export to ${format.toUpperCase()}`}</span>
+                </a>
+              )
+          )}
+        </div>
+      </Menu>
+    </Wrapper>
+  );
+}
+
+export default ExportMenu;

--- a/packages/lib/src/toolbar/controls/Selector/Selector.module.css
+++ b/packages/lib/src/toolbar/controls/Selector/Selector.module.css
@@ -3,7 +3,7 @@
   align-items: center;
 }
 
-.label {
+.selectorLabel {
   color: var(--h5w-selector-label--color, royalblue);
   margin-left: 0.25rem;
 }
@@ -20,6 +20,14 @@
 .btnLike {
   composes: btnLike from '../../Toolbar.module.css';
   padding: 0 0.375rem 0 0.5625rem !important; /* FIX style ordering issue with Vite */
+}
+
+.icon {
+  composes: icon from '../../Toolbar.module.css';
+}
+
+.label {
+  composes: label from '../../Toolbar.module.css';
 }
 
 .arrowIcon {
@@ -79,18 +87,15 @@
   white-space: nowrap;
 }
 
+.linkOption {
+  composes: btn from '../../Toolbar.module.css';
+  composes: option;
+}
+
 .option:hover {
   background-color: var(--h5w-selector-option-hover--bgColor, whitesmoke);
 }
 
 .option[data-selected] {
   background-color: var(--h5w-selector-option-selected--bgColor, #eee);
-}
-
-.gradient {
-  position: relative;
-  top: 1px;
-  width: 2rem;
-  height: 1.25em;
-  margin-left: 0.625rem;
 }

--- a/packages/lib/src/toolbar/controls/Selector/Selector.tsx
+++ b/packages/lib/src/toolbar/controls/Selector/Selector.tsx
@@ -34,7 +34,7 @@ function Selector<T extends string>(props: Props<T>) {
 
   return (
     <div className={styles.root}>
-      {label && <span className={styles.label}>{label}</span>}
+      {label && <span className={styles.selectorLabel}>{label}</span>}
 
       <Wrapper className={styles.wrapper} onSelection={onChange}>
         <Button className={styles.btn} tag="button" disabled={disabled}>

--- a/packages/lib/src/toolbar/controls/SnapshotButton.tsx
+++ b/packages/lib/src/toolbar/controls/SnapshotButton.tsx
@@ -11,7 +11,7 @@ function SnapshotButton() {
       getDownloadUrl={() => {
         // Create data URL from canvas (if rendered)
         const canvas = document.querySelector('canvas');
-        return canvas?.toDataURL() || false;
+        return canvas?.toDataURL();
       }}
     />
   );


### PR DESCRIPTION
Fix #35 

The feature detection is actually quite simple: I've discovered that an abstract class can have an optional method! So if the provider implements the method, it is defined; otherwise it isn't. This means that the toolbar can just check if `getTiffUrl` is defined to decide whether to show the export button.

I've provided a tentative implementation of the method for H5Grove. It returns a URL of this form: `https://<h5grove.url>/tiff/?<axios-params>&path=/foo&selection=0:,:`. Up to H5Grove to then respond at this URL with the TIFF data and the correct `Content-type` HTTP header (`image/tiff`).

![image](https://user-images.githubusercontent.com/2936402/144072879-d47a2099-91d0-490d-a5d2-ae9929ca088b.png)

---

### Update

I've merged #890 into this branch, so now it includes CSV and NPY exports as well.