### PR TITLE
Repair zoom if needed when "keep ratio" becomes enabled

### DIFF
--- a/packages/lib/src/interactions/SelectToZoom.tsx
+++ b/packages/lib/src/interactions/SelectToZoom.tsx
@@ -1,6 +1,6 @@
 import { useThree } from '@react-three/fiber';
 
-import { useVisibleDomains } from '../vis/hooks';
+import { useVisibleDomains, useFrameRendering } from '../vis/hooks';
 import { useAxisSystemContext } from '../vis/shared/AxisSystemProvider';
 import RatioSelectionRect from './RatioSelectionRect';
 import SelectionRect from './SelectionRect';
@@ -28,7 +28,9 @@ function SelectToZoom(props: Props) {
       (yVisibleDomain[1] - yVisibleDomain[0])
   );
 
-  const onSelectionEnd = (selection: Selection) => {
+  useFrameRendering();
+
+  function onSelectionEnd(selection: Selection) {
     const { startPoint: dataStartPoint, endPoint: dataEndPoint } = selection;
 
     // Work in world coordinates as we need to act on the world camera
@@ -50,7 +52,7 @@ function SelectToZoom(props: Props) {
     camera.updateMatrixWorld();
 
     moveCameraTo(zoomRectCenter.x, zoomRectCenter.y);
-  };
+  }
 
   return (
     <SelectionTool

--- a/packages/lib/src/toolbar/floating/ResetZoomButton.tsx
+++ b/packages/lib/src/toolbar/floating/ResetZoomButton.tsx
@@ -1,13 +1,12 @@
 import { useFrame, useThree } from '@react-three/fiber';
 import { useState } from 'react';
 
-import { useMoveCameraTo } from '../../interactions/hooks';
 import FloatingControl from './FloatingControl';
 import styles from './ResetZoomButton.module.css';
 
 function ResetZoomButton() {
   const camera = useThree((state) => state.camera);
-  const moveCameraTo = useMoveCameraTo();
+  const invalidate = useThree((state) => state.invalidate);
 
   const [isVisible, setVisible] = useState(false);
 
@@ -21,9 +20,10 @@ function ResetZoomButton() {
   function resetZoom() {
     camera.scale.x = 1;
     camera.scale.y = 1;
+    camera.position.x = 0;
+    camera.position.y = 0;
     camera.updateMatrixWorld();
-
-    moveCameraTo(0, 0);
+    invalidate();
   }
 
   return (

--- a/packages/lib/src/vis/shared/RatioEnforcer.tsx
+++ b/packages/lib/src/vis/shared/RatioEnforcer.tsx
@@ -1,0 +1,31 @@
+import { useThree } from '@react-three/fiber';
+import { useEffect } from 'react';
+
+import { useMoveCameraTo } from '../../interactions/hooks';
+
+interface Props {
+  visRatio: number | undefined;
+}
+
+function RatioEnforcer(props: Props) {
+  const { visRatio } = props;
+
+  const camera = useThree((state) => state.camera);
+  const moveCameraTo = useMoveCameraTo();
+
+  useEffect(() => {
+    if (!visRatio || camera.scale.x === camera.scale.y) {
+      return;
+    }
+
+    const targetScale = Math.max(camera.scale.x, camera.scale.y);
+    camera.scale.x = targetScale;
+    camera.scale.y = targetScale;
+    camera.updateMatrixWorld();
+    moveCameraTo(camera.position.x, camera.position.y);
+  }, [camera, moveCameraTo, visRatio]);
+
+  return null;
+}
+
+export default RatioEnforcer;

--- a/packages/lib/src/vis/shared/ViewportCenterer.tsx
+++ b/packages/lib/src/vis/shared/ViewportCenterer.tsx
@@ -8,12 +8,12 @@ import { useAxisSystemContext } from './AxisSystemProvider';
 function ViewportCenterer() {
   const { dataToWorld, worldToData } = useAxisSystemContext();
   const viewportCenter = useRef<Vector2>();
-  const { position } = useThree((state) => state.camera);
+  const camera = useThree((state) => state.camera);
 
   const moveCameraTo = useMoveCameraTo();
 
   useFrame(() => {
-    viewportCenter.current = worldToData(position);
+    viewportCenter.current = worldToData(camera.position);
   });
 
   useEffect(() => {
@@ -22,7 +22,7 @@ function ViewportCenterer() {
       const { x, y } = dataToWorld(viewportCenter.current);
       moveCameraTo(x, y);
     }
-  }, [viewportCenter, moveCameraTo, dataToWorld, position.x, position.y]);
+  }, [viewportCenter, moveCameraTo, dataToWorld, camera]);
 
   return null;
 }

--- a/packages/lib/src/vis/shared/VisCanvas.tsx
+++ b/packages/lib/src/vis/shared/VisCanvas.tsx
@@ -9,6 +9,7 @@ import { getSizeToFit, getAxisOffsets } from '../utils';
 import AxisSystem from './AxisSystem';
 import AxisSystemProvider from './AxisSystemProvider';
 import Html from './Html';
+import RatioEnforcer from './RatioEnforcer';
 import ViewportCenterer from './ViewportCenterer';
 import styles from './VisCanvas.module.css';
 
@@ -79,6 +80,7 @@ function VisCanvas(props: PropsWithChildren<Props>) {
                 <AxisSystem axisOffsets={axisOffsets} title={title} />
                 {children}
                 <ViewportCenterer />
+                <RatioEnforcer visRatio={visRatio} />
                 <Html>
                   <div
                     ref={(elem) => setFloatingToolbar(elem || undefined)}


### PR DESCRIPTION
Fix #1076

This issue is part of #993, but technically, the same problem can occur with the axial zoom components - i.e. you start zooming on one axis because `keepRatio` is `false` then toggle the flag to `true` and the visualisation is broken. Therefore, instead of putting the code in `SelectToZoom`, I decided to create a specialised `VisCanvas` component similarly to `ViewportCenterer`.

Also, instead of resetting the zoom to `(1, 1)` when `visRatio` becomes defined, I reset it to the scale of the axis that is most zoomed out - e.g. `(0.8, 0.6)` becomes `(0.8, 0.8)`. I also make sure that the scales of the two axes are actually different before resetting, to avoid triggering a frame unnecessarily.

![Peek 2022-04-25 14-22](https://user-images.githubusercontent.com/2936402/165088155-7cae644c-5d43-4690-8306-0ea53767f17b.gif)