### PR TITLE
Use void to mark promises that don't need to be awaited

### DIFF
--- a/apps/demo-cra-lib/package.json
+++ b/apps/demo-cra-lib/package.json
@@ -31,7 +31,7 @@
     "@types/react": "17.0.37",
     "@types/react-dom": "17.0.11",
     "eslint": "8.4.1",
-    "eslint-config-galex": "3.3.5",
+    "eslint-config-galex": "3.3.6",
     "react-app-rewire-alias": "1.0.3",
     "react-app-rewired": "2.1.8",
     "react-scripts": "4.0.3",

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -31,7 +31,7 @@
     "@types/react-dom": "17.0.11",
     "@types/react-router-dom": "5.3.2",
     "eslint": "8.4.1",
-    "eslint-config-galex": "3.3.5",
+    "eslint-config-galex": "3.3.6",
     "react-app-rewire-alias": "1.0.3",
     "react-app-rewired": "2.1.8",
     "react-scripts": "4.0.3",

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -40,7 +40,7 @@
     "@types/react": "17.0.37",
     "@types/react-dom": "17.0.11",
     "eslint": "8.4.1",
-    "eslint-config-galex": "3.3.5",
+    "eslint-config-galex": "3.3.6",
     "typescript": "4.5.2"
   },
   "browserslist": {

--- a/eslint.shared.js
+++ b/eslint.shared.js
@@ -37,7 +37,6 @@ const overrides = [
     files: tsFiles,
     rules: {
       '@typescript-eslint/ban-ts-comment': 'off', // too strict
-      '@typescript-eslint/no-floating-promises': 'off', // big crash sometimes better than silent fail
       '@typescript-eslint/lines-between-class-members': 'off', // allow grouping single-line members
       '@typescript-eslint/prefer-nullish-coalescing': 'off', // `||` is often conveninent and safe to use with TS
       '@typescript-eslint/explicit-module-boundary-types': 'off', // worsens readability sometimes (e.g. for React components)

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "cypress": "9.1.1",
     "cypress-image-snapshot": "4.0.1",
     "eslint": "8.4.1",
-    "eslint-config-galex": "3.3.5",
+    "eslint-config-galex": "3.3.6",
     "identity-obj-proxy": "3.0.0",
     "jest": "27.4.3",
     "jest-transform-stub": "2.0.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -70,7 +70,7 @@
     "@types/react": "17.0.37",
     "@types/react-slider": "1.3.1",
     "eslint": "8.4.1",
-    "eslint-config-galex": "3.3.5",
+    "eslint-config-galex": "3.3.6",
     "jest": "27.4.3",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/packages/app/src/breadcrumbs/CopyableCrumb.tsx
+++ b/packages/app/src/breadcrumbs/CopyableCrumb.tsx
@@ -20,7 +20,7 @@ function CopyableCrumb(props: Props) {
       type="button"
       title="Copy path to clipboard"
       onClick={() => {
-        navigator.clipboard.writeText(path);
+        void navigator.clipboard.writeText(path);
         setPathCopied(true);
       }}
       onPointerOut={() => setPathCopied(false)}

--- a/packages/app/src/providers/mock/mock-api.ts
+++ b/packages/app/src/providers/mock/mock-api.ts
@@ -86,7 +86,7 @@ export class MockApi extends ProviderApi {
       await new Promise<void>((resolve, reject) => {
         const timeout = setTimeout(() => resolve(), SLOW_TIMEOUT);
 
-        cancelSource.token.promise.then((error) => {
+        void cancelSource.token.promise.then((error) => {
           clearTimeout(timeout);
           reject(error);
         });

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -81,7 +81,7 @@
     "@types/react-window": "1.8.5",
     "@types/three": "0.135.0",
     "eslint": "8.4.1",
-    "eslint-config-galex": "3.3.5",
+    "eslint-config-galex": "3.3.6",
     "jest": "27.4.3",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -30,7 +30,7 @@
     "@types/react": "17.0.37",
     "d3-format": "3.1.0",
     "eslint": "8.4.1",
-    "eslint-config-galex": "3.3.5",
+    "eslint-config-galex": "3.3.6",
     "jest": "27.4.3",
     "lodash": "4.17.21",
     "ndarray": "1.0.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
       cypress: 9.1.1
       cypress-image-snapshot: 4.0.1
       eslint: 8.4.1
-      eslint-config-galex: 3.3.5
+      eslint-config-galex: 3.3.6
       identity-obj-proxy: 3.0.0
       jest: 27.4.3
       jest-transform-stub: 2.0.0
@@ -31,7 +31,7 @@ importers:
       cypress: 9.1.1
       cypress-image-snapshot: 4.0.1_cypress@9.1.1+jest@27.4.3
       eslint: 8.4.1
-      eslint-config-galex: 3.3.5_eslint@8.4.1+jest@27.4.3
+      eslint-config-galex: 3.3.6_eslint@8.4.1+jest@27.4.3
       identity-obj-proxy: 3.0.0
       jest: 27.4.3
       jest-transform-stub: 2.0.0
@@ -46,7 +46,7 @@ importers:
       '@types/react-dom': 17.0.11
       '@types/react-router-dom': 5.3.2
       eslint: 8.4.1
-      eslint-config-galex: 3.3.5
+      eslint-config-galex: 3.3.6
       normalize.css: 8.0.1
       react: 17.0.2
       react-app-polyfill: 2.0.0
@@ -68,7 +68,7 @@ importers:
       '@types/react-dom': 17.0.11
       '@types/react-router-dom': 5.3.2
       eslint: 8.4.1
-      eslint-config-galex: 3.3.5_eslint@8.4.1+jest@27.4.3
+      eslint-config-galex: 3.3.6_eslint@8.4.1+jest@27.4.3
       react-app-rewire-alias: 1.0.3_react-app-rewired@2.1.8
       react-app-rewired: 2.1.8_react-scripts@4.0.3
       react-scripts: 4.0.3_react@17.0.2+typescript@4.5.2
@@ -81,7 +81,7 @@ importers:
       '@types/react': 17.0.37
       '@types/react-dom': 17.0.11
       eslint: 8.4.1
-      eslint-config-galex: 3.3.5
+      eslint-config-galex: 3.3.6
       normalize.css: 8.0.1
       react: 17.0.2
       react-app-polyfill: 2.0.0
@@ -103,7 +103,7 @@ importers:
       '@types/react': 17.0.37
       '@types/react-dom': 17.0.11
       eslint: 8.4.1
-      eslint-config-galex: 3.3.5_eslint@8.4.1+jest@27.4.3
+      eslint-config-galex: 3.3.6_eslint@8.4.1+jest@27.4.3
       react-app-rewire-alias: 1.0.3_react-app-rewired@2.1.8
       react-app-rewired: 2.1.8_react-scripts@4.0.3
       react-scripts: 4.0.3_react@17.0.2+typescript@4.5.2
@@ -124,7 +124,7 @@ importers:
       '@types/react': 17.0.37
       '@types/react-dom': 17.0.11
       eslint: 8.4.1
-      eslint-config-galex: 3.3.5
+      eslint-config-galex: 3.3.6
       ndarray: 1.0.19
       normalize.css: 8.0.1
       react: 17.0.2
@@ -153,7 +153,7 @@ importers:
       '@types/react': 17.0.37
       '@types/react-dom': 17.0.11
       eslint: 8.4.1
-      eslint-config-galex: 3.3.5_eslint@8.4.1+jest@27.4.3
+      eslint-config-galex: 3.3.6_eslint@8.4.1+jest@27.4.3
       typescript: 4.5.2
 
   packages/app:
@@ -173,7 +173,7 @@ importers:
       axios: 0.24.0
       d3-format: 3.1.0
       eslint: 8.4.1
-      eslint-config-galex: 3.3.5
+      eslint-config-galex: 3.3.6
       jest: 27.4.3
       lodash: 4.17.21
       ndarray: 1.0.19
@@ -220,7 +220,7 @@ importers:
       '@types/react': 17.0.37
       '@types/react-slider': 1.3.1
       eslint: 8.4.1
-      eslint-config-galex: 3.3.5_eslint@8.4.1+jest@27.4.3
+      eslint-config-galex: 3.3.6_eslint@8.4.1+jest@27.4.3
       jest: 27.4.3
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -261,7 +261,7 @@ importers:
       d3-scale: 4.0.2
       d3-scale-chromatic: 3.0.0
       eslint: 8.4.1
-      eslint-config-galex: 3.3.5
+      eslint-config-galex: 3.3.6
       jest: 27.4.3
       lodash: 4.17.21
       ndarray: 1.0.19
@@ -322,7 +322,7 @@ importers:
       '@types/react-window': 1.8.5
       '@types/three': 0.135.0
       eslint: 8.4.1
-      eslint-config-galex: 3.3.5_eslint@8.4.1+jest@27.4.3
+      eslint-config-galex: 3.3.6_eslint@8.4.1+jest@27.4.3
       jest: 27.4.3
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -340,7 +340,7 @@ importers:
       '@types/react': 17.0.37
       d3-format: 3.1.0
       eslint: 8.4.1
-      eslint-config-galex: 3.3.5
+      eslint-config-galex: 3.3.6
       jest: 27.4.3
       lodash: 4.17.21
       ndarray: 1.0.19
@@ -354,7 +354,7 @@ importers:
       '@types/react': 17.0.37
       d3-format: 3.1.0
       eslint: 8.4.1
-      eslint-config-galex: 3.3.5_eslint@8.4.1+jest@27.4.3
+      eslint-config-galex: 3.3.6_eslint@8.4.1+jest@27.4.3
       jest: 27.4.3
       lodash: 4.17.21
       ndarray: 1.0.19
@@ -3632,8 +3632,8 @@ packages:
       glob-to-regexp: 0.3.0
     dev: true
 
-  /@next/eslint-plugin-next/12.0.6:
-    resolution: {integrity: sha512-MIBjPTlql+l9LTTse5HHhxAiFFpQG6FsQ46wQ2WDJFKjg7adE7DcbzUOpKPdkvgoK+RT/kJS23M3axSSEzKNYw==}
+  /@next/eslint-plugin-next/12.0.7:
+    resolution: {integrity: sha512-xk7eMjw4+roWWR/0ETIoToCNs2wdvCGgQUiUO390Rj33/82yxZsh+ODRSaFWkiKp8zHWQN5GCW+U5pfjt/gyQg==}
     dependencies:
       glob: 7.1.7
     dev: true
@@ -5860,8 +5860,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.5.0_7dce1c1998d507f579fc8c88aa3ea163:
-    resolution: {integrity: sha512-4bV6fulqbuaO9UMXU0Ia0o6z6if+kmMRW8rMRyfqXj/eGrZZRGedS4n0adeGNnjr8LKAM495hrQ7Tea52UWmQA==}
+  /@typescript-eslint/eslint-plugin/5.6.0_0d0cecf582ba45923647a091322795b0:
+    resolution: {integrity: sha512-MIbeMy5qfLqtgs1hWd088k1hOuRsN9JrHUPwVVKCD99EOUqScd7SrwoZl4Gso05EAP9w1kvLWUVGJOVpRPkDPA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^5.0.0
@@ -5871,17 +5871,17 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 5.5.0_eslint@8.4.1+typescript@4.5.2
-      '@typescript-eslint/parser': 5.5.0_eslint@8.4.1+typescript@4.5.2
-      '@typescript-eslint/scope-manager': 5.5.0
+      '@typescript-eslint/experimental-utils': 5.6.0_eslint@8.4.1+typescript@4.5.3
+      '@typescript-eslint/parser': 5.6.0_eslint@8.4.1+typescript@4.5.3
+      '@typescript-eslint/scope-manager': 5.6.0
       debug: 4.3.3
       eslint: 8.4.1
       functional-red-black-tree: 1.0.1
       ignore: 5.1.9
       regexpp: 3.2.0
       semver: 7.3.5
-      tsutils: 3.21.0_typescript@4.5.2
-      typescript: 4.5.2
+      tsutils: 3.21.0_typescript@4.5.3
+      typescript: 4.5.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5922,24 +5922,6 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/experimental-utils/5.5.0_eslint@8.4.1+typescript@4.5.2:
-    resolution: {integrity: sha512-kjWeeVU+4lQ1SLYErRKV5yDXbWDPkpbzTUUlfAUifPYvpX0qZlrcCZ96/6oWxt3QxtK5WVhXz+KsnwW9cIW+3A==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-    dependencies:
-      '@types/json-schema': 7.0.9
-      '@typescript-eslint/scope-manager': 5.5.0
-      '@typescript-eslint/types': 5.5.0
-      '@typescript-eslint/typescript-estree': 5.5.0_typescript@4.5.2
-      eslint: 8.4.1
-      eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@8.4.1
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
   /@typescript-eslint/experimental-utils/5.6.0_eslint@7.32.0+typescript@4.5.2:
     resolution: {integrity: sha512-VDoRf3Qj7+W3sS/ZBXZh3LBzp0snDLEgvp6qj0vOAIiAPM07bd5ojQ3CTzF/QFl5AKh7Bh1ycgj6lFBJHUt/DA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -5958,7 +5940,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/experimental-utils/5.6.0_eslint@8.4.1+typescript@4.5.2:
+  /@typescript-eslint/experimental-utils/5.6.0_eslint@8.4.1+typescript@4.5.3:
     resolution: {integrity: sha512-VDoRf3Qj7+W3sS/ZBXZh3LBzp0snDLEgvp6qj0vOAIiAPM07bd5ojQ3CTzF/QFl5AKh7Bh1ycgj6lFBJHUt/DA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5967,7 +5949,7 @@ packages:
       '@types/json-schema': 7.0.9
       '@typescript-eslint/scope-manager': 5.6.0
       '@typescript-eslint/types': 5.6.0
-      '@typescript-eslint/typescript-estree': 5.6.0_typescript@4.5.2
+      '@typescript-eslint/typescript-estree': 5.6.0_typescript@4.5.3
       eslint: 8.4.1
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.4.1
@@ -5996,8 +5978,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.5.0_eslint@8.4.1+typescript@4.5.2:
-    resolution: {integrity: sha512-JsXBU+kgQOAgzUn2jPrLA+Rd0Y1dswOlX3hp8MuRO1hQDs6xgHtbCXEiAu7bz5hyVURxbXcA2draasMbNqrhmg==}
+  /@typescript-eslint/parser/5.6.0_eslint@8.4.1+typescript@4.5.3:
+    resolution: {integrity: sha512-YVK49NgdUPQ8SpCZaOpiq1kLkYRPMv9U5gcMrywzI8brtwZjr/tG3sZpuHyODt76W/A0SufNjYt9ZOgrC4tLIQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -6006,12 +5988,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 5.5.0
-      '@typescript-eslint/types': 5.5.0
-      '@typescript-eslint/typescript-estree': 5.5.0_typescript@4.5.2
+      '@typescript-eslint/scope-manager': 5.6.0
+      '@typescript-eslint/types': 5.6.0
+      '@typescript-eslint/typescript-estree': 5.6.0_typescript@4.5.3
       debug: 4.3.3
       eslint: 8.4.1
-      typescript: 4.5.2
+      typescript: 4.5.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6114,6 +6096,27 @@ packages:
       semver: 7.3.5
       tsutils: 3.21.0_typescript@4.5.2
       typescript: 4.5.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/typescript-estree/5.6.0_typescript@4.5.3:
+    resolution: {integrity: sha512-92vK5tQaE81rK7fOmuWMrSQtK1IMonESR+RJR2Tlc7w4o0MeEdjgidY/uO2Gobh7z4Q1hhS94Cr7r021fMVEeA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.6.0
+      '@typescript-eslint/visitor-keys': 5.6.0
+      debug: 4.3.3
+      globby: 11.0.4
+      is-glob: 4.0.3
+      semver: 7.3.5
+      tsutils: 3.21.0_typescript@4.5.3
+      typescript: 4.5.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9501,11 +9504,11 @@ packages:
       has-symbols: 1.0.2
       internal-slot: 1.0.3
       is-callable: 1.2.4
-      is-negative-zero: 2.0.1
+      is-negative-zero: 2.0.2
       is-regex: 1.1.4
       is-shared-array-buffer: 1.0.1
       is-string: 1.0.7
-      is-weakref: 1.0.1
+      is-weakref: 1.0.2
       object-inspect: 1.11.1
       object-keys: 1.1.1
       object.assign: 4.1.2
@@ -9929,22 +9932,22 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /eslint-config-galex/3.3.5_eslint@8.4.1+jest@27.4.3:
-    resolution: {integrity: sha512-DZeUZrmADgoRPOngUxdwsbCD0yA2cCyLTOd8E6sujKxwSdcdmqVuVqoBX9C8Erc6iAl1bIgtBM6Qc2O+3jQj2w==}
+  /eslint-config-galex/3.3.6_eslint@8.4.1+jest@27.4.3:
+    resolution: {integrity: sha512-sT/Fzi7t8IOyBQb/ietQ8Nd9AUgf8CKSbidu4B6YRlRYL2yo0swLDYwD89L3mCULmYXKxrx8QNi7n7RnBEW/8A==}
     engines: {node: '>=14.17'}
     peerDependencies:
       eslint: '>=8.1.0'
     dependencies:
       '@babel/core': 7.16.0
       '@babel/eslint-parser': 7.16.3_@babel+core@7.16.0+eslint@8.4.1
-      '@next/eslint-plugin-next': 12.0.6
-      '@typescript-eslint/eslint-plugin': 5.5.0_7dce1c1998d507f579fc8c88aa3ea163
-      '@typescript-eslint/parser': 5.5.0_eslint@8.4.1+typescript@4.5.2
+      '@next/eslint-plugin-next': 12.0.7
+      '@typescript-eslint/eslint-plugin': 5.6.0_0d0cecf582ba45923647a091322795b0
+      '@typescript-eslint/parser': 5.6.0_eslint@8.4.1+typescript@4.5.3
       confusing-browser-globals: 1.0.10
       eslint: 8.4.1
       eslint-config-prettier: 8.3.0_eslint@8.4.1
       eslint-plugin-import: 2.25.3_eslint@8.4.1
-      eslint-plugin-jest: 25.3.0_ae1ea07bb156c5ec775f683415c290c4
+      eslint-plugin-jest: 25.3.0_1a7bbbfa7dde840f5808643c699d8780
       eslint-plugin-jest-dom: 3.9.2_eslint@8.4.1
       eslint-plugin-jest-formatting: 3.1.0_eslint@8.4.1
       eslint-plugin-jsx-a11y: 6.5.1_eslint@8.4.1
@@ -9952,10 +9955,10 @@ packages:
       eslint-plugin-react: 7.27.1_eslint@8.4.1
       eslint-plugin-react-hooks: 4.3.0_eslint@8.4.1
       eslint-plugin-sonarjs: 0.11.0_eslint@8.4.1
-      eslint-plugin-testing-library: 5.0.1_eslint@8.4.1+typescript@4.5.2
+      eslint-plugin-testing-library: 5.0.1_eslint@8.4.1+typescript@4.5.3
       eslint-plugin-unicorn: 39.0.0_eslint@8.4.1
       read-pkg-up: 7.0.1
-      typescript: 4.5.2
+      typescript: 4.5.3
     transitivePeerDependencies:
       - jest
       - supports-color
@@ -10115,7 +10118,7 @@ packages:
       - typescript
     dev: true
 
-  /eslint-plugin-jest/25.3.0_ae1ea07bb156c5ec775f683415c290c4:
+  /eslint-plugin-jest/25.3.0_1a7bbbfa7dde840f5808643c699d8780:
     resolution: {integrity: sha512-79WQtuBsTN1S8Y9+7euBYwxIOia/k7ykkl9OCBHL3xuww5ecursHy/D8GCIlvzHVWv85gOkS5Kv6Sh7RxOgK1Q==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     peerDependencies:
@@ -10128,8 +10131,8 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.5.0_7dce1c1998d507f579fc8c88aa3ea163
-      '@typescript-eslint/experimental-utils': 5.6.0_eslint@8.4.1+typescript@4.5.2
+      '@typescript-eslint/eslint-plugin': 5.6.0_0d0cecf582ba45923647a091322795b0
+      '@typescript-eslint/experimental-utils': 5.6.0_eslint@8.4.1+typescript@4.5.3
       eslint: 8.4.1
       jest: 27.4.3
     transitivePeerDependencies:
@@ -10274,13 +10277,13 @@ packages:
       - typescript
     dev: true
 
-  /eslint-plugin-testing-library/5.0.1_eslint@8.4.1+typescript@4.5.2:
+  /eslint-plugin-testing-library/5.0.1_eslint@8.4.1+typescript@4.5.3:
     resolution: {integrity: sha512-8ZV4HbbacvOwu+adNnGpYd8E64NRcil2a11aFAbc/TZDUB/xxK2c8Z+LoeoHUbxNBGbTUdpAE4YUugxK85pcwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0, npm: '>=6'}
     peerDependencies:
       eslint: ^7.5.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/experimental-utils': 5.6.0_eslint@8.4.1+typescript@4.5.2
+      '@typescript-eslint/experimental-utils': 5.6.0_eslint@8.4.1+typescript@4.5.3
       eslint: 8.4.1
     transitivePeerDependencies:
       - supports-color
@@ -12458,8 +12461,8 @@ packages:
     resolution: {integrity: sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=}
     dev: true
 
-  /is-negative-zero/2.0.1:
-    resolution: {integrity: sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==}
+  /is-negative-zero/2.0.2:
+    resolution: {integrity: sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==}
     engines: {node: '>= 0.4'}
     dev: true
 
@@ -12609,8 +12612,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /is-weakref/1.0.1:
-    resolution: {integrity: sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==}
+  /is-weakref/1.0.2:
+    resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
     dependencies:
       call-bind: 1.0.2
     dev: true
@@ -18966,6 +18969,16 @@ packages:
       typescript: 4.5.2
     dev: true
 
+  /tsutils/3.21.0_typescript@4.5.3:
+    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
+    engines: {node: '>= 6'}
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+    dependencies:
+      tslib: 1.14.1
+      typescript: 4.5.3
+    dev: true
+
   /tty-browserify/0.0.0:
     resolution: {integrity: sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=}
     dev: true
@@ -19052,6 +19065,12 @@ packages:
 
   /typescript/4.5.2:
     resolution: {integrity: sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: true
+
+  /typescript/4.5.3:
+    resolution: {integrity: sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true


### PR DESCRIPTION
See:

- https://github.com/ljosberinn/eslint-config-galex/releases/tag/v3.3.6
- https://github.com/ljosberinn/eslint-config-galex/issues/515
- https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-floating-promises.md#ignorevoid