### PR TITLE
Center annotation automatically when using `scaleOnZoom`

### DIFF
--- a/apps/storybook/src/HeatmapVisDisplay.stories.tsx
+++ b/apps/storybook/src/HeatmapVisDisplay.stories.tsx
@@ -124,17 +124,57 @@ WithAnnotation.args = {
 export const WithAnnotationZoom: Story<HeatmapVisProps> = (args) => (
   <HeatmapVis {...args}>
     <Annotation
-      x={30}
-      y={18}
-      style={{
-        width: '100px',
-        color: 'white',
-        textAlign: 'center',
-        fontSize: '0.75rem',
-      }}
+      x={10}
+      y={15}
       scaleOnZoom
+      style={{
+        width: '230px',
+        color: 'white',
+        fontSize: '0.875rem',
+        textAlign: 'center',
+      }}
     >
-      An annotation scaling with zoom
+      HTML annotation at (10, 15) that scales with zoom. Note that it is now
+      centred automatically.
+    </Annotation>
+    <Annotation
+      x={25}
+      y={10}
+      scaleOnZoom
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        width: 320,
+        height: 50,
+        color: 'white',
+        fontSize: '0.875rem',
+        textAlign: 'center',
+      }}
+    >
+      <>
+        <p style={{ flex: '1 1 0%', margin: 0, padding: '0.5rem' }}>
+          Annotations don't have to contain just text. You can draw shapes with
+          SVG or CSS, for instance.
+        </p>
+        <svg
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            overflow: 'visible',
+          }}
+        >
+          <rect
+            width="100%"
+            height="100%"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={5}
+          />
+        </svg>
+      </>
     </Annotation>
   </HeatmapVis>
 );

