### PR TITLE
Clarify what is documented and undocumented in lib index

### DIFF
--- a/apps/storybook/src/DataCurve.stories.tsx
+++ b/apps/storybook/src/DataCurve.stories.tsx
@@ -69,4 +69,7 @@ export default {
     curveType: CurveType.LineOnly,
     visible: true,
   },
+  argTypes: {
+    color: { control: { type: 'color' } },
+  },
 } as Meta;

--- a/apps/storybook/src/DataCurve.stories.tsx
+++ b/apps/storybook/src/DataCurve.stories.tsx
@@ -1,0 +1,72 @@
+import type { DataCurveProps } from '@h5web/lib';
+import { CurveType, DataCurve, useDomain, VisCanvas } from '@h5web/lib';
+import { assertDefined, mockValues } from '@h5web/shared';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import { range } from 'lodash';
+
+import FillHeight from './decorators/FillHeight';
+
+const Template: Story<DataCurveProps> = (args) => {
+  const { abscissas, ordinates } = args;
+
+  const abscissaDomain = useDomain(abscissas);
+  const ordinateDomain = useDomain(ordinates);
+  assertDefined(abscissaDomain);
+  assertDefined(ordinateDomain);
+
+  return (
+    <VisCanvas
+      abscissaConfig={{ visDomain: abscissaDomain, showGrid: true }}
+      ordinateConfig={{ visDomain: ordinateDomain, showGrid: true }}
+    >
+      <DataCurve {...args} />
+    </VisCanvas>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  abscissas: range(0, mockValues.oneD.length),
+  ordinates: mockValues.oneD,
+  color: 'green',
+};
+Default.argTypes = {
+  showErrors: { control: false },
+};
+
+export const Glyphs = Template.bind({});
+Glyphs.args = {
+  abscissas: range(0, mockValues.oneD.length),
+  ordinates: mockValues.oneD,
+  color: 'black',
+  curveType: CurveType.GlyphsOnly,
+};
+Glyphs.argTypes = {
+  showErrors: { control: false },
+};
+
+export const WithErrors = Template.bind({});
+WithErrors.args = {
+  abscissas: range(0, mockValues.oneD.length),
+  ordinates: mockValues.oneD,
+  errors: mockValues.oneD_errors,
+  showErrors: true,
+  color: 'blue',
+};
+
+export default {
+  title: 'Building Blocks/DataCurve',
+  component: DataCurve,
+  decorators: [FillHeight],
+  parameters: {
+    layout: 'fullscreen',
+    controls: {
+      sort: 'requiredFirst',
+      exclude: ['abscissas', 'ordinates', 'errors'],
+    },
+  },
+  args: {
+    curveType: CurveType.LineOnly,
+    visible: true,
+  },
+} as Meta;

--- a/apps/storybook/src/Overlay.stories.tsx
+++ b/apps/storybook/src/Overlay.stories.tsx
@@ -1,0 +1,35 @@
+import { Overlay, Pan, VisCanvas, Zoom } from '@h5web/lib';
+import type { Meta, Story } from '@storybook/react';
+
+import FillHeight from './decorators/FillHeight';
+
+export const Default: Story = () => {
+  return (
+    <VisCanvas
+      abscissaConfig={{ visDomain: [0, 3], showGrid: true }}
+      ordinateConfig={{ visDomain: [50, 100] }}
+    >
+      <Zoom />
+      <Pan />
+      <Overlay
+        style={{
+          background:
+            'linear-gradient(135deg, #444cf715 25%, transparent 25%) -20px 0/ 40px 40px, linear-gradient(225deg, #444cf715 25%, transparent 25%) -20px 0/ 40px 40px, linear-gradient(315deg, #444cf715 25%, transparent 25%) 0px 0/ 40px 40px, linear-gradient(45deg, #444cf715 25%, #e5e5f715 25%) 0px 0/ 40px 40px',
+        }}
+      >
+        <p style={{ position: 'absolute', top: 0, left: 10 }}>
+          This HTML overlay fills the canvas but lets pointer events through. It
+          appears above the axis system's grid and is not affected by
+          panning/zooming (unlike <code>Annotation</code>).
+        </p>
+      </Overlay>
+    </VisCanvas>
+  );
+};
+
+export default {
+  title: 'Building Blocks/Overlay',
+  component: Default,
+  parameters: { layout: 'fullscreen' },
+  decorators: [FillHeight],
+} as Meta;

--- a/apps/storybook/src/TiledHeatmapMesh.stories.tsx
+++ b/apps/storybook/src/TiledHeatmapMesh.stories.tsx
@@ -3,12 +3,17 @@ import {
   Pan,
   VisCanvas,
   Zoom,
-  TiledHeatmap,
+  TiledHeatmapMesh,
   TilesApi,
   ResetZoomButton,
   SelectToZoom,
 } from '@h5web/lib';
-import type { Domain, Size, TiledHeatmapProps, AxisConfig } from '@h5web/lib';
+import type {
+  Domain,
+  Size,
+  TiledHeatmapMeshProps,
+  AxisConfig,
+} from '@h5web/lib';
 import { ScaleType } from '@h5web/shared';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { clamp } from 'lodash';
@@ -119,7 +124,7 @@ class MandelbrotTilesApi extends TilesApi {
   }
 }
 
