### PR TITLE
Implement new `H5WasmProvider`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,8 +117,7 @@ Icons can be imported as React components from `react-icons/fi`.
   site
 - `pnpm serve` - serve the built demo at http://localhost:3000
 - `pnpm serve:storybook` - serve the built Storybook at http://localhost:6006
-- `pnpm packages` - build packages `@h5web/app` and `@h5web/lib` (cf. details
-  below)
+- `pnpm packages` - build packages (cf. details below)
 
 ### Package builds
 
@@ -132,7 +131,7 @@ The build process of `@h5web/lib` works as follows:
    that contains the compiled CSS modules that Vite comes across while building
    the React components. These styles are called "local" styles.
 
-2. Second, we run two scripts in parallel: `build:css` and `build:ts`.
+2. Second, we run two scripts in parallel: `build:css` and `build:dts`.
    - The job of `build:css` is to build the package's global styles and
      concatenate them with the local styles compiled at the first step. To do
      so, we run Vite again but with a different config: `vite.styles.config.js`,
@@ -141,7 +140,7 @@ The build process of `@h5web/lib` works as follows:
      (the global styles) and `dist/style.css` (the local styles) and output the
      result to `dist/styles.css`, which is the stylesheet referenced from
      `package.json` that consumers need to import.
-   - The job of `build:ts` is to generate type declarations for package
+   - The job of `build:dts` is to generate type declarations for package
      consumers who use TypeScript. This is a two step process: first we generate
      type declarations for all TS files in the `dist-ts` folder with `tsc`, then
      we use Rollup to merge all the declarations into a single file:
@@ -153,6 +152,10 @@ package's distributed styles - i.e. the output of the lib's `build:css` script.
 The lib's distributed styles include both its global _and_ local styles. This
 allows us to provide a single CSS bundle for consumers of `@h5web/app` to
 import.
+
+The build process of`@h5web/h5wasm` is also the same as the lib's, but since the
+package does not include any styles, `vite build` does not generate a
+`style.css` file and there's not `build:css` script.
 
 ## Code quality
 