--- a/apps/storybook/src/HeatmapVisDisplay.stories.tsx
+++ b/apps/storybook/src/HeatmapVisDisplay.stories.tsx
@@ -98,8 +98,20 @@ WithAxisLabels.args = {
 
 export const WithAnnotation: Story<HeatmapVisProps> = (args) => (
   <HeatmapVis {...args}>
-    <Annotation x={30} y={18} style={{ width: '200px', color: 'white' }}>
-      An annotation
+    <Annotation x={10} y={15} style={{ color: 'white' }}>
+      HTML annotation positioned at (10, 15)
+    </Annotation>
+    <Annotation
+      x={25}
+      y={8}
+      style={{
+        width: '200px',
+        transform: 'translate(-50%, -50%)',
+        color: 'white',
+        textAlign: 'center',
+      }}
+    >
+      Another annotation, manually centred on (25, 8)
     </Annotation>
   </HeatmapVis>
 );

--- a/apps/storybook/src/HeatmapVisDisplay.stories.tsx
+++ b/apps/storybook/src/HeatmapVisDisplay.stories.tsx
@@ -102,45 +102,20 @@ export const WithAnnotation: Story<HeatmapVisProps> = (args) => (
       HTML annotation positioned at (10, 15)
     </Annotation>
     <Annotation
-      x={25}
-      y={8}
-      style={{
-        width: '200px',
-        transform: 'translate(-50%, -50%)',
-        color: 'white',
-        textAlign: 'center',
-      }}
-    >
-      Another annotation, manually centred on (25, 8)
-    </Annotation>
-  </HeatmapVis>
-);
-
-WithAnnotation.args = {
-  dataArray,
-  domain,
-};
-
-export const WithAnnotationZoom: Story<HeatmapVisProps> = (args) => (
-  <HeatmapVis {...args}>
-    <Annotation
       x={10}
-      y={15}
-      scaleOnZoom
+      y={5}
+      center
       style={{
-        width: '230px',
+        width: 180,
         color: 'white',
-        fontSize: '0.875rem',
         textAlign: 'center',
       }}
     >
-      HTML annotation at (10, 15) that scales with zoom. Note that it is now
-      centred automatically.
+      Another annotation, <strong>centred</strong> on (10, 5)
     </Annotation>
     <Annotation
       x={25}
       y={10}
-      scaleOnZoom
       style={{
         display: 'flex',
         alignItems: 'center',
@@ -152,9 +127,16 @@ export const WithAnnotationZoom: Story<HeatmapVisProps> = (args) => (
       }}
     >
       <>
-        <p style={{ flex: '1 1 0%', margin: 0, padding: '0.5rem' }}>
-          Annotations don't have to contain just text. You can draw shapes with
-          SVG or CSS, for instance.
+        <p
+          style={{
+            flex: '1 1 0%',
+            margin: 0,
+            padding: '0.5rem',
+            border: '10px solid pink',
+          }}
+        >
+          Annotations don't have to contain just text. You can also draw shapes
+          with CSS and SVG.
         </p>
         <svg
           style={{
@@ -170,11 +152,43 @@ export const WithAnnotationZoom: Story<HeatmapVisProps> = (args) => (
             width="100%"
             height="100%"
             fill="none"
-            stroke="currentColor"
+            stroke="papayawhip"
             strokeWidth={5}
           />
         </svg>
       </>
+    </Annotation>
+  </HeatmapVis>
+);
+
+WithAnnotation.args = {
+  dataArray,
+  domain,
+};
+
+export const WithAnnotationZoom: Story<HeatmapVisProps> = (args) => (
+  <HeatmapVis {...args}>
+    <Annotation
+      x={10}
+      y={15}
+      scaleOnZoom
+      style={{ width: 230, color: 'white' }}
+    >
+      HTML annotation at (10, 15) that scales with zoom.
+    </Annotation>
+    <Annotation
+      x={25}
+      y={10}
+      scaleOnZoom
+      center
+      style={{
+        width: 320,
+        color: 'white',
+        textAlign: 'center',
+      }}
+    >
+      Another annotation that scales with zoom but this time{' '}
+      <strong>centred</strong> on (25, 10)
     </Annotation>
   </HeatmapVis>
 );

--- a/packages/lib/src/vis/shared/Annotation.tsx
+++ b/packages/lib/src/vis/shared/Annotation.tsx
@@ -16,11 +16,16 @@ function Annotation(props: Props) {
   const { x, y, scaleOnZoom, children, style, ...divProps } = props;
 
   const camera = useThree((state) => state.camera);
+  useFrameRendering();
 
   const { dataToWorld, worldToHtml } = useAxisSystemContext();
   const htmlPt = worldToHtml(dataToWorld(new Vector2(x, y)));
 
-  useFrameRendering();
+  if (scaleOnZoom && style?.transform) {
+    throw new Error(
+      'Annotation with `scaleOnZoom` cannot have its own `transform`'
+    );
+  }
 
   return (
     <Html>
@@ -31,8 +36,10 @@ function Annotation(props: Props) {
           left: htmlPt.x,
           pointerEvents: 'none',
           transform: scaleOnZoom
-            ? `scale(${1 / camera.scale.x}, ${1 / camera.scale.y})`
-            : '',
+            ? `translate(-50%, -50%) scale(${1 / camera.scale.x}, ${
+                1 / camera.scale.y
+              })`
+            : undefined,
           ...style,
         }}
         {...divProps}


### PR DESCRIPTION
With `scaleOnZoom`, if the annotation is not centered around its coordinates, it shifts once the user starts zooming. The annotation in the story is currently positioned at `(30, 18)`:

![image](https://user-images.githubusercontent.com/2936402/163387673-76c1cfa9-c0dc-42fc-aa69-93c84307d562.png)

But loses its position when zooming:

![image](https://user-images.githubusercontent.com/2936402/163387586-d4ff4e4d-ccbd-47fc-9b9b-7599ec3db792.png)

With this PR, I propose that we always center annotations when `scaleOnZoom` is `true`, with `translate(-50%, -50%)`.

I take the opportunity to improve the annotation stories a little, notably by showing how one might go about drawing an SVG rectangle:

![image](https://user-images.githubusercontent.com/2936402/163388069-2fd6a3b0-d28c-4289-8f91-685777e50d3c.png)

![image](https://user-images.githubusercontent.com/2936402/163388102-b32415d2-e6e0-44de-b746-beb01163dab8.png)

