### PR TITLE
Show progress while fetching dataset values

### DIFF
--- a/packages/app/src/providers/Provider.tsx
+++ b/packages/app/src/providers/Provider.tsx
@@ -8,15 +8,17 @@ import { hasAttribute } from '../utils';
 import type { ImageAttribute } from '../vis-packs/core/models';
 import type { NxAttribute } from '../vis-packs/nexus/models';
 import type { ProviderApi } from './api';
-import { ProviderContext } from './context';
+import { ProgressContext, ProviderContext } from './context';
 
 interface Props {
   api: ProviderApi;
+  progress: number;
+  resetProgress: () => void;
   children: ReactNode;
 }
 
 function Provider(props: Props) {
-  const { api, children } = props;
+  const { api, progress, resetProgress, children } = props;
 
   const entitiesStore = useMemo(() => {
     const childCache = new Map<string, Entity>();
@@ -91,9 +93,12 @@ function Provider(props: Props) {
         valuesStore,
         attrValuesStore,
         getExportURL: api.getExportURL?.bind(api),
+        resetProgress,
       }}
     >
-      {children}
+      <ProgressContext.Provider value={progress}>
+        {children}
+      </ProgressContext.Provider>
     </ProviderContext.Provider>
   );
 }

--- a/packages/app/src/providers/api.ts
+++ b/packages/app/src/providers/api.ts
@@ -28,9 +28,15 @@ export abstract class ProviderApi {
 
   protected readonly client: AxiosInstance;
   protected readonly valueRequests = new Set<ValueRequest>();
+  protected readonly onValueProgress;
 
-  public constructor(filepath: string, config?: AxiosRequestConfig) {
+  public constructor(
+    filepath: string,
+    config?: AxiosRequestConfig,
+    onValueProgress?: (val: number) => void
+  ) {
     this.filepath = filepath;
+    this.onValueProgress = onValueProgress;
     this.client = axios.create(config);
   }
 
@@ -68,6 +74,11 @@ export abstract class ProviderApi {
         cancelToken,
         params: queryParams || storeParams,
         responseType,
+        onDownloadProgress: (evt: ProgressEvent) => {
+          if (this.onValueProgress && evt.total > 0) {
+            this.onValueProgress((evt.loaded / evt.total) * 100);
+          }
+        },
       });
     } finally {
       // Remove cancellation source when request fulfills

--- a/packages/app/src/providers/context.ts
+++ b/packages/app/src/providers/context.ts
@@ -10,6 +10,9 @@ interface Context {
   valuesStore: ValuesStore;
   attrValuesStore: AttrValuesStore;
   getExportURL?: ProviderApi['getExportURL'];
+  resetProgress: () => void;
 }
 
 export const ProviderContext = createContext({} as Context);
+
+export const ProgressContext = createContext(0);

--- a/packages/app/src/providers/h5grove/H5GroveProvider.tsx
+++ b/packages/app/src/providers/h5grove/H5GroveProvider.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { useMemo } from 'react';
+import { useState, useMemo } from 'react';
 
 import Provider from '../Provider';
 import { H5GroveApi } from './h5grove-api';
@@ -14,12 +14,22 @@ interface Props {
 function H5GroveProvider(props: Props) {
   const { url, filepath, axiosParams, children } = props;
 
+  const [progress, setProgress] = useState(0);
+
   const api = useMemo(
-    () => new H5GroveApi(url, filepath, axiosParams),
+    () => new H5GroveApi(url, filepath, axiosParams, setProgress),
     [filepath, url, axiosParams]
   );
 
-  return <Provider api={api}>{children}</Provider>;
+  return (
+    <Provider
+      api={api}
+      progress={progress}
+      resetProgress={() => setProgress(0)}
+    >
+      {children}
+    </Provider>
+  );
 }
 
 export default H5GroveProvider;

--- a/packages/app/src/providers/h5grove/h5grove-api.ts
+++ b/packages/app/src/providers/h5grove/h5grove-api.ts
@@ -37,12 +37,10 @@ export class H5GroveApi extends ProviderApi {
   public constructor(
     url: string,
     filepath: string,
-    axiosParams?: Record<string, string>
+    axiosParams?: Record<string, string>,
+    onValueProgress?: (val: number) => void
   ) {
-    super(filepath, {
-      baseURL: url,
-      params: axiosParams,
-    });
+    super(filepath, { baseURL: url, params: axiosParams }, onValueProgress);
   }
 
   public async getEntity(path: string): Promise<Entity> {

--- a/packages/app/src/vis-packs/ValueLoader.tsx
+++ b/packages/app/src/vis-packs/ValueLoader.tsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react';
 import { useTimeout } from 'react-use';
 
-import { ProviderContext } from '../providers/context';
+import { ProgressContext, ProviderContext } from '../providers/context';
 import styles from './ValueLoader.module.css';
 
 interface Props {
@@ -11,6 +11,7 @@ interface Props {
 function ValueLoader(props: Props) {
   const { message = 'Loading data' } = props;
   const { valuesStore } = useContext(ProviderContext);
+  const progress = useContext(ProgressContext);
 
   // Wait a bit before showing loader to avoid flash
   const [isReady] = useTimeout(100);
@@ -32,7 +33,9 @@ function ValueLoader(props: Props) {
         <div />
         <div />
       </div>
-      <p>{message}...</p>
+      <p>
+        {message}... ({progress} %)
+      </p>
       <p>
         <button
           className={styles.cancelBtn}


### PR DESCRIPTION
Proof of concept for now. I'd like your view on the implementation before I add a proper progress bar.

![image](https://user-images.githubusercontent.com/2936402/144872330-04867088-e2bc-46f9-bcc4-7304e220feb2.png)

At the moment, I keep the progress state in `H5GroveProvider` so I can pass an `onValueProgress` callback when the API is instantiated. If I were to keep the progress state in `Provider`, I would have to add a `setOnValueProgress` or `setValueProgressCb method to the API to set the callback post-instantiation, which wouldn't be very elegant.

Since I only need the callback when actually fetching a value, I could add an argument to the API's `getValue` method. The downside is that I then need to propagate it to the `fetchValue`, `fetchBinaryValue` and `cancellableFetchValue` methods, which complexifies the signatures (especially for the latter method)...