### PR TITLE
H5wasm provider

### DIFF
--- a/apps/demo/.env
+++ b/apps/demo/.env
@@ -4,8 +4,11 @@
 #####
 
 # h5grove backend parameters
-VITE_H5GROVE_URL="http://localhost:8888/"
-VITE_H5GROVE_FALLBACK_FILEPATH="sans59510.nxs.ngv"
+VITE_H5GROVE_URL=
+VITE_H5GROVE_FALLBACK_FILEPATH="water_224.h5"
+
+# h5wasm backend parameters
+VITE_H5WASM_FALLBACK_FILEPATH="https://ncnr.nist.gov/pub/ncnrdata/ngbsans/202009/nonims294/data/sans114141.nxs.ngb"
 
 # HSDS parameters
 # URL, username, password and filepath as strings

--- a/apps/demo/.env
+++ b/apps/demo/.env
@@ -4,8 +4,8 @@
 #####
 
 # h5grove backend parameters
-VITE_H5GROVE_URL=
-VITE_H5GROVE_FALLBACK_FILEPATH="water_224.h5"
+VITE_H5GROVE_URL="http://localhost:8888/"
+VITE_H5GROVE_FALLBACK_FILEPATH="sans59510.nxs.ngv"
 
 # HSDS parameters
 # URL, username, password and filepath as strings

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@h5web/app": "workspace:*",
+    "h5wasm": "0.3.0",
     "normalize.css": "8.0.1",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/apps/demo/src/DemoApp.tsx
+++ b/apps/demo/src/DemoApp.tsx
@@ -6,6 +6,7 @@ import {
 } from 'react-router-dom';
 
 import H5GroveApp from './H5GroveApp';
+import H5WasmApp from './H5WasmApp';
 import HsdsApp from './HsdsApp';
 import MockApp from './MockApp';
 
@@ -16,6 +17,7 @@ function DemoApp() {
         <Route path="/" element={<H5GroveApp />} />
         <Route path="mock" element={<MockApp />} />
         <Route path="hsds" element={<HsdsApp />} />
+        <Route path="h5wasm" element={<H5WasmApp />} />
         <Route path="*" element={<Navigate to="/" />} />
       </Routes>
     </Router>

--- a/apps/demo/src/H5WasmApp.tsx
+++ b/apps/demo/src/H5WasmApp.tsx
@@ -1,0 +1,22 @@
+import { App, H5WasmProvider } from '@h5web/app';
+import { useLocation } from 'react-router-dom';
+
+import { getFeedbackURL } from './utils';
+
+const FILEPATH = import.meta.env.VITE_H5WASM_FALLBACK_FILEPATH as string;
+
+function H5WasmApp() {
+  const query = new URLSearchParams(useLocation().search);
+  const filepath = query.get('file') || FILEPATH;
+
+  return (
+    <H5WasmProvider url={filepath}>
+      <App
+        startFullscreen={query.has('fullscreen')}
+        getFeedbackURL={getFeedbackURL}
+      />
+    </H5WasmProvider>
+  );
+}
+
+export default H5WasmApp;

--- a/apps/demo/vite.config.js
+++ b/apps/demo/vite.config.js
@@ -1,10 +1,19 @@
 import react from '@vitejs/plugin-react';
+// import wasmLoader from 'esbuild-plugin-wasm';
 import { defineConfig } from 'vite';
 import eslintPlugin from 'vite-plugin-eslint';
 
 export default defineConfig({
   server: { open: true },
   preview: { open: true },
+  esbuild: {
+    target: 'es2020',
+    sourcemap: true,
+  },
+  build: {
+    target: 'es2020',
+    sourcemap: true,
+  },
   // css: { modules: { root: '.' } }, // https://github.com/vitejs/vite/issues/3092#issuecomment-915952727
   plugins: [react(), eslintPlugin()],
 });

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -47,7 +47,7 @@
     "@react-three/fiber": "7.0.26",
     "axios": "0.26.0",
     "d3-format": "3.1.0",
-    "h5wasm": "0.2.2",
+    "h5wasm": "0.3.0",
     "lodash": "4.17.21",
     "ndarray": "1.0.19",
     "ndarray-ops": "1.2.2",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -47,6 +47,7 @@
     "@react-three/fiber": "7.0.26",
     "axios": "0.26.0",
     "d3-format": "3.1.0",
+    "h5wasm": "0.2.2",
     "lodash": "4.17.21",
     "ndarray": "1.0.19",
     "ndarray-ops": "1.2.2",

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -3,6 +3,7 @@ export { default as App } from './App';
 export { default as MockProvider } from './providers/mock/MockProvider';
 export { default as HsdsProvider } from './providers/hsds/HsdsProvider';
 export { default as H5GroveProvider } from './providers/h5grove/H5GroveProvider';
+export { default as H5WasmProvider } from './providers/h5wasm/H5WasmProvider';
 
 export { getFeedbackMailto } from './breadcrumbs/utils';
 export type { FeedbackContext } from './breadcrumbs/models';

--- a/packages/app/src/metadata-viewer/AttributeLink.tsx
+++ b/packages/app/src/metadata-viewer/AttributeLink.tsx
@@ -41,7 +41,13 @@ function AttributeLink(props: Props) {
     );
   }
 
