### PR TITLE
Project points with camera rather than manually

### DIFF
--- a/apps/storybook/src/HeatmapVisDisplay.stories.tsx
+++ b/apps/storybook/src/HeatmapVisDisplay.stories.tsx
@@ -109,6 +109,28 @@ WithAnnotation.args = {
   domain,
 };
 
+export const WithAnnotationZoom: Story<HeatmapVisProps> = (args) => (
+  <HeatmapVis {...args}>
+    <Annotation
+      x={30}
+      y={18}
+      style={{
+        width: '100px',
+        color: 'white',
+        textAlign: 'center',
+        fontSize: '0.75rem',
+      }}
+      scaleOnZoom
+    >
+      An annotation scaling with zoom
+    </Annotation>
+  </HeatmapVis>
+);
+WithAnnotationZoom.args = {
+  dataArray,
+  domain,
+};
+
 export default {
   ...HeatmapVisStoriesConfig,
   title: 'Visualizations/HeatmapVis/Display',

--- a/packages/lib/src/vis/shared/AxisSystem.tsx
+++ b/packages/lib/src/vis/shared/AxisSystem.tsx
@@ -1,5 +1,6 @@
 import type { Domain } from '@h5web/shared';
 import { useThree } from '@react-three/fiber';
+import { Vector3 } from 'three';
 
 import { useFrameRendering } from '../hooks';
 import type { AxisOffsets } from '../models';
@@ -13,25 +14,30 @@ interface Props {
   title?: string;
 }
 
+const CAMERA_BOTTOM_LEFT = new Vector3(-1, -1, 0);
+const CAMERA_TOP_RIGHT = new Vector3(1, 1, 0);
+
 function AxisSystem(props: Props) {
   const { axisOffsets, title } = props;
 
   const { abscissaConfig, ordinateConfig, abscissaScale, ordinateScale } =
     useAxisSystemContext();
 
-  const { position, zoom } = useThree((state) => state.camera);
+  const camera = useThree((state) => state.camera);
   const canvasSize = useThree((state) => state.size);
   const { width, height } = canvasSize;
 
-  // Find visible domains from camera's zoom and position
+  const worldBottomLeft = CAMERA_BOTTOM_LEFT.clone().unproject(camera);
+  const worldTopRight = CAMERA_TOP_RIGHT.clone().unproject(camera);
+
   const xVisibleDomain: Domain = [
-    abscissaScale.invert(-width / (2 * zoom) + position.x),
-    abscissaScale.invert(width / (2 * zoom) + position.x),
+    abscissaScale.invert(worldBottomLeft.x), // left
+    abscissaScale.invert(worldTopRight.x), // right
   ];
 
   const yVisibleDomain: Domain = [
-    ordinateScale.invert(-height / (2 * zoom) + position.y),
-    ordinateScale.invert(height / (2 * zoom) + position.y),
+    ordinateScale.invert(worldBottomLeft.y), // bottom
+    ordinateScale.invert(worldTopRight.y), // top
   ];
 
   // Re-render on every R3F frame (i.e. on every change of camera zoom/position)

--- a/packages/lib/src/vis/shared/TooltipMesh.tsx
+++ b/packages/lib/src/vis/shared/TooltipMesh.tsx
@@ -6,6 +6,7 @@ import { useCallback } from 'react';
 import type { ReactElement } from 'react';
 
 import type { Coords } from '../models';
+import { projectCameraToHtml } from '../utils';
 import { useAxisSystemContext } from './AxisSystemContext';
 import Html from './Html';
 import styles from './TooltipMesh.module.css';
@@ -38,19 +39,19 @@ function TooltipMesh(props: Props) {
   // When panning, events are handled and stopped by texture mesh and do not reach this mesh (which is behind)
   const onPointerMove = useCallback(
     (evt: ThreeEvent<PointerEvent>) => {
-      const { zoom } = camera;
-      const projectedPoint = camera.worldToLocal(evt.unprojectedPoint.clone());
-
       const abscissaCoord = abscissaScale.invert(evt.unprojectedPoint.x);
       const ordinateCoord = ordinateScale.invert(evt.unprojectedPoint.y);
 
+      const cameraPoint = evt.unprojectedPoint.clone().project(camera);
+      const htmlPoint = projectCameraToHtml(cameraPoint, width, height);
+
       showTooltip({
-        tooltipLeft: projectedPoint.x * zoom + width / 2,
-        tooltipTop: -projectedPoint.y * zoom + height / 2,
+        tooltipLeft: htmlPoint.x,
+        tooltipTop: htmlPoint.y,
         tooltipData: [abscissaCoord, ordinateCoord],
       });
     },
-    [camera, abscissaScale, ordinateScale, showTooltip, width, height]
+    [camera, abscissaScale, ordinateScale, width, height, showTooltip]
   );
 
   // Hide tooltip when pointer leaves mesh or user starts panning

--- a/packages/lib/src/vis/utils.ts
+++ b/packages/lib/src/vis/utils.ts
@@ -12,6 +12,8 @@ import { scaleLinear, scaleThreshold } from '@visx/scale';
 import { tickStep, range } from 'd3-array';
 import type { ScaleLinear, ScaleThreshold } from 'd3-scale';
 import type { NdArray } from 'ndarray';
+import type { Vector3 } from 'three';
+import { Matrix4 } from 'three';
 import { clamp } from 'three/src/math/MathUtils';
 
 import type {
@@ -292,4 +294,16 @@ const TYPE_STRINGS: Record<NumericType['class'], string> = {
 
 export function formatNumType(numType: NumericType): string {
   return `${TYPE_STRINGS[numType.class]}${numType.size}`;
+}
+
+export function projectCameraToHtml(
+  cameraVector: Vector3,
+  width: number,
+  height: number
+): Vector3 {
+  const cameraToHtmlMatrix = new Matrix4().makeScale(width / 2, -height / 2, 1);
+  // Account for shift of (0,0) position (center for camera, top-left for HTML)
+  cameraToHtmlMatrix.setPosition(width / 2, height / 2);
+
+  return cameraVector.clone().applyMatrix4(cameraToHtmlMatrix);
 }


### PR DESCRIPTION
While working on #909, I realized that we made a lot of similar computations when going from canvas coordinates to HTML coordinates. These computations were "manually" using the camera parameters (zoom and position).

I refactored these computations to use the camera projection matrix instead, that already contain all the camera parameters. 

This has several advantages:
- The computations are more generic, taking in account *both* the camera field of view and the zoom. This will greatly simplify #909 and allow a seamless transition.
- The computations are more concise and easier to understand in my opinion.

I see one disadvantage tho, we have to deal with (_shudder_) mutable `Vector3`...

Let me know what you think !

_PS: This image from [this SO thread](https://stackoverflow.com/questions/46829113/transpose-z-position-from-perspective-to-orthographic-camera-in-three-js) was very useful:_

![image](https://i.stack.imgur.com/U1f5T.png)

_Note, however, that the X and Z are switched._
