### PR TITLE
Bring ScatterVis parameters in line with other vis

### DIFF
--- a/apps/storybook/src/ScatterVis.stories.tsx
+++ b/apps/storybook/src/ScatterVis.stories.tsx
@@ -2,6 +2,7 @@ import { getDomain, INTERPOLATORS, ScatterVis } from '@h5web/lib';
 import type { ScatterVisProps } from '@h5web/lib';
 import { ScaleType } from '@h5web/shared';
 import type { Meta, Story } from '@storybook/react/types-6-0';
+import ndarray from 'ndarray';
 
 import FillHeight from './decorators/FillHeight';
 
@@ -40,14 +41,36 @@ const data = [
 ];
 
 const domain = getDomain(data);
+const dataArray = ndarray(data);
 
 export const Default = Template.bind({});
-
 Default.args = {
   dataAbscissas: abscissas,
   dataOrdinates: ordinates.map((v) => v + 10),
-  data,
+  dataArray,
   domain,
+};
+
+export const TypedArray = Template.bind({});
+TypedArray.args = {
+  dataAbscissas: abscissas,
+  dataOrdinates: ordinates.map((v) => v + 10),
+  dataArray: ndarray(Float32Array.from(data)),
+  domain,
+};
+
+export const MarkerSize = Template.bind({});
+MarkerSize.args = {
+  ...Default.args,
+  size: 20,
+};
+
+export const Labels = Template.bind({});
+Labels.args = {
+  ...Default.args,
+  title: 'A Scatter vis',
+  abscissaLabel: 'Latitude',
+  ordinateLabel: 'Longitude',
 };
 
 export default {

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -44,6 +44,7 @@ export { default as Annotation } from './vis/shared/Annotation';
 export { default as LineSelectionMesh } from './vis/shared/LineSelectionMesh';
 export { default as RectSelectionMesh } from './vis/shared/RectSelectionMesh';
 export { default as SelectionMesh } from './vis/shared/SelectionMesh';
+export { default as ScatterPoints } from './vis/scatter/ScatterPoints';
 
 // Context hook
 export { useAxisSystemContext } from './vis/shared/AxisSystemContext';

--- a/packages/lib/src/vis/scatter/ScatterPoints.tsx
+++ b/packages/lib/src/vis/scatter/ScatterPoints.tsx
@@ -1,4 +1,4 @@
-import type { Domain, ScaleType } from '@h5web/shared';
+import type { Domain, NumArray, ScaleType } from '@h5web/shared';
 import { useThree } from '@react-three/fiber';
 import { rgb } from 'd3-color';
 import { useLayoutEffect, useMemo, useState } from 'react';
@@ -14,11 +14,12 @@ import { useBufferAttributes } from './hooks';
 interface Props {
   abscissas: number[];
   ordinates: number[];
-  data: number[];
+  data: NumArray;
   domain: Domain;
   scaleType: ScaleType;
   colorMap: ColorMap;
   invertColorMap: boolean;
+  size: number;
 }
 
 function ScatterPoints(props: Props) {
@@ -30,6 +31,7 @@ function ScatterPoints(props: Props) {
     scaleType,
     colorMap,
     invertColorMap,
+    size,
   } = props;
 
   const [dataGeometry] = useState(() => new BufferGeometry());
@@ -62,7 +64,7 @@ function ScatterPoints(props: Props) {
 
   return (
     <points geometry={dataGeometry}>
-      <GlyphMaterial size={10} glyphType={GlyphType.Circle} />
+      <GlyphMaterial size={size} glyphType={GlyphType.Circle} />
     </points>
   );
 }

--- a/packages/lib/src/vis/scatter/ScatterVis.tsx
+++ b/packages/lib/src/vis/scatter/ScatterVis.tsx
@@ -1,5 +1,7 @@
-import type { Domain } from '@h5web/shared';
-import { assertDataLength, ScaleType } from '@h5web/shared';
+import type { Domain, NumArray } from '@h5web/shared';
+import { assertDataLength, assertDefined, ScaleType } from '@h5web/shared';
+import type { NdArray } from 'ndarray';
+import type { ReactNode } from 'react';
 
 import ColorBar from '../heatmap/ColorBar';
 import type { ColorMap } from '../heatmap/models';
@@ -7,40 +9,49 @@ import { useAxisDomain } from '../hooks';
 import PanMesh from '../shared/PanMesh';
 import VisCanvas from '../shared/VisCanvas';
 import ZoomMesh from '../shared/ZoomMesh';
-import { DEFAULT_DOMAIN } from '../utils';
 import ScatterPoints from './ScatterPoints';
 import styles from './ScatterVis.module.css';
 
 interface Props {
   dataAbscissas: number[];
   dataOrdinates: number[];
-  data: number[];
+  dataArray: NdArray<NumArray>;
   domain: Domain;
   colorMap: ColorMap;
   invertColorMap?: boolean;
+  abscissaLabel?: string;
+  ordinateLabel?: string;
   scaleType?: ScaleType;
   showGrid?: boolean;
+  title?: string;
+  size?: number;
+  children: ReactNode;
 }
 
 function ScatterVis(props: Props) {
   const {
     dataAbscissas: abscissas,
     dataOrdinates: ordinates,
-    data,
+    dataArray,
     domain,
     colorMap,
     invertColorMap = false,
+    abscissaLabel,
+    ordinateLabel,
     scaleType = ScaleType.Linear,
     showGrid = true,
+    title,
+    size = 10,
+    children,
   } = props;
 
-  assertDataLength(abscissas, data, 'abscissa');
-  assertDataLength(ordinates, data, 'ordinates');
+  assertDataLength(abscissas, dataArray, 'abscissa');
+  assertDataLength(ordinates, dataArray, 'ordinates');
 
-  const abscissaDomain =
-    useAxisDomain(abscissas, undefined, 0.01) || DEFAULT_DOMAIN;
-  const ordinateDomain =
-    useAxisDomain(ordinates, undefined, 0.01) || DEFAULT_DOMAIN;
+  const abscissaDomain = useAxisDomain(abscissas, undefined, 0.01);
+  assertDefined(abscissaDomain, 'Abscissas have undefined domain');
+  const ordinateDomain = useAxisDomain(ordinates, undefined, 0.01);
+  assertDefined(ordinateDomain, 'Ordinates have undefined domain');
 
   return (
     <figure className={styles.root}>
@@ -48,23 +59,28 @@ function ScatterVis(props: Props) {
         abscissaConfig={{
           visDomain: abscissaDomain,
           showGrid,
+          label: abscissaLabel,
         }}
         ordinateConfig={{
           visDomain: ordinateDomain,
           showGrid,
+          label: ordinateLabel,
         }}
+        title={title}
       >
         <PanMesh />
         <ZoomMesh />
         <ScatterPoints
           abscissas={abscissas}
           ordinates={ordinates}
-          data={data}
+          data={dataArray.data}
           domain={domain}
           scaleType={scaleType}
           colorMap={colorMap}
           invertColorMap={invertColorMap}
+          size={size}
         />
+        {children}
       </VisCanvas>
       <ColorBar
         domain={domain}

--- a/packages/lib/src/vis/scatter/hooks.ts
+++ b/packages/lib/src/vis/scatter/hooks.ts
@@ -1,3 +1,4 @@
+import type { NumArray } from '@h5web/shared';
 import { useMemo } from 'react';
 
 import { useAxisSystemContext } from '../shared/AxisSystemContext';
@@ -7,7 +8,7 @@ const CAMERA_FAR = 1000; // R3F's default
 export function useBufferAttributes(
   abscissas: number[],
   ordinates: number[],
-  data: number[],
+  data: NumArray,
   dataToColorScale: (val: number) => [number, number, number]
 ) {
   const { abscissaScale, ordinateScale } = useAxisSystemContext();


### PR DESCRIPTION
Now accepts:
- a `ndarray` instead of `number[]`. The `ndarray` can contain a `number[]` or a `TypedArray`
- a `size` parameter
- a `title` parameter
- Labels for abscissas and ordinates
- `children`