-interface TiledHeatmapStoryProps extends TiledHeatmapProps {
+interface TiledHeatmapStoryProps extends TiledHeatmapMeshProps {
   abscissaConfig: AxisConfig;
   ordinateConfig: AxisConfig;
 }
@@ -140,7 +145,7 @@ const Template: Story<TiledHeatmapStoryProps> = (args) => {
       <Zoom />
       <SelectToZoom keepRatio modifierKey="Control" />
       <ResetZoomButton />
-      <TiledHeatmap api={api} {...tiledHeatmapProps} />
+      <TiledHeatmapMesh api={api} {...tiledHeatmapProps} />
     </VisCanvas>
   );
 };
@@ -212,8 +217,8 @@ FlippedAxes.args = {
 };
 
 export default {
-  title: 'Building Blocks/TiledHeatmap',
-  component: TiledHeatmap,
+  title: 'Building Blocks/TiledHeatmapMesh',
+  component: TiledHeatmapMesh,
   decorators: [FillHeight],
   parameters: { layout: 'fullscreen', controls: { sort: 'requiredFirst' } },
   args: {

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -32,6 +32,7 @@ export type { VisCanvasProps } from './vis/shared/VisCanvas';
 export { default as TooltipMesh } from './vis/shared/TooltipMesh';
 export type { TooltipMeshProps } from './vis/shared/TooltipMesh';
 export { default as Html } from './vis/shared/Html';
+export { default as Overlay } from './vis/shared/Overlay';
 export { default as Annotation } from './vis/shared/Annotation';
 
 export { default as ColorBar } from './vis/heatmap/ColorBar';
@@ -129,4 +130,3 @@ export { default as RgbVis } from './vis/rgb/RgbVis';
 export { default as VisMesh } from './vis/shared/VisMesh';
 export { default as ScatterPoints } from './vis/scatter/ScatterPoints';
 export { default as DataCurve } from './vis/line/DataCurve';
-export { default as Overlay } from './vis/shared/Overlay';

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -1,11 +1,11 @@
 // Visualizations
 export { default as MatrixVis } from './vis/matrix/MatrixVis';
-export { default as LineVis } from './vis/line/LineVis';
-export { default as HeatmapVis } from './vis/heatmap/HeatmapVis';
-export { default as ScatterVis } from './vis/scatter/ScatterVis';
 export type { MatrixVisProps } from './vis/matrix/MatrixVis';
+export { default as LineVis } from './vis/line/LineVis';
 export type { LineVisProps } from './vis/line/LineVis';
+export { default as HeatmapVis } from './vis/heatmap/HeatmapVis';
 export type { HeatmapVisProps } from './vis/heatmap/HeatmapVis';
+export { default as ScatterVis } from './vis/scatter/ScatterVis';
 export type { ScatterVisProps } from './vis/scatter/ScatterVis';
 
 // Toolbar and controls
@@ -31,15 +31,13 @@ export { default as VisCanvas } from './vis/shared/VisCanvas';
 export type { VisCanvasProps } from './vis/shared/VisCanvas';
 export { default as TooltipMesh } from './vis/shared/TooltipMesh';
 export type { TooltipMeshProps } from './vis/shared/TooltipMesh';
-export { default as VisMesh } from './vis/shared/VisMesh';
+export { default as Html } from './vis/shared/Html';
+export { default as Annotation } from './vis/shared/Annotation';
+
 export { default as ColorBar } from './vis/heatmap/ColorBar';
 export type { ColorBarProps } from './vis/heatmap/ColorBar';
 export { default as HeatmapMesh } from './vis/heatmap/HeatmapMesh';
 export type { HeatmapMeshProps } from './vis/heatmap/HeatmapMesh';
-export { default as DataCurve } from './vis/line/DataCurve';
-export { default as Html } from './vis/shared/Html';
-export { default as Overlay } from './vis/shared/Overlay';
-export { default as Annotation } from './vis/shared/Annotation';
 export { default as TiledHeatmapMesh } from './vis/tiles/TiledHeatmapMesh';
 export type { TiledHeatmapMeshProps } from './vis/tiles/TiledHeatmapMesh';
 export { getLayerSizes, TilesApi } from './vis/tiles/api';
@@ -92,6 +90,8 @@ export { useCanvasEvents } from './interactions/hooks';
 export { INTERPOLATORS } from './vis/heatmap/interpolators';
 export { ScaleType } from '@h5web/shared';
 export { CurveType } from './vis/line/models';
+export { ImageType } from './vis/rgb/models';
+
 export type {
   InteractionInfo,
   ModifierKey,
@@ -126,5 +126,7 @@ export { default as CellWidthInput } from './toolbar/controls/CellWidthInput';
 export { default as RawVis } from './vis/raw/RawVis';
 export { default as ScalarVis } from './vis/scalar/ScalarVis';
 export { default as RgbVis } from './vis/rgb/RgbVis';
+export { default as VisMesh } from './vis/shared/VisMesh';
 export { default as ScatterPoints } from './vis/scatter/ScatterPoints';
-export { ImageType } from './vis/rgb/models';
+export { default as DataCurve } from './vis/line/DataCurve';
+export { default as Overlay } from './vis/shared/Overlay';

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -40,8 +40,8 @@ export { default as DataCurve } from './vis/line/DataCurve';
 export { default as Html } from './vis/shared/Html';
 export { default as Overlay } from './vis/shared/Overlay';
 export { default as Annotation } from './vis/shared/Annotation';
-export { default as TiledHeatmap } from './vis/tiles/TiledHeatmap';
-export type { TiledHeatmapProps } from './vis/tiles/TiledHeatmap';
+export { default as TiledHeatmapMesh } from './vis/tiles/TiledHeatmapMesh';
+export type { TiledHeatmapMeshProps } from './vis/tiles/TiledHeatmapMesh';
 export { getLayerSizes, TilesApi } from './vis/tiles/api';
 
 // Interactions

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -35,6 +35,8 @@ export { default as Html } from './vis/shared/Html';
 export { default as Overlay } from './vis/shared/Overlay';
 export { default as Annotation } from './vis/shared/Annotation';
 
+export { default as DataCurve } from './vis/line/DataCurve';
+export type { DataCurveProps } from './vis/line/DataCurve';
 export { default as ColorBar } from './vis/heatmap/ColorBar';
 export type { ColorBarProps } from './vis/heatmap/ColorBar';
 export { default as HeatmapMesh } from './vis/heatmap/HeatmapMesh';
@@ -129,4 +131,3 @@ export { default as ScalarVis } from './vis/scalar/ScalarVis';
 export { default as RgbVis } from './vis/rgb/RgbVis';
 export { default as VisMesh } from './vis/shared/VisMesh';
 export { default as ScatterPoints } from './vis/scatter/ScatterPoints';
-export { default as DataCurve } from './vis/line/DataCurve';

--- a/packages/lib/src/vis/line/DataCurve.tsx
+++ b/packages/lib/src/vis/line/DataCurve.tsx
@@ -75,4 +75,5 @@ function DataCurve(props: Props) {
   );
 }
 
+export type { Props as DataCurveProps };
 export default DataCurve;

--- a/packages/lib/src/vis/tiles/TiledHeatmapMesh.tsx
+++ b/packages/lib/src/vis/tiles/TiledHeatmapMesh.tsx
@@ -15,7 +15,7 @@ interface Props extends ColorMapProps {
   qualityFactor?: number;
 }
 
-function TiledHeatmap(props: Props) {
+function TiledHeatmapMesh(props: Props) {
   const {
     api,
     displayLowerResolutions = true,
@@ -68,5 +68,5 @@ function TiledHeatmap(props: Props) {
   );
 }
 
-export type { Props as TiledHeatmapProps };
-export default TiledHeatmap;
+export type { Props as TiledHeatmapMeshProps };
+export default TiledHeatmapMesh;


### PR DESCRIPTION
Also, rename `TiledHeatmap` to `TiledHeatmapMesh` for consistency with `HeatmapMesh`. (Note that we could also have renamed `HeatmapMesh` to `Heatmap` instead, but I think `Mesh` makes it clearer that it is a building block meant to be used inside `VisCanvas`.)

New story for `Overlay`:

![image](https://user-images.githubusercontent.com/2936402/162991621-a62418b3-e65e-4191-9776-555ab09f12f8.png)

New stories for `DataCurve`:

![image](https://user-images.githubusercontent.com/2936402/162997773-362fb412-2ab7-48c9-8922-e96d195fcebb.png)
