### PR TITLE
Register interaction in interaction components through a custom hook

### DIFF
--- a/apps/storybook/src/HeatmapVis.stories.tsx
+++ b/apps/storybook/src/HeatmapVis.stories.tsx
@@ -104,6 +104,17 @@ TypedArray.args = {
   },
 };
 
+export const ChangeInteractionKeys = Template.bind({});
+ChangeInteractionKeys.args = {
+  dataArray,
+  domain,
+  interactions: {
+    XAxisZoom: false,
+    YAxisZoom: false,
+    SelectToZoom: { modifierKey: 'Shift' },
+  },
+};
+
 export default {
   title: 'Visualizations/HeatmapVis',
   component: HeatmapVis,

--- a/apps/storybook/src/Pan.stories.tsx
+++ b/apps/storybook/src/Pan.stories.tsx
@@ -10,15 +10,12 @@ interface TemplateProps {
 }
 
 const Template: Story<TemplateProps> = (args) => {
-  const { disabled, modifierKey } = args;
-
   return (
     <VisCanvas
       abscissaConfig={{ visDomain: [-10, 0], showGrid: true }}
       ordinateConfig={{ visDomain: [50, 100], showGrid: true }}
-      interactions={{ Pan: { modifierKey, disabled }, Zoom: true }}
     >
-      <Pan />
+      <Pan {...args} />
       <Zoom />
       <ResetZoomButton />
     </VisCanvas>

--- a/apps/storybook/src/SelectToZoom.stories.tsx
+++ b/apps/storybook/src/SelectToZoom.stories.tsx
@@ -24,21 +24,14 @@ interface TemplateProps {
 }
 
 const Template: Story<TemplateProps> = (args) => {
-  const { modifierKey } = args;
-
   return (
     <VisCanvas
       abscissaConfig={{ visDomain: [-5, 5], showGrid: true }}
       ordinateConfig={{ visDomain: [-0.5, 1.5], showGrid: true }}
-      interactions={{
-        Pan: true,
-        Zoom: true,
-        SelectToZoom: { modifierKey },
-      }}
     >
       <Pan />
       <Zoom />
-      <SelectToZoom />
+      <SelectToZoom {...args} />
       <ResetZoomButton />
       <GaussianCurve />
     </VisCanvas>

--- a/apps/storybook/src/Selection.stories.tsx
+++ b/apps/storybook/src/Selection.stories.tsx
@@ -53,18 +53,14 @@ const Template: Story<TemplateProps> = (args) => {
       }
       abscissaConfig={{ visDomain: [-10, 0], showGrid: true }}
       ordinateConfig={{ visDomain: [50, 100], showGrid: true }}
-      interactions={{
-        Pan: { disabled: disablePan },
-        Zoom: { disabled: disableZoom },
-        Selection: { modifierKey },
-      }}
     >
-      <Pan />
-      <Zoom />
+      <Pan disabled={disablePan} />
+      <Zoom disabled={disableZoom} />
       <ResetZoomButton />
       <SelectionTool
         onSelectionChange={setActiveSelection}
         onSelectionEnd={() => setActiveSelection(undefined)}
+        modifierKey={modifierKey}
       >
         {(selection) => <SelectionComponent {...selection} {...svgProps} />}
       </SelectionTool>
@@ -136,19 +132,15 @@ export const PersistSelection: Story<TemplateProps> = (args) => {
       }
       abscissaConfig={{ visDomain: [-10, 0], showGrid: true }}
       ordinateConfig={{ visDomain: [50, 100], showGrid: true }}
-      interactions={{
-        Pan: { disabled: disablePan },
-        Zoom: { disabled: disableZoom },
-        Selection: { modifierKey },
-      }}
     >
-      <Pan />
-      <Zoom />
+      <Pan disabled={disablePan} />
+      <Zoom disabled={disableZoom} />
       <SelectionTool
         onSelectionStart={() => {
           setPersistedSelection(undefined);
         }}
         onSelectionEnd={setPersistedSelection}
+        modifierKey={modifierKey}
       >
         {(selection) => <SelectionComponent {...selection} {...svgProps} />}
       </SelectionTool>

--- a/apps/storybook/src/XZoom.stories.tsx
+++ b/apps/storybook/src/XZoom.stories.tsx
@@ -10,16 +10,13 @@ interface TemplateProps {
 }
 
 const Template: Story<TemplateProps> = (args) => {
-  const { disabled, modifierKey } = args;
-
   return (
     <VisCanvas
       abscissaConfig={{ visDomain: [-10, 0], showGrid: true }}
       ordinateConfig={{ visDomain: [50, 100], showGrid: true }}
-      interactions={{ Pan: true, XAxisZoom: { modifierKey, disabled } }}
     >
       <Pan />
-      <XAxisZoom />
+      <XAxisZoom {...args} />
       <ResetZoomButton />
     </VisCanvas>
   );

--- a/apps/storybook/src/YZoom.stories.tsx
+++ b/apps/storybook/src/YZoom.stories.tsx
@@ -10,16 +10,13 @@ interface TemplateProps {
 }
 
 const Template: Story<TemplateProps> = (args) => {
-  const { disabled, modifierKey } = args;
-
   return (
     <VisCanvas
       abscissaConfig={{ visDomain: [-10, 0], showGrid: true }}
       ordinateConfig={{ visDomain: [50, 100], showGrid: true }}
-      interactions={{ Pan: true, YAxisZoom: { modifierKey, disabled } }}
     >
       <Pan />
-      <YAxisZoom />
+      <YAxisZoom {...args} />
       <ResetZoomButton />
     </VisCanvas>
   );

--- a/apps/storybook/src/Zoom.stories.tsx
+++ b/apps/storybook/src/Zoom.stories.tsx
@@ -10,16 +10,13 @@ interface TemplateProps {
 }
 
 const Template: Story<TemplateProps> = (args) => {
-  const { disabled, modifierKey } = args;
-
   return (
     <VisCanvas
       abscissaConfig={{ visDomain: [-10, 0], showGrid: true }}
       ordinateConfig={{ visDomain: [50, 100], showGrid: true }}
-      interactions={{ Pan: true, Zoom: { modifierKey, disabled } }}
     >
       <Pan />
-      <Zoom />
+      <Zoom {...args} />
       <ResetZoomButton />
     </VisCanvas>
   );

--- a/packages/lib/src/interactions/DefaultInteractions.tsx
+++ b/packages/lib/src/interactions/DefaultInteractions.tsx
@@ -1,0 +1,51 @@
+import { merge } from 'lodash';
+
+import Pan from '../interactions/Pan';
+import SelectToZoom from '../interactions/SelectToZoom';
+import XAxisZoom from '../interactions/XAxisZoom';
+import YAxisZoom from '../interactions/YAxisZoom';
+import Zoom from '../interactions/Zoom';
+import type { Interactions } from './models';
+import { getDefaultInteractions } from './utils';
+
+interface Props {
+  interactions?: Interactions;
+  keepRatio?: boolean;
+}
+
+function DefaultInteractions(props: Props) {
+  const { interactions: givenInteractions = {}, keepRatio } = props;
+
+  const parsedInteractions = Object.fromEntries(
+    Object.entries(givenInteractions).map(([k, v]) => {
+      if (v === true) {
+        return [k, {}];
+      }
+
+      if (v === false) {
+        return [k, null];
+      }
+
+      return [k, v];
+    })
+  );
+
+  const interactions = merge(
+    getDefaultInteractions(keepRatio),
+    parsedInteractions
+  );
+
+  return (
+    <>
+      {interactions.Pan && <Pan {...interactions.Pan} />}
+      {interactions.Zoom && <Zoom {...interactions.Zoom} />}
+      {interactions.XAxisZoom && <XAxisZoom {...interactions.XAxisZoom} />}
+      {interactions.YAxisZoom && <YAxisZoom {...interactions.YAxisZoom} />}
+      {interactions.SelectToZoom && (
+        <SelectToZoom {...interactions.SelectToZoom} keepRatio={keepRatio} />
+      )}
+    </>
+  );
+}
+
+export default DefaultInteractions;

--- a/packages/lib/src/interactions/Pan.tsx
+++ b/packages/lib/src/interactions/Pan.tsx
@@ -2,12 +2,15 @@ import { useThree } from '@react-three/fiber';
 import { useRef, useCallback } from 'react';
 import type { Vector3 } from 'three';
 
-import { useAxisSystemContext } from '../vis/shared/AxisSystemContext';
-import { useCanvasEvents, useMoveCameraTo } from './hooks';
-import type { CanvasEvent } from './models';
+import {
+  useCanvasEvents,
+  useMoveCameraTo,
+  useRegisterInteraction,
+} from './hooks';
+import type { CanvasEvent, Interaction } from './models';
 
-function Pan() {
-  const { shouldInteract } = useAxisSystemContext();
+function Pan(props: Interaction) {
+  const shouldInteract = useRegisterInteraction('Pan', props);
 
   const camera = useThree((state) => state.camera);
 
@@ -20,7 +23,7 @@ function Pan() {
       const { unprojectedPoint, sourceEvent } = evt;
       const { target, pointerId } = sourceEvent;
 
-      if (shouldInteract('Pan', sourceEvent)) {
+      if (shouldInteract(sourceEvent)) {
         (target as Element).setPointerCapture(pointerId); // https://stackoverflow.com/q/28900077/758806
         startOffsetPosition.current = unprojectedPoint.clone();
       }

--- a/packages/lib/src/interactions/SelectToZoom.tsx
+++ b/packages/lib/src/interactions/SelectToZoom.tsx
@@ -5,15 +5,15 @@ import { useAxisSystemContext } from '../vis/shared/AxisSystemContext';
 import SelectionRect from './SelectionRect';
 import SelectionTool from './SelectionTool';
 import { useMoveCameraTo } from './hooks';
-import type { Selection } from './models';
+import type { Interaction, Selection } from './models';
 import { getRatioEndPoint } from './utils';
 
-interface Props {
+interface Props extends Interaction {
   keepRatio?: boolean;
 }
 
 function SelectToZoom(props: Props) {
-  const { keepRatio } = props;
+  const { keepRatio, ...interactionProps } = props;
 
   const { dataToWorld } = useAxisSystemContext();
   const moveCameraTo = useMoveCameraTo();
@@ -59,7 +59,11 @@ function SelectToZoom(props: Props) {
   };
 
   return (
-    <SelectionTool onSelectionEnd={onSelectionEnd} id="SelectToZoom">
+    <SelectionTool
+      onSelectionEnd={onSelectionEnd}
+      id="SelectToZoom"
+      {...interactionProps}
+    >
       {({ startPoint, endPoint }) => (
         <>
           <SelectionRect

--- a/packages/lib/src/interactions/XAxisZoom.tsx
+++ b/packages/lib/src/interactions/XAxisZoom.tsx
@@ -1,11 +1,15 @@
-import { useAxisSystemContext } from '../vis/shared/AxisSystemContext';
-import { useCanvasEvents, useZoomOnWheel } from './hooks';
+import {
+  useCanvasEvents,
+  useRegisterInteraction,
+  useZoomOnWheel,
+} from './hooks';
+import type { Interaction } from './models';
 
-function XAxisZoom() {
-  const { shouldInteract } = useAxisSystemContext();
+function XAxisZoom(props: Interaction) {
+  const shouldInteract = useRegisterInteraction('XAxisZoom', props);
 
   const isZoomAllowed = (sourceEvent: WheelEvent) => ({
-    x: shouldInteract('XAxisZoom', sourceEvent),
+    x: shouldInteract(sourceEvent),
     y: false,
   });
 

--- a/packages/lib/src/interactions/YAxisZoom.tsx
+++ b/packages/lib/src/interactions/YAxisZoom.tsx
@@ -1,12 +1,16 @@
-import { useAxisSystemContext } from '../vis/shared/AxisSystemContext';
-import { useCanvasEvents, useZoomOnWheel } from './hooks';
+import {
+  useCanvasEvents,
+  useZoomOnWheel,
+  useRegisterInteraction,
+} from './hooks';
+import type { Interaction } from './models';
 
-function YAxisZoom() {
-  const { shouldInteract } = useAxisSystemContext();
+function YAxisZoom(props: Interaction) {
+  const shouldInteract = useRegisterInteraction('YAxisZoom', props);
 
   const isZoomAllowed = (sourceEvent: WheelEvent) => ({
     x: false,
-    y: shouldInteract('YAxisZoom', sourceEvent),
+    y: shouldInteract(sourceEvent),
   });
 
   useCanvasEvents({ onWheel: useZoomOnWheel(isZoomAllowed) });

--- a/packages/lib/src/interactions/Zoom.tsx
+++ b/packages/lib/src/interactions/Zoom.tsx
@@ -1,11 +1,15 @@
-import { useAxisSystemContext } from '../vis/shared/AxisSystemContext';
-import { useCanvasEvents, useZoomOnWheel } from './hooks';
+import {
+  useCanvasEvents,
+  useZoomOnWheel,
+  useRegisterInteraction,
+} from './hooks';
+import type { Interaction } from './models';
 
-function Zoom() {
-  const { shouldInteract } = useAxisSystemContext();
+function Zoom(props: Interaction) {
+  const shouldInteract = useRegisterInteraction('Zoom', props);
 
   const isZoomAllowed = (sourceEvent: WheelEvent) => {
-    const shouldZoom = shouldInteract('Zoom', sourceEvent);
+    const shouldZoom = shouldInteract(sourceEvent);
 
     return { x: shouldZoom, y: shouldZoom };
   };

--- a/packages/lib/src/interactions/hooks.ts
+++ b/packages/lib/src/interactions/hooks.ts
@@ -1,12 +1,12 @@
 import { useEventListener } from '@react-hookz/web';
 import { useThree } from '@react-three/fiber';
 import { clamp } from 'lodash';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { Vector3 } from 'three';
 
 import { useAxisSystemContext } from '../vis/shared/AxisSystemContext';
 import { getCameraFOV } from '../vis/utils';
-import type { CanvasEvent, CanvasEventCallbacks } from './models';
+import type { CanvasEvent, CanvasEventCallbacks, Interaction } from './models';
 
 const ZOOM_FACTOR = 0.95;
 
@@ -164,4 +164,19 @@ export function useCanvasEvents(callbacks: CanvasEventCallbacks): void {
   useEventListener(domElement, 'pointermove', handlePointerMove);
   useEventListener(domElement, 'pointerup', handlePointerUp);
   useEventListener(domElement, 'wheel', handleWheel);
+}
+
+export function useRegisterInteraction(id: string, value: Interaction) {
+  const { shouldInteract, registerInteraction, unregisterInteraction } =
+    useAxisSystemContext();
+
+  useEffect(() => {
+    registerInteraction(id, value);
+    return () => unregisterInteraction(id);
+  }, [id, registerInteraction, unregisterInteraction, value]);
+
+  return useCallback(
+    (event: MouseEvent) => shouldInteract(id, event),
+    [id, shouldInteract]
+  );
 }

--- a/packages/lib/src/interactions/models.ts
+++ b/packages/lib/src/interactions/models.ts
@@ -24,7 +24,9 @@ export interface InteractionInfo {
   description: string;
 }
 
-export type Interactions = Record<
-  string,
-  { modifierKey?: ModifierKey; disabled?: boolean } | true
->;
+export interface Interaction {
+  modifierKey?: ModifierKey;
+  disabled?: boolean;
+}
+
+export type Interactions = Record<string, Interaction | boolean>;

--- a/packages/lib/src/interactions/utils.ts
+++ b/packages/lib/src/interactions/utils.ts
@@ -4,7 +4,7 @@ import type { Vector3 } from 'three';
 import { Vector2 } from 'three';
 
 import { getCameraFOV } from '../vis/utils';
-import type { ModifierKey } from './models';
+import type { Interaction, ModifierKey } from './models';
 
 export function boundPointToFOV(
   unboundedPoint: Vector2 | Vector3,
@@ -52,4 +52,16 @@ export function getRatioEndPoint(
     startPoint.x + widthSign * width,
     startPoint.y + (heightSign * width) / ratio
   );
+}
+
+export function getDefaultInteractions(
+  keepRatio?: boolean
+): Record<string, Interaction> {
+  return {
+    Pan: {},
+    Zoom: {},
+    XAxisZoom: { modifierKey: 'Alt', disabled: keepRatio },
+    YAxisZoom: { modifierKey: 'Shift', disabled: keepRatio },
+    SelectToZoom: { modifierKey: 'Control' },
+  };
 }

--- a/packages/lib/src/vis/heatmap/HeatmapVis.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapVis.tsx
@@ -9,17 +9,14 @@ import {
 import type { NdArray } from 'ndarray';
 import type { ReactElement, ReactNode } from 'react';
 
-import Pan from '../../interactions/Pan';
+import DefaultInteractions from '../../interactions/DefaultInteractions';
 import ResetZoomButton from '../../interactions/ResetZoomButton';
-import SelectToZoom from '../../interactions/SelectToZoom';
-import XAxisZoom from '../../interactions/XAxisZoom';
-import YAxisZoom from '../../interactions/YAxisZoom';
-import Zoom from '../../interactions/Zoom';
+import type { Interactions } from '../../interactions/models';
 import { useAxisDomain, useValueToIndexScale } from '../hooks';
 import type { AxisParams, VisScaleType } from '../models';
 import TooltipMesh from '../shared/TooltipMesh';
 import VisCanvas from '../shared/VisCanvas';
-import { DEFAULT_DOMAIN, DEFAULT_INTERACTIONS, formatNumType } from '../utils';
+import { DEFAULT_DOMAIN, formatNumType } from '../utils';
 import ColorBar from './ColorBar';
 import HeatmapMesh from './HeatmapMesh';
 import styles from './HeatmapVis.module.css';
@@ -42,6 +39,7 @@ interface Props {
   flipYAxis?: boolean;
   renderTooltip?: (data: TooltipData) => ReactElement;
   children?: ReactNode;
+  interactions?: Interactions;
 }
 
 function HeatmapVis(props: Props) {
@@ -61,6 +59,7 @@ function HeatmapVis(props: Props) {
     flipYAxis,
     renderTooltip,
     children,
+    interactions,
   } = props;
   const { label: abscissaLabel, value: abscissaValue } = abscissaParams;
   const { label: ordinateLabel, value: ordinateValue } = ordinateParams;
@@ -104,17 +103,11 @@ function HeatmapVis(props: Props) {
           label: ordinateLabel,
           flip: flipYAxis,
         }}
-        interactions={{
-          ...DEFAULT_INTERACTIONS,
-          XAxisZoom: { modifierKey: 'Alt', disabled: keepRatio },
-          YAxisZoom: { modifierKey: 'Shift', disabled: keepRatio },
-        }}
       >
-        <Pan />
-        <Zoom />
-        <XAxisZoom />
-        <YAxisZoom />
-        <SelectToZoom keepRatio={keepRatio} />
+        <DefaultInteractions
+          interactions={interactions}
+          keepRatio={keepRatio}
+        />
         <ResetZoomButton />
         <TooltipMesh
           guides="both"

--- a/packages/lib/src/vis/line/LineVis.tsx
+++ b/packages/lib/src/vis/line/LineVis.tsx
@@ -12,22 +12,14 @@ import type { NdArray } from 'ndarray';
 import { useMemo } from 'react';
 import type { ReactElement, ReactNode } from 'react';
 
-import Pan from '../../interactions/Pan';
+import DefaultInteractions from '../../interactions/DefaultInteractions';
 import ResetZoomButton from '../../interactions/ResetZoomButton';
-import SelectToZoom from '../../interactions/SelectToZoom';
-import XAxisZoom from '../../interactions/XAxisZoom';
-import YAxisZoom from '../../interactions/YAxisZoom';
-import Zoom from '../../interactions/Zoom';
+import type { Interactions } from '../../interactions/models';
 import { useAxisDomain, useCustomColors, useValueToIndexScale } from '../hooks';
 import type { AxisParams, CustomColor } from '../models';
 import TooltipMesh from '../shared/TooltipMesh';
 import VisCanvas from '../shared/VisCanvas';
-import {
-  extendDomain,
-  DEFAULT_DOMAIN,
-  formatNumType,
-  DEFAULT_INTERACTIONS,
-} from '../utils';
+import { extendDomain, DEFAULT_DOMAIN, formatNumType } from '../utils';
 import DataCurve from './DataCurve';
 import styles from './LineVis.module.css';
 import type { TooltipData } from './models';
@@ -62,6 +54,7 @@ interface Props {
   auxArrays?: NdArray<NumArray>[];
   renderTooltip?: (data: TooltipData) => ReactElement;
   children?: ReactNode;
+  interactions?: Interactions;
 }
 
 function LineVis(props: Props) {
@@ -80,6 +73,7 @@ function LineVis(props: Props) {
     auxArrays = [],
     renderTooltip,
     children,
+    interactions,
   } = props;
 
   const {
@@ -135,13 +129,8 @@ function LineVis(props: Props) {
           scaleType,
           label: ordinateLabel,
         }}
-        interactions={DEFAULT_INTERACTIONS}
       >
-        <Pan />
-        <Zoom />
-        <XAxisZoom />
-        <YAxisZoom />
-        <SelectToZoom />
+        <DefaultInteractions interactions={interactions} />
         <ResetZoomButton />
         <TooltipMesh
           guides="vertical"

--- a/packages/lib/src/vis/rgb/RgbVis.tsx
+++ b/packages/lib/src/vis/rgb/RgbVis.tsx
@@ -4,16 +4,12 @@ import type { NdArray } from 'ndarray';
 import type { ReactNode } from 'react';
 import { useMemo } from 'react';
 
-import Pan from '../../interactions/Pan';
+import DefaultInteractions from '../../interactions/DefaultInteractions';
 import ResetZoomButton from '../../interactions/ResetZoomButton';
-import SelectToZoom from '../../interactions/SelectToZoom';
-import XAxisZoom from '../../interactions/XAxisZoom';
-import YAxisZoom from '../../interactions/YAxisZoom';
-import Zoom from '../../interactions/Zoom';
+import type { Interactions } from '../../interactions/models';
 import styles from '../heatmap/HeatmapVis.module.css';
 import type { Layout } from '../heatmap/models';
 import VisCanvas from '../shared/VisCanvas';
-import { DEFAULT_INTERACTIONS } from '../utils';
 import RgbMesh from './RgbMesh';
 import { ImageType } from './models';
 import { toRgbSafeNdArray } from './utils';
@@ -25,6 +21,7 @@ interface Props {
   title?: string;
   imageType?: ImageType;
   children?: ReactNode;
+  interactions?: Interactions;
 }
 
 function RgbVis(props: Props) {
@@ -35,6 +32,7 @@ function RgbVis(props: Props) {
     title,
     imageType = ImageType.RGB,
     children,
+    interactions,
   } = props;
 
   const { rows, cols } = getDims(dataArray);
@@ -59,17 +57,11 @@ function RgbVis(props: Props) {
           isIndexAxis: true,
           flip: true,
         }}
-        interactions={{
-          ...DEFAULT_INTERACTIONS,
-          XAxisZoom: { modifierKey: 'Alt', disabled: keepRatio },
-          YAxisZoom: { modifierKey: 'Shift', disabled: keepRatio },
-        }}
       >
-        <Pan />
-        <Zoom />
-        <XAxisZoom />
-        <YAxisZoom />
-        <SelectToZoom keepRatio={keepRatio} />
+        <DefaultInteractions
+          interactions={interactions}
+          keepRatio={keepRatio}
+        />
         <ResetZoomButton />
         <RgbMesh values={safeDataArray} bgr={imageType === ImageType.BGR} />
         {children}

--- a/packages/lib/src/vis/scatter/ScatterVis.tsx
+++ b/packages/lib/src/vis/scatter/ScatterVis.tsx
@@ -3,10 +3,9 @@ import { assertLength, assertDefined, ScaleType } from '@h5web/shared';
 import type { NdArray } from 'ndarray';
 import type { ReactNode } from 'react';
 
-import Pan from '../../interactions/Pan';
+import DefaultInteractions from '../../interactions/DefaultInteractions';
 import ResetZoomButton from '../../interactions/ResetZoomButton';
-import SelectToZoom from '../../interactions/SelectToZoom';
-import Zoom from '../../interactions/Zoom';
+import type { Interactions } from '../../interactions/models';
 import ColorBar from '../heatmap/ColorBar';
 import type { ColorMap } from '../heatmap/models';
 import { useAxisDomain } from '../hooks';
@@ -28,6 +27,7 @@ interface Props {
   title?: string;
   size?: number;
   children?: ReactNode;
+  interactions?: Interactions;
 }
 
 function ScatterVis(props: Props) {
@@ -45,6 +45,7 @@ function ScatterVis(props: Props) {
     title,
     size = 10,
     children,
+    interactions,
   } = props;
 
   assertLength(abscissas, dataArray.size, 'abscissa');
@@ -69,15 +70,10 @@ function ScatterVis(props: Props) {
           label: ordinateLabel,
         }}
         title={title}
-        interactions={{
-          Pan: true,
-          Zoom: true,
-          SelectToZoom: { modifierKey: 'Control' },
-        }}
       >
-        <Pan />
-        <Zoom />
-        <SelectToZoom />
+        <DefaultInteractions
+          interactions={{ XAxisZoom: false, YAxisZoom: false, ...interactions }}
+        />
         <ResetZoomButton />
         <ScatterPoints
           abscissas={abscissas}

--- a/packages/lib/src/vis/shared/AxisSystemContext.tsx
+++ b/packages/lib/src/vis/shared/AxisSystemContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext } from 'react';
 import type { Vector2, Vector3 } from 'three';
 
-import type { ModifierKey } from '../../interactions/models';
+import type { Interaction } from '../../interactions/models';
 import type { AxisConfig, AxisScale, Size } from '../models';
 
 export interface AxisSystemParams {
@@ -14,7 +14,8 @@ export interface AxisSystemParams {
   worldToData: (vec: Vector2 | Vector3) => Vector2;
   worldToHtml: (vec: Vector2 | Vector3) => Vector2;
   shouldInteract: (id: string, event: MouseEvent) => boolean;
-  getModifierKey: (id: string) => ModifierKey | undefined;
+  registerInteraction: (id: string, value: Interaction) => void;
+  unregisterInteraction: (id: string) => void;
 }
 
 export const AxisSystemContext = createContext<AxisSystemParams>(

--- a/packages/lib/src/vis/shared/VisCanvas.tsx
+++ b/packages/lib/src/vis/shared/VisCanvas.tsx
@@ -2,7 +2,6 @@ import { useMeasure } from '@react-hookz/web';
 import { Canvas } from '@react-three/fiber';
 import type { PropsWithChildren } from 'react';
 
-import type { Interactions } from '../../interactions/models';
 import type { AxisConfig } from '../models';
 import { getSizeToFit, getAxisOffsets } from '../utils';
 import AxisSystem from './AxisSystem';
@@ -16,7 +15,6 @@ interface Props {
   visRatio?: number | undefined;
   abscissaConfig: AxisConfig;
   ordinateConfig: AxisConfig;
-  interactions?: Interactions;
 }
 
 function VisCanvas(props: PropsWithChildren<Props>) {
@@ -27,7 +25,6 @@ function VisCanvas(props: PropsWithChildren<Props>) {
     abscissaConfig,
     ordinateConfig,
     children,
-    interactions: interactionKeys = {},
   } = props;
 
   const shouldMeasure = !!canvasRatio;
@@ -71,7 +68,6 @@ function VisCanvas(props: PropsWithChildren<Props>) {
               visRatio={visRatio}
               abscissaConfig={abscissaConfig}
               ordinateConfig={ordinateConfig}
-              interactionParams={interactionKeys}
             >
               <AxisSystem axisOffsets={axisOffsets} title={title} />
               {children}

--- a/packages/lib/src/vis/utils.ts
+++ b/packages/lib/src/vis/utils.ts
@@ -16,7 +16,6 @@ import { clamp } from 'lodash';
 import type { IUniform } from 'three';
 import { Vector3 } from 'three';
 
-import type { Interactions } from '../interactions/models';
 import type {
   Size,
   AxisScale,
@@ -34,14 +33,6 @@ export const CAMERA_BOTTOM_LEFT = new Vector3(-1, -1, 0);
 export const CAMERA_TOP_RIGHT = new Vector3(1, 1, 0);
 
 const AXIS_OFFSETS = { vertical: 72, horizontal: 40, fallback: 16 };
-
-export const DEFAULT_INTERACTIONS: Interactions = {
-  Pan: true,
-  Zoom: true,
-  XAxisZoom: { modifierKey: 'Alt' },
-  YAxisZoom: { modifierKey: 'Shift' },
-  SelectToZoom: { modifierKey: 'Control' },
-};
 
 export const adaptedNumTicks: ScaleLinear<number, number> = scaleLinear({
   domain: [300, 900],


### PR DESCRIPTION
Interaction components have their props back (`modifierKey` and `disabled`).

The registration of interactions is no longer done by `VisCanvas` but in each component using a custom hook that registers the interaction in the `AxisSystemContext`. `VisCanvas` therefore loses its `interactions` props

I also added a `DefaultInteractions` component to deduplicate the instantiations of interaction components in our vis. Props can be given to this component to modify the default components. This brings a bit of complexity in `DefaultInteractions`.