### PR TITLE
Allow passing custom `magFilter` to `HeatmapMesh`

### DIFF
--- a/apps/storybook/src/HeatmapMesh.stories.tsx
+++ b/apps/storybook/src/HeatmapMesh.stories.tsx
@@ -1,0 +1,121 @@
+import {
+  getDomain,
+  getMockDataArray,
+  HeatmapMesh,
+  VisCanvas,
+} from '@h5web/lib';
+import type { HeatmapMeshProps, Domain } from '@h5web/lib';
+import { ScaleType, toTypedNdArray } from '@h5web/shared';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import ndarray from 'ndarray';
+import {
+  ByteType,
+  FloatType,
+  HalfFloatType,
+  IntType,
+  LinearFilter,
+  NearestFilter,
+  ShortType,
+  UnsignedByteType,
+  UnsignedIntType,
+  UnsignedShortType,
+} from 'three';
+
+import FillHeight from './decorators/FillHeight';
+
+const dataArray = getMockDataArray('/nD_datasets/twoD');
+const domain = getDomain(dataArray.data);
+
+const uint16Values = [0x49_00, 0x4d_00, 0x4f_80, 0x51_00]; // 10, 20, 30, 40
+const uint16DataArray = ndarray(Uint16Array.from(uint16Values), [2, 2]);
+const uint16Domain: Domain = [10, 40];
+
+const Template: Story<HeatmapMeshProps> = (args) => {
+  const { shape } = args.values;
+  const [rows, cols] = shape;
+
+  return (
+    <VisCanvas
+      abscissaConfig={{ visDomain: [0, cols], isIndexAxis: true }}
+      ordinateConfig={{ visDomain: [0, rows], isIndexAxis: true }}
+    >
+      <HeatmapMesh {...args} />
+    </VisCanvas>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  values: toTypedNdArray(dataArray),
+  domain,
+  scaleType: ScaleType.SymLog,
+  colorMap: 'Inferno',
+};
+
+export const HalfFloatTexture = Template.bind({});
+HalfFloatTexture.args = {
+  values: uint16DataArray,
+  domain: uint16Domain,
+  scaleType: ScaleType.Linear,
+  colorMap: 'Blues',
+  textureType: HalfFloatType,
+};
+
+export const LinearMagFilter = Template.bind({});
+LinearMagFilter.args = {
+  ...Default.args,
+  magFilter: LinearFilter,
+};
+
+export default {
+  title: 'Building Blocks/HeatmapMesh',
+  component: HeatmapMesh,
+  decorators: [FillHeight],
+  parameters: { layout: 'fullscreen', controls: { sort: 'requiredFirst' } },
+  args: {
+    invertColorMap: false,
+    magFilter: NearestFilter,
+  },
+  argTypes: {
+    scaleType: {
+      control: { type: 'inline-radio' },
+      options: [
+        ScaleType.Linear,
+        ScaleType.Log,
+        ScaleType.SymLog,
+        ScaleType.Sqrt,
+      ],
+    },
+    magFilter: {
+      control: {
+        type: 'inline-radio',
+        labels: { [NearestFilter]: 'nearest', [LinearFilter]: 'linear' },
+      },
+      options: [NearestFilter, LinearFilter],
+    },
+    textureType: {
+      control: {
+        labels: {
+          [UnsignedByteType]: 'unsigned byte',
+          [ByteType]: 'byte',
+          [ShortType]: 'short',
+          [UnsignedShortType]: 'unsigned short',
+          [IntType]: 'int',
+          [UnsignedIntType]: 'unsigned int',
+          [FloatType]: 'float',
+          [HalfFloatType]: 'half float',
+        },
+      },
+      options: [
+        UnsignedByteType,
+        ByteType,
+        ShortType,
+        UnsignedShortType,
+        IntType,
+        UnsignedIntType,
+        FloatType,
+        HalfFloatType,
+      ],
+    },
+  },
+} as Meta;

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -34,6 +34,7 @@ export { default as VisMesh } from './vis/shared/VisMesh';
 export { default as ColorBar } from './vis/heatmap/ColorBar';
 export type { ColorBarProps } from './vis/heatmap/ColorBar';
 export { default as HeatmapMesh } from './vis/heatmap/HeatmapMesh';
+export type { HeatmapMeshProps } from './vis/heatmap/HeatmapMesh';
 export { default as DataCurve } from './vis/line/DataCurve';
 export { default as Html } from './vis/shared/Html';
 export { default as Annotation } from './vis/shared/Annotation';

--- a/packages/lib/src/vis/heatmap/HeatmapMesh.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapMesh.tsx
@@ -3,7 +3,7 @@ import { ScaleType, assertDefined, isScaleType } from '@h5web/shared';
 import { rgb } from 'd3-color';
 import type { NdArray } from 'ndarray';
 import { memo, useMemo } from 'react';
-import type { TextureDataType } from 'three';
+import type { TextureDataType, TextureFilter } from 'three';
 import { DataTexture, RGBFormat, UnsignedByteType } from 'three';
 
 import { useAxisSystemContext } from '../..';
@@ -19,6 +19,7 @@ interface Props {
   colorMap: ColorMap;
   invertColorMap?: boolean;
   textureType?: TextureDataType; // override default texture type (determined from `values.dtype`)
+  magFilter?: TextureFilter;
   alphaValues?: NdArray<CompatibleTypedArray>;
   alphaDomain?: Domain;
 }
@@ -143,6 +144,7 @@ function HeatmapMesh(props: Props) {
     colorMap,
     invertColorMap = false,
     textureType,
+    magFilter,
     alphaValues,
     alphaDomain,
   } = props;
@@ -150,8 +152,8 @@ function HeatmapMesh(props: Props) {
   const { ordinateConfig } = useAxisSystemContext();
 
   const dataTexture = useMemo(
-    () => getDataTexture(values, textureType),
-    [textureType, values]
+    () => getDataTexture(values, textureType, magFilter),
+    [magFilter, textureType, values]
   );
 
   const alphaTexture = useMemo(

--- a/packages/lib/src/vis/heatmap/HeatmapMesh.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapMesh.tsx
@@ -240,4 +240,5 @@ function HeatmapMesh(props: Props) {
   );
 }
 
+export type { Props as HeatmapMeshProps };
 export default memo(HeatmapMesh);

--- a/packages/lib/src/vis/heatmap/utils.ts
+++ b/packages/lib/src/vis/heatmap/utils.ts
@@ -4,19 +4,22 @@ import type { DataType, NdArray } from 'ndarray';
 import type { PixelFormat, TextureDataType } from 'three';
 import {
   ByteType,
-  IntType,
-  ShortType,
-  UnsignedByteType,
-  UnsignedIntType,
-  UnsignedShortType,
+  ClampToEdgeWrapping,
+  DataTexture,
   FloatType,
   HalfFloatType,
+  IntType,
   RedFormat,
   RedIntegerFormat,
+  ShortType,
+  UnsignedByteType,
   UnsignedInt248Type,
+  UnsignedIntType,
   UnsignedShort4444Type,
   UnsignedShort5551Type,
-  DataTexture,
+  UnsignedShortType,
+  UVMapping,
+  NearestFilter,
 } from 'three';
 
 import type { CustomDomain, DomainErrors } from '../models';
@@ -167,9 +170,22 @@ function getTextureFormatFromType(type: TextureDataType): PixelFormat {
 
 export function getDataTexture(
   values: NdArray<CompatibleTypedArray>,
-  textureType = TEXTURE_TYPE_BY_DTYPE[values.dtype]
+  textureType = TEXTURE_TYPE_BY_DTYPE[values.dtype],
+  magFilter = NearestFilter
 ): DataTexture {
   const { data, shape } = values;
+  const [rows, cols] = shape;
   const format = getTextureFormatFromType(textureType);
-  return new DataTexture(data, shape[1], shape[0], format, textureType);
+
+  return new DataTexture(
+    data,
+    cols,
+    rows,
+    format,
+    textureType,
+    UVMapping,
+    ClampToEdgeWrapping,
+    ClampToEdgeWrapping,
+    magFilter
+  );
 }


### PR DESCRIPTION
- I simply add a prop called `magFilter` to `HeatmapMesh` that I pass along to the new `getDataTexture` utility.
- I also document `HeatmapMesh` as a new building block in Storybook.

One of the stories tests the texture override feature by passing `HalfFloatTexture` with a `Uint16Array`. For some reason, I get a black heatmap... Not sure if I'm doing things wrong in the story, or if the texture override feature does not work as expected. Any idea?