### PR TITLE
Flip only the needed meshes rather than the whole canvas

### DIFF
--- a/apps/storybook/src/VisCanvasSelection.stories.tsx
+++ b/apps/storybook/src/VisCanvasSelection.stories.tsx
@@ -8,6 +8,7 @@ import VisCanvasStoriesConfig from './VisCanvas.stories';
 
 interface TemplateProps {
   selection?: 'line' | 'rectangle';
+  yFlip?: boolean;
 }
 
 function vectorToStr(vec: Vector2) {
@@ -15,7 +16,7 @@ function vectorToStr(vec: Vector2) {
 }
 
 const Template: Story<TemplateProps> = (args) => {
-  const { selection } = args;
+  const { selection, yFlip } = args;
 
   const [selectedVectors, setSelectedVectors] = useState<[Vector2, Vector2]>();
 
@@ -32,7 +33,7 @@ const Template: Story<TemplateProps> = (args) => {
       )}
       <VisCanvas
         abscissaConfig={{ visDomain: [-10, 0], showGrid: true }}
-        ordinateConfig={{ visDomain: [50, 100], showGrid: true }}
+        ordinateConfig={{ visDomain: [50, 100], showGrid: true, flip: yFlip }}
       >
         {selection === 'line' && (
           <LineSelectionMesh
@@ -62,16 +63,13 @@ SelectingLines.args = {
 export default {
   ...VisCanvasStoriesConfig,
   title: 'Building Blocks/VisCanvas/Selection',
+  args: {
+    yFlip: false,
+  },
   parameters: {
     ...VisCanvasStoriesConfig.parameters,
     controls: {
-      include: ['panZoom', 'tooltipValue', 'guides'],
-    },
-  },
-  argTypes: {
-    guides: {
-      control: { type: 'inline-radio' },
-      options: ['horizontal', 'vertical', 'both'],
+      include: ['yFlip'],
     },
   },
 } as Meta;

--- a/packages/lib/src/vis/heatmap/HeatmapMesh.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapMesh.tsx
@@ -10,6 +10,7 @@ import {
   UnsignedByteType,
 } from 'three';
 
+import { useAxisSystemContext } from '../..';
 import type { VisScaleType } from '../models';
 import VisMesh from '../shared/VisMesh';
 import type { ColorMap, ScaleShader } from './models';
@@ -152,6 +153,8 @@ function HeatmapMesh(props: Props) {
     alphaDomain,
   } = props;
 
+  const { ordinateConfig } = useAxisSystemContext();
+
   const dataTexture = useMemo(() => {
     const valuesArr = Float32Array.from(values);
     return new DataTexture(valuesArr, cols, rows, RedFormat, FloatType);
@@ -238,7 +241,7 @@ function HeatmapMesh(props: Props) {
   };
 
   return (
-    <VisMesh>
+    <VisMesh scale={[1, ordinateConfig.flip ? -1 : 1, 1]}>
       <shaderMaterial args={[shader]} />
     </VisMesh>
   );

--- a/packages/lib/src/vis/rgb/RgbVis.tsx
+++ b/packages/lib/src/vis/rgb/RgbVis.tsx
@@ -78,7 +78,7 @@ function RgbVis(props: Props) {
         }}
       >
         <PanZoomMesh />
-        <VisMesh>
+        <VisMesh scale={[1, -1, 1]}>
           <meshBasicMaterial map={texture} />
         </VisMesh>
         {children}

--- a/packages/lib/src/vis/shared/VisCanvas.tsx
+++ b/packages/lib/src/vis/shared/VisCanvas.tsx
@@ -69,15 +69,7 @@ function VisCanvas(props: PropsWithChildren<Props>) {
               ordinateConfig={ordinateConfig}
             >
               <AxisSystem axisOffsets={axisOffsets} title={title} />
-              <group
-                scale={[
-                  abscissaConfig.flip ? -1 : 1,
-                  ordinateConfig.flip ? -1 : 1,
-                  1,
-                ]}
-              >
-                {children}
-              </group>
+              {children}
             </AxisSystemProvider>
           </Canvas>
         </div>


### PR DESCRIPTION
This is in essence a revert of https://github.com/silx-kit/h5web/pull/813

While this seemed very elegant for texture-based meshes, this introduces an issue for meshes that make use of the axis scales to position themselves (through `dataToWorld`). 

Indeed, the `flip` is already accounted for in the scales (which make sense for axes) so that coordinates computed through them **already have the correct flipped coordinates**. As a consequence, having an inverting group around such meshes flip them once more **which is incorrect**.

Examples of such meshes include `SelectionMesh` or the ones used in `LineVis`.
 