### PR TITLE
Flatten arrays in backend in h5grove

### DIFF
--- a/packages/app/src/providers/api.ts
+++ b/packages/app/src/providers/api.ts
@@ -55,7 +55,7 @@ export abstract class ProviderApi {
   protected async cancellableFetchValue<T>(
     endpoint: string,
     storeParams: ValuesStoreParams,
-    queryParams?: Record<string, string | undefined>,
+    queryParams?: Record<string, string | boolean | undefined>,
     responseType?: ResponseType
   ): Promise<AxiosResponse<T>> {
     const cancelSource = axios.CancelToken.source();

--- a/packages/app/src/providers/h5grove/h5grove-api.ts
+++ b/packages/app/src/providers/h5grove/h5grove-api.ts
@@ -9,17 +9,12 @@ import type {
   NumericType,
   UnresolvedEntity,
 } from '@h5web/shared';
-import {
-  hasScalarShape,
-  hasArrayShape,
-  buildEntityPath,
-  EntityKind,
-} from '@h5web/shared';
+import { hasScalarShape, buildEntityPath, EntityKind } from '@h5web/shared';
 import { isString } from 'lodash';
 
 import { ProviderApi } from '../api';
 import type { ExportFormat, ValuesStoreParams } from '../models';
-import { convertDtype, flattenValue, handleAxiosError } from '../utils';
+import { convertDtype, handleAxiosError } from '../utils';
 import type {
   H5GroveAttribute,
   H5GroveAttrValuesResponse,
@@ -53,7 +48,7 @@ export class H5GroveApi extends ProviderApi {
   public async getValue(
     params: ValuesStoreParams
   ): Promise<H5GroveDataResponse> {
-    const { dataset, selection } = params;
+    const { dataset } = params;
 
     const DTypedArray = typedArrayFromDType(dataset.type);
     if (DTypedArray) {
@@ -62,10 +57,7 @@ export class H5GroveApi extends ProviderApi {
       return hasScalarShape(dataset) ? array[0] : [...array];
     }
 
-    const value = await this.fetchData(params);
-    return hasArrayShape(dataset)
-      ? flattenValue(value, dataset, selection)
-      : value;
+    return this.fetchData(params);
   }
 
   public async getAttrValues(entity: Entity): Promise<AttributeValues> {
@@ -132,7 +124,7 @@ export class H5GroveApi extends ProviderApi {
     const { data } = await this.cancellableFetchValue<H5GroveDataResponse>(
       `/data/`,
       params,
-      { path: params.dataset.path, selection: params.selection }
+      { path: params.dataset.path, selection: params.selection, flatten: true }
     );
     return data;
   }


### PR DESCRIPTION
Since [h5grove@0.0.12](https://github.com/silx-kit/h5grove/releases/tag/v0.0.12), it is possible to request a flattened array by setting the query parameter `flatten` to `true`.

The `flatten` has no effect for scalar datasets.