### PR TITLE
Add control to change cell width in MatrixVis toolbar

### DIFF
--- a/apps/storybook/src/Customization.stories.mdx
+++ b/apps/storybook/src/Customization.stories.mdx
@@ -51,30 +51,31 @@ as you see fit. For instance, if you'd like to change the color of the curve of 
 
 #### Visualizations
 
-| Name                           | Default                    | Description                 |
-| ------------------------------ | -------------------------- | --------------------------- |
-| `--h5w-canvas--bgColor`        | `transparent`              | Background color of canvas  |
-| `--h5w-plotTitle--color`       | `inherit`                  | Text color of plot title    |
-| `--h5w-plotTitle--fontFamily`  | `inherit`                  | Font family of plot title   |
-| `--h5w-plotTitle--fontSize`    | `1.125em`                  | Font size of plot title     |
-| `--h5w-plotTitle--fontWeight`  | `inherit`                  | Font weight of plot title   |
-| `--h5w-ticks--color`           | `gray`                     | Color of ticks              |
-| `--h5w-tickLabels--color`      | `#333`                     | Text color of tick labels   |
-| `--h5w-tickLabels--fontFamily` | `inherit`                  | Font family of tick labels  |
-| `--h5w-tickLabels--fontSize`   | `inherit`                  | Font size of tick labels    |
-| `--h5w-axisLabels--color`      | `#333`                     | Text color of axis labels   |
-| `--h5w-axisLabels--fontFamily` | `inherit`                  | Font family of axis labels  |
-| `--h5w-axisLabels--fontSize`   | `inherit`                  | Font size of axis labels    |
-| `--h5w-axisLabels--fontWeight` | `600`                      | Font weight of axis labels  |
-| `--h5w-grid--color`            | `gray`                     | Color of grid lines         |
-| `--h5w-grid--opacity`          | `0.33`                     | Opacity of grid lines       |
-| `--h5w-tooltip--color`         | `inherit`                  | Text color of tooltip       |
-| `--h5w-tooltip--bgColor`       | `rgba(255, 255, 255, 0.9)` | Background color of tooltip |
-| `--h5w-tooltip--fontFamily`    | `inherit`                  | Font family of tooltip      |
-| `--h5w-tooltip--fontSize`      | `0.75em`                   | Font size of tooltip        |
-| `--h5w-tooltip-guide--color`   | `gray`                     | Color of tooltip guide      |
-| `--h5w-tooltip-guide--width`   | `1.5`                      | Width of tooltip guide      |
-| `--h5w-tooltip-guide--opacity` | `0.5`                      | Opacity of tooltip guide    |
+| Name                           | Default                    | Description                                            |
+| ------------------------------ | -------------------------- | ------------------------------------------------------ |
+| `--h5w-canvas--bgColor`        | `transparent`              | Background color of canvas                             |
+| `--h5w-plotTitle--color`       | `inherit`                  | Text color of plot title                               |
+| `--h5w-plotTitle--fontFamily`  | `inherit`                  | Font family of plot title                              |
+| `--h5w-plotTitle--fontSize`    | `1.125em`                  | Font size of plot title                                |
+| `--h5w-plotTitle--fontWeight`  | `inherit`                  | Font weight of plot title                              |
+| `--h5w-ticks--color`           | `gray`                     | Color of ticks                                         |
+| `--h5w-tickLabels--color`      | `#333`                     | Text color of tick labels                              |
+| `--h5w-tickLabels--fontFamily` | `inherit`                  | Font family of tick labels                             |
+| `--h5w-tickLabels--fontSize`   | `inherit`                  | Font size of tick labels                               |
+| `--h5w-axisLabels--color`      | `#333`                     | Text color of axis labels                              |
+| `--h5w-axisLabels--fontFamily` | `inherit`                  | Font family of axis labels                             |
+| `--h5w-axisLabels--fontSize`   | `inherit`                  | Font size of axis labels                               |
+| `--h5w-axisLabels--fontWeight` | `600`                      | Font weight of axis labels                             |
+| `--h5w-grid--color`            | `gray`                     | Color of grid lines                                    |
+| `--h5w-grid--opacity`          | `0.33`                     | Opacity of grid lines                                  |
+| `--h5w-tooltip--color`         | `inherit`                  | Text color of tooltip                                  |
+| `--h5w-tooltip--bgColor`       | `rgba(255, 255, 255, 0.9)` | Background color of tooltip                            |
+| `--h5w-tooltip--fontFamily`    | `inherit`                  | Font family of tooltip                                 |
+| `--h5w-tooltip--fontSize`      | `0.75em`                   | Font size of tooltip                                   |
+| `--h5w-tooltip-guide--color`   | `gray`                     | Color of tooltip guide                                 |
+| `--h5w-tooltip-guide--width`   | `1.5`                      | Width of tooltip guide                                 |
+| `--h5w-tooltip-guide--opacity` | `0.5`                      | Opacity of tooltip guide                               |
+| `--h5w-error--color`           | `brown`                    | Color of error messages and UI elements in error state |
 
 ##### Line
 
