### PR TITLE
Allow modifier keys for SelectionMesh and PanZoomMesh

### DIFF
--- a/apps/storybook/src/VisCanvasInteraction.stories.tsx
+++ b/apps/storybook/src/VisCanvasInteraction.stories.tsx
@@ -7,19 +7,20 @@ import VisCanvasStoriesConfig from './VisCanvas.stories';
 
 interface TemplateProps {
   panZoom?: boolean;
+  panKey?: 'Alt' | 'Control' | 'Shift';
   tooltipValue?: string;
   guides?: TooltipMeshProps['guides'];
 }
 
 const Template: Story<TemplateProps> = (args) => {
-  const { panZoom = false, tooltipValue, guides } = args;
+  const { panZoom = false, tooltipValue, guides, panKey } = args;
 
   return (
     <VisCanvas
       abscissaConfig={{ visDomain: [-10, 0], showGrid: true }}
       ordinateConfig={{ visDomain: [50, 100], showGrid: true }}
     >
-      {panZoom && <PanZoomMesh />}
+      {panZoom && <PanZoomMesh panKey={panKey} />}
       {tooltipValue && (
         <TooltipMesh
           guides={guides}
@@ -39,6 +40,13 @@ const Template: Story<TemplateProps> = (args) => {
 
 export const PanZoom = Template.bind({});
 PanZoom.args = { panZoom: true };
+PanZoom.argTypes = { guides: { table: { disable: true } } };
+
+export const PanZoomModifiers = Template.bind({});
+PanZoomModifiers.args = {
+  panZoom: true,
+  panKey: 'Alt',
+};
 PanZoom.argTypes = { guides: { table: { disable: true } } };
 
 export const Tooltip = Template.bind({});
@@ -65,13 +73,17 @@ export default {
   parameters: {
     ...VisCanvasStoriesConfig.parameters,
     controls: {
-      include: ['panZoom', 'tooltipValue', 'guides'],
+      include: ['panZoom', 'tooltipValue', 'guides', 'panKey'],
     },
   },
   argTypes: {
     guides: {
       control: { type: 'inline-radio' },
       options: ['horizontal', 'vertical', 'both'],
+    },
+    panKey: {
+      control: { type: 'inline-radio' },
+      options: ['Alt', 'Control', 'Shift'],
     },
   },
 } as Meta;

--- a/apps/storybook/src/VisCanvasSelection.stories.tsx
+++ b/apps/storybook/src/VisCanvasSelection.stories.tsx
@@ -1,4 +1,9 @@
-import { LineSelectionMesh, RectSelectionMesh, VisCanvas } from '@h5web/lib';
+import {
+  LineSelectionMesh,
+  PanZoomMesh,
+  RectSelectionMesh,
+  VisCanvas,
+} from '@h5web/lib';
 import type { Meta, Story } from '@storybook/react';
 import { format } from 'd3-format';
 import { useState } from 'react';
@@ -9,6 +14,8 @@ import VisCanvasStoriesConfig from './VisCanvas.stories';
 interface TemplateProps {
   selection?: 'line' | 'rectangle';
   yFlip?: boolean;
+  panZoom?: boolean;
+  modifierKey?: 'Alt' | 'Control' | 'Shift';
 }
 
 function vectorToStr(vec: Vector2) {
@@ -16,7 +23,7 @@ function vectorToStr(vec: Vector2) {
 }
 
 const Template: Story<TemplateProps> = (args) => {
-  const { selection, yFlip } = args;
+  const { selection, yFlip = false, panZoom = false, modifierKey } = args;
 
   const [selectedVectors, setSelectedVectors] = useState<[Vector2, Vector2]>();
 
@@ -35,14 +42,17 @@ const Template: Story<TemplateProps> = (args) => {
         abscissaConfig={{ visDomain: [-10, 0], showGrid: true }}
         ordinateConfig={{ visDomain: [50, 100], showGrid: true, flip: yFlip }}
       >
+        {panZoom && <PanZoomMesh />}
         {selection === 'line' && (
           <LineSelectionMesh
             onSelection={(start, end) => setSelectedVectors([start, end])}
+            modifierKey={modifierKey}
           />
         )}
         {selection === 'rectangle' && (
           <RectSelectionMesh
             onSelection={(start, end) => setSelectedVectors([start, end])}
+            modifierKey={modifierKey}
           />
         )}
       </VisCanvas>
@@ -60,16 +70,26 @@ SelectingLines.args = {
   selection: 'line',
 };
 
+export const SelectingWithModifierAndZoom = Template.bind({});
+SelectingWithModifierAndZoom.args = {
+  selection: 'line',
+  panZoom: true,
+  modifierKey: 'Shift',
+};
+
 export default {
   ...VisCanvasStoriesConfig,
   title: 'Building Blocks/VisCanvas/Selection',
-  args: {
-    yFlip: false,
-  },
   parameters: {
     ...VisCanvasStoriesConfig.parameters,
     controls: {
-      include: ['yFlip'],
+      include: ['yFlip', 'panZoom', 'modifierKey'],
+    },
+  },
+  argTypes: {
+    modifierKey: {
+      control: { type: 'inline-radio' },
+      options: ['Alt', 'Control', 'Shift'],
     },
   },
 } as Meta;

--- a/packages/lib/src/vis/models.ts
+++ b/packages/lib/src/vis/models.ts
@@ -90,3 +90,5 @@ export interface HistogramParams {
   colorMap?: ColorMap;
   invertColorMap?: boolean;
 }
+
+export type ModifierKey = 'Alt' | 'Control' | 'Shift';

--- a/packages/lib/src/vis/shared/LineSelectionMesh.tsx
+++ b/packages/lib/src/vis/shared/LineSelectionMesh.tsx
@@ -1,14 +1,8 @@
-import type { MeshProps } from '@react-three/fiber';
-import type { Vector2 } from 'three';
-
 import SelectionLine from './SelectionLine';
+import type { SelectionMeshProps } from './SelectionMesh';
 import SelectionMesh from './SelectionMesh';
 
-interface Props extends MeshProps {
-  onSelection?: (startPoint: Vector2, endPoint: Vector2) => void;
-}
-
-function LineSelectionMesh(props: Props) {
+function LineSelectionMesh(props: SelectionMeshProps) {
   return <SelectionMesh selectionComponent={SelectionLine} {...props} />;
 }
 

--- a/packages/lib/src/vis/shared/RectSelectionMesh.tsx
+++ b/packages/lib/src/vis/shared/RectSelectionMesh.tsx
@@ -1,14 +1,8 @@
-import type { MeshProps } from '@react-three/fiber';
-import type { Vector2 } from 'three';
-
+import type { SelectionMeshProps } from './SelectionMesh';
 import SelectionMesh from './SelectionMesh';
 import SelectionRect from './SelectionRect';
 
-interface Props extends MeshProps {
-  onSelection?: (startPoint: Vector2, endPoint: Vector2) => void;
-}
-
-function RectSelectionMesh(props: Props) {
+function RectSelectionMesh(props: SelectionMeshProps) {
   return <SelectionMesh selectionComponent={SelectionRect} {...props} />;
 }
 

--- a/packages/lib/src/vis/utils.ts
+++ b/packages/lib/src/vis/utils.ts
@@ -23,6 +23,7 @@ import type {
   ScaleGammaConfig,
   VisxScaleConfig,
   VisScaleType,
+  ModifierKey,
 } from './models';
 import { H5WEB_SCALES } from './scales';
 
@@ -308,4 +309,16 @@ export function projectCameraToHtml(
   cameraToHtmlMatrix.setPosition(width / 2, height / 2);
 
   return cameraVector.clone().applyMatrix4(cameraToHtmlMatrix);
+}
+
+export function isEventValid(
+  event: MouseEvent,
+  modifierKey: ModifierKey | undefined
+) {
+  if (!modifierKey) {
+    // If no modifier key is given, the event is deemed valid only if no modifier key is pressed
+    return !event.altKey && !event.ctrlKey && !event.shiftKey;
+  }
+
+  return event.getModifierState(modifierKey);
 }


### PR DESCRIPTION
To use `SelectionMesh` and the `PanZoomMesh` on the same vis, we have to differentiate the clicks linked to the panning and the one linked to the selection.

This PR allows to specify a modifier key (`Alt`, `Ctrl` or `Shift`) to these meshes so that only clicks accompanied by the press of the key trigger the mesh callbacks. 

Also, previously, mesh callbacks were triggered on any clicks (including the one accompanied by press of modifier keys) so I had to change this so that clicks can be differentiated. 

I also added some stories to test things out.