### PR TITLE
TiledHeatmapMesh: added supports of scene transforms

### DIFF
--- a/apps/storybook/src/TiledHeatmapMesh.stories.tsx
+++ b/apps/storybook/src/TiledHeatmapMesh.stories.tsx
@@ -132,7 +132,7 @@ interface TiledHeatmapStoryProps extends TiledHeatmapMeshProps {
 }
 
 const Template: Story<TiledHeatmapStoryProps> = (args) => {
-  const { abscissaConfig, api, ordinateConfig, ...tiledHeatmapProps } = args;
+  const { abscissaConfig, ordinateConfig, ...tiledHeatmapProps } = args;
 
   return (
     <VisCanvas
@@ -150,7 +150,7 @@ const Template: Story<TiledHeatmapStoryProps> = (args) => {
       <group
         scale={[abscissaConfig.flip ? -1 : 1, ordinateConfig.flip ? -1 : 1, 1]}
       >
-        <TiledHeatmapMesh api={api} {...tiledHeatmapProps} />
+        <TiledHeatmapMesh {...tiledHeatmapProps} />
       </group>
     </VisCanvas>
   );
@@ -224,7 +224,7 @@ FlippedAxes.args = {
 
 function LinearAxesGroup(props: { children: ReactNode }) {
   const { children } = props;
-  const { visSize, abscissaConfig, ordinateConfig } = useAxisSystemContext();
+  const { abscissaConfig, ordinateConfig, visSize } = useAxisSystemContext();
   const { width, height } = visSize;
   const sx =
     ((abscissaConfig.flip ? -1 : 1) * width) /
@@ -236,7 +236,7 @@ function LinearAxesGroup(props: { children: ReactNode }) {
   const y = 0.5 * (ordinateConfig.visDomain[0] + ordinateConfig.visDomain[1]);
 
   return (
-    <group scale={[sx, sy, 1]} position={[-x * sx, -y * sy, 0]}>
+    <group position={[-x * sx, -y * sy, 0]} scale={[sx, sy, 1]}>
       {children}
     </group>
   );
@@ -283,7 +283,7 @@ WithTransforms.args = {
     visDomain: [0, 2],
     isIndexAxis: true,
     showGrid: false,
-    flip: true,
+    flip: false,
   },
 };
 

--- a/apps/storybook/src/TiledHeatmapMesh.stories.tsx
+++ b/apps/storybook/src/TiledHeatmapMesh.stories.tsx
@@ -147,7 +147,11 @@ const Template: Story<TiledHeatmapStoryProps> = (args) => {
       <Zoom />
       <SelectToZoom keepRatio modifierKey="Control" />
       <ResetZoomButton />
-      <TiledHeatmapMesh api={api} {...tiledHeatmapProps} />
+      <group
+        scale={[abscissaConfig.flip ? -1 : 1, ordinateConfig.flip ? -1 : 1, 1]}
+      >
+        <TiledHeatmapMesh api={api} {...tiledHeatmapProps} />
+      </group>
     </VisCanvas>
   );
 };
@@ -223,16 +227,25 @@ function LinearAxesGroup(props: { children: ReactNode }) {
   const { visSize, abscissaConfig, ordinateConfig } = useAxisSystemContext();
   const { width, height } = visSize;
   const sx =
-    width / (abscissaConfig.visDomain[1] - abscissaConfig.visDomain[0]);
+    ((abscissaConfig.flip ? -1 : 1) * width) /
+    (abscissaConfig.visDomain[1] - abscissaConfig.visDomain[0]);
   const sy =
-    height / (ordinateConfig.visDomain[1] - ordinateConfig.visDomain[0]);
+    ((ordinateConfig.flip ? -1 : 1) * height) /
+    (ordinateConfig.visDomain[1] - ordinateConfig.visDomain[0]);
+  const x = 0.5 * (abscissaConfig.visDomain[0] + abscissaConfig.visDomain[1]);
+  const y = 0.5 * (ordinateConfig.visDomain[0] + ordinateConfig.visDomain[1]);
 
-  return <group scale={[sx, sy, 1]}>{children}</group>;
+  return (
+    <group scale={[sx, sy, 1]} position={[-x * sx, -y * sy, 0]}>
+      {children}
+    </group>
+  );
 }
 
 export const WithTransforms: Story<TiledHeatmapStoryProps> = (args) => {
   const { abscissaConfig, api, ordinateConfig, ...tiledHeatmapProps } = args;
-  const size = { width: 1, height: 1 };
+  const { baseLayerSize } = api;
+  const size = { width: 1, height: baseLayerSize.height / baseLayerSize.width };
 
   return (
     <VisCanvas
@@ -248,7 +261,7 @@ export const WithTransforms: Story<TiledHeatmapStoryProps> = (args) => {
       <SelectToZoom keepRatio modifierKey="Control" />
       <ResetZoomButton />
       <LinearAxesGroup>
-        <group rotation={[0, 0, Math.PI / 4]} position={[1, -1, 0]}>
+        <group position={[1, 1, 0]} rotation={[0, 0, Math.PI / 4]}>
           <TiledHeatmapMesh api={api} {...tiledHeatmapProps} size={size} />
         </group>
         <group position={[-1, 1, 0]} scale={[2, 2, 1]}>
@@ -259,16 +272,18 @@ export const WithTransforms: Story<TiledHeatmapStoryProps> = (args) => {
   );
 };
 WithTransforms.args = {
-  api: defaultApi,
+  api: halfMandelbrotApi,
   abscissaConfig: {
-    visDomain: [-2, 2],
+    visDomain: [-2, 1.5],
     isIndexAxis: true,
     showGrid: false,
+    flip: false,
   },
   ordinateConfig: {
-    visDomain: [-2, 2],
+    visDomain: [0, 2],
     isIndexAxis: true,
     showGrid: false,
+    flip: true,
   },
 };
 

--- a/apps/storybook/src/TiledHeatmapMesh.stories.tsx
+++ b/apps/storybook/src/TiledHeatmapMesh.stories.tsx
@@ -7,6 +7,7 @@ import {
   TilesApi,
   ResetZoomButton,
   SelectToZoom,
+  useAxisSystemContext,
 } from '@h5web/lib';
 import type {
   Domain,
@@ -19,6 +20,7 @@ import type { Meta, Story } from '@storybook/react/types-6-0';
 import { clamp } from 'lodash';
 import ndarray from 'ndarray';
 import type { NdArray } from 'ndarray';
+import type { ReactNode } from 'react';
 import { createFetchStore } from 'react-suspense-fetch';
 import type { Vector2 } from 'three';
 
@@ -213,6 +215,60 @@ FlippedAxes.args = {
     isIndexAxis: true,
     showGrid: false,
     flip: true,
+  },
+};
+
+function LinearAxesGroup(props: { children: ReactNode }) {
+  const { children } = props;
+  const { visSize, abscissaConfig, ordinateConfig } = useAxisSystemContext();
+  const { width, height } = visSize;
+  const sx =
+    width / (abscissaConfig.visDomain[1] - abscissaConfig.visDomain[0]);
+  const sy =
+    height / (ordinateConfig.visDomain[1] - ordinateConfig.visDomain[0]);
+
+  return <group scale={[sx, sy, 1]}>{children}</group>;
+}
+
+export const WithTransforms: Story<TiledHeatmapStoryProps> = (args) => {
+  const { abscissaConfig, api, ordinateConfig, ...tiledHeatmapProps } = args;
+  const size = { width: 1, height: 1 };
+
+  return (
+    <VisCanvas
+      abscissaConfig={abscissaConfig}
+      ordinateConfig={ordinateConfig}
+      visRatio={Math.abs(
+        (abscissaConfig.visDomain[1] - abscissaConfig.visDomain[0]) /
+          (ordinateConfig.visDomain[1] - ordinateConfig.visDomain[0])
+      )}
+    >
+      <Pan />
+      <Zoom />
+      <SelectToZoom keepRatio modifierKey="Control" />
+      <ResetZoomButton />
+      <LinearAxesGroup>
+        <group rotation={[0, 0, Math.PI / 4]} position={[1, -1, 0]}>
+          <TiledHeatmapMesh api={api} {...tiledHeatmapProps} size={size} />
+        </group>
+        <group position={[-1, 1, 0]} scale={[2, 2, 1]}>
+          <TiledHeatmapMesh api={api} {...tiledHeatmapProps} size={size} />
+        </group>
+      </LinearAxesGroup>
+    </VisCanvas>
+  );
+};
+WithTransforms.args = {
+  api: defaultApi,
+  abscissaConfig: {
+    visDomain: [-2, 2],
+    isIndexAxis: true,
+    showGrid: false,
+  },
+  ordinateConfig: {
+    visDomain: [-2, 2],
+    isIndexAxis: true,
+    showGrid: false,
   },
 };
 

--- a/packages/lib/src/vis/tiles/TiledHeatmapMesh.tsx
+++ b/packages/lib/src/vis/tiles/TiledHeatmapMesh.tsx
@@ -1,18 +1,22 @@
 import { useThree } from '@react-three/fiber';
 import { clamp, range } from 'lodash';
+import { useRef } from 'react';
+import type { Group } from 'three';
 
 import { getInterpolator } from '../heatmap/utils';
 import { useCameraState } from '../hooks';
+import type { Size } from '../models';
 import { useAxisSystemContext } from '../shared/AxisSystemProvider';
 import TiledLayer from './TiledLayer';
 import type { TilesApi } from './api';
 import type { ColorMapProps } from './models';
-import { getScaledVisibleDomains } from './utils';
+import { getScaledVisibleBox } from './utils';
 
 interface Props extends ColorMapProps {
   api: TilesApi;
   displayLowerResolutions?: boolean;
   qualityFactor?: number;
+  size?: Size;
 }
 
 function TiledHeatmapMesh(props: Props) {
@@ -20,52 +24,66 @@ function TiledHeatmapMesh(props: Props) {
     api,
     displayLowerResolutions = true,
     qualityFactor = 1, // 0: Lower quality, less fetch; 1: Best quality
+    size,
     ...colorMapProps
   } = props;
   const { baseLayerIndex, baseLayerSize } = api;
 
   const canvasSize = useThree((state) => state.size);
   const { visSize } = useAxisSystemContext();
+  const meshSize = size ?? visSize;
 
-  const { xVisibleDomain, yVisibleDomain } = useCameraState(
-    (...args) => getScaledVisibleDomains(...args, baseLayerSize),
-    [baseLayerSize]
+  const groupRef = useRef<Group>(null);
+
+  const box = useCameraState(
+    (...args) =>
+      getScaledVisibleBox(...args, meshSize, baseLayerSize, groupRef),
+    [meshSize, baseLayerSize, groupRef]
   );
 
-  const itemsPerPixel = Math.max(
-    1,
-    Math.abs(xVisibleDomain[1] - xVisibleDomain[0]) / canvasSize.width,
-    Math.abs(yVisibleDomain[1] - yVisibleDomain[0]) / canvasSize.height
-  );
+  let layers: number[] = [];
+  if (box) {
+    const itemsPerPixel = Math.max(
+      1,
+      Math.abs(box.max.x - box.min.x) / canvasSize.width,
+      Math.abs(box.max.y - box.min.y) / canvasSize.height
+    );
 
-  const roundingOffset = 1 - clamp(qualityFactor, 0, 1);
-  const subsamplingLevel = Math.min(
-    Math.floor(Math.log2(itemsPerPixel) + roundingOffset),
-    baseLayerIndex
-  );
-  const currentLayerIndex = baseLayerIndex - subsamplingLevel;
+    const roundingOffset = 1 - clamp(qualityFactor, 0, 1);
+    const subsamplingLevel = Math.min(
+      Math.floor(Math.log2(itemsPerPixel) + roundingOffset),
+      baseLayerIndex
+    );
+    const currentLayerIndex = baseLayerIndex - subsamplingLevel;
 
-  // displayLowerResolutions selects which levels of detail layers are displayed:
-  // true: lower resolution layers displayed behind the current one
-  // false: only current level of detail layer is displayed
-  const layers = displayLowerResolutions
-    ? range(currentLayerIndex + 1)
-    : [currentLayerIndex];
+    // displayLowerResolutions selects which levels of detail layers are displayed:
+    // true: lower resolution layers displayed behind the current one
+    // false: only current level of detail layer is displayed
+    layers = displayLowerResolutions
+      ? range(currentLayerIndex + 1)
+      : [currentLayerIndex];
+  }
 
   const { colorMap, invertColorMap = false } = colorMapProps;
 
   return (
-    <>
+    <group ref={groupRef}>
       <mesh position={[0, 0, -0.1]}>
-        <planeGeometry args={[visSize.width, visSize.height]} />
+        <planeGeometry args={[meshSize.width, meshSize.height]} />
         <meshBasicMaterial
           color={getInterpolator(colorMap, invertColorMap)(0)}
         />
       </mesh>
       {layers.map((layer) => (
-        <TiledLayer key={layer} api={api} layer={layer} {...colorMapProps} />
+        <TiledLayer
+          key={layer}
+          api={api}
+          layer={layer}
+          size={meshSize}
+          {...colorMapProps}
+        />
       ))}
-    </>
+    </group>
   );
 }
 

--- a/packages/lib/src/vis/tiles/TiledLayer.tsx
+++ b/packages/lib/src/vis/tiles/TiledLayer.tsx
@@ -27,7 +27,6 @@ function TiledLayer(props: Props) {
   const layerSize = api.layerSizes[layer];
 
   const groupRef = useRef<Group>(null);
-  const { abscissaConfig, ordinateConfig } = useAxisSystemContext();
   const box = useCameraState(
     (...args) => getScaledVisibleBox(...args, meshSize, layerSize, groupRef),
     [meshSize, layerSize, groupRef]
@@ -42,11 +41,8 @@ function TiledLayer(props: Props) {
   }
 
   return (
-    // Transforms to handle axes flip and use level of details layer array coordinates
-    <group
-      ref={groupRef}
-      scale={[abscissaConfig.flip ? -1 : 1, ordinateConfig.flip ? -1 : 1, 1]}
-    >
+    // Transforms to use level of details layer array coordinates
+    <group ref={groupRef}>
       <group
         position={[
           -meshSize.width / 2,

--- a/packages/lib/src/vis/tiles/utils.ts
+++ b/packages/lib/src/vis/tiles/utils.ts
@@ -1,28 +1,25 @@
-import type { Domain } from '@h5web/shared';
 import { ScaleType } from '@h5web/shared';
 import type { Camera } from '@react-three/fiber';
-import { Vector2 } from 'three';
+import type { RefObject } from 'react';
+import { Box2, Box3, Matrix4, Vector2, Vector3 } from 'three';
+import type { Object3D } from 'three';
 
 import type { Size } from '../models';
 import type { AxisSystemContextValue } from '../shared/AxisSystemProvider';
-import { createAxisScale, getVisibleDomains, isDescending } from '../utils';
+import { createAxisScale } from '../utils';
 
-export function getTileOffsets(
-  xDomain: Domain,
-  yDomain: Domain,
-  tileSize: Size
-): Vector2[] {
+export function getTileOffsets(box: Box2, tileSize: Size): Vector2[] {
   const { width, height } = tileSize;
-
-  const [xMin, xMax] = isDescending(xDomain) ? [...xDomain].reverse() : xDomain;
-  const [yMin, yMax] = isDescending(yDomain) ? [...yDomain].reverse() : yDomain;
-
-  const nCols = Math.ceil(((xMin % width) + xMax - xMin) / width);
-  const nRows = Math.ceil(((yMin % height) + yMax - yMin) / height);
+  const nCols = Math.ceil(
+    ((box.min.x % width) + box.max.x - box.min.x) / width
+  );
+  const nRows = Math.ceil(
+    ((box.min.y % height) + box.max.y - box.min.y) / height
+  );
 
   const start = new Vector2(
-    Math.floor(xMin / width) * width,
-    Math.floor(yMin / height) * height
+    Math.floor(box.min.x / width) * width,
+    Math.floor(box.min.y / height) * height
   );
 
   const centers: Vector2[] = [];
@@ -50,32 +47,51 @@ export function sortTilesByDistanceTo(
   });
 }
 
-export function getScaledVisibleDomains(
+const NDC_BOX = new Box3(new Vector3(-1, -1, -1), new Vector3(1, 1, 1));
+
+function getObject3DVisibleBox(
   camera: Camera,
   context: AxisSystemContextValue,
-  size: Size
-): {
-  xVisibleDomain: Domain;
-  yVisibleDomain: Domain;
-} {
-  const { abscissaConfig, ordinateConfig } = context;
-  const { width, height } = size;
-  const { xVisibleDomain, yVisibleDomain } = getVisibleDomains(camera, context);
+  Object3DRef: RefObject<Object3D>
+): Box3 | undefined {
+  const object3D = Object3DRef.current;
+  if (!object3D) {
+    return undefined;
+  }
 
-  const xScale = createAxisScale(abscissaConfig.scaleType ?? ScaleType.Linear, {
-    domain: abscissaConfig.visDomain,
-    range: [0, width],
+  // Convert view box: Normalized Device Coordinates -> camera -> world -> local
+  const matrix = new Matrix4()
+    .multiplyMatrices(object3D.matrixWorld.invert(), camera.matrixWorld)
+    .multiply(camera.projectionMatrixInverse);
+  return NDC_BOX.clone().applyMatrix4(matrix);
+}
+
+export function getScaledVisibleBox(
+  camera: Camera,
+  context: AxisSystemContextValue,
+  meshSize: Size,
+  arraySize: Size,
+  ref: RefObject<Object3D>
+): Box2 | undefined {
+  const box3d = getObject3DVisibleBox(camera, context, ref);
+  if (!box3d) {
+    return undefined;
+  }
+
+  const xScale = createAxisScale(ScaleType.Linear, {
+    domain: [-meshSize.width / 2, meshSize.width / 2],
+    range: [0, arraySize.width],
     clamp: true,
   });
 
-  const yScale = createAxisScale(ordinateConfig.scaleType ?? ScaleType.Linear, {
-    domain: ordinateConfig.visDomain,
-    range: [0, height],
+  const yScale = createAxisScale(ScaleType.Linear, {
+    domain: [-meshSize.height / 2, meshSize.height / 2],
+    range: [0, arraySize.height],
     clamp: true,
   });
 
-  return {
-    xVisibleDomain: xVisibleDomain.map(xScale) as Domain,
-    yVisibleDomain: yVisibleDomain.map(yScale) as Domain,
-  };
+  return new Box2().setFromPoints([
+    new Vector2(xScale(box3d.min.x), yScale(box3d.min.y)),
+    new Vector2(xScale(box3d.max.x), yScale(box3d.max.y)),
+  ]);
 }


### PR DESCRIPTION
This PR renders usage of TiledHeatmapMesh more generic.
The computation of requested tiles no longer relies on the axes (thanks @axelboc!) and should also handle almost any transforms.

<img width="800" alt="Screen Shot 2022-05-03 at 18 27 19" src="https://user-images.githubusercontent.com/9449698/166496071-8b73729b-fe6c-470e-832d-fa994f1f6feb.png">
