### PR TITLE
Let HeatmapVis accept typed ndarrays

### DIFF
--- a/apps/storybook/src/HeatmapVis.stories.tsx
+++ b/apps/storybook/src/HeatmapVis.stories.tsx
@@ -6,7 +6,7 @@ import {
   getMockDataArray,
   INTERPOLATORS,
 } from '@h5web/lib';
-import { assertDefined } from '@h5web/shared';
+import { assertDefined, toTypedNdArray } from '@h5web/shared';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import ndarray from 'ndarray';
 
@@ -92,6 +92,13 @@ Alpha.args = {
   dataArray,
   domain,
   alpha: { array: alphaArray, domain: alphaDomain },
+};
+
+export const TypedArray = Template.bind({});
+TypedArray.args = {
+  dataArray: toTypedNdArray(dataArray),
+  domain,
+  alpha: { array: toTypedNdArray(alphaArray), domain: alphaDomain },
 };
 
 export default {

--- a/packages/lib/src/vis/heatmap/HeatmapVis.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapVis.tsx
@@ -1,5 +1,10 @@
 import type { Domain, NumericType } from '@h5web/shared';
-import { assertDefined, formatTooltipVal, ScaleType } from '@h5web/shared';
+import {
+  assertDefined,
+  formatTooltipVal,
+  toTypedNdArray,
+  ScaleType,
+} from '@h5web/shared';
 import type { NdArray } from 'ndarray';
 import type { ReactElement, ReactNode } from 'react';
 
@@ -13,11 +18,16 @@ import ColorBar from './ColorBar';
 import HeatmapMesh from './HeatmapMesh';
 import styles from './HeatmapVis.module.css';
 import { useAxisValues } from './hooks';
-import type { ColorMap, Layout, TooltipData } from './models';
+import type {
+  ColorMap,
+  CompatibleTypedArray,
+  Layout,
+  TooltipData,
+} from './models';
 import { getDims } from './utils';
 
 interface Props {
-  dataArray: NdArray<number[]>;
+  dataArray: NdArray<number[] | CompatibleTypedArray>;
   domain: Domain | undefined;
   colorMap?: ColorMap;
   scaleType?: VisScaleType;
@@ -28,7 +38,7 @@ interface Props {
   invertColorMap?: boolean;
   abscissaParams?: AxisParams;
   ordinateParams?: AxisParams;
-  alpha?: { array: NdArray<number[]>; domain: Domain };
+  alpha?: { array: NdArray<number[] | CompatibleTypedArray>; domain: Domain };
   flipYAxis?: boolean;
   renderTooltip?: (data: TooltipData) => ReactElement;
   children?: ReactNode;
@@ -52,7 +62,6 @@ function HeatmapVis(props: Props) {
     renderTooltip,
     children,
   } = props;
-
   const { label: abscissaLabel, value: abscissaValue } = abscissaParams;
   const { label: ordinateLabel, value: ordinateValue } = ordinateParams;
 
@@ -116,14 +125,12 @@ function HeatmapVis(props: Props) {
           }}
         />
         <HeatmapMesh
-          rows={rows}
-          cols={cols}
-          values={dataArray.data}
+          values={toTypedNdArray(dataArray)}
           domain={domain}
           colorMap={colorMap}
           invertColorMap={invertColorMap}
           scaleType={scaleType}
-          alphaValues={alpha?.array.data}
+          alphaValues={alpha && toTypedNdArray(alpha.array)}
           alphaDomain={alpha?.domain}
         />
         {children}

--- a/packages/lib/src/vis/heatmap/models.ts
+++ b/packages/lib/src/vis/heatmap/models.ts
@@ -1,4 +1,5 @@
 import type { Domain } from '@h5web/shared';
+import type { TypedArray } from 'ndarray';
 
 import type { INTERPOLATORS } from './interpolators';
 
@@ -29,3 +30,8 @@ export interface ScaleShader {
   ) => Record<string, { value: number }>;
   fragment: string;
 }
+
+export type CompatibleTypedArray = Exclude<
+  TypedArray,
+  Uint8ClampedArray | Float64Array
+>;

--- a/packages/shared/src/guards.ts
+++ b/packages/shared/src/guards.ts
@@ -1,4 +1,5 @@
-import type { NdArray } from 'ndarray';
+import { isTypedArray } from 'lodash';
+import type { NdArray, TypedArray } from 'ndarray';
 import type { ReactChild, ReactElement } from 'react';
 
 import { EntityKind, DTypeClass } from './models-hdf5';
@@ -350,4 +351,10 @@ export function isScaleType(val: unknown): val is ScaleType {
   return (
     typeof val === 'string' && Object.values<string>(ScaleType).includes(val)
   );
+}
+
+export function isTypedNdArray<T extends number[] | TypedArray>(
+  arr: NdArray<T>
+): arr is NdArray<Exclude<T, number[]>> {
+  return isTypedArray(arr.data);
 }

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -1,9 +1,9 @@
 import { format } from 'd3-format';
 import ndarray from 'ndarray';
-import type { NdArray } from 'ndarray';
+import type { NdArray, TypedArray } from 'ndarray';
 import { assign } from 'ndarray-ops';
 
-import { assertDataLength } from './guards';
+import { assertDataLength, isTypedNdArray } from './guards';
 import type { Entity, GroupWithChildren, H5WebComplex } from './models-hdf5';
 import { ScaleType } from './models-vis';
 import type { Bounds, Domain } from './models-vis';
@@ -38,6 +38,16 @@ function createComplexFormatter(specifier: string, full = false) {
 
 export function toArray(arr: NdArray<number[]> | number[]): number[] {
   return 'data' in arr ? arr.data : arr;
+}
+
+export function toTypedNdArray<T extends number[] | TypedArray>(
+  arr: NdArray<T>
+): NdArray<Exclude<T, number[]> | Float32Array> {
+  if (isTypedNdArray(arr)) {
+    return arr;
+  }
+
+  return ndarray(Float32Array.from(arr.data), arr.shape);
 }
 
 export function getChildEntity(


### PR DESCRIPTION
This adds support for typed ndarrays in both `HeatmapVis` and `HeatmapMesh`. I haven't touched `@h5web/app` yet, this is just for `@h5web/lib`.

Both `dataArray` and `alpha.array` can now have type `NdArray<number[] | CompatibleTypedArray>`, where `CompatibleTypedArray` is `TypedArray` without `Uint8ClampedArray` and `Float64Array`, neither of which are supported by WebGL (at least to my knowledge, feel free to correct me @t20100).

I've added a new story too. You can tell it works because the `dataArray` control shows that the `data` property of the ndarray has 820 "keys" (instead of "items" when the ndarray contains a simple JS array):

![image](https://user-images.githubusercontent.com/2936402/151822299-f3bc7b7a-5d5b-48da-9b3d-498742f4fc55.png)
