### PR TITLE
Add prop `overflowCanvas` to `Html` and `Annotation`

### DIFF
--- a/apps/storybook/src/Html.stories.tsx
+++ b/apps/storybook/src/Html.stories.tsx
@@ -5,13 +5,43 @@ import { createPortal } from 'react-dom';
 
 import FillHeight from './decorators/FillHeight';
 
-interface Props {
+export const Default: Story<{ overflowCanvas: boolean }> = (args) => {
+  const { overflowCanvas } = args;
+  return (
+    <VisCanvas
+      abscissaConfig={{ visDomain: [0, 3], showGrid: true }}
+      ordinateConfig={{ visDomain: [50, 100], showGrid: true }}
+    >
+      <Html overflowCanvas={overflowCanvas}>
+        <div
+          style={{
+            position: 'absolute',
+            top: 30,
+            left: -50,
+            width: '30em',
+            padding: '0.5rem',
+            border: '3px solid blue',
+            textAlign: 'center',
+          }}
+        >
+          This <code>div</code>{' '}
+          <strong>{overflowCanvas ? 'overflows' : 'does not overflow'}</strong>{' '}
+          the canvas.
+        </div>
+      </Html>
+    </VisCanvas>
+  );
+};
+
+Default.args = {
+  overflowCanvas: false,
+};
+
+export const Container: Story<{
   outside: boolean;
   mounted: boolean;
-}
-
-export const Default: Story<Props> = (props) => {
-  const { outside, mounted } = props;
+}> = (args) => {
+  const { outside, mounted } = args;
   const [outsideContainer, setOutsideContainer] = useState<HTMLDivElement>();
   const [portalContainer, setPortalContainer] = useState<HTMLDivElement>();
 
@@ -52,14 +82,13 @@ export const Default: Story<Props> = (props) => {
   );
 };
 
-Default.args = {
+Container.args = {
   outside: false,
   mounted: true,
 };
 
 export default {
   title: 'Building Blocks/Html',
-  component: Default,
   parameters: { layout: 'fullscreen' },
   decorators: [FillHeight],
 } as Meta;

--- a/packages/lib/src/vis/shared/Annotation.tsx
+++ b/packages/lib/src/vis/shared/Annotation.tsx
@@ -8,12 +8,22 @@ import Html from './Html';
 interface Props extends HTMLAttributes<HTMLDivElement> {
   x: number;
   y: number;
+  overflowCanvas?: boolean;
   scaleOnZoom?: boolean;
   center?: boolean;
 }
 
 function Annotation(props: Props) {
-  const { x, y, scaleOnZoom, center, children, style, ...divProps } = props;
+  const {
+    x,
+    y,
+    overflowCanvas,
+    scaleOnZoom,
+    center,
+    children,
+    style,
+    ...divProps
+  } = props;
 
   if ((center || scaleOnZoom) && style?.transform) {
     throw new Error(
@@ -35,7 +45,7 @@ function Annotation(props: Props) {
   ];
 
   return (
-    <Html>
+    <Html overflowCanvas={overflowCanvas}>
       <div
         style={{
           position: 'absolute',

--- a/packages/lib/src/vis/shared/Html.tsx
+++ b/packages/lib/src/vis/shared/Html.tsx
@@ -4,13 +4,25 @@ import type { ReactNode } from 'react';
 import ReactDOM from 'react-dom';
 
 interface Props {
+  overflowCanvas?: boolean;
   container?: HTMLElement;
   children?: ReactNode;
 }
 
 function Html(props: Props) {
-  const gl = useThree((state) => state.gl);
-  const { container = gl.domElement.parentElement, children } = props;
+  const {
+    overflowCanvas = false,
+    container: customContainer,
+    children,
+  } = props;
+
+  const r3fRoot = useThree((state) => state.gl.domElement.parentElement);
+  const canvasWrapper = r3fRoot?.parentElement;
+
+  // Choose DOM container in which to append `renderTarget`
+  // (`r3fRoot` hides overflow but its parent, `canvasWrapper`, does not -- cf. `VisCanvas`)
+  const container =
+    customContainer || (overflowCanvas ? canvasWrapper : r3fRoot);
 
   const [renderTarget] = useState(() => document.createElement('div'));
 


### PR DESCRIPTION
This brings:

- a way for `Annotation` to overflow the canvas, following #1105, as requested by @vallsv 
- a more convenient way to move an `Html` component to `canvasWrapper` to show the overflow (than setting the `container` prop manually). The `container` prop can still be set and takes priority over `overflowCanvas`.