### PR TITLE
Fix ratio of SelectToZoom for NXImage

### DIFF
--- a/packages/lib/src/interactions/SelectToZoom.tsx
+++ b/packages/lib/src/interactions/SelectToZoom.tsx
@@ -1,5 +1,6 @@
 import { useThree } from '@react-three/fiber';
 
+import { useVisibleDomains } from '../vis/hooks';
 import { useAxisSystemContext } from '../vis/shared/AxisSystemContext';
 import SelectionRect from './SelectionRect';
 import SelectionTool from './SelectionTool';
@@ -20,6 +21,12 @@ function SelectToZoom(props: Props) {
   const { width, height } = useThree((state) => state.size);
   const camera = useThree((state) => state.camera);
 
+  const { xVisibleDomain, yVisibleDomain } = useVisibleDomains();
+  const dataRatio = Math.abs(
+    (xVisibleDomain[1] - xVisibleDomain[0]) /
+      (yVisibleDomain[1] - yVisibleDomain[0])
+  );
+
   const onSelectionEnd = (selection: Selection) => {
     const { startPoint: dataStartPoint, endPoint: dataEndPoint } = selection;
 
@@ -27,7 +34,7 @@ function SelectToZoom(props: Props) {
     const startPoint = dataToWorld(dataStartPoint);
     const endPoint = dataToWorld(
       keepRatio
-        ? getRatioEndPoint(dataStartPoint, dataEndPoint, width / height)
+        ? getRatioEndPoint(dataStartPoint, dataEndPoint, dataRatio)
         : dataEndPoint
     );
     if (startPoint.x === endPoint.x && startPoint.y === endPoint.y) {
@@ -66,7 +73,7 @@ function SelectToZoom(props: Props) {
           {keepRatio && (
             <SelectionRect
               startPoint={startPoint}
-              endPoint={getRatioEndPoint(startPoint, endPoint, width / height)}
+              endPoint={getRatioEndPoint(startPoint, endPoint, dataRatio)}
               fillOpacity={0.25}
               fill="white"
               stroke="black"


### PR DESCRIPTION
While working on https://github.com/silx-kit/h5web/issues/1025, I noticed a small bug for NXImage with axes.
I captured it below: the ratio of the rectangle is not computed properly while it is for the image without axes.

![Peek 2022-03-23 09-53](https://user-images.githubusercontent.com/42204205/159660519-b3514675-d84a-4b43-85af-7829675bc25b.gif)

The cause is quite simple: the part that computes the endpoint to respect the ratio works in the data space but we gave the ratio in the world space (`width / height`). 

Most of the time, this works fine because the ratio in the world space is the same as the ratio in the data space (i.e. the changes in width/height are proportional to the changes in x/y). This obviously changes when using axes in NeXus visualisations where the ratio between abscissas and ordinates values can be different than the ratio between width and `height`.

So two ways of solving this:
- Keep the ratio in the world space but do the computation with vectors in the world space
- Do the computation with the ratio in the data space

I chose the latter solution