### PR TITLE
Upgrade react-slider

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -53,7 +53,7 @@
     "react-error-boundary": "3.1.4",
     "react-icons": "4.3.1",
     "react-reflex": "4.0.6",
-    "react-slider": "1.3.1",
+    "react-slider": "2.0.0",
     "react-suspense-fetch": "0.4.0",
     "react-use": "17.3.2",
     "three": "0.135.0",

--- a/packages/app/src/dimension-mapper/SlicingSlider.tsx
+++ b/packages/app/src/dimension-mapper/SlicingSlider.tsx
@@ -1,5 +1,5 @@
 import { useDebouncedCallback, useMeasure } from '@react-hookz/web';
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import ReactSlider from 'react-slider';
 
 import styles from './SlicingSlider.module.css';
@@ -17,15 +17,9 @@ function SlicingSlider(props: Props) {
   const { dimension, maxIndex, initialValue, onChange } = props;
 
   const [value, setValue] = useState(initialValue);
-
-  const [containerSize, containerRef] = useMeasure<HTMLDivElement>();
-  const sliderRef = useRef<ReactSlider>(null);
-
   const onDebouncedChange = useDebouncedCallback(onChange, [onChange], 250);
 
-  useEffect(() => {
-    sliderRef.current?.resize();
-  }, [containerSize]);
+  const [containerSize, containerRef] = useMeasure<HTMLDivElement>();
 
   return (
     <div key={dimension} ref={containerRef} className={styles.container}>
@@ -33,7 +27,6 @@ function SlicingSlider(props: Props) {
       <span className={styles.sublabel}>0:{maxIndex}</span>
       {maxIndex > 0 ? (
         <ReactSlider
-          ref={sliderRef}
           className={styles.slider}
           ariaLabel="Dimension slider"
           min={0}

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -63,7 +63,7 @@
     "react-icons": "4.3.1",
     "react-keyed-flatten-children": "1.3.0",
     "react-measure": "2.5.2",
-    "react-slider": "1.3.1",
+    "react-slider": "2.0.0",
     "react-use": "17.3.2",
     "react-window": "1.8.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,7 +159,7 @@ importers:
       react-error-boundary: 3.1.4
       react-icons: 4.3.1
       react-reflex: 4.0.6
-      react-slider: 1.3.1
+      react-slider: 2.0.0
       react-suspense-fetch: 0.4.0
       react-use: 17.3.2
       rollup: 2.68.0
@@ -180,7 +180,7 @@ importers:
       react-error-boundary: 3.1.4_react@17.0.2
       react-icons: 4.3.1_react@17.0.2
       react-reflex: 4.0.6_react-dom@17.0.2+react@17.0.2
-      react-slider: 1.3.1_react@17.0.2
+      react-slider: 2.0.0_react@17.0.2
       react-suspense-fetch: 0.4.0
       react-use: 17.3.2_react-dom@17.0.2+react@17.0.2
       three: 0.135.0
@@ -252,7 +252,7 @@ importers:
       react-icons: 4.3.1
       react-keyed-flatten-children: 1.3.0
       react-measure: 2.5.2
-      react-slider: 1.3.1
+      react-slider: 2.0.0
       react-use: 17.3.2
       react-window: 1.8.6
       rollup: 2.68.0
@@ -280,7 +280,7 @@ importers:
       react-icons: 4.3.1_react@17.0.2
       react-keyed-flatten-children: 1.3.0_react@17.0.2
       react-measure: 2.5.2_react-dom@17.0.2+react@17.0.2
-      react-slider: 1.3.1_react@17.0.2
+      react-slider: 2.0.0_react@17.0.2
       react-use: 17.3.2_react-dom@17.0.2+react@17.0.2
       react-window: 1.8.6_react-dom@17.0.2+react@17.0.2
     devDependencies:
@@ -12624,12 +12624,12 @@ packages:
       throttle-debounce: 3.0.1
     dev: true
 
-  /react-slider/1.3.1_react@17.0.2:
-    resolution: {integrity: sha512-bD8hHJJUgAHI8g1F6PY6432l+Dmcs2fqzUwDhd+0HWDdvfjwNoXRNC2cL9OWyGTjYlJM92A8nF/w1X4pyHfytQ==}
+  /react-slider/2.0.0_react@17.0.2:
+    resolution: {integrity: sha512-r2Z4VkGvtQXbmiANEYzYdCnb4SnTRpgog1QZa++Wl1x1n5vRL3QOufyf52VVkcaLQCLk5m0WPMwGNvRqcBDtmw==}
     peerDependencies:
-      prop-types: ^15.6
       react: ^16 || ^17
     dependencies:
+      prop-types: 15.8.1
       react: 17.0.2
     dev: false
 


### PR DESCRIPTION
Two [main changes](https://github.com/zillow/react-slider/releases/tag/v2.0.0) that concern us:

- `prop-types` is no longer a peer dependency, which means we won't get the warnings any more
- `react-slider` now re-renders itself when it is resized thanks to `ResizeObserver` (before, it used to just listen to the window's `resize` event), which means we no longer have to take care of this ourselves in `SlicingSlider` in order for the sliders to re-render when the H5Web notebook cell is resized in JLab.