-  return <>{JSON.stringify(value)}</>;
+  return (
+    <>
+      {JSON.stringify(value, (key, value) =>
+        typeof value === 'bigint' ? Number(value) : value
+      )}
+    </>
+  );
 }
 
 export default AttributeLink;

--- a/packages/app/src/providers/h5wasm/H5WasmProvider.tsx
+++ b/packages/app/src/providers/h5wasm/H5WasmProvider.tsx
@@ -6,8 +6,6 @@ import { H5WasmApi } from './h5wasm-api';
 
 interface Props {
   url: string;
-  filepath: string;
-  axiosParams?: Record<string, string>;
   children: ReactNode;
 }
 

--- a/packages/app/src/providers/h5wasm/H5WasmProvider.tsx
+++ b/packages/app/src/providers/h5wasm/H5WasmProvider.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from 'react';
+import { useMemo } from 'react';
+
+import Provider from '../Provider';
+import { H5WasmApi } from './h5wasm-api';
+
+interface Props {
+  url: string;
+  filepath: string;
+  axiosParams?: Record<string, string>;
+  children: ReactNode;
+}
+
+function H5WasmProvider(props: Props) {
+  const { url, children } = props;
+
+  const api = useMemo(() => new H5WasmApi(url), [url]);
+
+  return <Provider api={api}>{children}</Provider>;
+}
+
+export default H5WasmProvider;

