### PR TITLE
Add link info for soft and external links in h5grove provider

### DIFF
--- a/packages/app/src/providers/h5grove/models.ts
+++ b/packages/app/src/providers/h5grove/models.ts
@@ -5,21 +5,33 @@ export interface H5GroveEntityResponse {
   type:
     | EntityKind.Dataset
     | EntityKind.Group
-    | 'externalLink'
-    | 'softLink'
+    | 'external_link'
+    | 'soft_link'
     | 'other';
-  attributes?: H5GroveAttribute[];
 }
 
 export interface H5GroveDatasetReponse extends H5GroveEntityResponse {
   type: EntityKind.Dataset;
   dtype: string;
   shape: number[];
+  attributes: H5GroveAttribute[];
 }
 
 export interface H5GroveGroupResponse extends H5GroveEntityResponse {
   type: EntityKind.Group;
   children?: H5GroveEntityResponse[];
+  attributes: H5GroveAttribute[];
+}
+
+export interface H5GroveSoftLinkResponse extends H5GroveEntityResponse {
+  type: 'soft_link';
+  target_path: string;
+}
+
+export interface H5GroveExternalLinkResponse extends H5GroveEntityResponse {
+  type: 'external_link';
+  target_file: string;
+  target_path: string;
 }
 
 export interface H5GroveAttribute {

--- a/packages/app/src/providers/h5grove/utils.ts
+++ b/packages/app/src/providers/h5grove/utils.ts
@@ -4,7 +4,9 @@ import { DTypeClass, EntityKind, isNumericType } from '@h5web/shared';
 import type {
   H5GroveDatasetReponse,
   H5GroveEntityResponse,
+  H5GroveExternalLinkResponse,
   H5GroveGroupResponse,
+  H5GroveSoftLinkResponse,
 } from './models';
 
 export function isGroupResponse(
@@ -17,6 +19,18 @@ export function isDatasetResponse(
   response: H5GroveEntityResponse
 ): response is H5GroveDatasetReponse {
   return response.type === EntityKind.Dataset;
+}
+
+export function isSoftLinkResponse(
+  response: H5GroveEntityResponse
+): response is H5GroveSoftLinkResponse {
+  return response.type === 'soft_link';
+}
+
+export function isExternalLinkResponse(
+  response: H5GroveEntityResponse
+): response is H5GroveExternalLinkResponse {
+  return response.type === 'external_link';
 }
 
 export function typedArrayFromDType(dtype: DType) {


### PR DESCRIPTION
Related to #915 

In our entity model, there is a `link` model but we didn't make use of it in the h5grove provider.

This PR adds the parsing of soft and external links responses to fill the `link` field of entities. 

For now, I did not change the model of entity but I think it will worth discussing if links should be first-class entities or not.