### PR TITLE
Add a Reset zoom button to Heatmap, Line, Rgb and ScatterVis

### DIFF
--- a/packages/lib/src/vis/heatmap/HeatmapVis.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapVis.tsx
@@ -11,6 +11,7 @@ import type { ReactElement, ReactNode } from 'react';
 import { useAxisDomain, useValueToIndexScale } from '../hooks';
 import type { AxisParams, VisScaleType } from '../models';
 import PanMesh from '../shared/PanMesh';
+import ResetZoomButton from '../shared/ResetZoomButton';
 import TooltipMesh from '../shared/TooltipMesh';
 import VisCanvas from '../shared/VisCanvas';
 import ZoomMesh from '../shared/ZoomMesh';
@@ -100,6 +101,7 @@ function HeatmapVis(props: Props) {
         <PanMesh />
         <ZoomMesh />
         <ZoomSelectionMesh />
+        <ResetZoomButton />
         <TooltipMesh
           guides="both"
           renderTooltip={(x, y) => {

--- a/packages/lib/src/vis/line/LineVis.tsx
+++ b/packages/lib/src/vis/line/LineVis.tsx
@@ -19,6 +19,7 @@ import {
 } from '../hooks';
 import type { AxisParams } from '../models';
 import PanMesh from '../shared/PanMesh';
+import ResetZoomButton from '../shared/ResetZoomButton';
 import TooltipMesh from '../shared/TooltipMesh';
 import VisCanvas from '../shared/VisCanvas';
 import XAxisZoomMesh from '../shared/XAxisZoomMesh';
@@ -131,6 +132,7 @@ function LineVis(props: Props) {
         <XAxisZoomMesh />
         <YAxisZoomMesh />
         <ZoomSelectionMesh />
+        <ResetZoomButton />
         <TooltipMesh
           guides="vertical"
           renderTooltip={(x) => {

--- a/packages/lib/src/vis/rgb/RgbVis.tsx
+++ b/packages/lib/src/vis/rgb/RgbVis.tsx
@@ -7,6 +7,7 @@ import { useMemo } from 'react';
 import styles from '../heatmap/HeatmapVis.module.css';
 import type { Layout } from '../heatmap/models';
 import PanMesh from '../shared/PanMesh';
+import ResetZoomButton from '../shared/ResetZoomButton';
 import VisCanvas from '../shared/VisCanvas';
 import ZoomMesh from '../shared/ZoomMesh';
 import ZoomSelectionMesh from '../shared/ZoomSelectionMesh';
@@ -57,6 +58,7 @@ function RgbVis(props: Props) {
         <PanMesh />
         <ZoomMesh />
         <ZoomSelectionMesh />
+        <ResetZoomButton />
         <RgbMesh values={safeDataArray} bgr={imageType === ImageType.BGR} />
         {children}
       </VisCanvas>

--- a/packages/lib/src/vis/scatter/ScatterVis.tsx
+++ b/packages/lib/src/vis/scatter/ScatterVis.tsx
@@ -7,6 +7,7 @@ import ColorBar from '../heatmap/ColorBar';
 import type { ColorMap } from '../heatmap/models';
 import { useAxisDomain } from '../hooks';
 import PanMesh from '../shared/PanMesh';
+import ResetZoomButton from '../shared/ResetZoomButton';
 import VisCanvas from '../shared/VisCanvas';
 import ZoomMesh from '../shared/ZoomMesh';
 import ZoomSelectionMesh from '../shared/ZoomSelectionMesh';
@@ -72,6 +73,7 @@ function ScatterVis(props: Props) {
         <PanMesh />
         <ZoomMesh />
         <ZoomSelectionMesh />
+        <ResetZoomButton />
         <ScatterPoints
           abscissas={abscissas}
           ordinates={ordinates}

--- a/packages/lib/src/vis/shared/ResetZoomButton.module.css
+++ b/packages/lib/src/vis/shared/ResetZoomButton.module.css
@@ -1,9 +1,20 @@
 .container {
-  background-color: #ffffffaa;
-  pointer-events: auto;
+  top: auto !important;
+  left: auto !important;
+  right: 0;
+  bottom: 0;
 }
 
 .btn {
   composes: btn from '../../toolbar/Toolbar.module.css';
-  padding: 0.25rem !important;
+  padding: 0.5rem !important; /* FIX style ordering issue with Vite */
+  pointer-events: auto;
+  font-size: 0.875em;
+}
+
+.btnLike {
+  composes: btnLike from '../../toolbar/Toolbar.module.css';
+  background-color: rgba(255, 255, 255, 0.7);
+  box-shadow: rgba(0, 0, 0, 0.1) 0px 0px 0px 1px,
+    rgba(0, 0, 0, 0.1) 0px 4px 11px;
 }

--- a/packages/lib/src/vis/shared/ResetZoomButton.module.css
+++ b/packages/lib/src/vis/shared/ResetZoomButton.module.css
@@ -1,0 +1,9 @@
+.container {
+  background-color: #ffffffaa;
+  pointer-events: auto;
+}
+
+.btn {
+  composes: btn from '../../toolbar/Toolbar.module.css';
+  padding: 0.25rem !important;
+}

--- a/packages/lib/src/vis/shared/ResetZoomButton.tsx
+++ b/packages/lib/src/vis/shared/ResetZoomButton.tsx
@@ -26,7 +26,7 @@ function ResetZoomButton() {
   return isZoomedIn ? (
     <Html className={styles.container}>
       <button className={styles.btn} type="button" onClick={() => resetZoom()}>
-        Reset zoom
+        <span className={styles.btnLike}>Reset zoom</span>
       </button>
     </Html>
   ) : null;

--- a/packages/lib/src/vis/shared/ResetZoomButton.tsx
+++ b/packages/lib/src/vis/shared/ResetZoomButton.tsx
@@ -1,0 +1,35 @@
+import { useThree } from '@react-three/fiber';
+
+import { useFrameRendering } from '../hooks';
+import Html from './Html';
+import styles from './ResetZoomButton.module.css';
+import { useMoveCameraTo } from './hooks';
+
+function ResetZoomButton() {
+  const camera = useThree((state) => state.camera);
+  const moveCameraTo = useMoveCameraTo();
+
+  useFrameRendering();
+
+  const isZoomedIn = camera.scale.x < 1 || camera.scale.y < 1;
+
+  function resetZoom() {
+    camera.scale.x = 1;
+    camera.scale.y = 1;
+
+    camera.updateProjectionMatrix();
+    camera.updateMatrixWorld();
+
+    moveCameraTo(0, 0);
+  }
+
+  return isZoomedIn ? (
+    <Html className={styles.container}>
+      <button className={styles.btn} type="button" onClick={() => resetZoom()}>
+        Reset zoom
+      </button>
+    </Html>
+  ) : null;
+}
+
+export default ResetZoomButton;


### PR DESCRIPTION
Fix #984 

![image](https://user-images.githubusercontent.com/42204205/156527610-c4d83fed-ad05-4338-87fc-fe490352f539.png)

The button only appears when the zoom is not null.