### PR TITLE
Measure canvas area only when a specific canvas ratio is requested

### DIFF
--- a/apps/storybook/src/Utilities.stories.mdx
+++ b/apps/storybook/src/Utilities.stories.mdx
@@ -55,16 +55,6 @@ const extendedDomain3 = extendDomain([2, 2], 0.5); // [1, 3]
 const extendedDomain4 = extendDomain([1, 1], 1, ScaleType.Log); // [0.1, 10]
 ```
 
-#### computeCanvasSize
-
-Compute the optimal size for a visualization based on the available size and an aspect ratio. If `aspecRatio` is not provided, `availableSize` is returned unchanged.
-
-```ts
-computeCanvasSize(availableSize: Size, aspectRatio?: number): Size | undefined
-
-const size = computeCanvasSize({ width: 20, height: 10 }, 1.5); // { width: 15, height: 10 }
-```
-
 #### getLinearGradient
 
 Generate a CSS linear gradient for a given D3 interpolator, to be used as `background-image`. If `minMaxOnly` is `true`, the gradient will include only two colours stops.

--- a/packages/app/src/visualizer/VisManager.tsx
+++ b/packages/app/src/visualizer/VisManager.tsx
@@ -49,7 +49,7 @@ function VisManager(props: Props) {
         />
       </div>
 
-      <div className={styles.displayArea}>
+      <div className={styles.visArea}>
         <Profiler id={activeVis.name}>
           <Container
             key={entity.path}

--- a/packages/app/src/visualizer/Visualizer.module.css
+++ b/packages/app/src/visualizer/Visualizer.module.css
@@ -15,7 +15,7 @@
   background-color: var(--secondary-light-bg);
 }
 
-.displayArea {
+.visArea {
   flex: 1 1 0%;
   min-height: 0;
   display: flex;

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -45,7 +45,6 @@ export type { AxisSystemParams } from './vis/shared/AxisSystemContext';
 
 // Utilities
 export {
-  computeCanvasSize,
   getDomain,
   getDomains,
   getCombinedDomain,

--- a/packages/lib/src/vis/heatmap/HeatmapVis.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapVis.tsx
@@ -73,8 +73,8 @@ function HeatmapVis(props: Props) {
     <figure className={styles.root} aria-label={title} data-keep-canvas-colors>
       <VisCanvas
         title={title}
-        aspectRatio={layout === 'contain' ? cols / rows : undefined}
-        visRatio={layout === 'cover' ? cols / rows : undefined}
+        canvasRatio={layout === 'contain' ? cols / rows : undefined}
+        visRatio={layout !== 'fill' ? cols / rows : undefined}
         abscissaConfig={{
           visDomain: abscissaDomain,
           showGrid,

--- a/packages/lib/src/vis/hooks.ts
+++ b/packages/lib/src/vis/hooks.ts
@@ -6,7 +6,6 @@ import { useCallback, useMemo, useState } from 'react';
 import type { RefCallback } from 'react';
 import { createMemo } from 'react-use';
 
-import type { Size } from './models';
 import {
   getAxisDomain,
   getCombinedDomain,
@@ -46,21 +45,6 @@ export function useDomains(
     () => allBounds.map((bounds) => getValidDomainForScale(bounds, scaleType)),
     [allBounds, scaleType]
   );
-}
-
-export function useVisSize(ratioToRespect: number | undefined): Size {
-  const { width, height } = useThree((state) => state.size);
-
-  if (!ratioToRespect) {
-    return { width, height };
-  }
-
-  const canvasRatio = width / height;
-
-  return {
-    width: canvasRatio > ratioToRespect ? height * ratioToRespect : width,
-    height: canvasRatio < ratioToRespect ? width / ratioToRespect : height,
-  };
 }
 
 function onWheel(evt: WheelEvent) {

--- a/packages/lib/src/vis/rgb/RgbVis.tsx
+++ b/packages/lib/src/vis/rgb/RgbVis.tsx
@@ -63,8 +63,8 @@ function RgbVis(props: Props) {
     <figure className={styles.root} aria-label={title} data-keep-canvas-colors>
       <VisCanvas
         title={title}
-        aspectRatio={layout === 'contain' ? cols / rows : undefined}
-        visRatio={layout === 'cover' ? cols / rows : undefined}
+        canvasRatio={layout === 'contain' ? cols / rows : undefined}
+        visRatio={layout !== 'fill' ? cols / rows : undefined}
         abscissaConfig={{
           visDomain: [0, cols],
           showGrid,

--- a/packages/lib/src/vis/shared/AxisSystemProvider.tsx
+++ b/packages/lib/src/vis/shared/AxisSystemProvider.tsx
@@ -1,21 +1,22 @@
-import type { ReactNode } from 'react';
+import { useThree } from '@react-three/fiber';
+import type { PropsWithChildren } from 'react';
 
-import { useVisSize } from '../hooks';
 import type { AxisConfig } from '../models';
-import { getCanvasScale } from '../utils';
+import { getSizeToFit, getCanvasScale } from '../utils';
 import { AxisSystemContext } from './AxisSystemContext';
 
 interface Props {
-  visRatio?: number;
+  visRatio: number | undefined;
   abscissaConfig: AxisConfig;
   ordinateConfig: AxisConfig;
-  children: ReactNode;
 }
 
-function AxisSystemProvider(props: Props) {
+function AxisSystemProvider(props: PropsWithChildren<Props>) {
   const { visRatio, abscissaConfig, ordinateConfig, children } = props;
 
-  const visSize = useVisSize(visRatio);
+  const availableSize = useThree((state) => state.size);
+  const visSize = getSizeToFit(availableSize, visRatio);
+
   const abscissaScale = getCanvasScale(abscissaConfig, visSize.width);
   const ordinateScale = getCanvasScale(ordinateConfig, visSize.height);
 
@@ -34,5 +35,4 @@ function AxisSystemProvider(props: Props) {
   );
 }
 
-export type { Props as AxisSystemProviderProps };
 export default AxisSystemProvider;

--- a/packages/lib/src/vis/shared/VisCanvas.module.css
+++ b/packages/lib/src/vis/shared/VisCanvas.module.css
@@ -1,15 +1,16 @@
-.visArea {
+.canvasArea {
   position: relative;
   flex: 1 1 0%;
   overflow: hidden; /* prevent overflow when resizing */
 }
 
-.vis {
-  position: absolute; /* prevent feedback loop with `useMeasure` on wrapper */
+.canvasWrapper {
+  width: 100%; /* fill container by default (unless size is passed in JSX) */
+  height: 100%;
+  margin: 0 auto;
 }
 
-/* R3F's root element */
-.canvasWrapper {
+.r3fRoot {
   overflow: visible !important; /* show child axis grid, which is bigger than canvas */
   background-color: var(--h5w-canvas--bgColor, transparent);
 }

--- a/packages/lib/src/vis/utils.test.ts
+++ b/packages/lib/src/vis/utils.test.ts
@@ -3,7 +3,7 @@ import { ScaleType } from '@h5web/shared';
 import { tickStep } from 'd3-array';
 
 import {
-  computeCanvasSize,
+  getSizeToFit,
   getDomain,
   getDomains,
   extendDomain,
@@ -17,55 +17,21 @@ const MAX = Number.MAX_VALUE / 2;
 const POS_MIN = Number.MIN_VALUE;
 const { NaN: NAN, POSITIVE_INFINITY: INFINITY } = Number;
 
-describe('computeCanvasSize', () => {
-  describe('with aspect ratio > 1', () => {
-    it('should return available size with width reduced', () => {
-      const availableSize = { width: 20, height: 10 };
-      const size = computeCanvasSize(availableSize, 1.5);
-
-      expect(size?.width).toBeLessThanOrEqual(availableSize.width);
-      expect(size?.height).toBeLessThanOrEqual(availableSize.height);
-      expect(size).toEqual({ width: 10 * 1.5, height: 10 });
-    });
-
-    it('should return available size with height reduced', () => {
-      const availableSize = { width: 12, height: 50 };
-      const size = computeCanvasSize(availableSize, 3);
-
-      expect(size?.width).toBeLessThanOrEqual(availableSize.width);
-      expect(size?.height).toBeLessThanOrEqual(availableSize.height);
-      expect(size).toEqual({ width: 12, height: 12 / 3 });
-    });
+describe('getSizeToFit', () => {
+  it('should adjust width when requested ratio is greater than available ratio', () => {
+    const size = getSizeToFit({ width: 20, height: 10 }, 1.5);
+    expect(size).toEqual({ width: 10 * 1.5, height: 10 });
   });
 
-  describe('with aspect ratio < 1', () => {
-    it('should return available size with width reduced', () => {
-      const availableSize = { width: 20, height: 10 };
-      const size = computeCanvasSize(availableSize, 0.5);
-
-      expect(size?.width).toBeLessThanOrEqual(availableSize.width);
-      expect(size?.height).toBeLessThanOrEqual(availableSize.height);
-      expect(size).toEqual({ width: 10 * 0.5, height: 10 });
-    });
-
-    it('should return available size with height reduced', () => {
-      const availableSize = { width: 12, height: 50 };
-      const size = computeCanvasSize(availableSize, 0.75);
-
-      expect(size?.width).toBeLessThanOrEqual(availableSize.width);
-      expect(size?.height).toBeLessThanOrEqual(availableSize.height);
-      expect(size).toEqual({ width: 12, height: 12 / 0.75 });
-    });
+  it('should adjust height when request ratio is lower than available ratio', () => {
+    const availableSize = { width: 12, height: 50 };
+    const size = getSizeToFit(availableSize, 3);
+    expect(size).toEqual({ width: 12, height: 12 / 3 });
   });
 
   it('should return available size when no aspect ratio is provided', () => {
-    const size = computeCanvasSize({ width: 20, height: 10 }, undefined);
+    const size = getSizeToFit({ width: 20, height: 10 }, undefined);
     expect(size).toEqual({ width: 20, height: 10 });
-  });
-
-  it('should return `undefined` when no space is available for visualization', () => {
-    const size = computeCanvasSize({ width: 0, height: 0 }, 1);
-    expect(size).toBeUndefined();
   });
 });
 

--- a/packages/lib/src/vis/utils.ts
+++ b/packages/lib/src/vis/utils.ts
@@ -53,27 +53,22 @@ export function createAxisScale(
   return H5WEB_SCALES[ScaleType.Gamma].createScale({ ...config, exponent });
 }
 
-export function computeCanvasSize(
+export function getSizeToFit(
   availableSize: Size,
-  aspectRatio?: number
-): Size | undefined {
+  ratioToRespect: number | undefined
+): Size {
   const { width, height } = availableSize;
 
-  if (width <= 0 && height <= 0) {
-    return undefined;
+  if (!ratioToRespect) {
+    return { width, height };
   }
 
-  if (!aspectRatio) {
-    return availableSize;
-  }
+  const availableRatio = width / height;
 
-  // Determine how to compute canvas size to fit available space while maintaining aspect ratio
-  const idealHeight = width / aspectRatio;
-  const shouldReduceWidth = idealHeight > height;
-
-  return shouldReduceWidth
-    ? { width: height * aspectRatio, height }
-    : { width, height: width / aspectRatio };
+  return {
+    width: availableRatio > ratioToRespect ? height * ratioToRespect : width,
+    height: availableRatio < ratioToRespect ? width / ratioToRespect : height,
+  };
 }
 
 export function getDomain(


### PR DESCRIPTION
The goal is to avoid unnecessary re-renders of the heatmap vis' canvas when the layout is `fill` or `cover` (which is always the case in @h5web/app).

To make this behaviour a bit more readable, I actually reworked a few things:

- I merged `computeVisSize` and `useVisSize` into a single `getSizeToFit`, which takes an `availableSize` and a `ratioToRespect`.
- I moved the axis offsets padding to the measured container (now called `canvasArea` instead of `visArea`), removed the early return, etc.

As mentioned in a comment, one issue is that when the layout changes to/from `contain` dynamically (i.e. when the `canvasRatio` prop of `VisCanvas` changes between a number and `undefined`), the measuring either doesn't start (and nothing gets rendered), or doesn't stop (everything keeps re-rendering on resize).