@@ -111,18 +112,16 @@ as you see fit. For instance, if you'd like to change the color of the curve of 
 | `--h5w-matrix-indexCell--fontWeight` | `600`                                      | Font weight of index cells            |
 | `--h5w-matrix-anchorCell--bgColor`   | `silver`                                   | Background colour of anchor cell      |
 
-#### UI
+#### Toolbar
 
-| Name                 | Default | Description                                            |
-| -------------------- | ------- | ------------------------------------------------------ |
-| `--h5w-error--color` | `brown` | Color of error messages and UI elements in error state |
-
-##### Toolbar
-
-| Name                             | Default              | Description                 |
-| -------------------------------- | -------------------- | --------------------------- |
-| `--h5w-toolbar--bgColor`         | `aliceblue`          | Background color of toolbar |
-| `--h5w-toolbar-separator--color` | `rgba(0, 0, 0, 0.2)` | Color of toolbar separators |
+| Name                                     | Default              | Description                              |
+| ---------------------------------------- | -------------------- | ---------------------------------------- |
+| `--h5w-toolbar--bgColor`                 | `aliceblue`          | Background color of toolbar              |
+| `--h5w-toolbar-separator--color`         | `rgba(0, 0, 0, 0.2)` | Color of separators                      |
+| `--h5w-toolbar-label--color`             | `royalblue`          | Text color of control labels             |
+| `--h5w-toolbar-input--shadowColor`       | `dimgray`            | Box shadow color of text inputs          |
+| `--h5w-toolbar-input-hover--shadowColor` | `gray`               | Box shadow color of text inputs on hover |
+| `--h5w-toolbar-input-focus--shadowColor` | `royalblue`          | Box shadow color of text inputs on focus |
 
 ##### Buttons
 
@@ -138,14 +137,14 @@ as you see fit. For instance, if you'd like to change the color of the curve of 
 
 ##### Selectors
 
-| Name                                      | Default      | Description                          |
-| ----------------------------------------- | ------------ | ------------------------------------ |
-| `--h5w-selector-label--color`             | `royalblue`  | Text color of label                  |
-| `--h5w-selector-menu--bgColor`            | `white`      | Background color of menu             |
-| `--h5w-selector-arrowIcon--color`         | `dimgray`    | Color of arrow icon                  |
-| `--h5w-selector-option-hover--bgColor`    | `whitesmoke` | Background color of options on hover |
-| `--h5w-selector-option-selected--bgColor` | `#eee`       | Background color of selected option  |
-| `--h5w-selector-groupLabel--color`        | `gray`       | Text color of group labels in menu   |
+| Name                                      | Default                                      | Description                          |
+| ----------------------------------------- | -------------------------------------------- | ------------------------------------ |
+| `--h5w-selector-label--color`             | `var(--h5w-toolbar-label--color, royalblue)` | Text color of label                  |
+| `--h5w-selector-menu--bgColor`            | `white`                                      | Background color of menu             |
+| `--h5w-selector-arrowIcon--color`         | `dimgray`                                    | Color of arrow icon                  |
+| `--h5w-selector-option-hover--bgColor`    | `whitesmoke`                                 | Background color of options on hover |
+| `--h5w-selector-option-selected--bgColor` | `#eee`                                       | Background color of selected option  |
+| `--h5w-selector-groupLabel--color`        | `gray`                                       | Text color of group labels in menu   |
 
 ##### Domain slider
 

--- a/apps/storybook/src/MatrixVis.stories.tsx
+++ b/apps/storybook/src/MatrixVis.stories.tsx
@@ -48,5 +48,5 @@ export default {
   parameters: { layout: 'fullscreen' },
   decorators: [FillHeight],
   component: MatrixVis,
-  args: { cellWidth: 116 },
+  args: { cellWidth: 120 },
 } as Meta;

