### PR TITLE
Make E2E tests more robust

### DIFF
--- a/cypress/index.d.ts
+++ b/cypress/index.d.ts
@@ -1,0 +1,7 @@
+declare namespace Cypress {
+  interface Chainable {
+    waitForStableDOM(iteration?: number): void;
+    selectExplorerNode(name: string): void;
+    selectVisTab(name: string): void;
+  }
+}

--- a/cypress/specs/app.spec.ts
+++ b/cypress/specs/app.spec.ts
@@ -1,62 +1,54 @@
-const SNAPSHOT_DELAY = 500;
+// For ARIA-based checks
+const BE_SELECTED = ['have.attr', 'aria-selected', 'true'] as const;
+const BE_CHECKED = ['have.attr', 'aria-checked', 'true'] as const;
 
-describe('App', () => {
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe('/mock', () => {
   beforeEach(() => {
     cy.visit('/mock');
-  });
-
-  afterEach(() => {
-    window.localStorage.clear();
+    cy.waitForStableDOM();
   });
 
   it('visualize 1D dataset as Line', () => {
-    cy.findByRole('treeitem', { name: 'nD_datasets' }).click();
-    cy.findByRole('treeitem', { name: 'oneD' }).click();
+    cy.selectExplorerNode('nD_datasets');
+    cy.selectExplorerNode('oneD');
 
-    cy.findByRole('heading', { name: 'nD_datasets / oneD' }).should('exist');
-    cy.findByRole('tab', { name: 'Line' }).should('exist');
-    cy.findByRole('figure', { name: 'oneD' }).should('exist');
+    cy.findByRole('tab', { name: 'Line' }).should(...BE_SELECTED);
+    cy.findByRole('figure', { name: 'oneD' }).should('be.visible');
+    cy.findByRole('heading', { name: 'nD_datasets / oneD' }).should(
+      'be.visible'
+    );
 
     if (Cypress.env('TAKE_SNAPSHOTS')) {
-      cy.wait(SNAPSHOT_DELAY * 2); /* first spec seems to fail more often */
       cy.matchImageSnapshot('line_1D');
     }
   });
 
-  it('start with the explorer closed', () => {
-    cy.findByRole('tree').should('exist');
-
-    cy.visit('/mock?wide');
-    cy.findByRole('tree').should('not.exist');
-
-    if (Cypress.env('TAKE_SNAPSHOTS')) {
-      cy.wait(SNAPSHOT_DELAY);
-      cy.matchImageSnapshot('wide');
-    }
-  });
-
   it('visualize 1D complex dataset as Line', () => {
-    cy.findByRole('treeitem', { name: 'nD_datasets' }).click();
-    cy.findByRole('treeitem', { name: 'oneD_cplx' }).click();
+    cy.selectExplorerNode('nD_datasets');
+    cy.selectExplorerNode('oneD_cplx');
 
+    cy.findByRole('tab', { name: 'Line' }).should(...BE_SELECTED);
+    cy.findByRole('figure', { name: 'oneD_cplx' }).should('be.visible');
     cy.findByRole('heading', { name: 'nD_datasets / oneD_cplx' }).should(
-      'exist'
+      'be.visible'
     );
-    cy.findByRole('tab', { name: 'Line' }).should('exist');
-    cy.findByRole('figure', { name: 'oneD_cplx' }).should('exist');
 
     if (Cypress.env('TAKE_SNAPSHOTS')) {
-      cy.wait(SNAPSHOT_DELAY);
       cy.matchImageSnapshot('line_complex_1D');
     }
   });
 
   it('visualize 1D dataset as Matrix', () => {
-    cy.findByRole('treeitem', { name: 'nD_datasets' }).click();
-    cy.findByRole('treeitem', { name: 'oneD' }).click();
-    cy.findByRole('tab', { name: 'Matrix' }).click();
+    cy.selectExplorerNode('nD_datasets');
+    cy.selectExplorerNode('oneD');
+    cy.selectVisTab('Matrix');
 
-    cy.findByRole('table').should('exist');
+    cy.findByRole('tab', { name: 'Matrix' }).should(...BE_SELECTED);
+    cy.findByRole('table').should('be.visible');
     cy.findAllByRole('cell')
       .first()
       .should('have.attr', 'aria-rowindex', 0)
@@ -64,56 +56,48 @@ describe('App', () => {
   });
 
   it('visualize 2D dataset as Heatmap', () => {
-    // Wait for scale to update according to SILX_style on default root visualization
-    cy.findByRole('button', { name: 'SymLog' }).should('exist');
+    cy.selectExplorerNode('nD_datasets');
+    cy.selectExplorerNode('twoD');
 
-    cy.findByRole('treeitem', { name: 'nD_datasets' }).click();
-    cy.findByRole('treeitem', { name: 'twoD' }).click();
-
-    cy.findByRole('heading', { name: 'nD_datasets / twoD' }).should('exist');
-    cy.findByRole('tab', { name: 'Heatmap' }).should('exist');
-    cy.findByRole('figure', { name: 'twoD' }).should('exist');
-    cy.findByRole('button', { name: 'Edit domain' }).should('be.visible'); // wait for domain slider to appear
+    cy.findByRole('tab', { name: 'Heatmap' }).should(...BE_SELECTED);
+    cy.findByRole('figure', { name: 'twoD' }).should('be.visible');
+    cy.findByRole('heading', { name: 'nD_datasets / twoD' }).should(
+      'be.visible'
+    );
 
     if (Cypress.env('TAKE_SNAPSHOTS')) {
-      cy.wait(SNAPSHOT_DELAY);
       cy.matchImageSnapshot('heatmap_2D');
     }
 
     cy.findByRole('button', { name: 'More controls' }).click();
     cy.findByRole('button', { name: 'Invert' }).click();
+    cy.waitForStableDOM();
 
     if (Cypress.env('TAKE_SNAPSHOTS')) {
-      cy.wait(SNAPSHOT_DELAY);
       cy.matchImageSnapshot('heatmap_2D_inverted_cmap');
     }
   });
 
   it('visualize 2D complex dataset as Heatmap', () => {
-    // Wait for scale to update according to SILX_style on default root visualization
-    cy.findByRole('button', { name: 'SymLog' }).should('exist');
+    cy.selectExplorerNode('nD_datasets');
+    cy.selectExplorerNode('twoD_cplx');
 
-    cy.findByRole('treeitem', { name: 'nD_datasets' }).click();
-    cy.findByRole('treeitem', { name: 'twoD_cplx' }).click();
-
-    cy.findByRole('heading', { name: 'nD_datasets / twoD_cplx' }).should(
-      'exist'
+    cy.findByRole('tab', { name: 'Heatmap' }).should(...BE_SELECTED);
+    cy.findByRole('figure', { name: 'twoD_cplx (amplitude)' }).should(
+      'be.visible'
     );
-    cy.findByRole('tab', { name: 'Heatmap' }).should('exist');
-    cy.findByRole('figure', { name: /twoD_cplx/ }).should('exist');
+    cy.findByRole('heading', { name: 'nD_datasets / twoD_cplx' }).should(
+      'be.visible'
+    );
 
     if (Cypress.env('TAKE_SNAPSHOTS')) {
-      cy.wait(SNAPSHOT_DELAY);
       cy.matchImageSnapshot('heatmap_2D_complex');
     }
   });
 
   it('map dimensions of 4D dataset when visualized as Heatmap', () => {
-    // Wait for scale to update according to SILX_style on default root visualization
-    cy.findByRole('button', { name: 'SymLog' }).should('exist');
-
-    cy.findByRole('treeitem', { name: 'nD_datasets' }).click();
-    cy.findByRole('treeitem', { name: 'fourD' }).click();
+    cy.selectExplorerNode('nD_datasets');
+    cy.selectExplorerNode('fourD');
 
     cy.findByTitle('Number of elements in each dimension')
       .parent()
@@ -127,26 +111,17 @@ describe('App', () => {
 
     // Check default dimension mapping
     cy.get('@xRadioGroup').within(() => {
-      cy.findByRole('radio', { name: 'D3' }).should(
-        'have.attr', // 'be.checked' relies on CSS selector `:checked`, which ignores `aria-checked`
-        'aria-checked',
-        'true'
-      );
+      cy.findByRole('radio', { name: 'D3' }).should(...BE_CHECKED);
     });
     cy.get('@yRadioGroup').within(() => {
-      cy.findByRole('radio', { name: 'D2' }).should(
-        'have.attr',
-        'aria-checked',
-        'true'
-      );
+      cy.findByRole('radio', { name: 'D2' }).should(...BE_CHECKED);
     });
 
     // Check axes ticks
     cy.get('@xAxis').should('have.text', [0, 10, 20, 30, 40].join(''));
-    cy.get('@yAxis').should('have.text', ['−10', 0, 10, 20, 30].join('')); // Tick text uses minus sign − (U+2212) rather than hyphen minus - (U+002D)
+    cy.get('@yAxis').should('have.text', ['−10', 0, 10, 20, 30].join('')); // minus sign − (U+2212), not hyphen - (U+002D)
 
     if (Cypress.env('TAKE_SNAPSHOTS')) {
-      cy.wait(SNAPSHOT_DELAY);
       cy.matchImageSnapshot('heatmap_4d_default');
     }
 
@@ -154,236 +129,232 @@ describe('App', () => {
     cy.get('@yRadioGroup').within(() => {
       cy.findByRole('radio', { name: 'D1' }).click();
     });
+    cy.waitForStableDOM();
+
     cy.get('@yRadioGroup').within(() => {
-      cy.findByRole('radio', { name: 'D1' }).should(
-        'have.attr',
-        'aria-checked',
-        'true'
-      );
+      cy.findByRole('radio', { name: 'D1' }).should(...BE_CHECKED);
     });
 
     if (Cypress.env('TAKE_SNAPSHOTS')) {
-      cy.wait(SNAPSHOT_DELAY);
       cy.matchImageSnapshot('heatmap_4d_remapped');
     }
   });
 
   it('slice through 4D dataset when visualized as Heatmap', () => {
-    // Wait for scale to update according to SILX_style on default root visualization
-    cy.findByRole('button', { name: 'SymLog' }).should('exist');
+    cy.selectExplorerNode('nD_datasets');
+    cy.selectExplorerNode('fourD');
 
-    cy.findByRole('treeitem', { name: 'nD_datasets' }).click();
-    cy.findByRole('treeitem', { name: 'fourD' }).click();
-
-    cy.findByRole('figure', { name: 'fourD' }).as('vis').should('exist');
-
+    cy.findByRole('figure', { name: 'fourD' }).as('vis').should('be.visible');
     cy.findAllByRole('slider', { name: 'Dimension slider' })
       .should('have.length', 2)
       .last()
+      .as('d1Slider')
       .should('have.attr', 'aria-valuenow', 0)
       .and('have.attr', 'aria-valuemin', 0)
-      .and('have.attr', 'aria-valuemax', 8)
-      .as('slider');
+      .and('have.attr', 'aria-valuemax', 8);
 
     // Move slider up by three marks and check value
-    cy.get('@slider').type('{uparrow}');
-    cy.get('@slider').should('have.attr', 'aria-valuenow', 1);
-    cy.get('@slider').type('{uparrow}');
-    cy.get('@slider').should('have.attr', 'aria-valuenow', 2);
-    cy.get('@slider').type('{uparrow}');
-    cy.get('@slider').should('have.attr', 'aria-valuenow', 3);
+    cy.get('@d1Slider').type('{uparrow}{uparrow}{uparrow}');
+    cy.waitForStableDOM();
 
-    cy.findByRole('figure', { name: 'fourD' }).should('exist');
+    cy.get('@d1Slider').should('have.attr', 'aria-valuenow', 3);
     cy.get('@vis')
       .should('contain.text', '9.996e-1')
       .and('contain.text', '−1e+0');
 
     if (Cypress.env('TAKE_SNAPSHOTS')) {
-      cy.wait(SNAPSHOT_DELAY);
       cy.matchImageSnapshot('heatmap_4d_sliced');
     }
 
     // Move slider up by one mark to reach slice filled only with zeros
-    cy.get('@slider').type('{uparrow}');
+    cy.get('@d1Slider').type('{uparrow}');
+    cy.waitForStableDOM();
 
-    cy.findByRole('figure', { name: 'fourD' }).should('exist');
-    cy.get('@slider').should('have.attr', 'aria-valuenow', 4);
+    cy.get('@d1Slider').should('have.attr', 'aria-valuenow', 4);
+    cy.get('@vis').should('contain.text', '+∞').and('contain.text', '−∞');
 
     if (Cypress.env('TAKE_SNAPSHOTS')) {
-      cy.wait(SNAPSHOT_DELAY);
       cy.matchImageSnapshot('heatmap_4d_zeros');
     }
   });
 
   it('edit heatmap color map limits', () => {
-    // Wait for scale to update according to SILX_style on default root visualization
-    cy.findByRole('button', { name: 'SymLog' }).should('exist');
-
-    cy.findByRole('treeitem', { name: 'nD_datasets' }).click();
-    cy.findByRole('treeitem', { name: 'twoD' }).click();
+    cy.selectExplorerNode('nD_datasets');
+    cy.selectExplorerNode('twoD');
 
     cy.findByRole('button', { name: 'Edit domain' })
       .click()
       .should('have.attr', 'aria-pressed', 'true');
 
-    cy.findByLabelText('min')
-      .clear()
-      .type('50{enter}')
-      .should('have.value', '5e+1');
+    cy.findByLabelText('min').clear().type('50').as('min');
+    cy.findByRole('button', { name: 'Apply min' }).click();
+    cy.waitForStableDOM();
 
+    cy.get('@min').should('have.value', '5e+1');
     cy.findByRole('figure', { name: 'twoD' }).within(() => {
-      cy.findByText('5e+1').should('exist');
-      cy.findByText('4e+2').should('exist');
+      cy.findByText('5e+1').should('be.visible');
+      cy.findByText('4e+2').should('be.visible');
     });
 
     if (Cypress.env('TAKE_SNAPSHOTS')) {
-      cy.wait(SNAPSHOT_DELAY);
       cy.matchImageSnapshot('edit_domain');
     }
   });
 
   it('visualize image dataset as RGB', () => {
-    cy.findByRole('treeitem', { name: 'nD_datasets' }).click();
-    cy.findByRole('treeitem', { name: 'threeD_rgb' }).click();
+    cy.selectExplorerNode('nD_datasets');
+    cy.selectExplorerNode('threeD_rgb');
 
+    cy.findByRole('tab', { name: 'RGB' }).should(...BE_SELECTED);
+    cy.findByRole('figure', { name: 'threeD_rgb' }).should('be.visible');
     cy.findByRole('heading', { name: 'nD_datasets / threeD_rgb' }).should(
-      'exist'
+      'be.visible'
     );
-    cy.findByRole('tab', { name: 'RGB' }).should('exist');
-    cy.findByRole('figure', { name: 'threeD_rgb' }).should('exist');
 
     if (Cypress.env('TAKE_SNAPSHOTS')) {
-      cy.wait(SNAPSHOT_DELAY);
       cy.matchImageSnapshot('rgb_image');
     }
 
     cy.findByRole('radio', { name: 'BGR' }).click();
+    cy.waitForStableDOM();
 
     if (Cypress.env('TAKE_SNAPSHOTS')) {
-      cy.wait(SNAPSHOT_DELAY);
       cy.matchImageSnapshot('bgr_image');
     }
   });
 
   context('NeXus', () => {
     it('visualize default NXdata group as NxImage', () => {
-      cy.findByRole('treeitem', { name: 'source.h5' }).click();
+      cy.selectExplorerNode('source.h5');
 
-      cy.findByRole('heading', { name: 'source.h5' }).should('exist');
-      cy.findByRole('tab', { name: 'NX Image' }).should('exist');
-      cy.findByRole('figure', { name: 'NeXus 2D' }).should('exist');
+      cy.findByRole('tab', { name: 'NX Image' }).should(...BE_SELECTED);
+      cy.findByRole('heading', { name: 'source.h5' }).should('be.visible');
+      cy.findByRole('figure', { name: 'NeXus 2D' }).should('be.visible');
     });
 
     it('visualize dataset with "spectrum" interpretation as NxSpectrum', () => {
-      cy.findByRole('treeitem', { name: /^nexus_entry / }).click();
-      cy.findByRole('treeitem', { name: 'spectrum (NeXus group)' }).click();
+      cy.selectExplorerNode('nexus_entry');
+      cy.selectExplorerNode('spectrum');
 
+      cy.findByRole('tab', { name: 'NX Spectrum' }).should(...BE_SELECTED);
       cy.findByRole('heading', { name: 'nexus_entry / spectrum' }).should(
-        'exist'
+        'be.visible'
       );
-      cy.findByRole('tab', { name: 'NX Spectrum' }).should('exist');
       cy.findByRole('figure', { name: 'twoD_spectrum (arb. units)' }).should(
-        'exist'
+        'be.visible'
       );
+
       cy.get('svg[data-type="abscissa"] svg').should('have.text', 'X (nm)');
 
       if (Cypress.env('TAKE_SNAPSHOTS')) {
-        cy.wait(SNAPSHOT_DELAY);
         cy.matchImageSnapshot('nxspectrum');
       }
     });
 
     it('visualize dataset with "image" interpretation as NxImage', () => {
-      // Wait for scale to update according to SILX_style on default root visualization
-      cy.findByRole('button', { name: 'SymLog' }).should('exist');
+      cy.selectExplorerNode('nexus_entry');
+      cy.selectExplorerNode('image');
 
-      cy.findByRole('treeitem', { name: /^nexus_entry / }).click();
-      cy.findByRole('treeitem', { name: 'image (NeXus group)' }).click();
+      cy.findByRole('tab', { name: 'NX Image' }).should(...BE_SELECTED);
+      cy.findByRole('heading', { name: 'nexus_entry / image' }).should(
+        'be.visible'
+      );
+      cy.findByRole('figure', { name: 'Interference fringes' }).should(
+        'be.visible'
+      );
 
-      cy.findByRole('heading', { name: 'nexus_entry / image' }).should('exist');
-      cy.findByRole('tab', { name: 'NX Image' }).should('exist');
-      cy.findByRole('figure', { name: 'Interference fringes' }).should('exist');
       cy.get('svg[data-type="ordinate"] svg').should(
         'have.text',
         'Angle (degrees)'
       );
 
       if (Cypress.env('TAKE_SNAPSHOTS')) {
-        cy.wait(SNAPSHOT_DELAY);
         cy.matchImageSnapshot('nximage');
       }
     });
 
     it('use axis values to compute axis ticks', () => {
-      cy.findByRole('treeitem', { name: /^nexus_entry / }).click();
-      cy.findByRole('treeitem', { name: 'image (NeXus group)' }).click();
+      cy.selectExplorerNode('nexus_entry');
+      cy.selectExplorerNode('image');
 
       cy.get('svg[data-type="abscissa"] .visx-axis-tick').should(
         'have.text',
-        ['−20', '−10', '0', '10', '20'].join('') // Tick text uses minus sign − (U+2212) rather than hyphen minus - (U+002D)
+        ['−20', '−10', '0', '10', '20'].join('') // minus sign − (U+2212), not hyphen - (U+002D)
       );
     });
 
     it('visualize dataset with log scales on both axes on NxSpectrum with SILX_style', () => {
-      cy.findByRole('treeitem', { name: /^nexus_entry / }).click();
-      cy.findByRole('treeitem', { name: /log_spectrum/ }).click();
+      cy.selectExplorerNode('nexus_entry');
+      cy.selectExplorerNode('log_spectrum');
 
+      cy.findByRole('tab', { name: 'NX Spectrum' }).should(...BE_SELECTED);
       cy.findByRole('heading', { name: 'nexus_entry / log_spectrum' }).should(
-        'exist'
+        'be.visible'
       );
-      cy.findByRole('tab', { name: 'NX Spectrum' }).should('exist');
+
       cy.findAllByRole('button', { name: 'Log' }).should('have.length', 2);
 
       if (Cypress.env('TAKE_SNAPSHOTS')) {
-        cy.wait(SNAPSHOT_DELAY);
         cy.matchImageSnapshot('logspectrum');
       }
     });
 
     it('visualize signal and auxiliary signals datasets as NxSpectrum', () => {
-      cy.findByRole('treeitem', { name: /^nexus_entry / }).click();
-      cy.findByRole('treeitem', { name: /spectrum_with_aux/ }).click();
+      cy.selectExplorerNode('nexus_entry');
+      cy.selectExplorerNode('spectrum_with_aux');
 
       cy.findByRole('heading', {
         name: 'nexus_entry / spectrum_with_aux',
-      }).should('exist');
+      }).should('be.visible');
 
       if (Cypress.env('TAKE_SNAPSHOTS')) {
-        cy.wait(SNAPSHOT_DELAY);
         cy.matchImageSnapshot('auxspectrum');
       }
     });
 
     it('visualize dataset with "rgb-image" interpretation as NxRGB', () => {
-      cy.findByRole('treeitem', { name: /^nexus_entry / }).click();
-      cy.findByRole('treeitem', { name: /rgb-image/ }).click();
+      cy.selectExplorerNode('nexus_entry');
+      cy.selectExplorerNode('rgb-image');
 
+      cy.findByRole('tab', { name: 'NX RGB' }).should(...BE_SELECTED);
+      cy.findByRole('figure', { name: 'RGB CMY DGW' }).should('be.visible');
       cy.findByRole('heading', { name: 'nexus_entry / rgb-image' }).should(
-        'exist'
+        'be.visible'
       );
-      cy.findByRole('tab', { name: 'NX RGB' }).should('exist');
-      cy.findByRole('figure', { name: 'RGB CMY DGW' }).should('exist');
 
       if (Cypress.env('TAKE_SNAPSHOTS')) {
-        cy.wait(SNAPSHOT_DELAY);
         cy.matchImageSnapshot('nxrgb');
       }
     });
 
     it('visualize dataset with 1D signal and two 1D axes of same length as NxScatter', () => {
-      cy.findByRole('treeitem', { name: /^nexus_entry / }).click();
-      cy.findByRole('treeitem', { name: /scatter/ }).click();
+      cy.selectExplorerNode('nexus_entry');
+      cy.selectExplorerNode('scatter');
 
+      cy.findByRole('tab', { name: 'NX Scatter' }).should(...BE_SELECTED);
+      cy.findByRole('figure', { name: 'scatter_data' }).should('be.visible');
       cy.findByRole('heading', { name: 'nexus_entry / scatter' }).should(
-        'exist'
+        'be.visible'
       );
-      cy.findByRole('tab', { name: 'NX Scatter' }).should('exist');
-      cy.findByRole('figure', { name: 'scatter_data' }).should('exist');
 
       if (Cypress.env('TAKE_SNAPSHOTS')) {
-        cy.wait(SNAPSHOT_DELAY);
         cy.matchImageSnapshot('nxscatter');
       }
     });
+  });
+});
+
+describe('/mock?wide', () => {
+  beforeEach(() => {
+    cy.visit('/mock?wide');
+    cy.waitForStableDOM();
+  });
+
+  it('start with the explorer closed', () => {
+    cy.findByRole('tree').should('not.exist');
+
+    if (Cypress.env('TAKE_SNAPSHOTS')) {
+      cy.matchImageSnapshot('wide');
+    }
   });
 });

--- a/cypress/support.ts
+++ b/cypress/support.ts
@@ -1,4 +1,54 @@
+/* eslint-disable promise/no-nesting */
+/* eslint-disable promise/prefer-await-to-then */
 import '@testing-library/cypress/add-commands';
 import { addMatchImageSnapshotCommand } from 'cypress-image-snapshot/command';
+
+const INTERVAL = 300; // more than debounce on slicing slider
+const TIMEOUT = 2000;
+const OBSERVER_CONFIG = {
+  subtree: true,
+  childList: true,
+  attributes: true,
+  attributeOldValue: true,
+  characterData: true,
+  characterDataOldValue: true,
+};
+
+// Simplified version of https://github.com/narinluangrath/cypress-wait-for-stable-dom/ due to import issue
+function waitForStableDOM(iteration = 0) {
+  cy.document().then((document: Document) => {
+    let mutation: MutationRecord[];
+    const observer = new MutationObserver((m) => (mutation = m));
+    observer.observe(document, OBSERVER_CONFIG);
+
+    cy.wait(INTERVAL, { log: false }).then(() => {
+      if (!mutation) {
+        cy.log(`No changes detected for over ${INTERVAL}ms!`);
+        cy.log('Continuing with test...');
+        return;
+      } else if (iteration * INTERVAL < TIMEOUT) {
+        cy.log('Mutation detected... retrying...');
+        waitForStableDOM(iteration + 1);
+        return;
+      }
+
+      throw new Error('Timed out waiting for stable DOM');
+    });
+  });
+}
+
+Cypress.Commands.add('waitForStableDOM', waitForStableDOM);
+
+Cypress.Commands.add('selectExplorerNode', (name: string) => {
+  cy.findByRole('treeitem', {
+    name: new RegExp(`^${name}(?: \\(NeXus group\\))?$`, 'u'), // account for potential NeXus badge
+  }).click();
+  cy.waitForStableDOM();
+});
+
+Cypress.Commands.add('selectVisTab', (name: string) => {
+  cy.findByRole('tab', { name }).click();
+  cy.waitForStableDOM();
+});
 
 addMatchImageSnapshotCommand();


### PR DESCRIPTION
After working on the feature tests in #1119, it's clear that React Testing Library is much better than Cypress Testing Library at waiting for React to finish rendering. That's why we have a lot of workarounds in the E2E specs, waiting for unrelated things to appear, and why we get a lot of retry attempts in the CI.

In this PR, I'm introducing a query called `cy.waitForStableDom()` found here: https://github.com/narinluangrath/cypress-wait-for-stable-dom/, which seems to perfectly solve all our problems. It tells Cypress to wait until there are no more mutations in the DOM over a given period of time. By calling it after every user action (`click`, `type`, etc.), all the tests pass on their first attempts.

The polling interval is currently set to 300ms, a bit more than the slicing slider, just to be safe for the screenshots. In #1119, I'm introducing a way to detect when a slice selection is actually applied to the visualization, so once it is merged, I will try to refactor to reduce the delay.

![image](https://user-images.githubusercontent.com/2936402/172640554-4eb60811-5129-464a-9616-87ee88c82ee6.png)
