### PR TITLE
Fix CRA v5 compatibility by publishing lib and app as CommonJS packages

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -15,15 +15,16 @@
   ],
   "main": "src/index.ts",
   "publishConfig": {
-    "main": "dist/index.cjs",
-    "module": "dist/index.js",
+    "type": "commonjs",
+    "main": "dist/index.js",
+    "module": "dist/index.esm.js",
     "types": "dist/index.d.ts",
     "exports": {
       "./dist/styles.css": "./dist/styles.css",
       "./styles.css": "./dist/styles.css",
       ".": {
-        "require": "./dist/index.cjs",
-        "import": "./dist/index.js"
+        "require": "./dist/index.js",
+        "import": "./dist/index.esm.js"
       }
     }
   },

--- a/packages/app/vite.config.js
+++ b/packages/app/vite.config.js
@@ -26,7 +26,7 @@ export default defineConfig({
     lib: {
       entry: path.resolve('src/index.ts'),
       formats: ['es', 'cjs'],
-      fileName: (format) => `index.${format === 'es' ? 'js' : 'cjs'}`,
+      fileName: (format) => `index.${format === 'es' ? 'esm.js' : 'js'}`,
     },
     rollupOptions: {
       external: [...externals].map((dep) => new RegExp(`^${dep}($|\\/)`, 'u')), // e.g. externalize `react-icons/fi`

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -15,15 +15,16 @@
   ],
   "main": "src/index.ts",
   "publishConfig": {
-    "main": "dist/index.cjs",
-    "module": "dist/index.js",
+    "type": "commonjs",
+    "main": "dist/index.js",
+    "module": "dist/index.esm.js",
     "types": "dist/index.d.ts",
     "exports": {
       "./dist/styles.css": "./dist/styles.css",
       "./styles.css": "./dist/styles.css",
       ".": {
-        "require": "./dist/index.cjs",
-        "import": "./dist/index.js"
+        "require": "./dist/index.js",
+        "import": "./dist/index.esm.js"
       }
     }
   },

--- a/packages/lib/src/vis/utils.ts
+++ b/packages/lib/src/vis/utils.ts
@@ -12,9 +12,9 @@ import type { Camera } from '@react-three/fiber';
 import { scaleLinear, scaleThreshold } from '@visx/scale';
 import { tickStep, range } from 'd3-array';
 import type { ScaleLinear, ScaleThreshold } from 'd3-scale';
+import { clamp } from 'lodash';
 import type { IUniform } from 'three';
-import { Vector3, Matrix4, Vector2 } from 'three';
-import { clamp } from 'three/src/math/MathUtils';
+import { Vector2, Vector3, Matrix4 } from 'three';
 
 import type {
   Size,

--- a/packages/lib/vite.config.js
+++ b/packages/lib/vite.config.js
@@ -26,7 +26,7 @@ export default defineConfig({
     lib: {
       entry: path.resolve('src/index.ts'),
       formats: ['es', 'cjs'],
-      fileName: (format) => `index.${format === 'es' ? 'js' : 'cjs'}`,
+      fileName: (format) => `index.${format === 'es' ? 'esm.js' : 'js'}`,
     },
     rollupOptions: {
       external: [...externals].map((dep) => new RegExp(`^${dep}($|\\/)`, 'u')), // e.g. externalize `react-icons/fi`


### PR DESCRIPTION
Fix #986 

With `"type": "module"`, webpack v5 enforces Node-compliant paths. For `react-icons/fi`, this should be `react-icons/fi/index.esm.js`, but if I do this in the codebase, then TypeScript complains that it can't find the types...

I think this is linked to the way the `react-icons` package is organised, but not sure it's worth reporting since it works fine with `"type": "module"` removed (or rather overridden with its default value `"commonjs"` when published).