### PR TITLE
Add onClick callback to ScatterVis

### DIFF
--- a/apps/storybook/src/ScatterVis.stories.tsx
+++ b/apps/storybook/src/ScatterVis.stories.tsx
@@ -3,6 +3,7 @@ import type { ScatterVisProps } from '@h5web/lib';
 import { ScaleType } from '@h5web/shared';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import ndarray from 'ndarray';
+import { useState } from 'react';
 
 import FillHeight from './decorators/FillHeight';
 
@@ -88,6 +89,27 @@ AxisScaleTypes.args = {
   ordinateParams: { value: ordinates, scaleType: ScaleType.Log },
   dataArray,
   domain,
+};
+
+export const Click: Story<ScatterVisProps> = (args) => {
+  const [title, setTitle] = useState(`Click on a point !`);
+
+  return (
+    <ScatterVis
+      {...args}
+      title={title}
+      onPointClick={(index) => {
+        setTitle(
+          index !== undefined
+            ? `You clicked on point ${index} (value: ${data[index]})`
+            : `Click on a point !`
+        );
+      }}
+    />
+  );
+};
+Click.args = {
+  ...Default.args,
 };
 
 export default {

--- a/packages/lib/src/vis/scatter/ScatterVis.tsx
+++ b/packages/lib/src/vis/scatter/ScatterVis.tsx
@@ -1,5 +1,6 @@
 import type { Domain, NumArray } from '@h5web/shared';
 import { assertLength, assertDefined, ScaleType } from '@h5web/shared';
+import type { ThreeEvent } from '@react-three/fiber';
 import { toArray } from 'lodash';
 import type { NdArray } from 'ndarray';
 import type { ReactNode } from 'react';
@@ -28,6 +29,10 @@ interface Props {
   size?: number;
   children?: ReactNode;
   interactions?: Interactions;
+  onPointClick?: (
+    index: number | undefined,
+    evt: ThreeEvent<MouseEvent>
+  ) => void;
 }
 
 function ScatterVis(props: Props) {
@@ -44,6 +49,7 @@ function ScatterVis(props: Props) {
     size = 10,
     children,
     interactions,
+    onPointClick,
   } = props;
 
   const {
@@ -99,6 +105,7 @@ function ScatterVis(props: Props) {
           colorMap={colorMap}
           invertColorMap={invertColorMap}
           size={size}
+          onClick={onPointClick}
         />
 
         {children}


### PR DESCRIPTION
For daiquiri, I need to be able to trigger events when clicking on point of a `ScatterVis`. 

In my early tries, I noticed that when attaching `onClick` to `points`, the handler was only called when clicking on the very center of the point. I figured this was because the handler was unaware of the shader rendering of the point that gives a point of bigger size.

I was able to solve this by increasing [the threshold of the raycaster](https://threejs.org/docs/index.html?q=raycas#api/en/core/Raycaster.params) to the size of the point so that events are caught for the full point.

Note that there is a limitation: the threshold is given in world units but point size stay constant when zooming in the scene. This means that the hitbox does not match the point when zooming in.