--- a/apps/storybook/src/styles.css
+++ b/apps/storybook/src/styles.css
@@ -44,6 +44,7 @@ body {
   --h5w-btn-hover--bgColor: var(--secondary-lighter);
   --h5w-btnPressed--bgColor: var(--secondary-light);
   --h5w-toolbar--bgColor: var(--secondary-light-bg);
+  --h5w-toolbar-label--color: var(--secondary-dark);
   --h5w-domainSlider-track--bgColor: var(--secondary-dark-15);
   --h5w-domainSlider-dataTrack--bgColor: var(--secondary-dark);
   --h5w-domainSlider-dataTrack--shadowColor: var(--secondary-darker);
@@ -51,7 +52,6 @@ body {
   --h5w-domainSlider-thumb-auto--bgColor: var(--secondary-light);
   --h5w-domainSlider-boundInput-focus--shadowColor: var(--secondary-dark);
   --h5w-domainSlider-boundInput-editing--borderColor: var(--secondary-dark);
-  --h5w-selector-label--color: var(--secondary-dark);
   --h5w-selector-option-hover--bgColor: var(--secondary-light-bg);
   --h5w-selector-option-selected--bgColor: var(--secondary-light);
   --h5w-domainSlider-histogram--color: var(--secondary-dark);

--- a/packages/app/src/App.module.css
+++ b/packages/app/src/App.module.css
@@ -39,6 +39,8 @@
   --h5w-btn-hover--bgColor: var(--secondary-lighter);
   --h5w-btnPressed--bgColor: var(--secondary-light);
   --h5w-toolbar--bgColor: var(--secondary-light-bg);
+  --h5w-toolbar-label--color: var(--secondary-dark);
+  --h5w-toolbar-input-focus--shadowColor: var(--secondary-dark);
   --h5w-domainSlider-track--bgColor: var(--secondary-dark-15);
   --h5w-domainSlider-dataTrack--bgColor: var(--secondary-dark);
   --h5w-domainSlider-dataTrack--shadowColor: var(--secondary-darker);
@@ -46,7 +48,6 @@
   --h5w-domainSlider-thumb-auto--bgColor: var(--secondary-light);
   --h5w-domainSlider-boundInput-focus--shadowColor: var(--secondary-dark);
   --h5w-domainSlider-boundInput-editing--borderColor: var(--secondary-dark);
-  --h5w-selector-label--color: var(--secondary-dark);
   --h5w-selector-option-hover--bgColor: var(--secondary-light-bg);
   --h5w-selector-option-selected--bgColor: var(--secondary-light);
   --h5w-domainSlider-histogram--color: var(--secondary-dark);

--- a/packages/app/src/vis-packs/core/complex/config.tsx
+++ b/packages/app/src/vis-packs/core/complex/config.tsx
@@ -28,7 +28,7 @@ function createStore() {
 }
 
 const { Provider, useStore } = createContext<ComplexConfig>();
-export const useComplexConfig = useStore;
+export { useStore as useComplexConfig };
 
 export function ComplexConfigProvider(props: ConfigProviderProps) {
   const { children } = props;

--- a/packages/app/src/vis-packs/core/heatmap/config.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/config.tsx
@@ -71,7 +71,7 @@ function createStore() {
 }
 
 const { Provider, useStore } = createContext<HeatmapConfig>();
-export const useHeatmapConfig = useStore;
+export { useStore as useHeatmapConfig };
 
 export function HeatmapConfigProvider(props: ConfigProviderProps) {
   const { children } = props;

--- a/packages/app/src/vis-packs/core/line/config.tsx
+++ b/packages/app/src/vis-packs/core/line/config.tsx
@@ -61,7 +61,7 @@ function createStore() {
 }
 
 const { Provider, useStore } = createContext<LineConfig>();
-export const useLineConfig = useStore;
+export { useStore as useLineConfig };
 
 export function LineConfigProvider(props: ConfigProviderProps) {
   const { children } = props;

--- a/packages/app/src/vis-packs/core/matrix/MappedMatrixVis.tsx
+++ b/packages/app/src/vis-packs/core/matrix/MappedMatrixVis.tsx
@@ -6,11 +6,12 @@ import type {
   PrintableType,
 } from '@h5web/shared';
 import { createPortal } from 'react-dom';
+import shallow from 'zustand/shallow';
 
 import type { DimensionMapping } from '../../../dimension-mapper/models';
 import { useMappedArray, useSlicedDimsAndMapping } from '../hooks';
 import MatrixToolbar from './MatrixToolbar';
-import { useMatrixVisConfig } from './config';
+import { useMatrixConfig } from './config';
 import { getCellWidth, getFormatter } from './utils';
 
 interface Props {
@@ -26,7 +27,10 @@ function MappedMatrixVis(props: Props) {
   const { dataset, selection, value, dims, dimMapping, toolbarContainer } =
     props;
 
-  const sticky = useMatrixVisConfig((state) => state.sticky);
+  const { sticky, customCellWidth } = useMatrixConfig(
+    (state) => state,
+    shallow
+  );
 
   const [slicedDims, slicedMapping] = useSlicedDimsAndMapping(dims, dimMapping);
   const [mappedArray] = useMappedArray(value, slicedDims, slicedMapping);
@@ -38,14 +42,18 @@ function MappedMatrixVis(props: Props) {
     <>
       {toolbarContainer &&
         createPortal(
-          <MatrixToolbar dataset={dataset} selection={selection} />,
+          <MatrixToolbar
+            dataset={dataset}
+            selection={selection}
+            cellWidth={cellWidth}
+          />,
           toolbarContainer
         )}
 
       <MatrixVis
         dataArray={mappedArray}
         formatter={formatter}
-        cellWidth={cellWidth}
+        cellWidth={customCellWidth ?? cellWidth}
         sticky={sticky}
       />
     </>

--- a/packages/app/src/vis-packs/core/matrix/MatrixToolbar.tsx
+++ b/packages/app/src/vis-packs/core/matrix/MatrixToolbar.tsx
@@ -1,4 +1,10 @@
-import { Separator, ToggleBtn, Toolbar, ExportMenu } from '@h5web/lib';
+import {
+  Separator,
+  ToggleBtn,
+  Toolbar,
+  ExportMenu,
+  CellWidthInput,
+} from '@h5web/lib';
 import type { ArrayShape, Dataset, PrintableType } from '@h5web/shared';
 import { hasNumericType } from '@h5web/shared';
 import { useContext } from 'react';
@@ -6,23 +12,33 @@ import { FiAnchor } from 'react-icons/fi';
 
 import { ProviderContext } from '../../../providers/context';
 import type { ExportFormat } from '../../../providers/models';
-import { useMatrixVisConfig } from './config';
+import { useMatrixConfig } from './config';
 
 const EXPORT_FORMATS: ExportFormat[] = ['npy', 'csv'];
 
 interface Props {
   dataset: Dataset<ArrayShape, PrintableType>;
   selection: string | undefined;
+  cellWidth: number;
 }
 
 function MatrixToolbar(props: Props) {
-  const { dataset, selection } = props;
+  const { dataset, selection, cellWidth } = props;
   const { getExportURL } = useContext(ProviderContext);
 
-  const { sticky, toggleSticky } = useMatrixVisConfig();
+  const { sticky, toggleSticky, customCellWidth, setCustomCellWidth } =
+    useMatrixConfig();
 
   return (
     <Toolbar>
+      <CellWidthInput
+        value={customCellWidth}
+        defaultValue={cellWidth}
+        onChange={setCustomCellWidth}
+      />
+
+      <Separator />
+
       <ToggleBtn
         label="Freeze indices"
         icon={FiAnchor}

--- a/packages/app/src/vis-packs/core/matrix/config.tsx
+++ b/packages/app/src/vis-packs/core/matrix/config.tsx
@@ -7,6 +7,9 @@ import type { ConfigProviderProps } from '../../models';
 interface MatrixVisConfig {
   sticky: boolean;
   toggleSticky: () => void;
+
+  customCellWidth: number | undefined;
+  setCustomCellWidth: (val: number | undefined) => void;
 }
 
 function createStore() {
@@ -17,17 +20,22 @@ function createStore() {
       (set, get) => ({
         sticky: false,
         toggleSticky: () => set((state) => ({ sticky: !state.sticky })),
+
+        customCellWidth: undefined,
+        setCustomCellWidth: (customCellWidth) => {
+          set({ customCellWidth });
+        },
       }),
       {
         name: 'h5web:matrix',
-        version: 1,
+        version: 2,
       }
     )
   );
 }
 
 const { Provider, useStore } = createContext<MatrixVisConfig>();
-export const useMatrixVisConfig = useStore;
+export { useStore as useMatrixConfig };
 
 export function MatrixConfigProvider(props: ConfigProviderProps) {
   const { children } = props;

--- a/packages/app/src/vis-packs/core/matrix/utils.ts
+++ b/packages/app/src/vis-packs/core/matrix/utils.ts
@@ -5,6 +5,7 @@ import type {
   PrintableType,
 } from '@h5web/shared';
 import {
+  DTypeClass,
   formatMatrixComplex,
   formatMatrixValue,
   hasComplexType,
@@ -30,9 +31,19 @@ export function getFormatter(
 export function getCellWidth(
   dataset: Dataset<ArrayShape, PrintableType>
 ): number {
-  if (hasComplexType(dataset)) {
-    return 232;
+  const { type } = dataset;
+
+  if (type.class === DTypeClass.String) {
+    return type.length !== undefined ? 12 * type.length : 300;
   }
 
-  return 116;
+  if (type.class === DTypeClass.Bool) {
+    return 90;
+  }
+
+  if (type.class === DTypeClass.Complex) {
+    return 240;
+  }
+
+  return 120;
 }

--- a/packages/app/src/vis-packs/core/rgb/MappedRgbVis.tsx
+++ b/packages/app/src/vis-packs/core/rgb/MappedRgbVis.tsx
@@ -5,7 +5,7 @@ import shallow from 'zustand/shallow';
 
 import { useBaseArray } from '../hooks';
 import RgbToolbar from './RgbToolbar';
-import { useRgbVisConfig } from './config';
+import { useRgbConfig } from './config';
 
 interface Props {
   value: number[] | TypedArray;
@@ -19,7 +19,7 @@ function MappedRgbVis(props: Props) {
 
   const dataArray = useBaseArray(value, dims);
 
-  const { showGrid, layout, imageType } = useRgbVisConfig(
+  const { showGrid, layout, imageType } = useRgbConfig(
     (state) => state,
     shallow
   );

--- a/packages/app/src/vis-packs/core/rgb/RgbToolbar.tsx
+++ b/packages/app/src/vis-packs/core/rgb/RgbToolbar.tsx
@@ -9,11 +9,11 @@ import {
 import { MdAspectRatio } from 'react-icons/md';
 import shallow from 'zustand/shallow';
 
-import { useRgbVisConfig } from './config';
+import { useRgbConfig } from './config';
 
 function RgbToolbar() {
   const { layout, setLayout, showGrid, toggleGrid, imageType, setImageType } =
-    useRgbVisConfig((state) => state, shallow);
+    useRgbConfig((state) => state, shallow);
 
   return (
     <Toolbar>

--- a/packages/app/src/vis-packs/core/rgb/config.tsx
+++ b/packages/app/src/vis-packs/core/rgb/config.tsx
@@ -41,7 +41,7 @@ function createStore() {
 }
 
 const { Provider, useStore } = createContext<RgbVisConfig>();
-export const useRgbVisConfig = useStore;
+export { useStore as useRgbConfig };
 
 export function RgbConfigProvider(props: ConfigProviderProps) {
   const { children } = props;

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -23,6 +23,7 @@ export { default as GridToggler } from './toolbar/controls/GridToggler';
 export { default as FlipYAxisToggler } from './toolbar/controls/FlipYAxisToggler';
 export { default as Selector } from './toolbar/controls/Selector/Selector';
 export { default as ExportMenu } from './toolbar/controls/ExportMenu';
+export { default as CellWidthInput } from './toolbar/controls/CellWidthInput';
 
 // Building blocks
 export { default as VisCanvas } from './vis/shared/VisCanvas';

--- a/packages/lib/src/toolbar/controls/CellWidthInput.module.css
+++ b/packages/lib/src/toolbar/controls/CellWidthInput.module.css
@@ -1,0 +1,38 @@
+.root {
+  display: flex;
+  align-items: center;
+}
+
+.label {
+  color: var(--h5w-toolbar-label--color, royalblue);
+  margin: 0 0.25rem;
+}
+
+.input {
+  width: 4.5rem;
+  margin-right: 0.125rem;
+  padding: 0.25rem 0.375rem;
+  background-color: rgba(255, 255, 255, 0.5);
+  border: none;
+  border-radius: 0.125rem;
+  box-shadow: 0 0 2px var(--h5w-toolbar-input--shadowColor, dimgray);
+  font-weight: inherit;
+  line-height: inherit;
+  transition: background-color 0.05s ease-in-out, box-shadow 0.05s ease-in-out;
+}
+
+.input:hover {
+  box-shadow: 1px 1px 2px 1px var(--h5w-toolbar-input-hover--shadowColor, gray);
+}
+
+.input:focus {
+  background-color: white;
+  box-shadow: 1px 1px 2px 1px
+    var(--h5w-toolbar-input-focus--shadowColor, royalblue);
+  outline: none;
+}
+
+.input[data-modified] {
+  background-color: white;
+  font-weight: bold;
+}

--- a/packages/lib/src/toolbar/controls/CellWidthInput.tsx
+++ b/packages/lib/src/toolbar/controls/CellWidthInput.tsx
@@ -1,0 +1,79 @@
+import { useDebouncedCallback } from '@react-hookz/web';
+import { useState } from 'react';
+import { FiRotateCw } from 'react-icons/fi';
+
+import Btn from './Btn';
+import styles from './CellWidthInput.module.css';
+
+const ID = 'h5w-cell-width';
+const MIN = 50;
+
+interface Props {
+  value: number | undefined;
+  defaultValue: number;
+  onChange: (val: number | undefined) => void;
+}
+
+function CellWidthInput(props: Props) {
+  const { value, defaultValue: rawDefaultValue, onChange } = props;
+
+  const hasValue = value !== undefined;
+  const defaultValue = Math.max(rawDefaultValue, MIN);
+
+  const [inputValue, setInputValue] = useState(
+    (value ?? defaultValue).toString()
+  );
+
+  const onChangeDebounced = useDebouncedCallback(onChange, [onChange], 150);
+
+  return (
+    <div className={styles.root}>
+      <label id={`${ID}-label`} className={styles.label} htmlFor={ID}>
+        Cell width
+      </label>
+
+      <input
+        id={ID}
+        className={styles.input}
+        type="number"
+        value={inputValue}
+        step={10}
+        min={MIN}
+        placeholder={defaultValue.toString()}
+        aria-labelledby={`${ID}-label`} // https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/566
+        data-modified={hasValue || undefined}
+        onInput={(evt) => {
+          const { value } = evt.currentTarget;
+          setInputValue(value);
+
+          if (!value) {
+            onChange(undefined);
+            return;
+          }
+
+          const numValue = Number.parseInt(value);
+          const safeNumValue = Number.isNaN(numValue)
+            ? defaultValue
+            : Math.max(numValue, MIN);
+
+          onChangeDebounced(safeNumValue);
+        }}
+        onBlur={() => setInputValue((value ?? defaultValue).toString())}
+      />
+
+      <Btn
+        label="Reset"
+        icon={FiRotateCw}
+        iconOnly
+        small
+        disabled={!hasValue}
+        onClick={() => {
+          setInputValue(defaultValue.toString());
+          onChange(undefined);
+        }}
+      />
+    </div>
+  );
+}
+
+export default CellWidthInput;

--- a/packages/lib/src/toolbar/controls/Selector/Selector.module.css
+++ b/packages/lib/src/toolbar/controls/Selector/Selector.module.css
@@ -4,7 +4,10 @@
 }
 
 .selectorLabel {
-  color: var(--h5w-selector-label--color, royalblue);
+  color: var(
+    --h5w-selector-label--color,
+    var(--h5w-toolbar-label--color, royalblue)
+  );
   margin-left: 0.25rem;
 }
 


### PR DESCRIPTION
Fix #916

Following #976, I've made the computation of the cell width smarter for fixed-length strings, vlen strings and booleans.

![image](https://user-images.githubusercontent.com/2936402/155306754-e8a4bbd1-9278-49ae-9840-6732932f87e2.png)

![image](https://user-images.githubusercontent.com/2936402/155306704-2556253b-4f56-4041-b46d-a03e7cf5de85.png)

Since we cannot reasonably guess the optimal cell width for vlen strings (I've chosen an arbitrary default of 300px), I've also added a control to the toolbar so user can tweak the value themselves:

![image](https://user-images.githubusercontent.com/2936402/155306940-e1ff6e52-5487-4e72-9f13-86392b96c847.png)

The value can be reset to the default and is persisted to local storage.