### PR TITLE
Fix disappearing selection line when pan/zooming

### DIFF
--- a/packages/lib/src/vis/shared/SelectionLine.tsx
+++ b/packages/lib/src/vis/shared/SelectionLine.tsx
@@ -1,5 +1,5 @@
 import type { Object3DNode } from '@react-three/fiber';
-import { extend, invalidate } from '@react-three/fiber';
+import { extend, useThree } from '@react-three/fiber';
 import { useLayoutEffect, useState } from 'react';
 import type { Vector2 } from 'three';
 import { BufferGeometry, Line } from 'three';
@@ -25,11 +25,13 @@ interface Props {
 function SelectionLine(props: Props) {
   const { startPoint, endPoint, color = 'black' } = props;
   const [dataGeometry] = useState(() => new BufferGeometry());
+  const invalidate = useThree((state) => state.invalidate);
 
   useLayoutEffect(() => {
     dataGeometry.setFromPoints([startPoint, endPoint]);
+    dataGeometry.computeBoundingSphere();
     invalidate();
-  }, [dataGeometry, endPoint, startPoint]);
+  }, [dataGeometry, endPoint, invalidate, startPoint]);
 
   return (
     <line_ geometry={dataGeometry}>


### PR DESCRIPTION
Here is a small bug I noticed when working on the profile feature: after a line is drawn, it can disappear when panning/zooming:

![Peek 2022-02-10 11-11](https://user-images.githubusercontent.com/42204205/153387702-da47b199-9f36-4df0-a2c3-4f5030870832.gif)

I could reproduce it in a "regular" R3F environment (https://codesandbox.io/s/disappearing-lines-2tgt0) but not as consistently, unfortunately. Peculiar circumstances are needed: the line must not be instantiated at start (i.e. it must be drawn after canvas instantiation) and not every pan/zoom combination make the line disappear...

A quick search led me to try `depthTest=false` on interaction meshes (https://stackoverflow.com/questions/33346970/disappearing-line-object-in-three-js) but it didn't help.

I managed to fix it by computing the bounding sphere explicitly when setting the points of the bufferGeometry. I guess the computation is done under the hood by R3F when declaring the `geometry` but it seems the imperative code is needed for this particular case.