### PR TITLE
Fix react-scripts path resolution in storybook

### DIFF
--- a/apps/storybook/.storybook/main.js
+++ b/apps/storybook/.storybook/main.js
@@ -6,7 +6,11 @@ module.exports = {
   },
   stories: ['../src/**/*.stories.@(tsx|mdx)'],
   addons: [
-    '@storybook/preset-create-react-app',
+    {
+      name: '@storybook/preset-create-react-app',
+      // Override react-scripts package path as it resolves to the wrong path on Linux
+      options: { scriptsPackageName: '../node_modules/react-scripts' },
+    },
     '@storybook/addon-links',
     '@storybook/addon-essentials',
   ],


### PR DESCRIPTION
This happens only on Linux and was brought by #911.

On Linux, `preset-create-react-app` from Storybook searches for the react-scripts Webpack config by trying to resolve the symlink `node_modules/.bin/react_scripts` : https://github.com/storybookjs/presets/blob/227cd94ef65adf5b89a2a22cb971455e6f6239d6/packages/preset-create-react-app/src/helpers/getReactScriptsPath.ts#L37.

Before #911, this line raised an error because `react-scripts` was not installed in the Storybook. The resolution was therefore done by [this line instead](https://github.com/storybookjs/presets/blob/227cd94ef65adf5b89a2a22cb971455e6f6239d6/packages/preset-create-react-app/src/helpers/getReactScriptsPath.ts#L49) which gave the appropriate path.

In #911, we installed `react-scripts` which means that the resolution is now made by trying to resolve the symlink. For some reason (linked to the pnpm setup?), this resolves to `node_modules` instead of `node_modules/react-scripts` which prevents starting or building the Storybook on Linux.

This PR fixes the issue by overriding the problematic resolution by [supplying directly the appropriate path in option of the preset](https://github.com/storybookjs/presets/tree/master/packages/preset-create-react-app#custom-react-scripts-packages).