### PR TITLE
Display chunks and compression info in dataset metadata

### DIFF
--- a/packages/app/src/metadata-viewer/EntityInfo.tsx
+++ b/packages/app/src/metadata-viewer/EntityInfo.tsx
@@ -40,6 +40,12 @@ function EntityInfo(props: Props) {
           <td>{renderShape(entity.shape)}</td>
         </tr>
       )}
+      {isDataset(entity) && entity.chunks && (
+        <tr>
+          <th scope="row">Chunks</th>
+          <td>{renderShape(entity.chunks)}</td>
+        </tr>
+      )}
       {entity.link?.path && (
         <tr>
           <th scope="row">{entity.link.class} link</th>

--- a/packages/app/src/metadata-viewer/FiltersInfo.tsx
+++ b/packages/app/src/metadata-viewer/FiltersInfo.tsx
@@ -1,0 +1,26 @@
+import type { Filter } from '@h5web/shared';
+
+interface Props {
+  filters: Filter[];
+}
+
+function FiltersInfo(props: Props) {
+  const { filters } = props;
+
+  return (
+    <>
+      {filters.map((filter) => {
+        const { name, id } = filter;
+
+        return (
+          <tr key={id}>
+            <th scope="row">{id}</th>
+            <td>{name}</td>
+          </tr>
+        );
+      })}
+    </>
+  );
+}
+
+export default FiltersInfo;

--- a/packages/app/src/metadata-viewer/MetadataViewer.tsx
+++ b/packages/app/src/metadata-viewer/MetadataViewer.tsx
@@ -1,4 +1,9 @@
-import { buildEntityPath, EntityKind, isAbsolutePath } from '@h5web/shared';
+import {
+  buildEntityPath,
+  EntityKind,
+  isAbsolutePath,
+  isDataset,
+} from '@h5web/shared';
 import { capitalize } from 'lodash';
 import { Suspense, memo, useContext } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
@@ -8,6 +13,7 @@ import AttrErrorFallback from './AttrErrorFallback';
 import AttrValueLoader from './AttrValueLoader';
 import AttributesInfo from './AttributesInfo';
 import EntityInfo from './EntityInfo';
+import FiltersInfo from './FiltersInfo';
 import MetadataTable from './MetadataTable';
 import styles from './MetadataViewer.module.css';
 
@@ -50,6 +56,12 @@ function MetadataViewer(props: Props) {
               />
             </Suspense>
           </ErrorBoundary>
+        </MetadataTable>
+      )}
+
+      {isDataset(entity) && entity.filters && (
+        <MetadataTable title="Compression filters">
+          <FiltersInfo filters={entity.filters} />
         </MetadataTable>
       )}
     </div>

--- a/packages/app/src/providers/h5grove/h5grove-api.ts
+++ b/packages/app/src/providers/h5grove/h5grove-api.ts
@@ -30,7 +30,7 @@ import {
 } from './utils';
 
 export class H5GroveApi extends ProviderApi {
-  /* API compatible with h5grove@0.0.13 */
+  /* API compatible with h5grove@0.0.16 */
   public constructor(
     url: string,
     filepath: string,
@@ -172,7 +172,13 @@ export class H5GroveApi extends ProviderApi {
     }
 
     if (isDatasetResponse(response)) {
-      const { attributes: attrsMetadata, dtype, shape } = response;
+      const {
+        attributes: attrsMetadata,
+        dtype,
+        shape,
+        chunks,
+        filters,
+      } = response;
       const attributes = await this.processAttrsMetadata(path, attrsMetadata);
 
       return {
@@ -181,6 +187,8 @@ export class H5GroveApi extends ProviderApi {
         shape,
         type: convertDtype(dtype),
         rawType: dtype,
+        ...(chunks && { chunks }),
+        ...(filters && { filters }),
       } as Dataset;
     }
 

--- a/packages/app/src/providers/h5grove/models.ts
+++ b/packages/app/src/providers/h5grove/models.ts
@@ -1,4 +1,4 @@
-import type { AttributeValues, EntityKind } from '@h5web/shared';
+import type { AttributeValues, EntityKind, Filter } from '@h5web/shared';
 
 export interface H5GroveEntityResponse {
   name: string;
@@ -15,6 +15,8 @@ export interface H5GroveDatasetResponse extends H5GroveEntityResponse {
   dtype: string;
   shape: number[];
   attributes: H5GroveAttribute[];
+  chunks: number[] | null;
+  filters: Filter[] | null;
 }
 
 export interface H5GroveGroupResponse extends H5GroveEntityResponse {

--- a/packages/shared/src/models-hdf5.ts
+++ b/packages/shared/src/models-hdf5.ts
@@ -32,6 +32,8 @@ export interface Dataset<S extends Shape = Shape, T extends DType = DType>
   shape: S;
   type: T;
   rawType?: unknown;
+  chunks?: number[];
+  filters?: Filter[];
 }
 
 export interface Datatype<T = DType> extends Entity {
@@ -171,3 +173,8 @@ export type AttributeValues = Record<string, unknown>;
 
 export type H5WebComplex = [number, number];
 export type ComplexArray = (ComplexArray | H5WebComplex)[];
+
+export interface Filter {
+  id: number;
+  name: string;
+}


### PR DESCRIPTION
Fix #311 

Requires h5grove [v0.0.16](https://github.com/silx-kit/h5grove/releases/tag/v0.0.16)

**Updated** example on the compressed dataset in **water_224.h5**:
![image](https://user-images.githubusercontent.com/42204205/165552343-7a562e58-cb8f-4ad8-9f4d-abebea0f7df9.png)


You can also look at [compressed.h5](http://localhost:3000/h5grove?file=compressed.h5) for more examples