### PR TITLE
Fix support of TypedArray in Histogram value + add toArray/useToArray utils

### DIFF
--- a/apps/storybook/src/DomainSlider.stories.tsx
+++ b/apps/storybook/src/DomainSlider.stories.tsx
@@ -68,6 +68,16 @@ HistogramWithColorMap.args = {
   },
 };
 
+export const TypedHistogram = Template.bind({});
+
+TypedHistogram.args = {
+  ...Default.args,
+  histogram: {
+    values: new Int32Array([26, 50, 52, 60, 68, 76, 92, 130]),
+    bins: new Float32Array([4, 53.5, 103, 152.5, 202, 251.5, 301, 350.5, 400]),
+  },
+};
+
 export default {
   title: 'Toolbar/DomainSlider',
   component: DomainSlider,

--- a/apps/storybook/src/Utilities.stories.mdx
+++ b/apps/storybook/src/Utilities.stories.mdx
@@ -88,7 +88,7 @@ const visDomain2 = getVisDomain([null, 20], [0, 100]); // [0, 20]
 
 Make a domain safe in a given scale. This is typically called with a custom domain selected by the user (either directly or after calling `getVisDomain()`).
 If `domain` is determined to be unsafe, a safe domain based on `fallbackDomain` is returned along with an errors object. Note that `fallbackDomain` is assumed to be safe in the given scale.
-The domain is considered unsafe if it's inverted (`min > max`), or if the min and/or max bound is not suppoted by the scale.
+The domain is considered unsafe if it's inverted (`min > max`), or if the min and/or max bound is not supported by the scale.
 
 ```ts
 getSafeDomain(domain: Domain, fallbackDomain: Domain, scaleType: ScaleType): [Domain, DomainErrors]

--- a/packages/lib/src/toolbar/controls/DomainSlider/Histogram.tsx
+++ b/packages/lib/src/toolbar/controls/DomainSlider/Histogram.tsx
@@ -4,7 +4,7 @@ import { AxisBottom, AxisLeft } from '@visx/axis';
 import { scaleLinear } from '@visx/scale';
 
 import { useSafeDomain } from '../../../vis/heatmap/hooks';
-import { useCombinedDomain, useDomain } from '../../../vis/hooks';
+import { useToArray, useCombinedDomain, useDomain } from '../../../vis/hooks';
 import type { HistogramParams } from '../../../vis/models';
 import { H5WEB_SCALES } from '../../../vis/scales';
 import Tick from '../../../vis/shared/Tick';
@@ -33,6 +33,8 @@ function Histogram(props: Props) {
 
   const [size, ref] = useMeasure<HTMLDivElement>();
 
+  const valuesArray = useToArray(values);
+
   if (!size) {
     return <div ref={ref} className={styles.container} />;
   }
@@ -53,7 +55,7 @@ function Histogram(props: Props) {
   return (
     <div ref={ref} className={styles.container}>
       <svg width="100%" height="100%" className={styles.histogram}>
-        {(values as number[]).map((d, i) => (
+        {valuesArray.map((d, i) => (
           <rect
             className={styles.bar}
             key={i} // eslint-disable-line react/no-array-index-key

--- a/packages/lib/src/vis/heatmap/utils.ts
+++ b/packages/lib/src/vis/heatmap/utils.ts
@@ -1,10 +1,5 @@
 import type { Domain, NumArray } from '@h5web/shared';
-import {
-  getDims,
-  isTypedArray,
-  ScaleType,
-  toTypedNdArray,
-} from '@h5web/shared';
+import { getDims, ScaleType, toTypedNdArray } from '@h5web/shared';
 import { range } from 'lodash';
 import type { NdArray } from 'ndarray';
 import {
@@ -21,6 +16,7 @@ import {
 import type { CustomDomain, DomainErrors } from '../models';
 import { DomainError } from '../models';
 import { H5WEB_SCALES } from '../scales';
+import { toArray } from '../utils';
 import { INTERPOLATORS } from './interpolators';
 import type { ColorMap, D3Interpolator, TextureSafeTypedArray } from './models';
 
@@ -116,7 +112,7 @@ export function getAxisValues(
   }
 
   if (rawValues.length === pixelCount + 1) {
-    return isTypedArray(rawValues) ? [...rawValues] : rawValues;
+    return toArray(rawValues);
   }
 
   if (rawValues.length === pixelCount) {

--- a/packages/lib/src/vis/hooks.ts
+++ b/packages/lib/src/vis/hooks.ts
@@ -13,6 +13,7 @@ import {
   getAxisDomain,
   getCombinedDomain,
   getValueToIndexScale,
+  toArray,
 } from './utils';
 
 const useBounds = createMemo(getBounds);
@@ -21,6 +22,8 @@ const useValidDomainForScale = createMemo(getValidDomainForScale);
 export const useCombinedDomain = createMemo(getCombinedDomain);
 export const useValueToIndexScale = createMemo(getValueToIndexScale);
 export const useAxisDomain = createMemo(getAxisDomain);
+
+export const useToArray = createMemo(toArray);
 
 export function useDomain(
   valuesArray: AnyNumArray,

--- a/packages/lib/src/vis/line/LineVis.tsx
+++ b/packages/lib/src/vis/line/LineVis.tsx
@@ -1,6 +1,5 @@
 import type { Domain, NumArray, NumericType } from '@h5web/shared';
 import {
-  isTypedArray,
   assertLength,
   assertDefined,
   formatTooltipVal,
@@ -19,7 +18,7 @@ import { useAxisDomain, useCustomColors, useValueToIndexScale } from '../hooks';
 import type { AxisParams, CustomColor } from '../models';
 import TooltipMesh from '../shared/TooltipMesh';
 import VisCanvas from '../shared/VisCanvas';
-import { extendDomain, DEFAULT_DOMAIN, formatNumType } from '../utils';
+import { extendDomain, DEFAULT_DOMAIN, formatNumType, toArray } from '../utils';
 import DataCurve from './DataCurve';
 import styles from './LineVis.module.css';
 import type { TooltipData } from './models';
@@ -91,7 +90,7 @@ function LineVis(props: Props) {
       return range(dataArray.size);
     }
 
-    return isTypedArray(abscissaValue) ? [...abscissaValue] : abscissaValue;
+    return toArray(abscissaValue);
   }, [abscissaValue, dataArray.size]);
 
   const abscissaToIndex = useValueToIndexScale(abscissas, true);

--- a/packages/lib/src/vis/utils.ts
+++ b/packages/lib/src/vis/utils.ts
@@ -1,10 +1,11 @@
-import type { AnyNumArray, Domain, NumericType } from '@h5web/shared';
+import type { AnyNumArray, Domain, NumArray, NumericType } from '@h5web/shared';
 import {
   getValidDomainForScale,
   ScaleType,
   isDefined,
   formatTick,
   isScaleType,
+  isTypedArray,
   getBounds,
   DTypeClass,
 } from '@h5web/shared';
@@ -324,4 +325,8 @@ export function getCameraFOV(camera: Camera): {
   const bottomLeft = CAMERA_BOTTOM_LEFT.clone().unproject(camera);
 
   return { topRight, bottomLeft };
+}
+
+export function toArray(arr: NumArray): number[] {
+  return isTypedArray(arr) ? [...arr] : arr;
 }


### PR DESCRIPTION
This PR fixes an issue in the `Histogram` which didn't work with TypedArray because of  TypedArray.map returns a TypedArray instead of an Array:

https://github.com/silx-kit/h5web/blob/12a66f7563f8c4d415b4d9b8e7d14ce7a16572cd/packages/lib/src/toolbar/controls/DomainSlider/Histogram.tsx#L56-L65

It also adds a `toArray` function and the corresponding `useArray` hook.