--- a/README.md
+++ b/README.md
@@ -3,17 +3,19 @@
 [![Demo](https://img.shields.io/website?down_message=offline&label=demo&up_message=online&url=https%3A%2F%2Fh5web.panosc.eu%2F)](https://h5web.panosc.eu/)
 
 H5Web is a collection of React components to visualize and explore data. It
-consists of two packages:
+consists of three packages:
 
 - **@h5web/lib**: visualization components built with
   [react-three-fiber](https://github.com/react-spring/react-three-fiber).
 - **@h5web/app**: a component to explore and visualize data stored in HDF5 (or
   HDF5-like) files, and data providers to connect this component to various
   back-end solutions.
+- **@h5web/h5wasm**: an additional data provider that can read HDF5 files
+  straight in the browser.
 
-> While H5Web was initially built with the HDF5 format in mind, @h5web/lib
+> While H5Web was initially built with the HDF5 format in mind, `@h5web/lib`
 > visualization components are not tied to HDF5 and can be used to visualize
-> data from any source. Also, @h5web/app lets you write your own data provider
+> data from any source. Also, `@h5web/app` lets you write your own data provider
 > and can therefore work with any other hierarchical data format.
 
 If you're after a ready-made solution to view local HDF5 files, take a look at
@@ -46,13 +48,19 @@ Some examples of usage of `@h5web/lib`:
 HDF5 viewer component (`App`) and built-in data providers.
 
 Data providers are components that fetch data from HDF5 back-end solutions and
-provide this data to the app through React Context. H5Web currently includes two
-providers out of the box, which are both under active development:
+provide this data to the app through React Context. H5Web currently includes
+three providers, two of which are available in the `@h5web/app` package:
 
-- `H5GroveProvider` for [h5grove](https://github.com/silx-kit/h5grove), which is
-  used notably in
+- `H5GroveProvider` for server implementations based on
+  [H5Grove](https://github.com/silx-kit/h5grove), like
   [jupyterlab-h5web](https://github.com/silx-kit/jupyterlab-h5web)
 - `HsdsProvider` for [HSDS](https://github.com/HDFGroup/hsds)
+
+### [@h5web/h5wasm](https://www.npmjs.com/package/@h5web/h5wasm)
+
+This package includes a third data provider, `H5WasmProvider`, that can read
+HDF5 files straight in the browser thanks to the
+[h5wasm](https://github.com/usnistgov/h5wasm) library.
 
 ## Demos
 
@@ -87,6 +95,11 @@ All the HDF5 files mentionned above can be reached with a URL of the form
 `https://h5web.panosc.eu/hsds?file=<name>`. https://h5web.panosc.eu/hsds will
 default to `water_224.h5` but some datasets cannot be displayed as bitshuffle
 compression is not supported by HSDS yet.
+
+### [H5Wasm](https://github.com/usnistgov/h5wasm)
+
+This demo is available at https://h5web.panosc.eu/h5wasm. Just drop an HDF5 file
+from your local machine to get started.
 
 ### Mock data
 

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -22,9 +22,11 @@
   },
   "dependencies": {
     "@h5web/app": "workspace:*",
+    "@h5web/h5wasm": "workspace:*",
     "normalize.css": "8.0.1",
     "react": "17.0.2",
     "react-dom": "17.0.2",
+    "react-dropzone": "12.0.5",
     "react-router-dom": "6.2.1"
   },
   "devDependencies": {
@@ -37,16 +39,5 @@
     "typescript": "4.5.5",
     "vite": "2.8.4",
     "vite-plugin-eslint": "1.3.0"
-  },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version"
-    ]
   }
 }

--- a/apps/demo/src/DemoApp.tsx
+++ b/apps/demo/src/DemoApp.tsx
@@ -8,6 +8,7 @@ import {
 import H5GroveApp from './H5GroveApp';
 import HsdsApp from './HsdsApp';
 import MockApp from './MockApp';
+import H5WasmApp from './h5wasm/H5WasmApp';
 
 function DemoApp() {
   return (
@@ -16,6 +17,7 @@ function DemoApp() {
         <Route path="/" element={<H5GroveApp />} />
         <Route path="mock" element={<MockApp />} />
         <Route path="hsds" element={<HsdsApp />} />
+        <Route path="h5wasm" element={<H5WasmApp />} />
         <Route path="*" element={<Navigate to="/" />} />
       </Routes>
     </Router>

--- a/apps/demo/src/h5wasm/DropZone.tsx
+++ b/apps/demo/src/h5wasm/DropZone.tsx
@@ -1,0 +1,74 @@
+import { useCallback, useState } from 'react';
+import { useDropzone } from 'react-dropzone';
+
+import styles from './H5WasmApp.module.css';
+import type { H5File } from './models';
+
+const EXT = ['.h5', '.hdf5', '.hdf', '.nx', '.nx5', '.nexus', '.nxs', '.cxi'];
+
+interface Props {
+  onChange: (h5File: H5File) => void;
+}
+
+function DropZone(props: Props) {
+  const { onChange } = props;
+  const [isReadingFile, setReadingFile] = useState(false);
+
+  const onDropAccepted = useCallback(
+    ([file]: File[]) => {
+      const reader = new FileReader();
+      reader.addEventListener('abort', () => setReadingFile(false));
+      reader.addEventListener('error', () => setReadingFile(false));
+      reader.addEventListener('load', () => {
+        onChange({ filename: file.name, buffer: reader.result as ArrayBuffer });
+      });
+
+      reader.readAsArrayBuffer(file);
+      setReadingFile(true);
+    },
+    [onChange]
+  );
+
+  const { getRootProps, getInputProps, open, isDragActive, fileRejections } =
+    useDropzone({
+      accept: EXT,
+      multiple: false,
+      noClick: true,
+      noKeyboard: true,
+      disabled: isReadingFile,
+      onDropAccepted,
+    });
+
+  return (
+    <div
+      {...getRootProps({
+        className: isDragActive ? styles.activeDropZone : styles.dropZone,
+        'data-disabled': isReadingFile || undefined,
+      })}
+    >
+      <input {...getInputProps()} />
+      <div className={styles.inner}>
+        {isDragActive ? (
+          <p className={styles.dropIt}>Drop it!</p>
+        ) : (
+          <>
+            <p className={styles.content}>
+              Drop an HDF5 file here{' '}
+              <button className={styles.btn} type="button" onClick={open}>
+                or use a file picker instead
+              </button>
+            </p>
+            <p
+              className={styles.hint}
+              role={fileRejections.length > 0 ? 'alert' : undefined}
+            >
+              Extensions allowed: <strong>{EXT.join(' ')}</strong>
+            </p>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default DropZone;

--- a/apps/demo/src/h5wasm/H5WasmApp.module.css
+++ b/apps/demo/src/h5wasm/H5WasmApp.module.css
@@ -1,0 +1,60 @@
+.dropZone {
+  height: 100%;
+  padding: 2rem;
+  text-align: center;
+  background-color: var(--primary-bg);
+}
+
+.activeDropZone {
+  composes: dropZone;
+  background-color: var(--primary);
+}
+
+.dropZone[data-disabled] {
+  opacity: 0.3;
+  pointer-events: none;
+}
+
+.inner {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  padding-bottom: 3vh;
+  border: 3px dashed currentColor;
+  border-radius: 2rem;
+}
+
+.content {
+  font-size: 2rem;
+  margin: 0;
+}
+
+.btn {
+  composes: btnClean from global;
+  display: block;
+  margin: 0.25rem auto 0;
+  padding: 0.25rem 1rem;
+  color: #444;
+  font-size: 1.125rem;
+  text-decoration: underline;
+}
+
+.btn:hover,
+.btn:focus-visible {
+  text-decoration: none;
+}
+
+.hint {
+  margin: 2rem 0 0;
+  font-style: italic;
+}
+
+.hint[role='alert'] {
+  color: crimson;
+}
+
+.dropIt {
+  font-size: 5rem;
+}

--- a/apps/demo/src/h5wasm/H5WasmApp.tsx
+++ b/apps/demo/src/h5wasm/H5WasmApp.tsx
@@ -1,0 +1,25 @@
+import { App } from '@h5web/app';
+import { H5WasmProvider } from '@h5web/h5wasm';
+import { useState } from 'react';
+import { useLocation } from 'react-router-dom';
+
+import { getFeedbackURL } from '../utils';
+import DropZone from './DropZone';
+import type { H5File } from './models';
+
+function H5WasmApp() {
+  const query = new URLSearchParams(useLocation().search);
+  const [h5File, setH5File] = useState<H5File>();
+
+  if (!h5File) {
+    return <DropZone onChange={setH5File} />;
+  }
+
+  return (
+    <H5WasmProvider {...h5File}>
+      <App explorerOpen={!query.has('wide')} getFeedbackURL={getFeedbackURL} />
+    </H5WasmProvider>
+  );
+}
+
+export default H5WasmApp;

--- a/apps/demo/src/h5wasm/models.ts
+++ b/apps/demo/src/h5wasm/models.ts
@@ -1,0 +1,4 @@
+export interface H5File {
+  filename: string;
+  buffer: ArrayBuffer;
+}

--- a/apps/demo/src/styles.css
+++ b/apps/demo/src/styles.css
@@ -1,6 +1,41 @@
 @import 'normalize.css';
 @import '@h5web/app/src/styles.css'; /* global app styles */
 
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
+}
+
+body {
+  box-sizing: border-box;
+  font-family: var(--sans-serif);
+  line-height: 1.2;
+  color: #020402;
+}
+
+body {
+  --primary: #c0da74;
+  --primary-light: #d4e09b;
+  --primary-dark: #9aae5d;
+  --primary-bg: #f5fbef;
+  --primary-light-bg: #fafdf7;
+  --primary-dark-bg: #dde2d7;
+  --secondary: #8cdfc7;
+  --secondary-light: #b7fcf3;
+  --secondary-lighter: #dbfef9;
+  --secondary-dark: #1b998b;
+  --secondary-dark-15: #1b998b26;
+  --secondary-darker: #0e5846;
+  --secondary-bg: #d9f4ec;
+  --secondary-light-bg: #ecfaf6;
+  --monospace: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier,
+    monospace;
+  --sans-serif: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+    'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+}
+
 #root {
   height: 100vh;
 }

--- a/apps/demo/vite.config.js
+++ b/apps/demo/vite.config.js
@@ -6,5 +6,6 @@ export default defineConfig({
   server: { open: true },
   preview: { open: true },
   // css: { modules: { root: '.' } }, // https://github.com/vitejs/vite/issues/3092#issuecomment-915952727
+  build: { target: 'es2020', sourcemap: true }, // `es2020` required by @h5web/h5wasm for BigInt `123n` notation support
   plugins: [react(), eslintPlugin()],
 });

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -1,21 +1,22 @@
 # H5Web App & Providers
 
-[![Demo](https://img.shields.io/website?down_message=offline&label=demo&up_message=online&url=https%3A%2F%2Fh5web-docs.panosc.eu%2F)](https://h5web.panosc.eu/)
+[![Demo](https://img.shields.io/website?down_message=offline&label=demo&up_message=online&url=https%3A%2F%2Fh5web.panosc.eu%2F)](https://h5web.panosc.eu/)
 [![Version](https://img.shields.io/npm/v/@h5web/app)](https://www.npmjs.com/package/@h5web/app)
 
-H5Web is a collection of React components to visualize and explore data. It
-consists of two packages:
+[H5Web](https://github.com/silx-kit/h5web) is a collection of React components
+to visualize and explore data. It consists of two main packages:
 
-- `@h5web/lib`: visualization components built with
+- [`@h5web/lib`](https://www.npmjs.com/package/@h5web/lib): visualization
+  components built with
   [react-three-fiber](https://github.com/react-spring/react-three-fiber).
-- `@h5web/app`: a stand-alone, web-based viewer to explore HDF5 files **(this
-  library)**.
+- **[`@h5web/app`](https://www.npmjs.com/package/@h5web/app): a stand-alone,
+  web-based viewer to explore HDF5 files (this library)**.
 
-`@h5web/app` exposes the HDF5 viewer component `App`, as well as the built-in
-data providers:
+`@h5web/app` exposes the HDF5 viewer component `App`, as well as the following
+built-in data providers:
 
-- `H5GroveProvider` for use with [H5Grove](https://github.com/silx-kit/h5grove)
-  server implementations, like
+- `H5GroveProvider` for use with server implementations based on
+  [H5Grove](https://github.com/silx-kit/h5grove), like
   [jupyterlab-h5web](https://github.com/silx-kit/jupyterlab-h5web);
 - `HsdsProvider` for use with [HSDS](https://github.com/HDFGroup/hsds);
 - `MockProvider` for testing purposes.

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -6,3 +6,9 @@ export { default as H5GroveProvider } from './providers/h5grove/H5GroveProvider'
 
 export { getFeedbackMailto } from './breadcrumbs/utils';
 export type { FeedbackContext } from './breadcrumbs/models';
+
+// Undocumented (for @h5web/h5wasm)
+export { default as Provider } from './providers/Provider';
+export { ProviderApi } from './providers/api';
+export type { ValuesStoreParams } from './providers/models';
+export { convertDtype } from './providers/utils';

--- a/packages/app/src/providers/Provider.tsx
+++ b/packages/app/src/providers/Provider.tsx
@@ -9,6 +9,7 @@ import type { ImageAttribute } from '../vis-packs/core/models';
 import type { NxAttribute } from '../vis-packs/nexus/models';
 import type { ProviderApi } from './api';
 import { ProviderContext } from './context';
+import { getNameFromPath } from './utils';
 
 interface Props {
   api: ProviderApi;
@@ -65,8 +66,6 @@ function Provider(props: Props) {
     });
   }, [api]);
 
-  const filepathMembers = api.filepath.split('/');
-
   const attrValuesStore = useMemo(() => {
     const store = createFetchStore(api.getAttrValues.bind(api), {
       type: 'Map',
@@ -86,7 +85,7 @@ function Provider(props: Props) {
     <ProviderContext.Provider
       value={{
         filepath: api.filepath,
-        filename: filepathMembers[filepathMembers.length - 1],
+        filename: getNameFromPath(api.filepath),
         entitiesStore,
         valuesStore,
         attrValuesStore,

--- a/packages/app/src/providers/utils.ts
+++ b/packages/app/src/providers/utils.ts
@@ -111,3 +111,8 @@ export async function handleAxiosError<T>(
     throw error;
   }
 }
+
+export function getNameFromPath(path: string) {
+  const segments = path.split('/');
+  return segments[segments.length - 1];
+}

--- a/packages/h5wasm/.eslintignore
+++ b/packages/h5wasm/.eslintignore
@@ -1,0 +1,2 @@
+/dist*/
+/node_modules/

--- a/packages/h5wasm/.eslintrc.cjs
+++ b/packages/h5wasm/.eslintrc.cjs
@@ -1,0 +1,9 @@
+const { createConfig } = require('eslint-config-galex/src/createConfig');
+
+const { rules, overrides } = require('../../eslint.shared');
+
+module.exports = createConfig({
+  cwd: __dirname,
+  rules,
+  overrides,
+});

--- a/packages/h5wasm/README.md
+++ b/packages/h5wasm/README.md
@@ -1,0 +1,139 @@
+# H5Web's H5Wasm Provider
+
+[![Demo](https://img.shields.io/website?down_message=offline&label=demo&up_message=online&url=https%3A%2F%2Fh5web.panosc.eu%2Fh5wasm)](https://h5web.panosc.eu/h5wasm)
+[![Version](https://img.shields.io/npm/v/@h5web/h5wasm)](https://www.npmjs.com/package/@h5web/h5wasm)
+
+[H5Web](https://github.com/silx-kit/h5web) is a collection of React components
+to visualize and explore data. It consists of two main packages:
+
+- [@h5web/lib](https://www.npmjs.com/package/@h5web/lib): visualization
+  components built with
+  [react-three-fiber](https://github.com/react-spring/react-three-fiber).
+- [@h5web/app](https://www.npmjs.com/package/@h5web/app): a stand-alone,
+  web-based viewer to explore HDF5 files.
+
+`@h5web/app` exposes the HDF5 viewer component `App`, as well as the following
+built-in data providers:
+
+- `H5GroveProvider` for use with [H5Grove](https://github.com/silx-kit/h5grove)
+  server implementations, like
+  [jupyterlab-h5web](https://github.com/silx-kit/jupyterlab-h5web);
+- `HsdsProvider` for use with [HSDS](https://github.com/HDFGroup/hsds);
+- `MockProvider` for testing purposes.
+
+This package, `@h5web/h5wasm`, provides one additional data provider,
+`H5WasmProvider`, that can **read HDF5 files straight in the browser** thanks to
+the [h5wasm](https://github.com/usnistgov/h5wasm) library.
+
+<!-- Check out [this code sandbox]() for a demonstration of how to set up
+@h5web/h5wasm and use the `H5WasmProvider`. -->
+
+## Getting started 🚀
+
+```bash
+npm install @h5web/app @h5web/h5wasm
+```
+
+```tsx
+import '@h5web/app/dist/styles.css';
+
+import React from 'react';
+import { App } from '@h5web/app';
+import { H5WasmProvider } from '@h5web/h5wasm';
+
+interface H5File {
+  filename: string;
+  buffer: ArrayBuffer;
+}
+
+function MyApp() {
+  const [h5File, setH5File] = useState<H5File>();
+
+  function handleFileInputChange(evt: ChangeEvent<HTMLInputElement>) {
+    const file = evt.target.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    /* `H5WasmProvider` expects an HDF5 file in the form of an `ArrayBuffer`.
+     * The way you get this buffer is up to you. Here, we show a simple file picker
+     * and use the FileReader API to process the selected file. */
+    const reader = new FileReader();
+    reader.addEventListener('load', () => {
+      setH5File({
+        filename: file.name,
+        buffer: reader.result as ArrayBuffer,
+      });
+    });
+
+    reader.readAsArrayBuffer(file);
+  }
+
+  if (!h5File) {
+    return (
+      <input
+        aria-label="Pick HDF5 file"
+        type="file"
+        accept=".h5"
+        onChange={handleFileInputChange}
+      />
+    );
+  }
+
+  return (
+    <div style={{ height: '100vh' }}>
+      <H5WasmProvider {...h5File}>
+        <App />
+      </H5WasmProvider>
+    </div>
+  );
+}
+
+export default MyApp;
+```
+
+> If your bundler supports it (e.g. webpack 5), you may be able to shorten the
+> stylesheet import path as follows:
+>
+> ```ts
+> import '@h5web/app/styles.css';
+> ```
+
+## Caveats
+
+### Requires BigInt support
+
+The `h5wasm` library uses the BigInt `123n` notation, which
+[is challenging to polyfill](https://javascript.info/bigint#polyfills). This
+means that:
+
+- your build tool must understand the BigInt notation (e.g.
+  [babel-plugin-syntax-bigint](https://babeljs.io/docs/en/babel-plugin-syntax-bigint))
+- your application will only run in browsers that
+  [support BigInt](https://caniuse.com/bigint).
+
+### External links are not resolved
+
+The provider doesn't know how to resolve links to groups and datasets contained
+in other HDF5 files. Such links will appear as unresolved entities in the
+viewer.
+
+### File size is limited
+
+Since `h5wasm` requires the entire HDF5 file to be passed as a single
+`ArrayBuffer`, there's a limit to how big a file you can load. This limit
+depends on your browser, on your operating system, and on your machine's
+resources.
+
+## API reference
+
+### `H5WasmProvider`
+
+- `filename: string` (required) - the name of the file
+- `buffer: ArrayBuffer` (required) - the content of the file
+
+```tsx
+<H5WasmProvider filename="foo.h5" buffer={buffer}>
+  <App />
+</H5WasmProvider>
+```

--- a/packages/h5wasm/package.json
+++ b/packages/h5wasm/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@h5web/h5wasm",
+  "version": "0.0.1",
+  "description": "H5Web providers based on H5Wasm",
+  "author": "European Synchrotron Radiation Facility",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/silx-kit/h5web"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "main": "src/index.ts",
+  "publishConfig": {
+    "type": "",
+    "main": "dist/index.js",
+    "module": "dist/index.esm.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+      ".": {
+        "require": "./dist/index.js",
+        "import": "./dist/index.esm.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "vite build && pnpm build:dts",
+    "build:dts": "tsc --build tsconfig.build.json && rollup -c",
+    "lint:eslint": "eslint \"**/*.{js,cjs,ts,tsx}\" --max-warnings=0",
+    "lint:tsc": "tsc --noEmit",
+    "analyze": "pnpm dlx source-map-explorer dist/index.js --no-border-checks"
+  },
+  "peerDependencies": {
+    "@h5web/app": "workspace:*",
+    "react": ">=16"
+  },
+  "dependencies": {
+    "h5wasm": "0.3.1"
+  },
+  "devDependencies": {
+    "@h5web/app": "workspace:*",
+    "@h5web/shared": "workspace:*",
+    "@types/react": "17.0.39",
+    "eslint": "8.9.0",
+    "eslint-config-galex": "3.6.5",
+    "react": "17.0.2",
+    "rollup": "2.68.0",
+    "rollup-plugin-dts": "4.1.0",
+    "typescript": "4.5.5",
+    "vite": "2.8.4"
+  }
+}

--- a/packages/h5wasm/rollup.config.js
+++ b/packages/h5wasm/rollup.config.js
@@ -1,0 +1,13 @@
+import dts from 'rollup-plugin-dts';
+
+import { externals } from './vite.config';
+
+/** @type {import('rollup').MergedRollupOptions} */
+const config = {
+  input: './dist-ts/index.d.ts',
+  output: [{ file: 'dist/index.d.ts', format: 'es' }],
+  external: [...externals, /\.css$/u],
+  plugins: [dts({ respectExternal: true })],
+};
+
+export default config;

--- a/packages/h5wasm/src/H5WasmProvider.tsx
+++ b/packages/h5wasm/src/H5WasmProvider.tsx
@@ -1,0 +1,28 @@
+import { Provider } from '@h5web/app';
+import type { ReactNode } from 'react';
+import { useEffect, useMemo } from 'react';
+
+import { H5WasmApi } from './h5wasm-api';
+
+interface Props {
+  filename: string;
+  buffer: ArrayBuffer;
+  children: ReactNode;
+}
+
+function H5WasmProvider(props: Props) {
+  const { filename, buffer, children } = props;
+
+  const api = useMemo(
+    () => new H5WasmApi(filename, buffer),
+    [filename, buffer]
+  );
+
+  useEffect(() => {
+    return () => void api.cleanUp();
+  }, [api]);
+
+  return <Provider api={api}>{children}</Provider>;
+}
+
+export default H5WasmProvider;

--- a/packages/h5wasm/src/h5wasm-api.ts
+++ b/packages/h5wasm/src/h5wasm-api.ts
@@ -1,0 +1,140 @@
+import type { ValuesStoreParams } from '@h5web/app';
+import { convertDtype, ProviderApi } from '@h5web/app';
+import { getNameFromPath } from '@h5web/app/src/providers/utils';
+import type {
+  AttributeValues,
+  Dataset,
+  Entity,
+  Group,
+  GroupWithChildren,
+  UnresolvedEntity,
+} from '@h5web/shared';
+import {
+  buildEntityPath,
+  DTypeClass,
+  EntityKind,
+  hasScalarShape,
+} from '@h5web/shared';
+import { File as H5WasmFile, FS, ready } from 'h5wasm';
+
+import type { H5WasmAttribute, H5WasmEntity } from './models';
+import {
+  assertH5WasmDataset,
+  assertH5WasmEntityWithAttrs,
+  isH5WasmDataset,
+  isH5WasmGroup,
+  isHDF5,
+} from './utils';
+
+export class H5WasmApi extends ProviderApi {
+  private readonly file: Promise<H5WasmFile>;
+
+  public constructor(filename: string, buffer: ArrayBuffer) {
+    super(filename);
+
+    if (!isHDF5(buffer)) {
+      throw new Error('Expected valid HDF5 file');
+    }
+
+    this.file = this.initFile(buffer);
+  }
+
+  public async getEntity(path: string): Promise<Entity> {
+    const file = await this.file;
+    const h5wEntity = file.get(path);
+
+    return this.processH5WasmEntity(getNameFromPath(path), path, h5wEntity);
+  }
+
+  public async getValue(params: ValuesStoreParams): Promise<unknown> {
+    const { dataset } = params;
+
+    const file = await this.file;
+    const h5wDataset = file.get(dataset.path);
+    assertH5WasmDataset(h5wDataset);
+
+    const array = h5wDataset.value;
+    return hasScalarShape(dataset) ? array[0] : array;
+  }
+
+  public async getAttrValues(entity: Entity): Promise<AttributeValues> {
+    const file = await this.file;
+    const h5wEntity = file.get(entity.path);
+    assertH5WasmEntityWithAttrs(h5wEntity);
+
+    return Object.fromEntries(
+      Object.entries(h5wEntity.attrs).map(([name, attr]) => {
+        return [name, (attr as H5WasmAttribute).value];
+      })
+    );
+  }
+
+  public async cleanUp(): Promise<void> {
+    const file = await this.file;
+    file.close();
+  }
+
+  private async initFile(buffer: ArrayBuffer): Promise<H5WasmFile> {
+    await ready;
+
+    FS.writeFile(this.filepath, new Uint8Array(buffer), { flags: 'w+' });
+    return new H5WasmFile(this.filepath, 'r');
+  }
+
+  private processH5WasmEntity(
+    name: string,
+    path: string,
+    h5wEntity: H5WasmEntity,
+    isChild = false
+  ): Entity {
+    const baseEntity = { name, path };
+
+    if (isH5WasmGroup(h5wEntity)) {
+      const baseGroup: Group = {
+        ...baseEntity,
+        kind: EntityKind.Group,
+        attributes: this.processH5WasmAttrs(h5wEntity.attrs),
+      };
+
+      if (isChild) {
+        return baseGroup;
+      }
+
+      const children = h5wEntity.keys().map((name) => {
+        const h5wChild = h5wEntity.get(name);
+        const childPath = buildEntityPath(path, name);
+        return this.processH5WasmEntity(name, childPath, h5wChild, true);
+      });
+
+      return { ...baseGroup, children } as GroupWithChildren;
+    }
+
+    if (isH5WasmDataset(h5wEntity)) {
+      const { shape, dtype } = h5wEntity;
+
+      return {
+        ...baseEntity,
+        kind: EntityKind.Dataset,
+        attributes: this.processH5WasmAttrs(h5wEntity.attrs),
+        shape,
+        type:
+          typeof dtype === 'string'
+            ? convertDtype(dtype)
+            : { class: DTypeClass.Compound, fields: dtype.compound },
+        rawType: dtype,
+      } as Dataset;
+    }
+
+    return {
+      ...baseEntity,
+      kind: EntityKind.Unresolved,
+    } as UnresolvedEntity;
+  }
+
+  private processH5WasmAttrs(h5wAttrs: Record<string, unknown>) {
+    return Object.entries(h5wAttrs).map(([name, attr]) => {
+      const { shape, dtype } = attr as H5WasmAttribute;
+      return { name, shape, type: convertDtype(dtype) };
+    });
+  }
+}

--- a/packages/h5wasm/src/index.ts
+++ b/packages/h5wasm/src/index.ts
@@ -1,0 +1,1 @@
+export { default as H5WasmProvider } from './H5WasmProvider';

--- a/packages/h5wasm/src/models.ts
+++ b/packages/h5wasm/src/models.ts
@@ -1,0 +1,19 @@
+import type { Shape } from '@h5web/shared';
+import type {
+  BrokenSoftLink as H5WasmBrokenSoftLink,
+  Dataset as H5WasmDataset,
+  ExternalLink as H5WasmExternalLink,
+  Group as H5WasmGroup,
+} from 'h5wasm';
+
+export type H5WasmEntity =
+  | H5WasmBrokenSoftLink
+  | H5WasmExternalLink
+  | H5WasmGroup
+  | H5WasmDataset;
+
+export interface H5WasmAttribute {
+  value: unknown;
+  shape: Shape;
+  dtype: string;
+}

--- a/packages/h5wasm/src/types.d.ts
+++ b/packages/h5wasm/src/types.d.ts
@@ -1,0 +1,3 @@
+/* eslint-disable spaced-comment */
+
+/// <reference types="vite/client" />

--- a/packages/h5wasm/src/utils.ts
+++ b/packages/h5wasm/src/utils.ts
@@ -1,0 +1,36 @@
+import { Group as H5WasmGroup, Dataset as H5WasmDataset } from 'h5wasm';
+
+import type { H5WasmEntity } from './models';
+
+// https://www.loc.gov/preservation/digital/formats/fdd/fdd000229.shtml
+const HDF5_MAGIC_NUMBER = [0x89, 0x48, 0x44, 0x46, 0x0d, 0x0a, 0x1a, 0x0a]; // ASCII: \211 HDF \r \n \032 \n
+
+export function isHDF5(buffer: ArrayBuffer): boolean {
+  return new Uint8Array(buffer.slice(0, HDF5_MAGIC_NUMBER.length)).every(
+    (num, i) => num === HDF5_MAGIC_NUMBER[i]
+  );
+}
+
+export function isH5WasmGroup(entity: H5WasmEntity): entity is H5WasmGroup {
+  return entity instanceof H5WasmGroup;
+}
+
+export function isH5WasmDataset(entity: H5WasmEntity): entity is H5WasmDataset {
+  return entity instanceof H5WasmDataset;
+}
+
+export function assertH5WasmDataset(
+  entity: H5WasmEntity
+): asserts entity is H5WasmDataset {
+  if (!isH5WasmDataset(entity)) {
+    throw new Error('Expected H5Wasm entity to be dataset');
+  }
+}
+
+export function assertH5WasmEntityWithAttrs(
+  entity: H5WasmEntity
+): asserts entity is H5WasmGroup | H5WasmDataset {
+  if (!isH5WasmGroup(entity) && !isH5WasmDataset(entity)) {
+    throw new Error('Expected H5Wasm entity with attributes');
+  }
+}

--- a/packages/h5wasm/tsconfig.build.json
+++ b/packages/h5wasm/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist-ts",
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "tsBuildInfoFile": "tsconfig.build.tsbuildinfo"
+  }
+}

--- a/packages/h5wasm/tsconfig.json
+++ b/packages/h5wasm/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/packages/h5wasm/vite.config.js
+++ b/packages/h5wasm/vite.config.js
@@ -1,0 +1,36 @@
+import fs from 'fs';
+import path from 'path';
+import { URL, fileURLToPath } from 'url';
+import { defineConfig } from 'vite';
+
+const dirname = fileURLToPath(new URL('.', import.meta.url));
+
+const [pkg, appPkg, sharedPkg] = ['.', '../app', '../shared'].map((prefix) =>
+  JSON.parse(fs.readFileSync(path.resolve(dirname, `${prefix}/package.json`)))
+);
+
+export const externals = new Set([
+  ...Object.keys(sharedPkg.peerDependencies),
+  ...Object.keys(appPkg.dependencies),
+  ...Object.keys(appPkg.peerDependencies),
+  ...Object.keys(pkg.dependencies),
+  ...Object.keys(pkg.peerDependencies),
+]);
+
+export default defineConfig({
+  // css: { modules: { root: '.' } }, // https://github.com/vitejs/vite/issues/3092#issuecomment-915952727
+  esbuild: {
+    jsxInject: `import React from 'react'`,
+  },
+  build: {
+    lib: {
+      entry: path.resolve('src/index.ts'),
+      formats: ['es', 'cjs'],
+      fileName: (format) => `index.${format === 'es' ? 'esm.js' : 'js'}`,
+    },
+    rollupOptions: {
+      external: [...externals].map((dep) => new RegExp(`^${dep}($|\\/)`, 'u')), // e.g. externalize `react-icons/fi`
+    },
+    sourcemap: true,
+  },
+});

--- a/packages/lib/README.md
+++ b/packages/lib/README.md
@@ -3,17 +3,19 @@
 [![Docs](https://img.shields.io/website?down_message=offline&label=docs&up_message=online&url=https%3A%2F%2Fh5web-docs.panosc.eu%2F)](https://h5web-docs.panosc.eu/)
 [![Version](https://img.shields.io/npm/v/@h5web/lib)](https://www.npmjs.com/package/@h5web/lib)
 
-H5Web is a collection of React components to visualize and explore data. It
-consists of two packages:
+[H5Web](https://github.com/silx-kit/h5web) is a collection of React components
+to visualize and explore data. It consists of two main packages:
 
-- `@h5web/lib`: visualization components built with
-  [react-three-fiber](https://github.com/react-spring/react-three-fiber) **(this
+- **[`@h5web/lib`](https://www.npmjs.com/package/@h5web/lib): visualization
+  components built with
+  [react-three-fiber](https://github.com/react-spring/react-three-fiber) (this
   library)**.
-- `@h5web/app`: a stand-alone, web-based viewer to explore HDF5 files.
+- [`@h5web/app`](https://www.npmjs.com/package/@h5web/app): a stand-alone,
+  web-based viewer to explore HDF5 files.
 
-While used in `@h5web/app` for HDF5 files, **`@h5web/lib` visualization
-components are not tied to HDF5 and can be used to visualize data from any
-source.**
+While used in `@h5web/app` with HDF5 files, `@h5web/lib` visualization
+components are **not tied to HDF5** and can be used to visualize data from any
+source.
 
 For more information, visit the
 [Storybook documentation site](https://h5web-docs.panosc.eu/).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,7 @@ importers:
   apps/demo:
     specifiers:
       '@h5web/app': workspace:*
+      '@h5web/h5wasm': workspace:*
       '@types/react': 17.0.39
       '@types/react-dom': 17.0.11
       '@types/react-router-dom': 5.3.3
@@ -54,15 +55,18 @@ importers:
       normalize.css: 8.0.1
       react: 17.0.2
       react-dom: 17.0.2
+      react-dropzone: 12.0.5
       react-router-dom: 6.2.1
       typescript: 4.5.5
       vite: 2.8.4
       vite-plugin-eslint: 1.3.0
     dependencies:
       '@h5web/app': link:../../packages/app
+      '@h5web/h5wasm': link:../../packages/h5wasm
       normalize.css: 8.0.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
+      react-dropzone: 12.0.5_react@17.0.2
       react-router-dom: 6.2.1_react-dom@17.0.2+react@17.0.2
     devDependencies:
       '@types/react': 17.0.39
@@ -202,6 +206,33 @@ importers:
       npm-run-all: 4.1.5
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
+      rollup: 2.68.0
+      rollup-plugin-dts: 4.1.0_rollup@2.68.0+typescript@4.5.5
+      typescript: 4.5.5
+      vite: 2.8.4
+
+  packages/h5wasm:
+    specifiers:
+      '@h5web/app': workspace:*
+      '@h5web/shared': workspace:*
+      '@types/react': 17.0.39
+      eslint: '>=8'
+      eslint-config-galex: 3.6.5
+      h5wasm: 0.3.1
+      react: 17.0.2
+      rollup: 2.68.0
+      rollup-plugin-dts: 4.1.0
+      typescript: 4.5.5
+      vite: 2.8.4
+    dependencies:
+      h5wasm: 0.3.1
+    devDependencies:
+      '@h5web/app': link:../app
+      '@h5web/shared': link:../shared
+      '@types/react': 17.0.39
+      eslint: 8.9.0
+      eslint-config-galex: 3.6.5_eslint@8.9.0+jest@27.5.1
+      react: 17.0.2
       rollup: 2.68.0
       rollup-plugin-dts: 4.1.0_rollup@2.68.0+typescript@4.5.5
       typescript: 4.5.5
@@ -5421,6 +5452,11 @@ packages:
     hasBin: true
     dev: true
 
+  /attr-accept/2.2.2:
+    resolution: {integrity: sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==}
+    engines: {node: '>=4'}
+    dev: false
+
   /autoprefixer/9.8.8:
     resolution: {integrity: sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==}
     hasBin: true
@@ -8387,6 +8423,13 @@ packages:
       webpack: 4.46.0
     dev: true
 
+  /file-selector/0.4.0:
+    resolution: {integrity: sha512-iACCiXeMYOvZqlF1kTiYINzgepRBymz1wwjiuup9u9nayhb6g4fSwiyJ/6adli+EPwrWtpgQAh2PoS7HukEGEg==}
+    engines: {node: '>= 10'}
+    dependencies:
+      tslib: 2.3.1
+    dev: false
+
   /file-system-cache/1.0.5:
     resolution: {integrity: sha1-hCWbNqK7uNPW6xAh0xMv/mTP/08=}
     dependencies:
@@ -8947,6 +8990,10 @@ packages:
   /graceful-fs/4.2.9:
     resolution: {integrity: sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==}
     dev: true
+
+  /h5wasm/0.3.1:
+    resolution: {integrity: sha512-7zd2VvVSAjcfy00Gql70gILSU7m0FiSkOnwO9tfn04jYKsdKryOuGc7gSX3rh7hXr97+pbLBAuuHYHIQkmVfQg==}
+    dev: false
 
   /handlebars/4.7.7:
     resolution: {integrity: sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==}
@@ -12446,6 +12493,18 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     dev: true
+
+  /react-dropzone/12.0.5_react@17.0.2:
+    resolution: {integrity: sha512-zUjZigD0VJ91CSm9T1h7ErxFReBLaa9sjS2dUL0+inb0RROZpSJTNDHPY1rrBES5V2NXhF8v0kghmaHc81BMFg==}
+    engines: {node: '>= 10.13'}
+    peerDependencies:
+      react: '>= 16.8'
+    dependencies:
+      attr-accept: 2.2.2
+      file-selector: 0.4.0
+      prop-types: 15.8.1
+      react: 17.0.2
+    dev: false
 
   /react-element-to-jsx-string/14.3.4_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-t4ZwvV6vwNxzujDQ+37bspnLwA4JlgUPWhLjBJWsNIDceAf6ZKUTCjdm08cN6WeZ5pTMKiCJkmAYnpmR4Bm+dg==}


### PR DESCRIPTION
The provider code is ported from #1031 and https://github.com/bmaranville/h5web/pull/1/ but limited to the low-level `H5WasmProvider` first discussed in https://github.com/silx-kit/h5web/pull/1031#pullrequestreview-924227264. The provider just accepts an `ArrayBuffer` as prop and reads it on demand with `h5wasm`; it doesn't do any fetching and doesn't provide any UI for picking files.

To demonstrate the use of the provider, I implemented a demo with a file picker/drag-and-drop interface. It's available at http://localhost:3000/h5wasm if you want to test it.

![Peek 2022-04-22 14-24](https://user-images.githubusercontent.com/2936402/164713844-9c34d792-7323-481d-84b6-0a510900941e.gif)

The focus for now is to bootstrap the low-level provider and deal with the BigInt issue. I didn't port the slicing code, didn't worry about broken and external links, and didn't fix some of the dtype inconsistencies with H5Grove that I noticed along the way. These things will come in subsequent PRs.

To work around the BigInt issue, I put the new provider in a separate package called `@h5web/h5wasm`. This way, people can still install `@h5web/app` in their apps without having to target browsers that support BigInt. I didn't bother creating a separate demo app, though, so the demo now only works in browsers that support BigInt (thanks to `build: { target: 'es2020' }`) in `demo/vite.config.js`. I don't think it's a big deal; what's important is that the JLab extension and Hibou still support older browsers. I've explained the browser support caveat in the new package's README.