### PR TITLE
implement resolution of old-style signal on NXdata

### DIFF
--- a/packages/app/src/__tests__/NexusPack.test.tsx
+++ b/packages/app/src/__tests__/NexusPack.test.tsx
@@ -88,6 +88,20 @@ test('visualize NXentry group with absolute path to 2D default signal', async ()
   ).resolves.toBeVisible();
 });
 
+test('visualize NXentry group with old-style signal', async () => {
+  const { selectExplorerNode } = await renderApp();
+  await selectExplorerNode('nexus_entry/nx_process/old-style_signal');
+
+  const tabs = await findVisSelectorTabs();
+  expect(tabs).toHaveLength(2);
+  expect(tabs[0]).toHaveTextContent(NexusVis.NxSpectrum);
+  expect(tabs[1]).toHaveTextContent(NexusVis.NxImage);
+
+  await expect(
+    screen.findByRole('figure', { name: 'twoD' }) // name of dataset with `signal` attribute
+  ).resolves.toBeVisible();
+});
+
 test('visualize NXroot group with 2D default signal', async () => {
   await renderApp();
 
@@ -193,6 +207,18 @@ test('show error when `signal` entity is not a dataset', async () => {
   await selectExplorerNode('nexus_malformed/signal_not_dataset');
   await expect(
     screen.findByText('Expected "some_group" signal to be a dataset')
+  ).resolves.toBeVisible();
+
+  expect(errorSpy).toHaveBeenCalledTimes(2); // React logs two stack traces
+});
+
+test('show error when old-style `signal` entity is not a dataset', async () => {
+  const { selectExplorerNode } = await renderApp();
+
+  const errorSpy = mockConsoleMethod('error');
+  await selectExplorerNode('nexus_malformed/signal_old-style_not_dataset');
+  await expect(
+    screen.findByText('Expected old-style "some_group" signal to be a dataset')
   ).resolves.toBeVisible();
 
   expect(errorSpy).toHaveBeenCalledTimes(2); // React logs two stack traces

--- a/packages/app/src/vis-packs/nexus/utils.ts
+++ b/packages/app/src/vis-packs/nexus/utils.ts
@@ -61,10 +61,8 @@ export function findSignalDataset(
   let dataset;
   let signal = attrValuesStore.getSingle(group, 'signal');
   if (signal !== undefined) {
-    // assertDefined(signal, "Expected 'signal' attribute");
     assertStr(signal, "Expected 'signal' attribute to be a string");
     dataset = getChildEntity(group, signal);
-    assertDefined(dataset, `Expected "${signal}" signal entity to exist`);
   } else {
     dataset = group.children.find(
       (entity) =>

--- a/packages/app/src/visualizer/utils.ts
+++ b/packages/app/src/visualizer/utils.ts
@@ -94,11 +94,15 @@ function getSupportedNxVis(
   entity: Entity,
   attrValuesStore: AttrValuesStore
 ): VisDef[] {
-  if (!isGroup(entity) || !isNxDataGroup(entity, attrValuesStore)) {
+  if (!isGroup(entity)) {
     return [];
   }
 
   assertGroupWithChildren(entity);
+  if (!isNxDataGroup(entity, attrValuesStore)) {
+    return [];
+  }
+
   const dataset = findSignalDataset(entity, attrValuesStore);
   const isCplx = hasComplexType(dataset);
   const { interpretation } = attrValuesStore.get(dataset);

--- a/packages/shared/src/mock/metadata.ts
+++ b/packages/shared/src/mock/metadata.ts
@@ -17,6 +17,7 @@ import {
   makeDataset,
   withImageAttributes,
   withAttributes,
+  makeIntAttr,
 } from './metadata-utils';
 
 export const mockFilepath = 'source.h5';
@@ -80,6 +81,13 @@ export const mockMetadata = makeNxGroup(mockFilepath, 'NXroot', {
             }),
             makeNxGroup('absolute_default_path', 'NXentry', {
               defaultPath: '/nexus_entry/nx_process/nx_data',
+            }),
+            makeNxGroup('old-style_signal', 'NXdata', {
+              children: [
+                makeDataset('twoD', intType, [20, 41], {
+                  attributes: [makeIntAttr('signal', 1)],
+                }),
+              ],
             }),
           ],
         }),
@@ -202,6 +210,13 @@ export const mockMetadata = makeNxGroup(mockFilepath, 'NXroot', {
       makeNxGroup('signal_not_dataset', 'NXdata', {
         children: [makeGroup('some_group')],
         attributes: [makeStrAttr('signal', 'some_group')],
+      }),
+      makeNxGroup('signal_old-style_not_dataset', 'NXdata', {
+        children: [
+          makeGroup('some_group', [], {
+            attributes: [makeIntAttr('signal', 1)],
+          }),
+        ],
       }),
       makeNxGroup('signal_not_array', 'NXdata', {
         children: [makeScalarDataset('some_scalar', intType)],


### PR DESCRIPTION
For older NeXus files, the plottable signal is identified by a ```@signal``` attribute on the dataset itself, rather than the NXdata group (see Version 1 and Version 2 at https://manual.nexusformat.org/datarules.html#find-plottable-data). 

This PR implements a fallback strategy for finding these plottable datasets by searching the children of the NXdata group to find a dataset with the ```signal``` attribute.

It does not implement the identification of axes using those older lookup algorithms, and that is still to-do.

---

Part of #1062 