### PR TITLE
Make zoom work with camera FOV

### DIFF
--- a/packages/lib/src/vis/hooks.ts
+++ b/packages/lib/src/vis/hooks.ts
@@ -5,6 +5,7 @@ import type { NdArray } from 'ndarray';
 import { useCallback, useMemo, useState } from 'react';
 import type { RefCallback } from 'react';
 import { createMemo } from 'react-use';
+import { OrthographicCamera } from 'three';
 
 import {
   getAxisDomain,
@@ -81,4 +82,13 @@ export function useCSSCustomProperties(...names: string[]): {
     }),
     refCallback,
   };
+}
+
+export function useCamera(): OrthographicCamera {
+  const camera = useThree((state) => state.camera);
+  if (!(camera instanceof OrthographicCamera)) {
+    throw new TypeError('Camera is not orthographic');
+  }
+
+  return camera;
 }

--- a/packages/lib/src/vis/shared/PanZoomMesh.tsx
+++ b/packages/lib/src/vis/shared/PanZoomMesh.tsx
@@ -4,7 +4,7 @@ import { clamp } from 'lodash';
 import { useRef, useCallback, useEffect } from 'react';
 import { Vector2, Vector3 } from 'three';
 
-import { useWheelCapture } from '../hooks';
+import { useCamera, useWheelCapture } from '../hooks';
 import { useAxisSystemContext } from './AxisSystemContext';
 
 const ZOOM_FACTOR = 0.95;
@@ -15,7 +15,7 @@ function PanZoomMesh() {
   const { abscissaScale, ordinateScale, visSize } = useAxisSystemContext();
   const { width: visWidth, height: visHeight } = visSize;
 
-  const camera = useThree((state) => state.camera);
+  const camera = useCamera();
   const { width, height } = useThree((state) => state.size);
   const invalidate = useThree((state) => state.invalidate);
 
@@ -98,7 +98,11 @@ function PanZoomMesh() {
       const { sourceEvent } = evt;
       const factor = sourceEvent.deltaY > 0 ? ZOOM_FACTOR : 1 / ZOOM_FACTOR;
 
-      camera.zoom = Math.max(1, camera.zoom * factor);
+      camera.left = Math.max(-width / 2, camera.left / factor);
+      camera.right = Math.min(width / 2, camera.right / factor);
+      camera.bottom = Math.max(-height / 2, camera.bottom / factor);
+      camera.top = Math.min(height / 2, camera.top / factor);
+
       camera.updateProjectionMatrix();
 
       const projectedPoint = camera.worldToLocal(evt.unprojectedPoint.clone());
@@ -110,7 +114,7 @@ function PanZoomMesh() {
         camY + pointerY * (1 - 1 / factor)
       );
     },
-    [camera, moveCameraTo]
+    [camera, height, moveCameraTo, width]
   );
 
   useEffect(() => {

--- a/packages/lib/src/vis/shared/VisCanvas.tsx
+++ b/packages/lib/src/vis/shared/VisCanvas.tsx
@@ -54,6 +54,7 @@ function VisCanvas(props: PropsWithChildren<Props>) {
         >
           <Canvas
             className={styles.r3fRoot}
+            camera={{ manual: true }}
             orthographic
             linear // disable automatic color encoding and gamma correction
             flat // disable tone mapping


### PR DESCRIPTION
Our implementation of the zoom on the vis was using the Three.js camera zoom. 

While this is very handy, this prevents from scaling differently in X and in Y making issues like #769 impossible to resolve.

Zooming **with a orthographic camera** consists simply in reducing the field of the view of the camera (see https://threejs.org/manual/examples/cameras-orthographic-2-scenes.html). The field of the view is constrained by the properties `left`, `right`, `top` and `bottom` of the camera.

So, instead of using `camera.zoom`, I change the field of view "manually" by changing the aforementioned parameters. This will allow to change the zoom in X (`left`/`right`) independently from the zoom in Y (`top`/`bottom`) when needed.