### PR TITLE
Move `worldToHtml` to new `CameraContext`

### DIFF
--- a/apps/storybook/.storybook/preview.js
+++ b/apps/storybook/.storybook/preview.js
@@ -10,10 +10,13 @@ export const parameters = {
       order: [
         'Getting started',
         'Utilities',
+        'Contexts',
         'Customization',
         'Visualizations',
         'Building Blocks',
         ['VisCanvas'],
+        'Toolbar',
+        ['Toolbar'],
       ],
     },
   },

--- a/apps/storybook/src/Contexts.stories.mdx
+++ b/apps/storybook/src/Contexts.stories.mdx
@@ -1,0 +1,48 @@
+import { Meta } from '@storybook/addon-docs';
+
+<Meta title="Contexts" />
+
+## Contexts
+
+Children of `VisCanvas` can access two React contexts: `AxisSystemContext` and `CameraContext`.
+
+### AxisSystemContext
+
+`AxisSystemContext` includes helpful utilities to convert vectors from data space to world space and back.
+It exposes the size of the visualization, as well as the axis configs passed to `VisCanvas` for convenience.
+
+This context re-renders **whenever the size of the canvas changes**.
+
+```ts
+useAxisSystemContext(): AxisSystemParams
+
+const { visSize, dataToWorld, worldToData } = useAxisSystemContext();
+```
+
+| Name             | Description                                                                                                        | Type                                                  |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
+| `visSize`        | Visualization size (different from canvas size on ratio-constrained visualizations, like `HeatmapVis`)             | <code>Size</code>                                     |
+| `abscissaConfig` | Abscissa configuration object passed to `VisCanvas`                                                                | <code>AxisConfig</code>                               |
+| `ordinateConfig` | Ordinate configuration object passed to `VisCanvas`                                                                | <code>AxisConfig</code>                               |
+| `abscissaScale`  | Computes the X coordinate in world space of a given abscissa value (or the opposite with `abscissaScale.invert()`) | <code>AxisScale</code>                                |
+| `ordinateScale`  | Computes the Y coordinate in world space of a given ordinate value (or the opposite with `ordinateScale.invert()`) | <code>AxisScale</code>                                |
+| `dataToWorld`    | Converts a vector from data space to world space (calls `abscissaScale()` and `ordinateScale`)                     | <code>(vec: Vector2 &#124; Vector3) => Vector2</code> |
+| `worldToData`    | Converts a vector from world space to data space (calls `abscissaScale.invert()` and `ordinateScale.invert`)       | <code>(vec: Vector2 &#124; Vector3) => Vector2</code> |
+
+> This table is not exhaustive. Please consider any undocumented property as experimental or meant for internal use only.
+
+### CameraContext
+
+`CameraContext` provides utilities that make use of the position and scale (i.e. zoom level) of the camera.
+
+This context should be used sparingly and as far down as possible in the rendering tree, as it re-renders **every time the position and/or scale of the camera changes** (i.e. on every React Three Fiber frame).
+
+```ts
+useCameraContext(): CameraContextValue
+
+const { worldToHtml } = useCameraContext();
+```
+
+| Name          | Description                                      | Type                                                  |
+| ------------- | ------------------------------------------------ | ----------------------------------------------------- |
+| `worldToHtml` | Converts a vector from world space to HTML space | <code>(vec: Vector2 &#124; Vector3) => Vector2</code> |

--- a/apps/storybook/src/HeatmapVis.stories.tsx
+++ b/apps/storybook/src/HeatmapVis.stories.tsx
@@ -57,13 +57,13 @@ AxisValues.args = {
   domain,
   abscissaParams: {
     value: Array.from(
-      { length: dataArray.shape[1] }, // works even when right edge of last pixel is not provided
+      { length: dataArray.shape[1] }, // far edge of last pixel must not be included
       (_, i) => 100 + 10 * i
     ),
   },
   ordinateParams: {
     value: Array.from(
-      { length: dataArray.shape[0] + 1 },
+      { length: dataArray.shape[0] }, // far edge of last pixel must not be included
       (_, i) => (-5 + 0.5 * i) / 100
     ),
   },
@@ -74,14 +74,11 @@ DescendingAxisValues.args = {
   dataArray,
   domain,
   abscissaParams: {
-    value: Array.from(
-      { length: dataArray.shape[1] }, // works even when right edge of last pixel is not provided
-      (_, i) => -100 - 10 * i
-    ),
+    value: Array.from({ length: dataArray.shape[1] }, (_, i) => -100 - 10 * i),
   },
   ordinateParams: {
     value: Array.from(
-      { length: dataArray.shape[0] + 1 },
+      { length: dataArray.shape[0] },
       (_, i) => (5 - 0.5 * i) / 100
     ),
   },

--- a/apps/storybook/src/Selection.stories.tsx
+++ b/apps/storybook/src/Selection.stories.tsx
@@ -17,9 +17,8 @@ import FillHeight from './decorators/FillHeight';
 
 interface TemplateProps {
   selectionType: 'line' | 'rectangle';
-  disablePan?: boolean;
-  disableZoom?: boolean;
-  modifierKey?: ModifierKey;
+  selectionModifierKey?: ModifierKey;
+  panModifierKey?: ModifierKey;
   fill?: string;
   stroke?: string;
 }
@@ -29,18 +28,22 @@ function vectorToStr(vec: Vector2) {
 }
 
 const Template: Story<TemplateProps> = (args) => {
-  const {
-    selectionType,
-    disablePan = true,
-    disableZoom = true,
-    modifierKey,
-    ...svgProps
-  } = args;
+  const { selectionType, selectionModifierKey, panModifierKey, ...svgProps } =
+    args;
 
   const [activeSelection, setActiveSelection] = useState<Selection>();
 
   const SelectionComponent =
     selectionType === 'line' ? SelectionLine : SelectionRect;
+
+  if (selectionModifierKey === panModifierKey) {
+    return (
+      <p style={{ margin: '1rem', color: 'darkred' }}>
+        Pan and selection modifier keys cannot both be{' '}
+        <code>{panModifierKey || 'undefined'}</code>
+      </p>
+    );
+  }
 
   return (
     <VisCanvas
@@ -54,13 +57,14 @@ const Template: Story<TemplateProps> = (args) => {
       abscissaConfig={{ visDomain: [-10, 0], showGrid: true }}
       ordinateConfig={{ visDomain: [50, 100], showGrid: true }}
     >
-      <Pan disabled={disablePan} />
-      <Zoom disabled={disableZoom} />
+      <Pan modifierKey={panModifierKey} />
+      <Zoom />
       <ResetZoomButton />
+
       <SelectionTool
         onSelectionChange={setActiveSelection}
         onSelectionEnd={() => setActiveSelection(undefined)}
-        modifierKey={modifierKey}
+        modifierKey={selectionModifierKey}
       >
         {(selection) => <SelectionComponent {...selection} {...svgProps} />}
       </SelectionTool>
@@ -68,58 +72,82 @@ const Template: Story<TemplateProps> = (args) => {
   );
 };
 
-export const SelectingRegions = Template.bind({});
-SelectingRegions.args = {
+export const Rectangle = Template.bind({});
+Rectangle.args = {
   selectionType: 'rectangle',
+  panModifierKey: 'Control',
 };
-
-export const SelectingLines = Template.bind({});
-SelectingLines.args = {
-  selectionType: 'line',
-};
-
-export const SelectingWithModifierAndZoom = Template.bind({});
-SelectingWithModifierAndZoom.args = {
-  selectionType: 'line',
-  disablePan: false,
-  disableZoom: false,
-  modifierKey: 'Shift',
-};
-SelectingWithModifierAndZoom.argTypes = {
-  modifierKey: {
+Rectangle.argTypes = {
+  panModifierKey: {
     control: { type: 'inline-radio' },
     options: ['Alt', 'Control', 'Shift'],
   },
 };
 
-export const ChangeSelectionStyle = Template.bind({});
-ChangeSelectionStyle.args = {
-  selectionType: 'rectangle',
-  fill: 'blue',
-  stroke: 'darkslategray',
+export const Line = Template.bind({});
+Line.args = {
+  selectionType: 'line',
+  panModifierKey: 'Control',
 };
-ChangeSelectionStyle.argTypes = {
-  fill: {
-    control: { type: 'color' },
-  },
-  stroke: {
-    control: { type: 'color' },
+Line.argTypes = {
+  panModifierKey: {
+    control: { type: 'inline-radio' },
+    options: ['Alt', 'Control', 'Shift'],
   },
 };
 
-export const PersistSelection: Story<TemplateProps> = (args) => {
-  const {
-    selectionType,
-    disablePan = true,
-    disableZoom = true,
-    modifierKey,
-    ...svgProps
-  } = args;
+export const WithModifierKey = Template.bind({});
+WithModifierKey.args = {
+  selectionType: 'rectangle',
+  selectionModifierKey: 'Control',
+  panModifierKey: undefined,
+};
+WithModifierKey.argTypes = {
+  selectionModifierKey: {
+    control: { type: 'inline-radio' },
+    options: ['Alt', 'Control', 'Shift', undefined],
+  },
+  panModifierKey: {
+    control: { type: 'inline-radio' },
+    options: ['Alt', 'Control', 'Shift', undefined],
+  },
+};
+
+export const CustomStyles = Template.bind({});
+CustomStyles.args = {
+  selectionType: 'rectangle',
+  fill: 'blue',
+  stroke: 'darkslategray',
+  panModifierKey: 'Control',
+};
+CustomStyles.argTypes = {
+  fill: { control: { type: 'color' } },
+  stroke: { control: { type: 'color' } },
+  panModifierKey: {
+    control: { type: 'inline-radio' },
+    options: ['Alt', 'Control', 'Shift'],
+  },
+};
+CustomStyles.parameters = {
+  controls: { exclude: ['selectionType'] },
+};
+
+export const Persisted: Story<TemplateProps> = (args) => {
+  const { selectionType, selectionModifierKey, panModifierKey } = args;
 
   const [persistedSelection, setPersistedSelection] = useState<Selection>();
 
   const SelectionComponent =
     selectionType === 'line' ? SelectionLine : SelectionRect;
+
+  if (selectionModifierKey === panModifierKey) {
+    return (
+      <p style={{ margin: '1rem', color: 'darkred' }}>
+        Pan and selection modifier keys cannot both be{' '}
+        <code>{panModifierKey || 'undefined'}</code>
+      </p>
+    );
+  }
 
   return (
     <VisCanvas
@@ -133,16 +161,18 @@ export const PersistSelection: Story<TemplateProps> = (args) => {
       abscissaConfig={{ visDomain: [-10, 0], showGrid: true }}
       ordinateConfig={{ visDomain: [50, 100], showGrid: true }}
     >
-      <Pan disabled={disablePan} />
-      <Zoom disabled={disableZoom} />
+      <Pan modifierKey={panModifierKey} />
+      <Zoom />
+      <ResetZoomButton />
+
       <SelectionTool
         onSelectionStart={() => {
           setPersistedSelection(undefined);
         }}
         onSelectionEnd={setPersistedSelection}
-        modifierKey={modifierKey}
+        modifierKey={selectionModifierKey}
       >
-        {(selection) => <SelectionComponent {...selection} {...svgProps} />}
+        {(selection) => <SelectionComponent {...selection} />}
       </SelectionTool>
       {persistedSelection && (
         <SelectionComponent
@@ -153,28 +183,26 @@ export const PersistSelection: Story<TemplateProps> = (args) => {
     </VisCanvas>
   );
 };
-PersistSelection.args = {
+Persisted.args = {
   selectionType: 'rectangle',
+  selectionModifierKey: 'Control',
+  panModifierKey: undefined,
 };
-PersistSelection.argTypes = {
-  modifierKey: {
+Persisted.argTypes = {
+  selectionModifierKey: {
     control: { type: 'inline-radio' },
-    options: ['Alt', 'Control', 'Shift'],
+    options: ['Alt', 'Control', 'Shift', undefined],
   },
-  fill: {
-    control: { type: 'color' },
-  },
-  stroke: {
-    control: { type: 'color' },
+  panModifierKey: {
+    control: { type: 'inline-radio' },
+    options: ['Alt', 'Control', 'Shift', undefined],
   },
 };
 
 export default {
   title: 'Building Blocks/Selection',
   decorators: [FillHeight],
-  parameters: {
-    layout: 'fullscreen',
-  },
+  parameters: { layout: 'fullscreen' },
   argTypes: {
     selectionType: {
       control: { type: 'inline-radio' },

--- a/apps/storybook/src/Utilities.stories.mdx
+++ b/apps/storybook/src/Utilities.stories.mdx
@@ -180,42 +180,6 @@ const handlePointerDown = useCallback((evt: PointerEvent) => { ... }, []);
 useCanvasEvents({ onPointerDown: handlePointerDown }); // also supported: `onPointerMove`, `onPointerUp` and `onWheel`
 ```
 
-### AxisSystemContext
-
-Children of `VisCanvas` have access to the `AxisSystemContext`, which exposes the visualization's size, the axes' configurations and scales, as well as utilities to convert between coordinate spaces:
-
-```ts
-useAxisSystemContext(): AxisSystemParams
-
-const {
-  visSize,
-  abscissaConfig,
-  ordinateConfig,
-  abscissaScale,
-  ordinateScale,
-  dataToWorld,
-  worldToData,
-} = useAxisSystemContext();
-```
-
-| Name             | Description                                                                                                        | Type                                                  |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
-| `visSize`        | Visualization size (different from canvas size on ratio-constrained visualizations, like `HeatmapVis`)             | <code>Size</code>                                     |
-| `abscissaConfig` | Abscissa configuration object passed to `VisCanvas`                                                                | <code>AxisConfig</code>                               |
-| `ordinateConfig` | Ordinate configuration object passed to `VisCanvas`                                                                | <code>AxisConfig</code>                               |
-| `abscissaScale`  | Computes the X coordinate in world space of a given abscissa value (or the opposite with `abscissaScale.invert()`) | <code>AxisScale</code>                                |
-| `ordinateScale`  | Computes the Y coordinate in world space of a given ordinate value (or the opposite with `ordinateScale.invert()`) | <code>AxisScale</code>                                |
-| `dataToWorld`    | Converts a vector from data space to world space (calls `abscissaScale()` and `ordinateScale`)                     | <code>(vec: Vector2 &#124; Vector3) => Vector2</code> |
-| `worldToData`    | Converts a vector from world space to data space (calls `abscissaScale.invert()` and `ordinateScale.invert`)       | <code>(vec: Vector2 &#124; Vector3) => Vector2</code> |
-
-## useWorldToHtml
-
-Returns a function to convert a vector from world space to HTML space. A component calling this hook will re-render at each frame so that the transformation from world to HTML remains correct. Must be called from a child component of `VisCanvas`.
-
-```ts
-useWorldToHtml(): (vec: Vector2 | Vector3) => Vector2
-```
-
 ### Mock data
 
 The library exposes a utility function to retrieve a mock entity's metadata and a mock dataset's value as ndarray for testing purposes.

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -55,9 +55,11 @@ export { default as SelectionRect } from './interactions/SelectionRect';
 export { default as SelectionTool } from './interactions/SelectionTool';
 export type { SelectionProps } from './interactions/SelectionTool';
 
-// Context hook
+// Contexts
 export { useAxisSystemContext } from './vis/shared/AxisSystemContext';
+export { useCameraContext } from './vis/shared/CameraProvider';
 export type { AxisSystemParams } from './vis/shared/AxisSystemContext';
+export type { CameraContextValue } from './vis/shared/CameraProvider';
 
 // Utilities
 export {
@@ -75,7 +77,6 @@ export {
   useVisibleDomains,
   useFrameRendering,
   useValueToIndexScale,
-  useWorldToHtml,
 } from './vis/hooks';
 
 export {

--- a/packages/lib/src/interactions/SelectionLine.tsx
+++ b/packages/lib/src/interactions/SelectionLine.tsx
@@ -2,8 +2,8 @@ import { useThree } from '@react-three/fiber';
 import type { SVGProps } from 'react';
 import type { Vector2 } from 'three';
 
-import { useWorldToHtml } from '../vis/hooks';
 import { useAxisSystemContext } from '../vis/shared/AxisSystemContext';
+import { useCameraContext } from '../vis/shared/CameraProvider';
 import Overlay from '../vis/shared/Overlay';
 
 interface Props extends SVGProps<SVGLineElement> {
@@ -20,9 +20,8 @@ function SelectionLine(props: Props) {
   } = props;
 
   const { width, height } = useThree((state) => state.size);
-
   const { dataToWorld } = useAxisSystemContext();
-  const worldToHtml = useWorldToHtml();
+  const { worldToHtml } = useCameraContext();
 
   const htmlStartPt = worldToHtml(dataToWorld(dataStartPoint));
   const htmlEndPt = worldToHtml(dataToWorld(dataEndPoint));

--- a/packages/lib/src/interactions/SelectionRect.tsx
+++ b/packages/lib/src/interactions/SelectionRect.tsx
@@ -2,7 +2,7 @@ import { useThree } from '@react-three/fiber';
 import type { SVGProps } from 'react';
 import type { Vector2 } from 'three';
 
-import { useWorldToHtml } from '../vis/hooks';
+import { useCameraContext } from '..';
 import { useAxisSystemContext } from '../vis/shared/AxisSystemContext';
 import Overlay from '../vis/shared/Overlay';
 
@@ -23,7 +23,7 @@ function SelectionRect(props: Props) {
   const { width, height } = useThree((state) => state.size);
 
   const { dataToWorld } = useAxisSystemContext();
-  const worldToHtml = useWorldToHtml();
+  const { worldToHtml } = useCameraContext();
 
   const htmlStartPt = worldToHtml(dataToWorld(dataStartPoint));
   const htmlEndPt = worldToHtml(dataToWorld(dataEndPoint));

--- a/packages/lib/src/vis/hooks.ts
+++ b/packages/lib/src/vis/hooks.ts
@@ -5,7 +5,6 @@ import { useFrame, useThree } from '@react-three/fiber';
 import { useCallback, useMemo, useState } from 'react';
 import type { RefCallback } from 'react';
 import { createMemo } from 'react-use';
-import { Matrix4, Vector2, Vector3 } from 'three';
 
 import type { CustomColor } from './models';
 import { useAxisSystemContext } from './shared/AxisSystemContext';
@@ -101,21 +100,4 @@ export function useCustomColors(
   });
 
   return [colors, refCallback];
-}
-
-export function useWorldToHtml(): (point: Vector2 | Vector3) => Vector2 {
-  const camera = useThree((state) => state.camera);
-
-  const { width, height } = useThree((state) => state.size);
-  const cameraToHtmlMatrix = new Matrix4().makeScale(width / 2, -height / 2, 1);
-  // Account for shift of (0,0) position (center for camera, top-left for HTML)
-  cameraToHtmlMatrix.setPosition(width / 2, height / 2);
-
-  useFrameRendering();
-
-  return (point: Vector2 | Vector3) => {
-    const cameraPoint = new Vector3(point.x, point.y, 0).project(camera);
-    const htmlPoint = cameraPoint.clone().applyMatrix4(cameraToHtmlMatrix);
-    return new Vector2(htmlPoint.x, htmlPoint.y);
-  };
 }

--- a/packages/lib/src/vis/shared/Annotation.tsx
+++ b/packages/lib/src/vis/shared/Annotation.tsx
@@ -2,8 +2,8 @@ import { useThree } from '@react-three/fiber';
 import type { HTMLAttributes } from 'react';
 import { Vector2 } from 'three';
 
-import { useWorldToHtml } from '../hooks';
 import { useAxisSystemContext } from './AxisSystemContext';
+import { useCameraContext } from './CameraProvider';
 import Html from './Html';
 
 interface Props extends HTMLAttributes<HTMLDivElement> {
@@ -18,7 +18,7 @@ function Annotation(props: Props) {
   const camera = useThree((state) => state.camera);
 
   const { dataToWorld } = useAxisSystemContext();
-  const worldToHtml = useWorldToHtml();
+  const { worldToHtml } = useCameraContext();
 
   const htmlPt = worldToHtml(dataToWorld(new Vector2(x, y)));
 

--- a/packages/lib/src/vis/shared/AxisSystemContext.tsx
+++ b/packages/lib/src/vis/shared/AxisSystemContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext } from 'react';
-import type { Vector2, Vector3 } from 'three';
+import type { Matrix4, Vector2, Vector3 } from 'three';
 
 import type { Interaction } from '../../interactions/models';
 import type { AxisConfig, AxisScale, Size } from '../models';
@@ -12,15 +12,16 @@ export interface AxisSystemParams {
   ordinateScale: AxisScale;
   dataToWorld: (vec: Vector2 | Vector3) => Vector2;
   worldToData: (vec: Vector2 | Vector3) => Vector2;
+
+  // For internal use only
+  cameraToHtmlMatrix: Matrix4;
   floatingToolbar: HTMLDivElement | undefined;
-  shouldInteract: (id: string, event: MouseEvent) => boolean;
   registerInteraction: (id: string, value: Interaction) => void;
   unregisterInteraction: (id: string) => void;
+  shouldInteract: (id: string, event: MouseEvent) => boolean;
 }
 
-export const AxisSystemContext = createContext<AxisSystemParams>(
-  {} as AxisSystemParams
-);
+export const AxisSystemContext = createContext({} as AxisSystemParams);
 
 export function useAxisSystemContext() {
   return useContext(AxisSystemContext);

--- a/packages/lib/src/vis/shared/AxisSystemProvider.tsx
+++ b/packages/lib/src/vis/shared/AxisSystemProvider.tsx
@@ -3,7 +3,7 @@ import { useThree } from '@react-three/fiber';
 import type { PropsWithChildren } from 'react';
 import { useCallback, useState } from 'react';
 import type { Vector3 } from 'three';
-import { Vector2 } from 'three';
+import { Matrix4, Vector2 } from 'three';
 
 import type { Interaction } from '../../interactions/models';
 import type { AxisConfig } from '../models';
@@ -37,7 +37,26 @@ function AxisSystemProvider(props: PropsWithChildren<Props>) {
   const dataToWorld = (vec: Vector2 | Vector3) =>
     new Vector2(abscissaScale(vec.x), ordinateScale(vec.y));
 
+  const { width, height } = availableSize;
+  const cameraToHtmlMatrix = new Matrix4()
+    .makeScale(width / 2, -height / 2, 1)
+    .setPosition(width / 2, height / 2); // account for shift of (0,0) position (center for camera, top-left for HTML)
+
   const [interactionMap] = useState(new Map<string, Interaction>());
+
+  const registerInteraction = useCallback(
+    (id: string, value: Interaction) => {
+      interactionMap.set(id, value);
+    },
+    [interactionMap]
+  );
+
+  const unregisterInteraction = useCallback(
+    (id: string) => {
+      interactionMap.delete(id);
+    },
+    [interactionMap]
+  );
 
   const shouldInteract = useCallback(
     (id: string, event: MouseEvent) => {
@@ -63,20 +82,6 @@ function AxisSystemProvider(props: PropsWithChildren<Props>) {
     [interactionMap]
   );
 
-  const registerInteraction = useCallback(
-    (id: string, value: Interaction) => {
-      interactionMap.set(id, value);
-    },
-    [interactionMap]
-  );
-
-  const unregisterInteraction = useCallback(
-    (id: string) => {
-      interactionMap.delete(id);
-    },
-    [interactionMap]
-  );
-
   return (
     <AxisSystemContext.Provider
       value={{
@@ -87,10 +92,11 @@ function AxisSystemProvider(props: PropsWithChildren<Props>) {
         ordinateScale,
         worldToData,
         dataToWorld,
-        floatingToolbar,
-        shouldInteract,
+        cameraToHtmlMatrix,
         registerInteraction,
         unregisterInteraction,
+        shouldInteract,
+        floatingToolbar,
       }}
     >
       {children}

--- a/packages/lib/src/vis/shared/CameraProvider.tsx
+++ b/packages/lib/src/vis/shared/CameraProvider.tsx
@@ -1,0 +1,40 @@
+import { useThree } from '@react-three/fiber';
+import type { ReactNode } from 'react';
+import { createContext, useContext } from 'react';
+import { Vector2, Vector3 } from 'three';
+
+import { useFrameRendering } from '../hooks';
+import { useAxisSystemContext } from './AxisSystemContext';
+
+export interface CameraContextValue {
+  worldToHtml: (point: Vector2 | Vector3) => Vector2;
+}
+
+const CameraContext = createContext({} as CameraContextValue);
+
+export function useCameraContext() {
+  return useContext(CameraContext);
+}
+
+function CameraProvider(props: { children: ReactNode }) {
+  const { children } = props;
+
+  const camera = useThree((state) => state.camera);
+  const { cameraToHtmlMatrix } = useAxisSystemContext();
+
+  useFrameRendering();
+
+  function worldToHtml(point: Vector2 | Vector3) {
+    const cameraPoint = new Vector3(point.x, point.y, 0).project(camera);
+    const htmlPoint = cameraPoint.clone().applyMatrix4(cameraToHtmlMatrix);
+    return new Vector2(htmlPoint.x, htmlPoint.y);
+  }
+
+  return (
+    <CameraContext.Provider value={{ worldToHtml }}>
+      {children}
+    </CameraContext.Provider>
+  );
+}
+
+export default CameraProvider;

--- a/packages/lib/src/vis/shared/VisCanvas.tsx
+++ b/packages/lib/src/vis/shared/VisCanvas.tsx
@@ -7,6 +7,7 @@ import type { AxisConfig } from '../models';
 import { getSizeToFit, getAxisOffsets } from '../utils';
 import AxisSystem from './AxisSystem';
 import AxisSystemProvider from './AxisSystemProvider';
+import CameraProvider from './CameraProvider';
 import Html from './Html';
 import ViewportCenterer from './ViewportCenterer';
 import styles from './VisCanvas.module.css';
@@ -74,15 +75,17 @@ function VisCanvas(props: PropsWithChildren<Props>) {
               ordinateConfig={ordinateConfig}
               floatingToolbar={floatingToolbar}
             >
-              <AxisSystem axisOffsets={axisOffsets} title={title} />
-              {children}
-              <ViewportCenterer />
-              <Html>
-                <div
-                  ref={(elem) => setFloatingToolbar(elem || undefined)}
-                  className={styles.floatingToolbar}
-                />
-              </Html>
+              <CameraProvider>
+                <AxisSystem axisOffsets={axisOffsets} title={title} />
+                {children}
+                <ViewportCenterer />
+                <Html>
+                  <div
+                    ref={(elem) => setFloatingToolbar(elem || undefined)}
+                    className={styles.floatingToolbar}
+                  />
+                </Html>
+              </CameraProvider>
             </AxisSystemProvider>
           </Canvas>
         </div>


### PR DESCRIPTION
The end goal is to never have to use the `camera` directly in the components, so as to not worry about re-rendering on every R3F frame. For now, I introduce the new `CameraContext` and provide only `worldToHtml` through it. In my next PR, I will try to refactor all the places where we use `useThree` to retrieve the `camera` object. For instance, I'll provide getters for the `scale` and `position` that will return already-cloned, always-up-to-date vectors. Hopefully this will solve all our frame-related challenges and allow us to stop exposing `useFrameRendering`.