### PR TITLE
Add CRA and Vite sandboxes and fix @h5web/lib stylesheet export

### DIFF
--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -54,6 +54,14 @@ export default MyApp;
 > import '@h5web/app/style.css';
 > ```
 
+### Examples
+
+The following code sandboxes demonstrate how to set up and use `@h5web/app` with
+various front-end development stacks:
+
+- [Vite](https://codesandbox.io/s/h5webapp-vite-5c204)
+- [Create React App v4](https://codesandbox.io/s/h5webapp-cra-v4-0y1lj)
+
 ## API reference
 
 ### `startFullscreen?: boolean` (optional)

--- a/packages/lib/README.md
+++ b/packages/lib/README.md
@@ -54,3 +54,11 @@ function MyApp() {
 
 export default MyApp;
 ```
+
+### Examples
+
+The following code sandboxes demonstrate how to set up and use `@h5web/lib` with
+various front-end development stacks:
+
+- [Vite](https://codesandbox.io/s/h5weblib-vite-xru04)
+- [Create React App v4](https://codesandbox.io/s/h5weblib-cra-v4-2te48)

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -19,6 +19,8 @@
     "module": "dist/index.js",
     "types": "dist/index.d.ts",
     "exports": {
+      "./dist/style.css": "./dist/style.css",
+      "./style.css": "./dist/style.css",
       ".": {
         "require": "./dist/index.cjs",
         "import": "./dist/index.js"


### PR DESCRIPTION
Next up, I'll remove the `demo-cra-lib` project from the repo.