### PR TITLE
Add a VisGroup (for linear axes only)

### DIFF
--- a/apps/storybook/src/VisGroup.stories.tsx
+++ b/apps/storybook/src/VisGroup.stories.tsx
@@ -33,12 +33,12 @@ const Template: Story<VisGroupStoryProps> = (args) => {
           <planeGeometry args={[20, 20]} />
           <meshBasicMaterial color="rgb(255, 0, 0)" />
         </mesh>
-        {points.map((pt) => (
-          <Annotation key={`${pt.x},${pt.y}`} center x={pt.x} y={pt.y}>
-            ({pt.x}, {pt.y})
-          </Annotation>
-        ))}
       </VisGroup>
+      {points.map((pt) => (
+        <Annotation key={`${pt.x},${pt.y}`} center x={pt.x} y={pt.y}>
+          ({pt.x}, {pt.y})
+        </Annotation>
+      ))}
     </VisCanvas>
   );
 };
@@ -52,7 +52,7 @@ Default.args = {
     flip: false,
   },
   ordinateConfig: {
-    visDomain: [0, 40],
+    visDomain: [40, 0],
     isIndexAxis: true,
     showGrid: false,
     flip: false,
@@ -68,7 +68,7 @@ FlippedAxes.args = {
     flip: true,
   },
   ordinateConfig: {
-    visDomain: [0, 40],
+    visDomain: [40, 0],
     isIndexAxis: true,
     showGrid: false,
     flip: true,

--- a/apps/storybook/src/VisGroup.stories.tsx
+++ b/apps/storybook/src/VisGroup.stories.tsx
@@ -1,0 +1,83 @@
+import type { AxisConfig } from '@h5web/lib';
+import {
+  Annotation,
+  Pan,
+  ResetZoomButton,
+  VisCanvas,
+  VisGroup,
+  Zoom,
+} from '@h5web/lib';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+
+import FillHeight from './decorators/FillHeight';
+
+interface VisGroupStoryProps {
+  abscissaConfig: AxisConfig;
+  ordinateConfig: AxisConfig;
+}
+
+const Template: Story<VisGroupStoryProps> = (args) => {
+  const points = [
+    { x: 10, y: 10 },
+    { x: 30, y: 10 },
+    { x: 30, y: 30 },
+    { x: 10, y: 30 },
+  ];
+  return (
+    <VisCanvas {...args}>
+      <Pan />
+      <Zoom />
+      <ResetZoomButton />
+      <VisGroup>
+        <mesh position={[20, 20, 0]}>
+          <planeGeometry args={[20, 20]} />
+          <meshBasicMaterial color="rgb(255, 0, 0)" />
+        </mesh>
+        {points.map((pt) => (
+          <Annotation key={`${pt.x},${pt.y}`} center x={pt.x} y={pt.y}>
+            ({pt.x}, {pt.y})
+          </Annotation>
+        ))}
+      </VisGroup>
+    </VisCanvas>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  abscissaConfig: {
+    visDomain: [0, 50],
+    isIndexAxis: true,
+    showGrid: false,
+    flip: false,
+  },
+  ordinateConfig: {
+    visDomain: [0, 40],
+    isIndexAxis: true,
+    showGrid: false,
+    flip: false,
+  },
+};
+
+export const FlippedAxes = Template.bind({});
+FlippedAxes.args = {
+  abscissaConfig: {
+    visDomain: [0, 50],
+    isIndexAxis: true,
+    showGrid: false,
+    flip: true,
+  },
+  ordinateConfig: {
+    visDomain: [0, 40],
+    isIndexAxis: true,
+    showGrid: false,
+    flip: true,
+  },
+};
+
+export default {
+  title: 'Experimental/VisGroup',
+  component: VisGroup,
+  decorators: [FillHeight],
+  parameters: { layout: 'fullscreen', controls: { sort: 'requiredFirst' } },
+} as Meta;

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -124,6 +124,8 @@ export { default as CellWidthInput } from './toolbar/controls/CellWidthInput';
 export { default as RawVis } from './vis/raw/RawVis';
 export { default as ScalarVis } from './vis/scalar/ScalarVis';
 export { default as RgbVis } from './vis/rgb/RgbVis';
+export { default as VisGroup } from './vis/shared/VisGroup';
+export type { VisGroupProps } from './vis/shared/VisGroup';
 export { default as VisMesh } from './vis/shared/VisMesh';
 export { default as ScatterPoints } from './vis/scatter/ScatterPoints';
 export { default as TiledHeatmapMesh } from './vis/tiles/TiledHeatmapMesh';

--- a/packages/lib/src/vis/shared/VisGroup.tsx
+++ b/packages/lib/src/vis/shared/VisGroup.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from 'react';
+
+import { useAxisSystemContext } from './AxisSystemProvider';
+
+interface Props {
+  children: ReactNode;
+}
+
+function VisGroup(props: Props) {
+  const { children } = props;
+  const { abscissaConfig, ordinateConfig, visSize } = useAxisSystemContext();
+  const { width, height } = visSize;
+
+  const sx =
+    ((abscissaConfig.flip ? -1 : 1) * width) /
+    (abscissaConfig.visDomain[1] - abscissaConfig.visDomain[0]);
+  const sy =
+    ((ordinateConfig.flip ? -1 : 1) * height) /
+    (ordinateConfig.visDomain[1] - ordinateConfig.visDomain[0]);
+  const x = 0.5 * (abscissaConfig.visDomain[0] + abscissaConfig.visDomain[1]);
+  const y = 0.5 * (ordinateConfig.visDomain[0] + ordinateConfig.visDomain[1]);
+
+  return (
+    <group position={[-x * sx, -y * sy, 0]} scale={[sx, sy, 1]}>
+      {children}
+    </group>
+  );
+}
+
+export type { Props as VisGroupProps };
+export default VisGroup;

--- a/packages/lib/src/vis/shared/VisGroup.tsx
+++ b/packages/lib/src/vis/shared/VisGroup.tsx
@@ -1,15 +1,23 @@
-import type { ReactNode } from 'react';
+import { ScaleType } from '@h5web/shared';
+import type { PropsWithChildren } from 'react';
 
 import { useAxisSystemContext } from './AxisSystemProvider';
 
-interface Props {
-  children: ReactNode;
-}
+interface Props {}
 
-function VisGroup(props: Props) {
+function VisGroup(props: PropsWithChildren<Props>) {
   const { children } = props;
   const { abscissaConfig, ordinateConfig, visSize } = useAxisSystemContext();
   const { width, height } = visSize;
+  const { scaleType: abscissaScaleType = ScaleType.Linear } = abscissaConfig;
+  const { scaleType: ordinateScaleType = ScaleType.Linear } = ordinateConfig;
+
+  if (
+    abscissaScaleType !== ScaleType.Linear ||
+    ordinateScaleType !== ScaleType.Linear
+  ) {
+    throw new Error('VisGroup supports only linear axes');
+  }
 
   const sx =
     ((abscissaConfig.flip ? -1 : 1) * width) /
@@ -17,11 +25,13 @@ function VisGroup(props: Props) {
   const sy =
     ((ordinateConfig.flip ? -1 : 1) * height) /
     (ordinateConfig.visDomain[1] - ordinateConfig.visDomain[0]);
-  const x = 0.5 * (abscissaConfig.visDomain[0] + abscissaConfig.visDomain[1]);
-  const y = 0.5 * (ordinateConfig.visDomain[0] + ordinateConfig.visDomain[1]);
+  const centerX =
+    0.5 * (abscissaConfig.visDomain[0] + abscissaConfig.visDomain[1]);
+  const centerY =
+    0.5 * (ordinateConfig.visDomain[0] + ordinateConfig.visDomain[1]);
 
   return (
-    <group position={[-x * sx, -y * sy, 0]} scale={[sx, sy, 1]}>
+    <group position={[-centerX * sx, -centerY * sy, 0]} scale={[sx, sy, 1]}>
       {children}
     </group>
   );


### PR DESCRIPTION
This PR proposes to have a threejs group that uses the coordinates defined by the axes system.
There is a huge obvious limitation in that it only supports linear axes (I was wondering whether to raise an error or not to display anything in this case).
But when using linear axes, it helps organising multiple meshes in a "data" coordinate system.

What do you think?

Extracted from story in #1096