### PR TITLE
Move mandlebrot to web worker in tiled heatmap story

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -84,6 +84,12 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 
+      - name: Cache Cypress binary 📌
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/Cypress
+          key: cypress-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
       - name: Install ⚙️
         run: pnpm install --frozen-lockfile
 

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -26,6 +26,7 @@
     "@react-hookz/web": "14.2.2",
     "@react-three/fiber": "7.0.26",
     "d3-format": "3.1.0",
+    "greenlet": "1.1.0",
     "lodash": "4.17.21",
     "ndarray": "1.0.19",
     "normalize.css": "8.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,7 @@ importers:
       d3-format: 3.1.0
       eslint: '>=8'
       eslint-config-galex: 3.6.5
+      greenlet: 1.1.0
       lodash: 4.17.21
       ndarray: 1.0.19
       normalize.css: 8.0.1
@@ -119,6 +120,7 @@ importers:
       '@react-hookz/web': 14.2.2_sfoxds7t5ydpegc3knd667wn6m
       '@react-three/fiber': 7.0.26_apkfqzawxbvyaakrxvzzbm6zli
       d3-format: 3.1.0
+      greenlet: 1.1.0
       lodash: 4.17.21
       ndarray: 1.0.19
       normalize.css: 8.0.1
@@ -9209,6 +9211,10 @@ packages:
   /graceful-fs/4.2.9:
     resolution: {integrity: sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==}
     dev: true
+
+  /greenlet/1.1.0:
+    resolution: {integrity: sha512-W/kKzq7ZSF/LFItIjaSaccw8L6js+9SMSS5buXZs/Td7qZAT91Kd0LTxuUjSWDwuyv4MPo/fhZdkRLV1zsuClg==}
+    dev: false
 
   /h5wasm/0.4.2:
     resolution: {integrity: sha512-RFDlZaEgBu/Aj9ei8zeVe3Rc7q69azZxtlHLJtbt1vaxBAsOjJLXW/Y9EENpbAu6CmyCR7+CMRmVtRyRcQzcWA==}


### PR DESCRIPTION
I've found a library called [greenlet](https://github.com/developit/greenlet), which works beautifully. It creates an inline worker with the function you give it: https://github.com/developit/greenlet and wraps it in a promise API. It's super tiny too.

The demo is a lot more fluid, though still not amazing on my machine, as we're still doing all the computations on the CPU. It can't compare exactly to a fetch-based scenario, but it's already a lot better.