### PR TITLE
Show auxiliary plot colors in line vis tooltip

### DIFF
--- a/packages/lib/src/vis/line/LineVis.module.css
+++ b/packages/lib/src/vis/line/LineVis.module.css
@@ -6,15 +6,33 @@
   margin: 1rem;
 }
 
-.tooltipValue {
+.tooltipItem {
+  display: flex;
+  align-items: baseline;
+}
+
+.tooltipValue,
+.tooltipAux {
+  composes: tooltipItem;
+}
+
+.tooltipValue,
+.tooltipValue + .tooltipAux {
   margin-top: 0.25rem;
 }
 
-.tooltipValue:not(:last-child) {
-  margin-bottom: 0.25rem;
-}
-
-.tooltipValue > strong {
+.tooltipValue strong {
   font-weight: 600;
   font-size: 1.125em;
+}
+
+.mark {
+  content: '';
+  display: block;
+  width: 0.75em;
+  height: 0.375rem;
+  margin-right: 0.375rem;
+  padding-bottom: 0.125rem;
+  background-color: currentColor;
+  transform: translateY(-1px);
 }

--- a/packages/lib/src/vis/line/LineVis.tsx
+++ b/packages/lib/src/vis/line/LineVis.tsx
@@ -152,15 +152,28 @@ function LineVis(props: Props) {
                 {`${abscissaLabel ?? 'x'} = ${formatTooltipVal(abscissa)}`}
 
                 <div className={styles.tooltipValue}>
-                  <strong>{formatTooltipVal(value)}</strong>
-                  {error && ` ±${formatTooltipErr(error)}`}
-                  {dtype && <em>{` (${formatNumType(dtype)})`}</em>}
+                  {auxiliaries.length > 0 && (
+                    <span
+                      className={styles.mark}
+                      style={{ color: curveColor }}
+                    />
+                  )}
+                  <span>
+                    <strong>{formatTooltipVal(value)}</strong>
+                    {error !== undefined && ` ±${formatTooltipErr(error)}`}
+                    {dtype && <em>{` (${formatNumType(dtype)})`}</em>}
+                  </span>
                 </div>
 
-                {auxiliaries.map(({ label, array }) => {
-                  const val = formatTooltipVal(array.get(xi));
-                  return <div key={label}>{`${label} = ${val}`}</div>;
-                })}
+                {auxiliaries.map(({ label, array }, index) => (
+                  <div className={styles.tooltipAux} key={label}>
+                    <span
+                      className={styles.mark}
+                      style={{ color: auxColors[index % auxColors.length] }}
+                    />
+                    {label} = {formatTooltipVal(array.get(xi))}
+                  </div>
+                ))}
               </>
             );
           }}
@@ -179,7 +192,7 @@ function LineVis(props: Props) {
             key={i} // eslint-disable-line react/no-array-index-key
             abscissas={abscissas}
             ordinates={array.data}
-            color={auxColors[i < auxColors.length ? i : auxColors.length - 1]}
+            color={auxColors[i % auxColors.length]}
             curveType={curveType}
           />
         ))}


### PR DESCRIPTION
Fix #970 

The tooltip remains unchanged when no auxiliaries are passed (i.e. the color of the main plot is not shown unless there are auxiliary plots).

![image](https://user-images.githubusercontent.com/2936402/161240579-804cb3b4-52ce-452c-860b-1a681c802d22.png)

The tooltip code of the line vis is starting to take quite a bit of space, but I wasn't sure if it was worth extracting the whole thing into a separate component, since we need access to so many props/variables from `LineVis`. Perhaps there's a way to abstract things but I'm not seeing it yet, especially since everything in there is so specific to the line vis at the moment.