### PR TITLE
Fixes TiledHeatmap display with flipped axes

### DIFF
--- a/apps/storybook/src/TiledHeatmap.stories.tsx
+++ b/apps/storybook/src/TiledHeatmap.stories.tsx
@@ -174,11 +174,24 @@ const halfMandelbrotApi = new MandelbrotTilesApi(
   [0, 1.5]
 );
 
-export const ArbitraryDomain = Template.bind({});
-ArbitraryDomain.args = {
+export const AxisValues = Template.bind({});
+AxisValues.args = {
   api: halfMandelbrotApi,
   abscissaConfig: { visDomain: halfMandelbrotApi.xDomain, showGrid: false },
   ordinateConfig: { visDomain: halfMandelbrotApi.yDomain, showGrid: false },
+};
+
+export const DescendingAxisValues = Template.bind({});
+DescendingAxisValues.args = {
+  api: halfMandelbrotApi,
+  abscissaConfig: {
+    visDomain: [...halfMandelbrotApi.xDomain].reverse() as Domain,
+    showGrid: false,
+  },
+  ordinateConfig: {
+    visDomain: [...halfMandelbrotApi.yDomain].reverse() as Domain,
+    showGrid: false,
+  },
 };
 
 export const FlippedAxes = Template.bind({});

--- a/apps/storybook/src/TiledHeatmap.stories.tsx
+++ b/apps/storybook/src/TiledHeatmap.stories.tsx
@@ -5,8 +5,10 @@ import {
   Zoom,
   TiledHeatmap,
   TilesApi,
+  ResetZoomButton,
+  SelectToZoom,
 } from '@h5web/lib';
-import type { Domain, Size, TiledHeatmapProps } from '@h5web/lib';
+import type { Domain, Size, TiledHeatmapProps, AxisConfig } from '@h5web/lib';
 import { ScaleType } from '@h5web/shared';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { clamp } from 'lodash';
@@ -118,30 +120,26 @@ class MandelbrotTilesApi extends TilesApi {
 }
 
 interface TiledHeatmapStoryProps extends TiledHeatmapProps {
-  abscissaDomain: Domain;
-  ordinateDomain: Domain;
+  abscissaConfig: AxisConfig;
+  ordinateConfig: AxisConfig;
 }
 
 const Template: Story<TiledHeatmapStoryProps> = (args) => {
-  const { abscissaDomain, api, ordinateDomain, ...tiledHeatmapProps } = args;
+  const { abscissaConfig, api, ordinateConfig, ...tiledHeatmapProps } = args;
 
   return (
     <VisCanvas
-      abscissaConfig={{
-        visDomain: abscissaDomain,
-        showGrid: false,
-      }}
-      ordinateConfig={{
-        visDomain: ordinateDomain,
-        showGrid: false,
-      }}
+      abscissaConfig={abscissaConfig}
+      ordinateConfig={ordinateConfig}
       visRatio={Math.abs(
-        (abscissaDomain[1] - abscissaDomain[0]) /
-          (ordinateDomain[1] - ordinateDomain[0])
+        (abscissaConfig.visDomain[1] - abscissaConfig.visDomain[0]) /
+          (ordinateConfig.visDomain[1] - ordinateConfig.visDomain[0])
       )}
     >
       <Pan />
       <Zoom />
+      <SelectToZoom keepRatio modifierKey="Control" />
+      <ResetZoomButton />
       <TiledHeatmap api={api} {...tiledHeatmapProps} />
     </VisCanvas>
   );
@@ -157,11 +155,19 @@ const defaultApi = new MandelbrotTilesApi(
 export const Default = Template.bind({});
 Default.args = {
   api: defaultApi,
-  abscissaDomain: [0, defaultApi.baseLayerSize.width],
-  ordinateDomain: [0, defaultApi.baseLayerSize.height],
+  abscissaConfig: {
+    visDomain: [0, defaultApi.baseLayerSize.width],
+    isIndexAxis: true,
+    showGrid: false,
+  },
+  ordinateConfig: {
+    visDomain: [0, defaultApi.baseLayerSize.height],
+    isIndexAxis: true,
+    showGrid: false,
+  },
 };
 
-const arbitraryDomainApi = new MandelbrotTilesApi(
+const halfMandelbrotApi = new MandelbrotTilesApi(
   { width: 1e9, height: 5e8 },
   { width: 256, height: 128 },
   [-2, 1],
@@ -170,9 +176,26 @@ const arbitraryDomainApi = new MandelbrotTilesApi(
 
 export const ArbitraryDomain = Template.bind({});
 ArbitraryDomain.args = {
-  api: arbitraryDomainApi,
-  abscissaDomain: arbitraryDomainApi.xDomain,
-  ordinateDomain: arbitraryDomainApi.yDomain,
+  api: halfMandelbrotApi,
+  abscissaConfig: { visDomain: halfMandelbrotApi.xDomain, showGrid: false },
+  ordinateConfig: { visDomain: halfMandelbrotApi.yDomain, showGrid: false },
+};
+
+export const FlippedAxes = Template.bind({});
+FlippedAxes.args = {
+  api: halfMandelbrotApi,
+  abscissaConfig: {
+    visDomain: [0, halfMandelbrotApi.baseLayerSize.width],
+    isIndexAxis: true,
+    showGrid: false,
+    flip: true,
+  },
+  ordinateConfig: {
+    visDomain: [0, halfMandelbrotApi.baseLayerSize.height],
+    isIndexAxis: true,
+    showGrid: false,
+    flip: true,
+  },
 };
 
 export default {

--- a/packages/lib/src/vis/heatmap/HeatmapMesh.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapMesh.tsx
@@ -6,14 +6,14 @@ import { memo, useMemo } from 'react';
 import type { TextureFilter } from 'three';
 import { DataTexture, RGBAFormat, UnsignedByteType } from 'three';
 
-import { useAxisSystemContext } from '../..';
-import type { Size, VisScaleType } from '../models';
+import type { VisScaleType } from '../models';
+import type { VisMeshProps } from '../shared/VisMesh';
 import VisMesh from '../shared/VisMesh';
 import { DEFAULT_DOMAIN, getUniforms, VERTEX_SHADER } from '../utils';
 import type { ColorMap, TextureSafeTypedArray } from './models';
 import { getDataTexture, getInterpolator, scaleDomain } from './utils';
 
-interface Props {
+interface Props extends VisMeshProps {
   values: NdArray<TextureSafeTypedArray | Uint16Array>; // uint16 values are treated as half floats
   domain: Domain;
   scaleType: VisScaleType;
@@ -22,7 +22,6 @@ interface Props {
   magFilter?: TextureFilter;
   alphaValues?: NdArray<TextureSafeTypedArray | Uint16Array>; // uint16 values are treated as half floats
   alphaDomain?: Domain;
-  size?: Size;
 }
 
 const CMAP_SIZE = 256;
@@ -48,10 +47,8 @@ function HeatmapMesh(props: Props) {
     magFilter,
     alphaValues,
     alphaDomain = DEFAULT_DOMAIN,
-    size,
+    ...visMeshProps
   } = props;
-
-  const { ordinateConfig } = useAxisSystemContext();
 
   const dataTexture = useMemo(
     () => getDataTexture(values, magFilter),
@@ -143,7 +140,7 @@ function HeatmapMesh(props: Props) {
   };
 
   return (
-    <VisMesh scale={[1, ordinateConfig.flip ? -1 : 1, 1]} size={size}>
+    <VisMesh {...visMeshProps}>
       <shaderMaterial args={[shader]} />
     </VisMesh>
   );

--- a/packages/lib/src/vis/heatmap/HeatmapVis.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapVis.tsx
@@ -144,6 +144,7 @@ function HeatmapVis(props: Props) {
           scaleType={scaleType}
           alphaValues={safeAlphaArray}
           alphaDomain={alpha?.domain}
+          scale={[1, flipYAxis ? -1 : 1, 1]}
         />
 
         {children}

--- a/packages/lib/src/vis/tiles/TiledHeatmap.tsx
+++ b/packages/lib/src/vis/tiles/TiledHeatmap.tsx
@@ -31,8 +31,8 @@ function TiledHeatmap(props: Props) {
 
   const itemsPerPixel = Math.max(
     1,
-    (xVisibleDomain[1] - xVisibleDomain[0]) / canvasSize.width,
-    (yVisibleDomain[1] - yVisibleDomain[0]) / canvasSize.height
+    Math.abs(xVisibleDomain[1] - xVisibleDomain[0]) / canvasSize.width,
+    Math.abs(yVisibleDomain[1] - yVisibleDomain[0]) / canvasSize.height
   );
 
   const roundingOffset = 1 - clamp(qualityFactor, 0, 1);

--- a/packages/lib/src/vis/tiles/TiledLayer.tsx
+++ b/packages/lib/src/vis/tiles/TiledLayer.tsx
@@ -20,10 +20,9 @@ function TiledLayer(props: Props) {
   const { baseLayerIndex, numLayers, tileSize } = api;
   const layerSize = api.layerSizes[layer];
 
-  const { visSize } = useAxisSystemContext();
+  const { abscissaConfig, ordinateConfig, visSize } = useAxisSystemContext();
   const { xVisibleDomain, yVisibleDomain } = useScaledVisibleDomains(layerSize);
 
-  // Transform visible domain to current level-of-detail array coordinates
   const tileOffsets = getTileOffsets(xVisibleDomain, yVisibleDomain, tileSize);
 
   // Sort tiles from closest to vis center to farthest away
@@ -31,27 +30,33 @@ function TiledLayer(props: Props) {
   sortTilesByDistanceTo(tileOffsets, tileSize, center);
 
   return (
-    // Tranforms to use level of details layer array coordinates
+    // Transforms to handle axes flip and use level of details layer array coordinates
     <group
-      position={[-visSize.width / 2, -visSize.height / 2, layer / numLayers]}
-      scale={[
-        visSize.width / layerSize.width,
-        visSize.height / layerSize.height,
-        1,
-      ]}
+      scale={[abscissaConfig.flip ? -1 : 1, ordinateConfig.flip ? -1 : 1, 1]}
     >
-      {tileOffsets.map((offset) => (
-        <Suspense key={`${offset.x},${offset.y}`} fallback={null}>
-          <Tile
-            api={api}
-            layer={layer}
-            x={offset.x}
-            y={offset.y}
-            {...colorMapProps}
-            magFilter={layer === baseLayerIndex ? NearestFilter : LinearFilter}
-          />
-        </Suspense>
-      ))}
+      <group
+        position={[-visSize.width / 2, -visSize.height / 2, layer / numLayers]}
+        scale={[
+          visSize.width / layerSize.width,
+          visSize.height / layerSize.height,
+          1,
+        ]}
+      >
+        {tileOffsets.map((offset) => (
+          <Suspense key={`${offset.x},${offset.y}`} fallback={null}>
+            <Tile
+              api={api}
+              layer={layer}
+              x={offset.x}
+              y={offset.y}
+              {...colorMapProps}
+              magFilter={
+                layer === baseLayerIndex ? NearestFilter : LinearFilter
+              }
+            />
+          </Suspense>
+        ))}
+      </group>
     </group>
   );
 }

--- a/packages/lib/src/vis/tiles/hooks.ts
+++ b/packages/lib/src/vis/tiles/hooks.ts
@@ -14,12 +14,17 @@ export function useScaledVisibleDomains(size: Size): {
   const { abscissaConfig, ordinateConfig } = useAxisSystemContext();
 
   const xScale = scaleLinear({
-    domain: abscissaConfig.visDomain,
+    domain: abscissaConfig.flip
+      ? abscissaConfig.visDomain.reverse()
+      : abscissaConfig.visDomain,
     range: [0, width],
     clamp: true,
   });
+
   const yScale = scaleLinear({
-    domain: ordinateConfig.visDomain,
+    domain: ordinateConfig.flip
+      ? ordinateConfig.visDomain.reverse()
+      : ordinateConfig.visDomain,
     range: [0, height],
     clamp: true,
   });

--- a/packages/lib/src/vis/tiles/hooks.ts
+++ b/packages/lib/src/vis/tiles/hooks.ts
@@ -1,9 +1,10 @@
+import { ScaleType } from '@h5web/shared';
 import type { Domain } from '@h5web/shared';
-import { scaleLinear } from '@visx/scale';
 
 import { useVisibleDomains } from '../hooks';
 import type { Size } from '../models';
 import { useAxisSystemContext } from '../shared/AxisSystemContext';
+import { createAxisScale } from '../utils';
 
 export function useScaledVisibleDomains(size: Size): {
   xVisibleDomain: Domain;
@@ -13,18 +14,14 @@ export function useScaledVisibleDomains(size: Size): {
   const { xVisibleDomain, yVisibleDomain } = useVisibleDomains();
   const { abscissaConfig, ordinateConfig } = useAxisSystemContext();
 
-  const xScale = scaleLinear({
-    domain: abscissaConfig.flip
-      ? abscissaConfig.visDomain.reverse()
-      : abscissaConfig.visDomain,
+  const xScale = createAxisScale(abscissaConfig.scaleType ?? ScaleType.Linear, {
+    domain: abscissaConfig.visDomain,
     range: [0, width],
     clamp: true,
   });
 
-  const yScale = scaleLinear({
-    domain: ordinateConfig.flip
-      ? ordinateConfig.visDomain.reverse()
-      : ordinateConfig.visDomain,
+  const yScale = createAxisScale(ordinateConfig.scaleType ?? ScaleType.Linear, {
+    domain: ordinateConfig.visDomain,
     range: [0, height],
     clamp: true,
   });

--- a/packages/lib/src/vis/tiles/utils.ts
+++ b/packages/lib/src/vis/tiles/utils.ts
@@ -2,6 +2,7 @@ import type { Domain } from '@h5web/shared';
 import { Vector2 } from 'three';
 
 import type { Size } from '../models';
+import { isDescending } from '../utils';
 
 export function getTileOffsets(
   xDomain: Domain,
@@ -10,15 +11,15 @@ export function getTileOffsets(
 ): Vector2[] {
   const { width, height } = tileSize;
 
-  const [xOrigin, xEnd] = xDomain;
-  const [yOrigin, yEnd] = yDomain;
+  const [xMin, xMax] = isDescending(xDomain) ? [...xDomain].reverse() : xDomain;
+  const [yMin, yMax] = isDescending(yDomain) ? [...yDomain].reverse() : yDomain;
 
-  const nCols = Math.ceil(((xOrigin % width) + xEnd - xOrigin) / width);
-  const nRows = Math.ceil(((yOrigin % height) + yEnd - yOrigin) / height);
+  const nCols = Math.ceil(((xMin % width) + xMax - xMin) / width);
+  const nRows = Math.ceil(((yMin % height) + yMax - yMin) / height);
 
   const start = new Vector2(
-    Math.floor(xOrigin / width) * width,
-    Math.floor(yOrigin / height) * height
+    Math.floor(xMin / width) * width,
+    Math.floor(yMin / height) * height
   );
 
   const centers: Vector2[] = [];


### PR DESCRIPTION
This PR fixes display issues of tiles heatmap when an axis is flipped.
It adds a story with both axes flipped.
It supports flipped axes by handling the axes flip early with a `<group>` in `TiledLayer` instead of late in `HeatmapMesh` and by supporting reverted domains.