### PR TITLE
Revert CI triggers but skip double runs

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,14 +1,16 @@
 name: Lint & Test
 
 on:
+  pull_request: # for PRs from forks
   push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+    branches-ignore:
+      - 'update-snapshots'
 
 jobs:
   lint:
     runs-on: ubuntu-latest
+    # Skip `pull_request` runs on local PRs for which `push` runs are already triggered
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout 🏷️
         uses: actions/checkout@v2
@@ -38,6 +40,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    # Skip `pull_request` runs on local PRs for which `push` runs are already triggered
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout 🏷️
         uses: actions/checkout@v2
@@ -69,6 +73,8 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+    # Skip `pull_request` runs on local PRs for which `push` runs are already triggered
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout 🏷️
         uses: actions/checkout@v2


### PR DESCRIPTION
So I've looked a bit more into it and it really sucks... Only way I could find is to add a condition to each job to skip it if it's triggered by a local PR. Downside is that the skipped jobs still appear in the UI.

Running the CI on `push` to any branch is quite convenient in my opinion for a few reasons:

- By the time you open the PR, the CI is likely to have already passed, which means you can be sure it's ready to be reviewed. This saves us a lot of time on a day-to-day basis.
- If you push a new branch and you know you forgot to fix the linting or the tests, you can cancel the CI run or force-push the fixes before opening the PR.
- If you work on something that might affect the screenshots or the CI workflows themselves, it can be useful have a branch to push to before you can be sure that the solution you settle on is correct and worthy of a PR. Arguable, since you can always open a draft PR.

Let me know what you prefer: skipped jobs in the UI vs the points above.

![image](https://user-images.githubusercontent.com/2936402/165703180-c1ed9020-d572-4c17-9c16-9ed7bb9e36dc.png)
