### PR TITLE
Allow SelectToZoom rectangle to respect the FOV ratio

### DIFF
--- a/packages/lib/src/vis/heatmap/HeatmapVis.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapVis.tsx
@@ -8,6 +8,7 @@ import {
 import type { NdArray } from 'ndarray';
 import type { ReactElement, ReactNode } from 'react';
 
+import { XAxisZoom, YAxisZoom } from '../..';
 import { useAxisDomain, useValueToIndexScale } from '../hooks';
 import type { AxisParams, VisScaleType } from '../models';
 import Pan from '../shared/Pan';
@@ -78,12 +79,14 @@ function HeatmapVis(props: Props) {
   const safeDataArray = useTextureSafeNdArray(dataArray);
   const safeAlphaArray = useTextureSafeNdArray(alpha?.array);
 
+  const keepRatio = layout !== 'fill';
+
   return (
     <figure className={styles.root} aria-label={title} data-keep-canvas-colors>
       <VisCanvas
         title={title}
         canvasRatio={layout === 'contain' ? cols / rows : undefined}
-        visRatio={layout !== 'fill' ? cols / rows : undefined}
+        visRatio={keepRatio ? cols / rows : undefined}
         abscissaConfig={{
           visDomain: abscissaDomain,
           showGrid,
@@ -100,7 +103,9 @@ function HeatmapVis(props: Props) {
       >
         <Pan />
         <Zoom />
-        <SelectToZoom />
+        <XAxisZoom disabled={keepRatio} />
+        <YAxisZoom disabled={keepRatio} />
+        <SelectToZoom keepRatio={keepRatio} />
         <ResetZoomButton />
         <TooltipMesh
           guides="both"

--- a/packages/lib/src/vis/rgb/RgbVis.tsx
+++ b/packages/lib/src/vis/rgb/RgbVis.tsx
@@ -10,6 +10,8 @@ import Pan from '../shared/Pan';
 import ResetZoomButton from '../shared/ResetZoomButton';
 import SelectToZoom from '../shared/SelectToZoom';
 import VisCanvas from '../shared/VisCanvas';
+import XAxisZoom from '../shared/XAxisZoom';
+import YAxisZoom from '../shared/YAxisZoom';
 import Zoom from '../shared/Zoom';
 import RgbMesh from './RgbMesh';
 import { ImageType } from './models';
@@ -37,12 +39,14 @@ function RgbVis(props: Props) {
   const { rows, cols } = getDims(dataArray);
   const safeDataArray = useMemo(() => toRgbSafeNdArray(dataArray), [dataArray]);
 
+  const keepRatio = layout !== 'fill';
+
   return (
     <figure className={styles.root} aria-label={title} data-keep-canvas-colors>
       <VisCanvas
         title={title}
         canvasRatio={layout === 'contain' ? cols / rows : undefined}
-        visRatio={layout !== 'fill' ? cols / rows : undefined}
+        visRatio={keepRatio ? cols / rows : undefined}
         abscissaConfig={{
           visDomain: [0, cols],
           showGrid,
@@ -57,7 +61,9 @@ function RgbVis(props: Props) {
       >
         <Pan />
         <Zoom />
-        <SelectToZoom />
+        <XAxisZoom disabled={keepRatio} />
+        <YAxisZoom disabled={keepRatio} />
+        <SelectToZoom keepRatio={keepRatio} />
         <ResetZoomButton />
         <RgbMesh values={safeDataArray} bgr={imageType === ImageType.BGR} />
         {children}

--- a/packages/lib/src/vis/utils.ts
+++ b/packages/lib/src/vis/utils.ts
@@ -71,10 +71,9 @@ export function getSizeToFit(
 
   const availableRatio = width / height;
 
-  return {
-    width: availableRatio > ratioToRespect ? height * ratioToRespect : width,
-    height: availableRatio < ratioToRespect ? width / ratioToRespect : height,
-  };
+  return availableRatio > ratioToRespect
+    ? { width: height * ratioToRespect, height }
+    : { width, height: width / ratioToRespect };
 }
 
 export function getDomain(
@@ -347,4 +346,31 @@ export function checkModifierKey(
   }
 
   return event.getModifierState(modifierKey);
+}
+
+export function getRatioEndPoint(
+  startPoint: Vector2,
+  endPoint: Vector2,
+  ratio: number
+) {
+  const widthSign = Math.sign(endPoint.x - startPoint.x);
+  const width = Math.abs(endPoint.x - startPoint.x);
+
+  const heightSign = Math.sign(endPoint.y - startPoint.y);
+  const height = Math.abs(endPoint.y - startPoint.y);
+
+  const originalRatio =
+    Math.abs(endPoint.x - startPoint.x) / Math.abs(endPoint.y - startPoint.y);
+
+  if (originalRatio < ratio) {
+    return new Vector2(
+      startPoint.x + widthSign * height * ratio,
+      startPoint.y + heightSign * height
+    );
+  }
+
+  return new Vector2(
+    startPoint.x + widthSign * width,
+    startPoint.y + (heightSign * width) / ratio
+  );
 }


### PR DESCRIPTION
Fix #999 

Following the process described in https://github.com/silx-kit/h5web/issues/993#issuecomment-1058190341

The behaviour is activated when checking `Keep ratio` on **Heatmap** and **RGB** vis. 