### PR TITLE
Show auxiliary values in tooltip

### DIFF
--- a/apps/storybook/src/LineVis.stories.tsx
+++ b/apps/storybook/src/LineVis.stories.tsx
@@ -37,15 +37,16 @@ const Template: Story<LineVisProps> = (args) => {
     domain: storyDomain,
     scaleType,
     errorsArray,
-    auxArrays,
+    auxiliaries,
   } = args;
 
   // If story doesn't provide `domain`, compute it automatically
+  const auxArrays = (auxiliaries || []).map(({ array }) => array);
   const domain =
     storyDomain ||
     getCombinedDomain([
       getDomain(dataArray, scaleType, errorsArray),
-      ...(auxArrays ? getDomains(auxArrays, scaleType) : []),
+      ...getDomains(auxArrays, scaleType),
     ]);
 
   return <LineVis {...args} domain={domain} />;
@@ -91,14 +92,19 @@ ErrorBars.args = {
 export const AuxiliaryArrays = Template.bind({});
 AuxiliaryArrays.args = {
   dataArray: primaryArray,
-  auxArrays: [secondaryArray, tertiaryArray],
+  auxiliaries: [
+    { label: 'secondary', array: secondaryArray },
+    { label: 'tertiary', array: tertiaryArray },
+  ],
 };
 
 export const TypedArrays = Template.bind({});
 TypedArrays.args = {
   dataArray: toTypedNdArray(primaryArray, Float32Array),
   errorsArray: toTypedNdArray(errorsArray, Float32Array),
-  auxArrays: [toTypedNdArray(secondaryArray, Float32Array)],
+  auxiliaries: [
+    { label: 'secondary', array: toTypedNdArray(secondaryArray, Float32Array) },
+  ],
   showErrors: true,
 };
 

--- a/packages/app/src/test-utils.tsx
+++ b/packages/app/src/test-utils.tsx
@@ -1,14 +1,13 @@
 import type { RenderResult } from '@testing-library/react';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import type { UserEvent } from '@testing-library/user-event/dist/types/setup';
 
 import App from './App';
 import MockProvider from './providers/mock/MockProvider';
 import type { Vis } from './vis-packs/core/visualizations';
 
 interface RenderAppResult extends RenderResult {
-  user: UserEvent;
+  user: ReturnType<typeof userEvent.setup>;
   selectExplorerNode: (path: string) => Promise<void>;
   selectVisTab: (name: Vis) => Promise<void>;
 }

--- a/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
+++ b/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
@@ -10,6 +10,7 @@ import { createPortal } from 'react-dom';
 import shallow from 'zustand/shallow';
 
 import type { DimensionMapping } from '../../../dimension-mapper/models';
+import type { Auxiliary } from '../../nexus/models';
 import {
   useMappedArrays,
   useMappedArray,
@@ -28,7 +29,7 @@ interface Props {
   valueLabel?: string;
   valueScaleType?: ScaleType;
   errors?: NumArray;
-  auxiliaries?: NumArray[];
+  auxiliaries?: Auxiliary[];
   dims: number[];
   dimMapping: DimensionMapping;
   axisMapping?: AxisMapping;
@@ -63,7 +64,10 @@ function MappedLineVis(props: Props) {
 
   const [dataArray, dataForDomain] = useMappedArray(value, ...hookArgs);
   const [errorArray, errorsForDomain] = useMappedArray(errors, ...hookArgs);
-  const [auxArrays, auxForDomain] = useMappedArrays(auxiliaries, ...hookArgs);
+  const [auxArrays, auxForDomain] = useMappedArrays(
+    auxiliaries.map((aux) => aux.value),
+    ...hookArgs
+  );
 
   const dataDomain = useDomain(
     dataForDomain,
@@ -106,7 +110,10 @@ function MappedLineVis(props: Props) {
         dtype={dataset?.type}
         errorsArray={errorArray}
         showErrors={showErrors}
-        auxArrays={auxArrays}
+        auxiliaries={auxiliaries.map(({ label }, i) => ({
+          label,
+          array: auxArrays[i],
+        }))}
       />
     </>
   );

--- a/packages/app/src/vis-packs/nexus/NxValuesFetcher.tsx
+++ b/packages/app/src/vis-packs/nexus/NxValuesFetcher.tsx
@@ -3,12 +3,8 @@ import type { ReactNode } from 'react';
 import { useContext } from 'react';
 
 import { ProviderContext } from '../../providers/context';
-import {
-  useDatasetValue,
-  useDatasetValues,
-  usePrefetchValues,
-} from '../core/hooks';
-import { useAxisMapping } from './hooks';
+import { useDatasetValue, usePrefetchValues } from '../core/hooks';
+import { useAuxiliaries, useAxisMapping } from './hooks';
 import type { NxData, NxValues } from './models';
 import { getDatasetLabel } from './utils';
 
@@ -37,7 +33,7 @@ function NxValuesFetcher<T extends NumericType | ComplexType>(props: Props<T>) {
   const signalLabel = getDatasetLabel(signalDataset, attrValuesStore);
   const errors = useDatasetValue(errorsDataset, selection);
   const axisMapping = useAxisMapping(axisDatasets, silxStyle.axisScaleTypes);
-  const auxiliaries = Object.values(useDatasetValues(auxDatasets, selection));
+  const auxiliaries = useAuxiliaries(auxDatasets, selection);
   const title = useDatasetValue(titleDataset) || signalLabel;
 
   return (

--- a/packages/app/src/vis-packs/nexus/hooks.ts
+++ b/packages/app/src/vis-packs/nexus/hooks.ts
@@ -1,11 +1,15 @@
-import type { GroupWithChildren, ScaleType } from '@h5web/shared';
+import type {
+  GroupWithChildren,
+  NumArrayDataset,
+  ScaleType,
+} from '@h5web/shared';
 import { isDefined } from '@h5web/shared';
 import { useContext } from 'react';
 
 import { ProviderContext } from '../../providers/context';
 import { useDatasetValues } from '../core/hooks';
 import type { AxisMapping } from '../core/models';
-import type { AxisDatasetMapping, NxData } from './models';
+import type { Auxiliary, AxisDatasetMapping, NxData } from './models';
 import {
   assertNxDataGroup,
   findAssociatedDatasets,
@@ -55,4 +59,18 @@ export function useAxisMapping(
       }
     );
   });
+}
+
+export function useAuxiliaries(
+  auxDatasets: NumArrayDataset[],
+  selection: string | undefined
+): Auxiliary[] {
+  const { attrValuesStore } = useContext(ProviderContext);
+
+  const auxValues = useDatasetValues(auxDatasets, selection);
+
+  return auxDatasets.map((dataset) => ({
+    label: getDatasetLabel(dataset, attrValuesStore),
+    value: auxValues[dataset.name],
+  }));
 }

--- a/packages/app/src/vis-packs/nexus/models.ts
+++ b/packages/app/src/vis-packs/nexus/models.ts
@@ -40,7 +40,7 @@ export interface NxValues<T extends NumericType | ComplexType> {
   signalLabel: string;
   errors?: NumArray;
   axisMapping: AxisMapping;
-  auxiliaries?: NumArray[];
+  auxiliaries?: Auxiliary[];
   title: string;
 }
 
@@ -49,4 +49,9 @@ export type AxisDatasetMapping = (NumArrayDataset | undefined)[];
 export interface SilxStyle {
   signalScaleType?: ScaleType;
   axisScaleTypes?: ScaleType[];
+}
+
+export interface Auxiliary {
+  label: string;
+  value: NumArray;
 }

--- a/packages/lib/src/vis/line/LineVis.module.css
+++ b/packages/lib/src/vis/line/LineVis.module.css
@@ -10,6 +10,10 @@
   margin-top: 0.25rem;
 }
 
+.tooltipValue:not(:last-child) {
+  margin-bottom: 0.25rem;
+}
+
 .tooltipValue > strong {
   font-weight: 600;
   font-size: 1.125em;

--- a/packages/lib/src/vis/line/models.ts
+++ b/packages/lib/src/vis/line/models.ts
@@ -1,3 +1,6 @@
+import type { NumArray } from '@h5web/shared';
+import type { NdArray } from 'ndarray';
+
 export enum CurveType {
   LineOnly = 'OnlyLine',
   GlyphsOnly = 'OnlyGlyphs',
@@ -15,4 +18,9 @@ export interface TooltipData {
   abscissa: number;
   xi: number;
   x: number;
+}
+
+export interface AuxiliaryParams {
+  label: string;
+  array: NdArray<NumArray>;
 }


### PR DESCRIPTION
First part of #970 

In order to display the auxiliaries in the tooltip and the legend, we need to know their names. So I change the API of `LineVis` as follows: the `auxArray: NdArray<NumArray>[]` prop becomes `auxiliaries: Auxiliary[]`, where `Auxiliary` is an object with a `name`, `label` and `array`.

Since this was quite the refactoring already, I decided to implement the legend in a separate PR. So for now, I use the `name` in the tooltip. I plan to use the `label` (either `long_name`, or dataset name + `units`, or just dataset name) in the legend, since I'll have more space to work with.

![image](https://user-images.githubusercontent.com/2936402/161059222-d1c47046-1606-460a-b08f-37852df54939.png)