--- a/packages/app/src/providers/h5wasm/h5wasm-api.ts
+++ b/packages/app/src/providers/h5wasm/h5wasm-api.ts
@@ -1,0 +1,244 @@
+import type {
+  ArrayShape,
+  Attribute,
+  AttributeValues,
+  Dataset,
+  Entity,
+  Group,
+  GroupWithChildren,
+  NumericType,
+  UnresolvedEntity,
+} from '@h5web/shared';
+import { Shape, DType, DTypeClass } from '@h5web/shared';
+import { hasScalarShape, buildEntityPath, EntityKind } from '@h5web/shared';
+import {
+  ready as h5wasm_ready,
+  File,
+  Group as h5wasm_Group,
+  Dataset as h5wasm_Dataset,
+  FS as h5wasm_FS,
+} from 'h5wasm';
+import { isString } from 'lodash';
+
+import { ProviderApi } from '../api';
+import type { ExportFormat, ValuesStoreParams } from '../models';
+import { convertDtype, handleAxiosError } from '../utils';
+import type {
+  H5WasmAttribute,
+  H5WasmAttrValuesResponse,
+  H5WasmDataResponse,
+  H5WasmEntityResponse,
+} from './models';
+import {
+  isDatasetResponse,
+  isExternalLinkResponse,
+  isGroupResponse,
+  isSoftLinkResponse,
+  typedArrayFromDType,
+} from './utils';
+
+function convert_attrs(attrs: object): Attribute[] {
+  return Object.entries(attrs).map(([name, value]) => ({
+    name,
+    shape: [],
+    type: convertDtype('<f4'),
+  }));
+}
+
+export class H5WasmApi extends ProviderApi {
+  /* API compatible with h5wasm@0.2.10 */
+  public file_obj: File | undefined;
+
+  public constructor(filepath: string) {
+    super(filepath);
+  }
+
+  public async getEntity(path: string): Promise<Entity> {
+    if (this.file_obj === null) {
+      await h5wasm_ready;
+      const response = await this.client.get<ArrayBuffer>(this.filepath, {
+        responseType: 'arraybuffer',
+      });
+      const ab = response.data;
+      h5wasm_FS.writeFile('current.h5', new Uint8Array(ab));
+      this.file_obj = new File('current.h5', 'r');
+    }
+
+    const entity_obj = (this.file_obj as File).get(path);
+    if (entity_obj instanceof h5wasm_Group) {
+      return {
+        name: path,
+        path,
+        kind: EntityKind.Group,
+        attributes: convert_attrs(entity_obj.attrs),
+        children: [],
+      } as GroupWithChildren;
+    }
+
+    // } (entity_obj instanceof h5wasm_Dataset) {
+    return {
+      name: path,
+      path,
+      kind: EntityKind.Dataset,
+      attributes: convert_attrs(entity_obj.attrs),
+    } as Dataset;
+  }
+
+  public async getValue(
+    params: ValuesStoreParams
+  ): Promise<H5WasmDataResponse> {
+    const { dataset } = params;
+
+    const DTypedArray = typedArrayFromDType(dataset.type);
+    if (DTypedArray) {
+      const buffer = await this.fetchBinaryData(params);
+      const array = new DTypedArray(buffer);
+      return hasScalarShape(dataset) ? array[0] : array;
+    }
+
+    return this.fetchData(params);
+  }
+
+  public async getAttrValues(entity: Entity): Promise<AttributeValues> {
+    const { path, attributes } = entity;
+    return attributes.length > 0 ? this.fetchAttrValues(path) : {};
+  }
+
+  public getExportURL(
+    dataset: Dataset<ArrayShape, NumericType>,
+    selection: string | undefined,
+    format: ExportFormat
+  ): string | undefined {
+    const { baseURL, params } = this.client.defaults;
+
+    const searchParams = new URLSearchParams(params as Record<string, string>);
+    searchParams.set('path', dataset.path);
+    searchParams.set('format', format);
+
+    if (selection) {
+      searchParams.set('selection', selection);
+    }
+
+    return `${baseURL as string}/data/?${searchParams.toString()}`;
+  }
+
+  private async fetchAttrValues(
+    path: string
+  ): Promise<H5WasmAttrValuesResponse> {
+    const { data } = await this.client.get<H5WasmAttrValuesResponse>(`/attr/`, {
+      params: { path },
+    });
+    return data;
+  }
+
+  private async fetchData(
+    params: ValuesStoreParams
+  ): Promise<H5WasmDataResponse> {
+    const { data } = await this.cancellableFetchValue<H5WasmDataResponse>(
+      `/data/`,
+      params,
+      { path: params.dataset.path, selection: params.selection, flatten: true }
+    );
+    return data;
+  }
+
+  private async fetchBinaryData(
+    params: ValuesStoreParams
+  ): Promise<ArrayBuffer> {
+    const { data } = await this.cancellableFetchValue<ArrayBuffer>(
+      '/data/',
+      params,
+      { path: params.dataset.path, selection: params.selection, format: 'bin' },
+      'arraybuffer'
+    );
+
+    return data;
+  }
+
+  private async processEntityResponse(
+    path: string,
+    response: H5WasmEntityResponse
+  ): Promise<Entity> {
+    const { name, type: kind } = response;
+
+    const baseEntity = { name, path, kind };
+
+    if (isGroupResponse(response)) {
+      const { children, attributes: attrsMetadata } = response;
+      const attributes = await this.processAttrsMetadata(path, attrsMetadata);
+
+      if (!children) {
+        /* `/meta` stops at one nesting level
+         * (i.e. children of child groups are not returned) */
+        return { ...baseEntity, attributes } as Group;
+      }
+
+      return {
+        ...baseEntity,
+        attributes,
+        // Fetch attribute values of any child groups in parallel
+        children: await Promise.all(
+          children.map((child) =>
+            this.processEntityResponse(buildEntityPath(path, child.name), child)
+          )
+        ),
+      } as GroupWithChildren;
+    }
+
+    if (isDatasetResponse(response)) {
+      const { attributes: attrsMetadata, dtype, shape } = response;
+      const attributes = await this.processAttrsMetadata(path, attrsMetadata);
+
+      return {
+        ...baseEntity,
+        attributes,
+        shape,
+        type: convertDtype(dtype),
+        rawType: dtype,
+      } as Dataset;
+    }
+
+    if (isSoftLinkResponse(response)) {
+      const { target_path } = response;
+
+      return {
+        ...baseEntity,
+        attributes: [],
+        kind: EntityKind.Unresolved,
+        link: { class: 'Soft', path: target_path },
+      };
+    }
+
+    if (isExternalLinkResponse(response)) {
+      const { target_file, target_path } = response;
+
+      return {
+        ...baseEntity,
+        kind: EntityKind.Unresolved,
+        attributes: [],
+        link: {
+          class: 'External',
+          file: target_file,
+          path: target_path,
+        },
+      };
+    }
+
+    // Treat 'other' entities as unresolved
+    return {
+      ...baseEntity,
+      kind: EntityKind.Unresolved,
+    } as UnresolvedEntity;
+  }
+
+  private async processAttrsMetadata(
+    path: string,
+    attrsMetadata: H5WasmAttribute[]
+  ): Promise<Attribute[]> {
+    return attrsMetadata.map<Attribute>(({ name, dtype, shape }) => ({
+      name,
+      shape,
+      type: convertDtype(dtype),
+    }));
+  }
+}

