### PR TITLE
Remove `type: module` from published app/lib package.json

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -15,6 +15,7 @@
   ],
   "main": "src/index.ts",
   "publishConfig": {
+    "type": "commonjs",
     "main": "dist/index.cjs",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -15,6 +15,7 @@
   ],
   "main": "src/index.ts",
   "publishConfig": {
+    "type": "commonjs",
     "main": "dist/index.cjs",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
Trying this fix for #914. I've tested @h5web/app with CRA v5 outside of the repo and came across a couple of errors that I managed to fix by removing `"type": "module"` from the package, so I thought I'd give it a try.

Note that `"type": "module"` is required in development, so I "revert" it by setting to `"commonjs"` inside `"publishConfig"`.

I'll publish a beta version once merged.