### PR TITLE
Update README with new files and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,22 +68,10 @@ The following HDF5 files can be reached with a URL of the form
 
 This demo is available at https://h5web.panosc.eu/hsds.
 
-The following HDF5 files can be reached with a URL of the form
-`https://h5web.panosc.eu/hsds?file=<name>`:
-
-- [`/home/reader/water`](https://h5web.panosc.eu/hsds) (**default**): The file
-  `water_224.h5`. Some datasets cannot be displayed as bitshuffle compression is
-  not supported by HSDS yet.
-- [`/home/reader/compressed`](https://h5web.panosc.eu/hsds?file=/home/reader/compressed):
-  The file `compressed.h5`.
-- [`/home/reader/epics`](https://h5web.panosc.eu/hsds?file=/home/reader/epics):
-  The file `epics.h5`.
-- [`/home/reader/grove`](https://h5web.panosc.eu/hsds?file=/home/reader/grove):
-  The file `grove.h5`.
-- [`/home/reader/links`](https://h5web.panosc.eu/hsds?file=/home/reader/links):
-  The file `links.h5`.
-- [`/home/reader/tall`](https://h5web.panosc.eu/hsds?file=/home/reader/tall):
-  The file `tall.h5`.
+All the HDF5 files mentionned above can be reached with a URL of the form
+`https://h5web.panosc.eu/hsds?file=<name>`. https://h5web.panosc.eu/hsds will
+default to `water_224.h5` but some datasets cannot be displayed as bitshuffle
+compression is not supported by HSDS yet.
 
 ### Mock data
 

--- a/README.md
+++ b/README.md
@@ -51,12 +51,18 @@ This demo is available at https://h5web.panosc.eu.
 The following HDF5 files can be reached with a URL of the form
 `https://h5web.panosc.eu/?file=<name>`:
 
-- `water_224.h5` (**default**): A typical NeXus file with various real-world
-  datasets to demonstrate the visualizations.
-- `compressed.h5`: A file with datasets compressed with various filters to test
-  decompression.
-- `links.h5`: A file with external links, soft links and a virtual dataset to
-  test link resolution.
+- [`water_224.h5`](https://h5web.panosc.eu/) (**default**): A typical NeXus file
+  with various real-world datasets to demonstrate the visualizations.
+- [`compressed.h5`](https://h5web.panosc.eu/?file=compressed.h5): A file with
+  datasets compressed with various filters to test decompression.
+- [`epics.h5`](https://h5web.panosc.eu/?file=epics.h5): A test file from
+  [EPICS](https://epics.anl.gov/) group (Argonne national lab).
+- [`grove.h5`](https://h5web.panosc.eu/?file=grove.h5): A file used to test the
+  provider. It contains datasets with NaN/Infinity values, booleans, complexes
+  and other types of datasets such as RGB images and 4D stacks.
+- [`links.h5`](https://h5web.panosc.eu/?file=links.h5): A file with external
+  links, soft links and a virtual dataset to test link resolution.
+- [`tall.h5`](https://h5web.panosc.eu/?file=tall.h5): The demo file of HSDS.
 
 ### [HSDS](https://github.com/HDFGroup/hsds)
 
@@ -65,11 +71,19 @@ This demo is available at https://h5web.panosc.eu/hsds.
 The following HDF5 files can be reached with a URL of the form
 `https://h5web.panosc.eu/hsds?file=<name>`:
 
-- `/home/reader/water` (**default**): The file `water_224.h5`. Some datasets
-  cannot be displayed as bitshuffle compression is not supported by HSDS yet.
-- `/home/reader/links`: The file `links.h5`.
-- `/home/reader/compressed`: The file `compressed.h5`.
-- `/home/reader/tall`: The demo file of HSDS.
+- [`/home/reader/water`](https://h5web.panosc.eu/hsds) (**default**): The file
+  `water_224.h5`. Some datasets cannot be displayed as bitshuffle compression is
+  not supported by HSDS yet.
+- [`/home/reader/compressed`](https://h5web.panosc.eu/hsds?file=/home/reader/compressed):
+  The file `compressed.h5`.
+- [`/home/reader/epics`](https://h5web.panosc.eu/hsds?file=/home/reader/epics):
+  The file `epics.h5`.
+- [`/home/reader/grove`](https://h5web.panosc.eu/hsds?file=/home/reader/grove):
+  The file `grove.h5`.
+- [`/home/reader/links`](https://h5web.panosc.eu/hsds?file=/home/reader/links):
+  The file `links.h5`.
+- [`/home/reader/tall`](https://h5web.panosc.eu/hsds?file=/home/reader/tall):
+  The file `tall.h5`.
 
 ### Mock data
 

--- a/apps/demo/.env
+++ b/apps/demo/.env
@@ -16,10 +16,12 @@ REACT_APP_H5GROVE_FALLBACK_FILEPATH="water_224.h5"
 
 # HSDS parameters
 # URL, username, password and filepath as strings
+# A subdomain can be supplied that will be prefixed to all filepaths
 REACT_APP_HSDS_URL=
 REACT_APP_HSDS_USERNAME=
 REACT_APP_HSDS_PASSWORD=
-REACT_APP_HSDS_FALLBACK_FILEPATH="/home/reader/water"
+REACT_APP_HSDS_SUBDOMAIN="/home/reader/"
+REACT_APP_HSDS_FALLBACK_FILEPATH="water_224.h5"
 
 # Feedback email
 REACT_APP_FEEDBACK_EMAIL="h5web@esrf.fr"

--- a/apps/demo/src/HsdsApp.tsx
+++ b/apps/demo/src/HsdsApp.tsx
@@ -6,11 +6,12 @@ import { getFeedbackURL } from './utils';
 const URL = process.env.REACT_APP_HSDS_URL || '';
 const USERNAME = process.env.REACT_APP_HSDS_USERNAME || '';
 const PASSWORD = process.env.REACT_APP_HSDS_PASSWORD || '';
+const SUBDOMAIN = process.env.REACT_APP_HSDS_SUBDOMAIN || '';
 const FILEPATH = process.env.REACT_APP_HSDS_FALLBACK_FILEPATH || '';
 
 function HsdsApp() {
   const query = new URLSearchParams(useLocation().search);
-  const filepath = query.get('file') || FILEPATH;
+  const filepath = `${SUBDOMAIN}${query.get('file') || FILEPATH}`;
 
   return (
     <HsdsProvider


### PR DESCRIPTION
Part of #926 

I thought it might be easier to be able to specify the subdomain of HSDS so that files can be referred the same way whatever the provider.

I also cleaned-up the files on the back-end side.