### PR TITLE
Add tiles image with multiple level of details layer support

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -30,6 +30,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-icons": "4.3.1",
+    "react-suspense-fetch": "0.4.0",
     "three": "0.135.0"
   },
   "devDependencies": {

--- a/apps/storybook/src/TiledHeatmap.stories.tsx
+++ b/apps/storybook/src/TiledHeatmap.stories.tsx
@@ -118,8 +118,7 @@ class MandelbrotTilesApi extends TilesApi {
 }
 const Template: Story<TiledHeatmapProps> = (args) => {
   const { api, ...tiledHeatmapProps } = args;
-  const [layer0Size] = api.layerSizes;
-  const { width, height } = layer0Size;
+  const { width, height } = api.imageSize;
 
   return (
     <VisCanvas

--- a/apps/storybook/src/TiledHeatmap.stories.tsx
+++ b/apps/storybook/src/TiledHeatmap.stories.tsx
@@ -59,7 +59,7 @@ function mandelbrot(
   return array;
 }
 
-interface TileKey {
+interface TileParams {
   lod: number;
   offset: Vector2;
 }
@@ -80,7 +80,7 @@ class MandelbrotTilesApi extends TilesApi {
     this.yDomain = yDomain;
 
     this.store = createFetchStore(
-      async (tile: TileKey) => {
+      async (tile: TileParams) => {
         const { lod, offset } = tile;
         const layerSize = this.layerSizes[lod];
         // Clip slice to size of the level
@@ -106,7 +106,7 @@ class MandelbrotTilesApi extends TilesApi {
       },
       {
         type: 'Map',
-        areEqual: (a: TileKey, b: TileKey) =>
+        areEqual: (a: TileParams, b: TileParams) =>
           a.lod === b.lod && a.offset.equals(b.offset),
       }
     );

--- a/apps/storybook/src/TiledHeatmap.stories.tsx
+++ b/apps/storybook/src/TiledHeatmap.stories.tsx
@@ -1,0 +1,182 @@
+import {
+  getLayerSizes,
+  PanMesh,
+  VisCanvas,
+  ZoomMesh,
+  TiledHeatmap,
+  TilesApi,
+} from '@h5web/lib';
+import type { Domain, Size, TiledHeatmapProps } from '@h5web/lib';
+import { ScaleType } from '@h5web/shared';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import { clamp } from 'lodash';
+import ndarray from 'ndarray';
+import type { NdArray } from 'ndarray';
+import { createFetchStore } from 'react-suspense-fetch';
+import type { Vector2 } from 'three';
+
+import FillHeight from './decorators/FillHeight';
+
+// See https://en.wikipedia.org/wiki/Mandelbrot_set
+function mandelbrot(
+  iterations: number,
+  xDomain: Domain,
+  yDomain: Domain,
+  size: Size
+): NdArray<Float32Array> {
+  const { width, height } = size;
+  const xRange = xDomain[1] - xDomain[0];
+  const yRange = yDomain[1] - yDomain[0];
+
+  const array = ndarray(new Float32Array(height * width), [height, width]);
+
+  for (let row = 0; row < height; row += 1) {
+    const cImag = yDomain[0] + yRange * (row / (height - 1));
+    for (let col = 0; col < width; col += 1) {
+      let value = 0;
+
+      const cReal = xDomain[0] + xRange * (col / (width - 1));
+      // z = c
+      let zReal = cReal;
+      let zImag = cImag;
+      for (let index = 0; index <= iterations; index += 1) {
+        // z = z**2 + c
+        const zRealSq = zReal ** 2;
+        const zImagSq = zImag ** 2;
+        zImag = 2 * zReal * zImag + cImag;
+        zReal = zRealSq - zImagSq + cReal;
+
+        // check divergence
+        if (zRealSq + zImagSq > 4) {
+          value = index / iterations;
+          break;
+        }
+      }
+
+      array.set(row, col, value);
+    }
+  }
+  return array;
+}
+
+interface TileKey {
+  lod: number;
+  offset: Vector2;
+}
+
+class MandelbrotTilesApi extends TilesApi {
+  public readonly xDomain: Domain;
+  public readonly yDomain: Domain;
+  private readonly store;
+
+  public constructor(
+    size: Size,
+    tileSize: Size,
+    xDomain: Domain,
+    yDomain: Domain
+  ) {
+    super(tileSize, getLayerSizes(size, tileSize));
+    this.xDomain = xDomain;
+    this.yDomain = yDomain;
+
+    this.store = createFetchStore(
+      async (tile: TileKey) => {
+        const { lod, offset } = tile;
+        const layerSize = this.layerSizes[lod];
+        // Clip slice to size of the level
+        const width = clamp(layerSize.width - offset.x, 0, this.tileSize.width);
+        const height = clamp(
+          layerSize.height - offset.y,
+          0,
+          this.tileSize.height
+        );
+
+        const xScale = (this.xDomain[1] - this.xDomain[0]) / layerSize.width;
+        const xRange: Domain = [
+          this.xDomain[0] + xScale * offset.x,
+          this.xDomain[0] + xScale * (offset.x + width),
+        ];
+        const yScale = (this.yDomain[1] - this.yDomain[0]) / layerSize.height;
+        const yRange: Domain = [
+          this.yDomain[0] + yScale * offset.y,
+          this.yDomain[0] + yScale * (offset.y + height),
+        ];
+
+        return mandelbrot(50, xRange, yRange, { width, height });
+      },
+      {
+        type: 'Map',
+        areEqual: (a: TileKey, b: TileKey) =>
+          a.lod === b.lod && a.offset.equals(b.offset),
+      }
+    );
+  }
+
+  public get(lod: number, offset: Vector2): NdArray<Float32Array> {
+    return this.store.get({ lod, offset });
+  }
+}
+const Template: Story<TiledHeatmapProps> = (args) => {
+  const { api, ...tiledHeatmapProps } = args;
+  const [layer0Size] = api.layerSizes;
+  const { width, height } = layer0Size;
+
+  return (
+    <VisCanvas
+      abscissaConfig={{
+        visDomain: [0, width],
+        isIndexAxis: true,
+        showGrid: false,
+      }}
+      ordinateConfig={{
+        visDomain: [0, height],
+        isIndexAxis: true,
+        showGrid: false,
+      }}
+      visRatio={width / height}
+    >
+      <PanMesh />
+      <ZoomMesh />
+      <TiledHeatmap api={api} {...tiledHeatmapProps} />
+    </VisCanvas>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  api: new MandelbrotTilesApi(
+    { width: 1e9, height: 1e9 },
+    { width: 128, height: 128 },
+    [-2, 1],
+    [-1.5, 1.5]
+  ),
+  domain: [0, 1],
+};
+
+export default {
+  title: 'Building Blocks/TiledHeatmap',
+  component: TiledHeatmap,
+  decorators: [FillHeight],
+  parameters: { layout: 'fullscreen', controls: { sort: 'requiredFirst' } },
+  args: {
+    invertColorMap: false,
+    colorMap: 'Viridis',
+    scaleType: ScaleType.Linear,
+    displayLowerResolutions: true,
+    qualityFactor: 1,
+  },
+  argTypes: {
+    scaleType: {
+      control: { type: 'inline-radio' },
+      options: [
+        ScaleType.Linear,
+        ScaleType.Log,
+        ScaleType.SymLog,
+        ScaleType.Sqrt,
+      ],
+    },
+    qualityFactor: {
+      control: { type: 'range', min: 0, max: 1, step: 0.1 },
+    },
+  },
+} as Meta;

--- a/apps/storybook/src/TiledHeatmap.stories.tsx
+++ b/apps/storybook/src/TiledHeatmap.stories.tsx
@@ -60,7 +60,7 @@ function mandelbrot(
 }
 
 interface TileParams {
-  lod: number;
+  layer: number;
   offset: Vector2;
 }
 
@@ -81,8 +81,8 @@ class MandelbrotTilesApi extends TilesApi {
 
     this.store = createFetchStore(
       async (tile: TileParams) => {
-        const { lod, offset } = tile;
-        const layerSize = this.layerSizes[lod];
+        const { layer, offset } = tile;
+        const layerSize = this.layerSizes[layer];
         // Clip slice to size of the level
         const width = clamp(layerSize.width - offset.x, 0, this.tileSize.width);
         const height = clamp(
@@ -107,13 +107,13 @@ class MandelbrotTilesApi extends TilesApi {
       {
         type: 'Map',
         areEqual: (a: TileParams, b: TileParams) =>
-          a.lod === b.lod && a.offset.equals(b.offset),
+          a.layer === b.layer && a.offset.equals(b.offset),
       }
     );
   }
 
-  public get(lod: number, offset: Vector2): NdArray<Float32Array> {
-    return this.store.get({ lod, offset });
+  public get(layer: number, offset: Vector2): NdArray<Float32Array> {
+    return this.store.get({ layer, offset });
   }
 }
 const Template: Story<TiledHeatmapProps> = (args) => {

--- a/apps/storybook/src/TiledHeatmap.stories.tsx
+++ b/apps/storybook/src/TiledHeatmap.stories.tsx
@@ -118,7 +118,7 @@ class MandelbrotTilesApi extends TilesApi {
 }
 const Template: Story<TiledHeatmapProps> = (args) => {
   const { api, ...tiledHeatmapProps } = args;
-  const { width, height } = api.imageSize;
+  const { width, height } = api.baseLayerSize;
 
   return (
     <VisCanvas

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -47,6 +47,9 @@ export { default as ScatterPoints } from './vis/scatter/ScatterPoints';
 export type { SelectionMeshProps } from './vis/shared/SelectionMesh';
 export { default as SelectionLine } from './vis/shared/SelectionLine';
 export { default as SelectionRect } from './vis/shared/SelectionRect';
+export { default as TiledHeatmap } from './vis/tiles/TiledHeatmap';
+export type { TiledHeatmapProps } from './vis/tiles/TiledHeatmap';
+export { getLayerSizes, TilesApi } from './vis/tiles/api';
 export { default as ZoomSelectionMesh } from './vis/shared/ZoomSelectionMesh';
 
 // Context hook

--- a/packages/lib/src/vis/heatmap/HeatmapMesh.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapMesh.tsx
@@ -7,7 +7,7 @@ import type { TextureFilter } from 'three';
 import { DataTexture, RGBAFormat, UnsignedByteType } from 'three';
 
 import { useAxisSystemContext } from '../..';
-import type { VisScaleType } from '../models';
+import type { Size, VisScaleType } from '../models';
 import VisMesh from '../shared/VisMesh';
 import { DEFAULT_DOMAIN, getUniforms, VERTEX_SHADER } from '../utils';
 import type { ColorMap, TextureSafeTypedArray } from './models';
@@ -22,6 +22,7 @@ interface Props {
   magFilter?: TextureFilter;
   alphaValues?: NdArray<TextureSafeTypedArray | Uint16Array>; // uint16 values are treated as half floats
   alphaDomain?: Domain;
+  size?: Size;
 }
 
 const CMAP_SIZE = 256;
@@ -47,6 +48,7 @@ function HeatmapMesh(props: Props) {
     magFilter,
     alphaValues,
     alphaDomain = DEFAULT_DOMAIN,
+    size,
   } = props;
 
   const { ordinateConfig } = useAxisSystemContext();
@@ -141,7 +143,7 @@ function HeatmapMesh(props: Props) {
   };
 
   return (
-    <VisMesh scale={[1, ordinateConfig.flip ? -1 : 1, 1]}>
+    <VisMesh scale={[1, ordinateConfig.flip ? -1 : 1, 1]} size={size}>
       <shaderMaterial args={[shader]} />
     </VisMesh>
   );

--- a/packages/lib/src/vis/shared/VisMesh.tsx
+++ b/packages/lib/src/vis/shared/VisMesh.tsx
@@ -1,18 +1,25 @@
 import type { MeshProps } from '@react-three/fiber';
 
+import type { Size } from '../models';
 import { useAxisSystemContext } from './AxisSystemContext';
 
-function VisMesh(props: MeshProps) {
-  const { children, ...meshProps } = props;
+interface Props extends MeshProps {
+  size?: Size;
+}
+
+function VisMesh(props: Props) {
+  const { children, size, ...meshProps } = props;
 
   const { visSize } = useAxisSystemContext();
+  const { width, height } = size ?? visSize;
 
   return (
     <mesh {...meshProps}>
-      <planeGeometry args={[visSize.width, visSize.height]} />
+      <planeGeometry args={[width, height]} />
       {children}
     </mesh>
   );
 }
 
+export type { Props as VisMeshProps };
 export default VisMesh;

--- a/packages/lib/src/vis/tiles/Tile.tsx
+++ b/packages/lib/src/vis/tiles/Tile.tsx
@@ -1,0 +1,36 @@
+import { memo } from 'react';
+import { Vector2 } from 'three';
+import type { TextureFilter } from 'three';
+
+import HeatmapMesh from '../heatmap/HeatmapMesh';
+import { useAxisSystemContext } from '../shared/AxisSystemContext';
+import type { TilesApi } from './api';
+import type { ColorMapProps } from './models';
+
+interface Props extends ColorMapProps {
+  api: TilesApi;
+  lod: number;
+  x: number;
+  y: number;
+  magFilter: TextureFilter;
+}
+
+function Tile(props: Props) {
+  const { api, lod, x, y, magFilter, ...colorMapProps } = props;
+
+  const { visSize } = useAxisSystemContext();
+
+  const array = api.get(lod, new Vector2(x, y));
+  const [height, width] = array.shape;
+
+  return (
+    <group
+      position={[x + width / 2, y + height / 2, 0]} // Tile center
+      scale={[width / visSize.width, height / visSize.height, 1]}
+    >
+      <HeatmapMesh values={array} {...colorMapProps} magFilter={magFilter} />
+    </group>
+  );
+}
+
+export default memo(Tile);

--- a/packages/lib/src/vis/tiles/Tile.tsx
+++ b/packages/lib/src/vis/tiles/Tile.tsx
@@ -8,16 +8,16 @@ import type { ColorMapProps } from './models';
 
 interface Props extends ColorMapProps {
   api: TilesApi;
-  lod: number;
+  layer: number;
   x: number;
   y: number;
   magFilter: TextureFilter;
 }
 
 function Tile(props: Props) {
-  const { api, lod, x, y, magFilter, ...colorMapProps } = props;
+  const { api, layer, x, y, magFilter, ...colorMapProps } = props;
 
-  const array = api.get(lod, new Vector2(x, y));
+  const array = api.get(layer, new Vector2(x, y));
   const [height, width] = array.shape;
 
   return (

--- a/packages/lib/src/vis/tiles/Tile.tsx
+++ b/packages/lib/src/vis/tiles/Tile.tsx
@@ -3,7 +3,6 @@ import { Vector2 } from 'three';
 import type { TextureFilter } from 'three';
 
 import HeatmapMesh from '../heatmap/HeatmapMesh';
-import { useAxisSystemContext } from '../shared/AxisSystemContext';
 import type { TilesApi } from './api';
 import type { ColorMapProps } from './models';
 
@@ -18,17 +17,19 @@ interface Props extends ColorMapProps {
 function Tile(props: Props) {
   const { api, lod, x, y, magFilter, ...colorMapProps } = props;
 
-  const { visSize } = useAxisSystemContext();
-
   const array = api.get(lod, new Vector2(x, y));
   const [height, width] = array.shape;
 
   return (
     <group
       position={[x + width / 2, y + height / 2, 0]} // Tile center
-      scale={[width / visSize.width, height / visSize.height, 1]}
     >
-      <HeatmapMesh values={array} {...colorMapProps} magFilter={magFilter} />
+      <HeatmapMesh
+        values={array}
+        {...colorMapProps}
+        magFilter={magFilter}
+        size={{ width, height }}
+      />
     </group>
   );
 }

--- a/packages/lib/src/vis/tiles/TiledHeatmap.tsx
+++ b/packages/lib/src/vis/tiles/TiledHeatmap.tsx
@@ -25,15 +25,15 @@ function TiledHeatmap(props: Props) {
   const { visSize } = useAxisSystemContext();
   const { xDataPerPixel, yDataPerPixel } = useDataPerPixel();
 
-  const { imageLayerIndex } = api;
+  const { baseLayerIndex } = api;
 
   const dataPerPixel = Math.max(1, xDataPerPixel, yDataPerPixel);
   const roundingOffset = 1 - clamp(qualityFactor, 0, 1);
   const subsamplingLevel = Math.min(
     Math.floor(Math.log2(dataPerPixel) + roundingOffset),
-    imageLayerIndex
+    baseLayerIndex
   );
-  const currentLayerIndex = imageLayerIndex - subsamplingLevel;
+  const currentLayerIndex = baseLayerIndex - subsamplingLevel;
 
   // displayLowerResolutions selects which levels of detail layers are displayed:
   // true: lower resolution layers displayed behind the current one

--- a/packages/lib/src/vis/tiles/TiledHeatmap.tsx
+++ b/packages/lib/src/vis/tiles/TiledHeatmap.tsx
@@ -27,10 +27,11 @@ function TiledHeatmap(props: Props) {
 
   const { numLayers } = api;
 
+  const dataPerPixel = Math.max(1, xDataPerPixel, yDataPerPixel);
   const quality = 1 - clamp(qualityFactor, 0, 1);
   const levelOfDetail = Math.min(
-    Math.floor(Math.log2(Math.max(1, xDataPerPixel, yDataPerPixel)) + quality),
-    Math.max(numLayers - 1, 0)
+    Math.floor(Math.log2(dataPerPixel) + quality),
+    numLayers - 1
   );
 
   // displayLowerResolutions selects which levels of detail layers are displayed:

--- a/packages/lib/src/vis/tiles/TiledHeatmap.tsx
+++ b/packages/lib/src/vis/tiles/TiledHeatmap.tsx
@@ -28,18 +28,19 @@ function TiledHeatmap(props: Props) {
   const { numLayers } = api;
 
   const dataPerPixel = Math.max(1, xDataPerPixel, yDataPerPixel);
-  const quality = 1 - clamp(qualityFactor, 0, 1);
-  const levelOfDetail = Math.min(
-    Math.floor(Math.log2(dataPerPixel) + quality),
+  const roundingOffset = 1 - clamp(qualityFactor, 0, 1);
+  const subsamplingLevel = Math.min(
+    Math.floor(Math.log2(dataPerPixel) + roundingOffset),
     numLayers - 1
   );
+  const currentLayerIndex = numLayers - 1 - subsamplingLevel;
 
   // displayLowerResolutions selects which levels of detail layers are displayed:
   // true: lower resolution layers displayed behind the current one
   // false: only current level of detail layer is displayed
-  const lods = displayLowerResolutions
-    ? range(levelOfDetail, numLayers).reverse()
-    : [levelOfDetail];
+  const layers = displayLowerResolutions
+    ? range(currentLayerIndex + 1)
+    : [currentLayerIndex];
 
   const { colorMap, invertColorMap = false } = colorMapProps;
 
@@ -53,8 +54,8 @@ function TiledHeatmap(props: Props) {
           color={getInterpolator(colorMap, invertColorMap)(0)}
         />
       </mesh>
-      {lods.map((lod) => (
-        <TiledLayer key={lod} api={api} lod={lod} {...colorMapProps} />
+      {layers.map((layer) => (
+        <TiledLayer key={layer} api={api} layer={layer} {...colorMapProps} />
       ))}
     </>
   );

--- a/packages/lib/src/vis/tiles/TiledHeatmap.tsx
+++ b/packages/lib/src/vis/tiles/TiledHeatmap.tsx
@@ -1,0 +1,63 @@
+import { clamp, range } from 'lodash';
+
+import { getInterpolator } from '../heatmap/utils';
+import { useFrameRendering } from '../hooks';
+import { useAxisSystemContext } from '../shared/AxisSystemContext';
+import TiledLayer from './TiledLayer';
+import type { TilesApi } from './api';
+import { useDataPerPixel } from './hooks';
+import type { ColorMapProps } from './models';
+
+interface Props extends ColorMapProps {
+  api: TilesApi;
+  displayLowerResolutions?: boolean;
+  qualityFactor?: number;
+}
+
+function TiledHeatmap(props: Props) {
+  const {
+    api,
+    displayLowerResolutions = true,
+    qualityFactor = 1, // 0: Lower quality, less fetch; 1: Best quality
+    ...colorMapProps
+  } = props;
+
+  const { visSize } = useAxisSystemContext();
+  const { xDataPerPixel, yDataPerPixel } = useDataPerPixel();
+
+  const nLevels = api.layerSizes.length;
+
+  const quality = 1 - clamp(qualityFactor, 0, 1);
+  const levelOfDetail = Math.min(
+    Math.floor(Math.log2(Math.max(1, xDataPerPixel, yDataPerPixel)) + quality),
+    Math.max(nLevels - 1, 0)
+  );
+
+  // displayLowerResolutions selects which levels of detail layers are displayed:
+  // true: lower resolution layers displayed behind the current one
+  // false: only current level of detail layer is displayed
+  const lods = displayLowerResolutions
+    ? range(levelOfDetail, nLevels).reverse()
+    : [levelOfDetail];
+
+  const { colorMap, invertColorMap = false } = colorMapProps;
+
+  useFrameRendering();
+
+  return (
+    <>
+      <mesh position={[0, 0, -0.1]}>
+        <planeGeometry args={[visSize.width, visSize.height]} />
+        <meshBasicMaterial
+          color={getInterpolator(colorMap, invertColorMap)(0)}
+        />
+      </mesh>
+      {lods.map((lod) => (
+        <TiledLayer key={lod} api={api} lod={lod} {...colorMapProps} />
+      ))}
+    </>
+  );
+}
+
+export type { Props as TiledHeatmapProps };
+export default TiledHeatmap;

--- a/packages/lib/src/vis/tiles/TiledHeatmap.tsx
+++ b/packages/lib/src/vis/tiles/TiledHeatmap.tsx
@@ -25,19 +25,19 @@ function TiledHeatmap(props: Props) {
   const { visSize } = useAxisSystemContext();
   const { xDataPerPixel, yDataPerPixel } = useDataPerPixel();
 
-  const nLevels = api.layerSizes.length;
+  const { numLayers } = api;
 
   const quality = 1 - clamp(qualityFactor, 0, 1);
   const levelOfDetail = Math.min(
     Math.floor(Math.log2(Math.max(1, xDataPerPixel, yDataPerPixel)) + quality),
-    Math.max(nLevels - 1, 0)
+    Math.max(numLayers - 1, 0)
   );
 
   // displayLowerResolutions selects which levels of detail layers are displayed:
   // true: lower resolution layers displayed behind the current one
   // false: only current level of detail layer is displayed
   const lods = displayLowerResolutions
-    ? range(levelOfDetail, nLevels).reverse()
+    ? range(levelOfDetail, numLayers).reverse()
     : [levelOfDetail];
 
   const { colorMap, invertColorMap = false } = colorMapProps;

--- a/packages/lib/src/vis/tiles/TiledHeatmap.tsx
+++ b/packages/lib/src/vis/tiles/TiledHeatmap.tsx
@@ -25,15 +25,15 @@ function TiledHeatmap(props: Props) {
   const { visSize } = useAxisSystemContext();
   const { xDataPerPixel, yDataPerPixel } = useDataPerPixel();
 
-  const { numLayers } = api;
+  const { imageLayerIndex } = api;
 
   const dataPerPixel = Math.max(1, xDataPerPixel, yDataPerPixel);
   const roundingOffset = 1 - clamp(qualityFactor, 0, 1);
   const subsamplingLevel = Math.min(
     Math.floor(Math.log2(dataPerPixel) + roundingOffset),
-    numLayers - 1
+    imageLayerIndex
   );
-  const currentLayerIndex = numLayers - 1 - subsamplingLevel;
+  const currentLayerIndex = imageLayerIndex - subsamplingLevel;
 
   // displayLowerResolutions selects which levels of detail layers are displayed:
   // true: lower resolution layers displayed behind the current one

--- a/packages/lib/src/vis/tiles/TiledLayer.tsx
+++ b/packages/lib/src/vis/tiles/TiledLayer.tsx
@@ -16,7 +16,7 @@ interface Props extends ColorMapProps {
 function TiledLayer(props: Props) {
   const { api, layer, ...colorMapProps } = props;
 
-  const { imageSize, numLayers } = api;
+  const { imageLayerIndex, imageSize, numLayers } = api;
   const { width, height } = api.layerSizes[layer];
   const { tileSize } = api;
 
@@ -54,7 +54,7 @@ function TiledLayer(props: Props) {
             x={offset.x}
             y={offset.y}
             {...colorMapProps}
-            magFilter={layer === numLayers - 1 ? NearestFilter : LinearFilter}
+            magFilter={layer === imageLayerIndex ? NearestFilter : LinearFilter}
           />
         </Suspense>
       ))}

--- a/packages/lib/src/vis/tiles/TiledLayer.tsx
+++ b/packages/lib/src/vis/tiles/TiledLayer.tsx
@@ -16,7 +16,7 @@ interface Props extends ColorMapProps {
 function TiledLayer(props: Props) {
   const { api, layer, ...colorMapProps } = props;
 
-  const { imageLayerIndex, imageSize, numLayers } = api;
+  const { baseLayerIndex, baseLayerSize, numLayers } = api;
   const { width, height } = api.layerSizes[layer];
   const { tileSize } = api;
 
@@ -24,8 +24,8 @@ function TiledLayer(props: Props) {
   const { visSize } = useAxisSystemContext();
 
   // Transform visible domain to current level-of-detail array coordinates
-  const xScale = width / imageSize.width;
-  const yScale = height / imageSize.height;
+  const xScale = width / baseLayerSize.width;
+  const yScale = height / baseLayerSize.height;
   const origin = new Vector2(
     Math.max(0, xVisibleDomain[0] * xScale),
     Math.max(0, yVisibleDomain[0] * yScale)
@@ -54,7 +54,7 @@ function TiledLayer(props: Props) {
             x={offset.x}
             y={offset.y}
             {...colorMapProps}
-            magFilter={layer === imageLayerIndex ? NearestFilter : LinearFilter}
+            magFilter={layer === baseLayerIndex ? NearestFilter : LinearFilter}
           />
         </Suspense>
       ))}

--- a/packages/lib/src/vis/tiles/TiledLayer.tsx
+++ b/packages/lib/src/vis/tiles/TiledLayer.tsx
@@ -10,14 +10,14 @@ import { getTileOffsets, sortTilesByDistanceTo } from './utils';
 
 interface Props extends ColorMapProps {
   api: TilesApi;
-  lod: number;
+  layer: number;
 }
 
 function TiledLayer(props: Props) {
-  const { api, lod, ...colorMapProps } = props;
+  const { api, layer, ...colorMapProps } = props;
 
   const { imageSize, numLayers } = api;
-  const { width, height } = api.layerSizes[lod];
+  const { width, height } = api.layerSizes[layer];
   const { tileSize } = api;
 
   const { xVisibleDomain, yVisibleDomain } = useVisibleDomains();
@@ -43,22 +43,18 @@ function TiledLayer(props: Props) {
   return (
     // Tranforms to use level of details layer array coordinates
     <group
-      position={[
-        -visSize.width / 2,
-        -visSize.height / 2,
-        (numLayers - lod) / (numLayers + 1),
-      ]}
+      position={[-visSize.width / 2, -visSize.height / 2, layer / numLayers]}
       scale={[visSize.width / width, visSize.height / height, 1]}
     >
       {tileOffsets.map((offset) => (
         <Suspense key={`${offset.x},${offset.y}`} fallback={null}>
           <Tile
             api={api}
-            lod={lod}
+            layer={layer}
             x={offset.x}
             y={offset.y}
             {...colorMapProps}
-            magFilter={lod === 0 ? NearestFilter : LinearFilter}
+            magFilter={layer === numLayers - 1 ? NearestFilter : LinearFilter}
           />
         </Suspense>
       ))}

--- a/packages/lib/src/vis/tiles/TiledLayer.tsx
+++ b/packages/lib/src/vis/tiles/TiledLayer.tsx
@@ -16,8 +16,7 @@ interface Props extends ColorMapProps {
 function TiledLayer(props: Props) {
   const { api, lod, ...colorMapProps } = props;
 
-  const nLevels = api.layerSizes.length;
-  const [layer0Size] = api.layerSizes;
+  const { imageSize, numLayers } = api;
   const { width, height } = api.layerSizes[lod];
   const { tileSize } = api;
 
@@ -25,8 +24,8 @@ function TiledLayer(props: Props) {
   const { visSize } = useAxisSystemContext();
 
   // Transform visible domain to current level-of-detail array coordinates
-  const xScale = width / layer0Size.width;
-  const yScale = height / layer0Size.height;
+  const xScale = width / imageSize.width;
+  const yScale = height / imageSize.height;
   const origin = new Vector2(
     Math.max(0, xVisibleDomain[0] * xScale),
     Math.max(0, yVisibleDomain[0] * yScale)
@@ -47,7 +46,7 @@ function TiledLayer(props: Props) {
       position={[
         -visSize.width / 2,
         -visSize.height / 2,
-        (nLevels - lod) / (nLevels + 1),
+        (numLayers - lod) / (numLayers + 1),
       ]}
       scale={[visSize.width / width, visSize.height / height, 1]}
     >

--- a/packages/lib/src/vis/tiles/TiledLayer.tsx
+++ b/packages/lib/src/vis/tiles/TiledLayer.tsx
@@ -1,0 +1,70 @@
+import { Suspense } from 'react';
+import { LinearFilter, NearestFilter, Vector2 } from 'three';
+
+import { useVisibleDomains } from '../hooks';
+import { useAxisSystemContext } from '../shared/AxisSystemContext';
+import Tile from './Tile';
+import type { TilesApi } from './api';
+import type { ColorMapProps } from './models';
+import { getTileOffsets, sortTilesByDistanceTo } from './utils';
+
+interface Props extends ColorMapProps {
+  api: TilesApi;
+  lod: number;
+}
+
+function TiledLayer(props: Props) {
+  const { api, lod, ...colorMapProps } = props;
+
+  const nLevels = api.layerSizes.length;
+  const [layer0Size] = api.layerSizes;
+  const { width, height } = api.layerSizes[lod];
+  const { tileSize } = api;
+
+  const { xVisibleDomain, yVisibleDomain } = useVisibleDomains();
+  const { visSize } = useAxisSystemContext();
+
+  // Transform visible domain to current level-of-detail array coordinates
+  const xScale = width / layer0Size.width;
+  const yScale = height / layer0Size.height;
+  const origin = new Vector2(
+    Math.max(0, xVisibleDomain[0] * xScale),
+    Math.max(0, yVisibleDomain[0] * yScale)
+  );
+  const end = new Vector2(
+    Math.min(width, xVisibleDomain[1] * xScale),
+    Math.min(height, yVisibleDomain[1] * yScale)
+  );
+  const tileOffsets = getTileOffsets(origin, end, tileSize);
+
+  // Sort tiles from closest to vis center to farthest away
+  const center = new Vector2((origin.x + end.x) / 2, (origin.y + end.y) / 2);
+  sortTilesByDistanceTo(tileOffsets, tileSize, center);
+
+  return (
+    // Tranforms to use level of details layer array coordinates
+    <group
+      position={[
+        -visSize.width / 2,
+        -visSize.height / 2,
+        (nLevels - lod) / (nLevels + 1),
+      ]}
+      scale={[visSize.width / width, visSize.height / height, 1]}
+    >
+      {tileOffsets.map((offset) => (
+        <Suspense key={`${offset.x},${offset.y}`} fallback={null}>
+          <Tile
+            api={api}
+            lod={lod}
+            x={offset.x}
+            y={offset.y}
+            {...colorMapProps}
+            magFilter={lod === 0 ? NearestFilter : LinearFilter}
+          />
+        </Suspense>
+      ))}
+    </group>
+  );
+}
+
+export default TiledLayer;

--- a/packages/lib/src/vis/tiles/api.ts
+++ b/packages/lib/src/vis/tiles/api.ts
@@ -44,6 +44,10 @@ export abstract class TilesApi {
     return this.layerSizes[this.numLayers - 1];
   }
 
+  public get imageLayerIndex(): number {
+    return this.numLayers - 1;
+  }
+
   public get numLayers(): number {
     return this.layerSizes.length;
   }

--- a/packages/lib/src/vis/tiles/api.ts
+++ b/packages/lib/src/vis/tiles/api.ts
@@ -25,7 +25,7 @@ export function getLayerSizes(
         width: 1 + Math.floor((imageSize.width - 1) / 2),
         height: 1 + Math.floor((imageSize.height - 1) / 2),
       };
-  return [imageSize, ...getLayerSizes(nextLayerSize, tileSize, roundToEven)];
+  return [...getLayerSizes(nextLayerSize, tileSize, roundToEven), imageSize];
 }
 
 export abstract class TilesApi {
@@ -41,7 +41,7 @@ export abstract class TilesApi {
   }
 
   public get imageSize(): Size {
-    return this.layerSizes[0];
+    return this.layerSizes[this.numLayers - 1];
   }
 
   public get numLayers(): number {
@@ -49,7 +49,7 @@ export abstract class TilesApi {
   }
 
   public abstract get(
-    lod: number,
+    layer: number,
     offset: Vector2
   ): NdArray<TextureSafeTypedArray | Uint16Array>; // uint16 values are treated as half floats
 }

--- a/packages/lib/src/vis/tiles/api.ts
+++ b/packages/lib/src/vis/tiles/api.ts
@@ -5,27 +5,30 @@ import type { TextureSafeTypedArray } from '../heatmap/models';
 import type { Size } from '../models';
 
 export function getLayerSizes(
-  imageSize: Size,
+  baseLayerSize: Size,
   tileSize: Size,
   roundToEven = false
 ): Size[] {
   if (
-    imageSize.width <= tileSize.width &&
-    imageSize.height <= tileSize.height
+    baseLayerSize.width <= tileSize.width &&
+    baseLayerSize.height <= tileSize.height
   ) {
-    return [imageSize];
+    return [baseLayerSize];
   }
 
   const nextLayerSize: Size = roundToEven
     ? {
-        width: Math.floor(imageSize.width / 2),
-        height: Math.floor(imageSize.height / 2),
+        width: Math.floor(baseLayerSize.width / 2),
+        height: Math.floor(baseLayerSize.height / 2),
       }
     : {
-        width: 1 + Math.floor((imageSize.width - 1) / 2),
-        height: 1 + Math.floor((imageSize.height - 1) / 2),
+        width: 1 + Math.floor((baseLayerSize.width - 1) / 2),
+        height: 1 + Math.floor((baseLayerSize.height - 1) / 2),
       };
-  return [...getLayerSizes(nextLayerSize, tileSize, roundToEven), imageSize];
+  return [
+    ...getLayerSizes(nextLayerSize, tileSize, roundToEven),
+    baseLayerSize,
+  ];
 }
 
 export abstract class TilesApi {
@@ -40,11 +43,11 @@ export abstract class TilesApi {
     this.layerSizes = layerSizes;
   }
 
-  public get imageSize(): Size {
+  public get baseLayerSize(): Size {
     return this.layerSizes[this.numLayers - 1];
   }
 
-  public get imageLayerIndex(): number {
+  public get baseLayerIndex(): number {
     return this.numLayers - 1;
   }
 

--- a/packages/lib/src/vis/tiles/api.ts
+++ b/packages/lib/src/vis/tiles/api.ts
@@ -37,6 +37,14 @@ export abstract class TilesApi {
     this.layerSizes = layerSizes;
   }
 
+  public get imageSize(): Size {
+    return this.layerSizes[0];
+  }
+
+  public get numLayers(): number {
+    return this.layerSizes.length;
+  }
+
   public abstract get(
     lod: number,
     offset: Vector2

--- a/packages/lib/src/vis/tiles/api.ts
+++ b/packages/lib/src/vis/tiles/api.ts
@@ -33,6 +33,9 @@ export abstract class TilesApi {
   public readonly layerSizes: Size[];
 
   public constructor(tileSize: Size, layerSizes: Size[]) {
+    if (layerSizes.length === 0) {
+      throw new Error('layerSizes must not be empty');
+    }
     this.tileSize = tileSize;
     this.layerSizes = layerSizes;
   }

--- a/packages/lib/src/vis/tiles/api.ts
+++ b/packages/lib/src/vis/tiles/api.ts
@@ -1,0 +1,44 @@
+import type { NdArray } from 'ndarray';
+import type { Vector2 } from 'three';
+
+import type { TextureSafeTypedArray } from '../heatmap/models';
+import type { Size } from '../models';
+
+export function getLayerSizes(
+  imageSize: Size,
+  tileSize: Size,
+  roundToEven = false
+): Size[] {
+  if (
+    imageSize.width <= tileSize.width &&
+    imageSize.height <= tileSize.height
+  ) {
+    return [imageSize];
+  }
+
+  const nextLayerSize: Size = roundToEven
+    ? {
+        width: Math.floor(imageSize.width / 2),
+        height: Math.floor(imageSize.height / 2),
+      }
+    : {
+        width: 1 + Math.floor((imageSize.width - 1) / 2),
+        height: 1 + Math.floor((imageSize.height - 1) / 2),
+      };
+  return [imageSize, ...getLayerSizes(nextLayerSize, tileSize, roundToEven)];
+}
+
+export abstract class TilesApi {
+  public readonly tileSize: Size;
+  public readonly layerSizes: Size[];
+
+  public constructor(tileSize: Size, layerSizes: Size[]) {
+    this.tileSize = tileSize;
+    this.layerSizes = layerSizes;
+  }
+
+  public abstract get(
+    lod: number,
+    offset: Vector2
+  ): NdArray<TextureSafeTypedArray | Uint16Array>; // uint16 values are treated as half floats
+}

--- a/packages/lib/src/vis/tiles/hooks.ts
+++ b/packages/lib/src/vis/tiles/hooks.ts
@@ -1,0 +1,13 @@
+import { useThree } from '@react-three/fiber';
+
+import { useVisibleDomains } from '../hooks';
+
+export function useDataPerPixel() {
+  const { xVisibleDomain, yVisibleDomain } = useVisibleDomains();
+  const { width, height } = useThree((state) => state.size);
+
+  return {
+    xDataPerPixel: (xVisibleDomain[1] - xVisibleDomain[0]) / width,
+    yDataPerPixel: (yVisibleDomain[1] - yVisibleDomain[0]) / height,
+  };
+}

--- a/packages/lib/src/vis/tiles/models.ts
+++ b/packages/lib/src/vis/tiles/models.ts
@@ -1,0 +1,11 @@
+import type { Domain } from '@h5web/shared';
+
+import type { ColorMap } from '../heatmap/models';
+import type { VisScaleType } from '../models';
+
+export interface ColorMapProps {
+  domain: Domain;
+  scaleType: VisScaleType;
+  colorMap: ColorMap;
+  invertColorMap?: boolean;
+}

--- a/packages/lib/src/vis/tiles/utils.ts
+++ b/packages/lib/src/vis/tiles/utils.ts
@@ -1,0 +1,43 @@
+import { Vector2 } from 'three';
+
+import type { Size } from '../models';
+
+export function getTileOffsets(
+  origin: Vector2,
+  end: Vector2,
+  tileSize: Size
+): Vector2[] {
+  const { width, height } = tileSize;
+
+  const nCols = Math.ceil(((origin.x % width) + end.x - origin.x) / width);
+  const nRows = Math.ceil(((origin.y % height) + end.y - origin.y) / height);
+
+  const start = new Vector2(
+    Math.floor(origin.x / width) * width,
+    Math.floor(origin.y / height) * height
+  );
+
+  const centers: Vector2[] = [];
+  for (let row = 0; row < nRows; row += 1) {
+    for (let col = 0; col < nCols; col += 1) {
+      centers.push(new Vector2(start.x + col * width, start.y + row * height));
+    }
+  }
+
+  return centers;
+}
+
+// Sort tiles from closest to farthest away from ref
+export function sortTilesByDistanceTo(
+  offsets: Vector2[],
+  tileSize: Size,
+  ref: Vector2
+) {
+  const { width, height } = tileSize;
+
+  offsets.sort((a, b) => {
+    const aCenter = new Vector2(a.x + width / 2, a.y + height / 2);
+    const bCenter = new Vector2(b.x + width / 2, b.y + height / 2);
+    return aCenter.distanceToSquared(ref) - bCenter.distanceToSquared(ref);
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,7 @@ importers:
       react-dom: 17.0.2
       react-icons: 4.3.1
       react-scripts: 4.0.3
+      react-suspense-fetch: 0.4.0
       three: 0.135.0
       typescript: 4.5.4
       webpack: 4.46.0
@@ -113,6 +114,7 @@ importers:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-icons: 4.3.1_react@17.0.2
+      react-suspense-fetch: 0.4.0
       three: 0.135.0
     devDependencies:
       '@babel/core': 7.16.12


### PR DESCRIPTION
This PR adds a component to render (large) images as tiles with pyramid of level-of-details image support.

The axes are used to compute the level of detail to use rather than the size of the array, this needs to be solved.

~~commit https://github.com/silx-kit/h5web/commit/cc293bc86d51e0d37a991e23a746280d278f908c provides a proof of concept for h5grove-based fetch of subsampled slices. It is there for demo and should be removed before merging.~~