### PR TITLE
Optimise debouncing of re-renders on resize

### DIFF
--- a/packages/lib/src/vis/shared/VisCanvas.tsx
+++ b/packages/lib/src/vis/shared/VisCanvas.tsx
@@ -55,6 +55,7 @@ function VisCanvas(props: Props) {
           frameloop="demand" // disable game loop
           dpr={[1, 3]} // https://discoverthreejs.com/tips-and-tricks/#performance
           gl={{ preserveDrawingBuffer: true }} // for screenshot feature
+          resize={{ debounce: { scroll: 20, resize: 200 }, scroll: false }} // https://github.com/pmndrs/react-three-fiber/discussions/1906
         >
           <ambientLight />
           <AxisSystemProvider {...providerProps}>


### PR DESCRIPTION
I've opened a discussion thread on R3F's repo that explains what's going on: https://github.com/pmndrs/react-three-fiber/discussions/1906