--- a/packages/app/src/providers/h5wasm/models.ts
+++ b/packages/app/src/providers/h5wasm/models.ts
@@ -1,0 +1,44 @@
+import type { AttributeValues, EntityKind } from '@h5web/shared';
+
+export interface H5WasmEntityResponse {
+  name: string;
+  type:
+    | EntityKind.Dataset
+    | EntityKind.Group
+    | 'external_link'
+    | 'soft_link'
+    | 'other';
+}
+
+export interface H5WasmDatasetReponse extends H5WasmEntityResponse {
+  type: EntityKind.Dataset;
+  dtype: string;
+  shape: number[];
+  attributes: H5WasmAttribute[];
+}
+
+export interface H5WasmGroupResponse extends H5WasmEntityResponse {
+  type: EntityKind.Group;
+  children?: H5WasmEntityResponse[];
+  attributes: H5WasmAttribute[];
+}
+
+export interface H5WasmSoftLinkResponse extends H5WasmEntityResponse {
+  type: 'soft_link';
+  target_path: string;
+}
+
+export interface H5WasmExternalLinkResponse extends H5WasmEntityResponse {
+  type: 'external_link';
+  target_file: string;
+  target_path: string;
+}
+
+export interface H5WasmAttribute {
+  dtype: string;
+  name: string;
+  shape: number[];
+}
+
+export type H5WasmAttrValuesResponse = AttributeValues;
+export type H5WasmDataResponse = unknown;

--- a/packages/app/src/providers/h5wasm/utils.ts
+++ b/packages/app/src/providers/h5wasm/utils.ts
@@ -1,0 +1,82 @@
+import type { DType } from '@h5web/shared';
+import { DTypeClass, EntityKind, isNumericType } from '@h5web/shared';
+
+import type {
+  H5WasmDatasetReponse,
+  H5WasmEntityResponse,
+  H5WasmExternalLinkResponse,
+  H5WasmGroupResponse,
+  H5WasmSoftLinkResponse,
+} from './models';
+
+export function isGroupResponse(
+  response: H5WasmEntityResponse
+): response is H5WasmGroupResponse {
+  return response.type === EntityKind.Group;
+}
+
+export function isDatasetResponse(
+  response: H5WasmEntityResponse
+): response is H5WasmDatasetReponse {
+  return response.type === EntityKind.Dataset;
+}
+
+export function isSoftLinkResponse(
+  response: H5WasmEntityResponse
+): response is H5WasmSoftLinkResponse {
+  return response.type === 'soft_link';
+}
+
+export function isExternalLinkResponse(
+  response: H5WasmEntityResponse
+): response is H5WasmExternalLinkResponse {
+  return response.type === 'external_link';
+}
+
+export function typedArrayFromDType(dtype: DType) {
+  /* Adapted from https://github.com/ludwigschubert/js-numpy-parser/blob/v1.2.3/src/main.js#L116 */
+  if (!isNumericType(dtype)) {
+    return undefined;
+  }
+
+  const { class: dtypeClass, size } = dtype;
+
+  if (dtypeClass === DTypeClass.Integer) {
+    switch (size) {
+      case 8:
+        return Int8Array;
+      case 16:
+        return Int16Array;
+      case 32:
+        return Int32Array;
+      case 64: // No support for 64-bit integer values in JS
+        return undefined;
+    }
+  }
+
+  if (dtypeClass === DTypeClass.Unsigned) {
+    switch (size) {
+      case 8:
+        return Uint8Array;
+      case 16:
+        return Uint16Array;
+      case 32:
+        return Uint32Array;
+      case 64: // No support for 64-bit unsigned integer values in JS
+        return undefined;
+    }
+  }
+
+  if (dtypeClass === DTypeClass.Float) {
+    switch (size) {
+      case 16: // No support for 16-bit floating values in JS
+        return undefined;
+      case 32:
+        return Float32Array;
+      case 64:
+        return Float64Array;
+    }
+  }
+
+  return undefined;
+}

--- a/packages/app/src/providers/h5wasm/utils.ts
+++ b/packages/app/src/providers/h5wasm/utils.ts
@@ -1,5 +1,4 @@
-import type { DType } from '@h5web/shared';
-import { DTypeClass, EntityKind, isNumericType } from '@h5web/shared';
+import { EntityKind } from '@h5web/shared';
 
 import type {
   H5WasmDatasetReponse,
@@ -31,52 +30,4 @@ export function isExternalLinkResponse(
   response: H5WasmEntityResponse
 ): response is H5WasmExternalLinkResponse {
   return response.type === 'external_link';
-}
-
-export function typedArrayFromDType(dtype: DType) {
-  /* Adapted from https://github.com/ludwigschubert/js-numpy-parser/blob/v1.2.3/src/main.js#L116 */
-  if (!isNumericType(dtype)) {
-    return undefined;
-  }
-
-  const { class: dtypeClass, size } = dtype;
-
-  if (dtypeClass === DTypeClass.Integer) {
-    switch (size) {
-      case 8:
-        return Int8Array;
-      case 16:
-        return Int16Array;
-      case 32:
-        return Int32Array;
-      case 64: // No support for 64-bit integer values in JS
-        return undefined;
-    }
-  }
-
-  if (dtypeClass === DTypeClass.Unsigned) {
-    switch (size) {
-      case 8:
-        return Uint8Array;
-      case 16:
-        return Uint16Array;
-      case 32:
-        return Uint32Array;
-      case 64: // No support for 64-bit unsigned integer values in JS
-        return undefined;
-    }
-  }
-
-  if (dtypeClass === DTypeClass.Float) {
-    switch (size) {
-      case 16: // No support for 16-bit floating values in JS
-        return undefined;
-      case 32:
-        return Float32Array;
-      case 64:
-        return Float64Array;
-    }
-  }
-
-  return undefined;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,7 @@ importers:
       '@vitejs/plugin-react': 1.2.0
       eslint: '>=8'
       eslint-config-galex: 3.6.5
+      h5wasm: 0.3.0
       normalize.css: 8.0.1
       react: 17.0.2
       react-dom: 17.0.2
@@ -60,6 +61,7 @@ importers:
       vite-plugin-eslint: 1.3.0
     dependencies:
       '@h5web/app': link:../../packages/app
+      h5wasm: 0.3.0
       normalize.css: 8.0.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -149,7 +151,7 @@ importers:
       d3-format: 3.1.0
       eslint: '>=8'
       eslint-config-galex: 3.6.5
-      h5wasm: 0.2.2
+      h5wasm: 0.3.0
       jest: 27.5.1
       lodash: 4.17.21
       ndarray: 1.0.19
@@ -175,7 +177,7 @@ importers:
       '@react-three/fiber': 7.0.26_03d4586416b86b800151bd7390b3d95a
       axios: 0.26.0
       d3-format: 3.1.0
-      h5wasm: 0.2.2
+      h5wasm: 0.3.0
       lodash: 4.17.21
       ndarray: 1.0.19
       ndarray-ops: 1.2.2
@@ -9006,8 +9008,8 @@ packages:
     resolution: {integrity: sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==}
     dev: true
 
-  /h5wasm/0.2.2:
-    resolution: {integrity: sha512-2C1Yq+6xO/LeJCZS62WFdsVGtMVw0NFTxx2zpet9xkH2+k+9hyRlT0y1LK0cthbdHVt8bXSvsxwgG+spsy7xlg==}
+  /h5wasm/0.3.0:
+    resolution: {integrity: sha512-wYh09BmCQ6reRmxhN9upaPXGT23UQxKlwcRdPdTYXBcYc/9XHnDT6rxtfP/TJkQMCtyKkGhaZgMyI9Jw+ZF4Sg==}
     dev: false
 
   /handlebars/4.7.7:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,7 @@ importers:
       d3-format: 3.1.0
       eslint: '>=8'
       eslint-config-galex: 3.6.5
+      h5wasm: 0.2.2
       jest: 27.5.1
       lodash: 4.17.21
       ndarray: 1.0.19
@@ -174,6 +175,7 @@ importers:
       '@react-three/fiber': 7.0.26_03d4586416b86b800151bd7390b3d95a
       axios: 0.26.0
       d3-format: 3.1.0
+      h5wasm: 0.2.2
       lodash: 4.17.21
       ndarray: 1.0.19
       ndarray-ops: 1.2.2
@@ -9003,6 +9005,10 @@ packages:
   /graceful-fs/4.2.9:
     resolution: {integrity: sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==}
     dev: true
+
+  /h5wasm/0.2.2:
+    resolution: {integrity: sha512-2C1Yq+6xO/LeJCZS62WFdsVGtMVw0NFTxx2zpet9xkH2+k+9hyRlT0y1LK0cthbdHVt8bXSvsxwgG+spsy7xlg==}
+    dev: false
 
   /handlebars/4.7.7:
     resolution: {integrity: sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "module": "esnext",
+    "module": "es2020",
     "moduleResolution": "node",
-    "target": "esnext",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "target": "es2020",
+    "lib": ["dom", "dom.iterable", "es2020"],
     "jsx": "react-jsx",
     "allowJs": true,
     "skipLibCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "module": "es2020",
+    "module": "esnext",
     "moduleResolution": "node",
-    "target": "es2020",
-    "lib": ["dom", "dom.iterable", "es2020"],
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
     "jsx": "react-jsx",
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
This creates a new provider that reads the HDF5 file directly in the browser, using hdf5 libraries compiled to WebAssembly ([h5wasm](https://github.com/usnistgov/h5wasm)) 

Currently it is set up to receive a URL for an HDF5 file that is available from a web server;

It is also straightforward to add another option for the user to directly "upload" a file from their computer (it only gets loaded into the browser context, not actually uploaded to a server), or to enable "drag-and-drop" so that users could drag a file from their filesystem onto the page and have it upload and process/view the file.

It is not in a finished state, and there is still some cleanup to do.  I thought it might be interesting to the developers, though.