### PR TITLE
Update h5grove API to 1.0.0

### DIFF
--- a/packages/app/src/providers/h5grove/h5grove-api.ts
+++ b/packages/app/src/providers/h5grove/h5grove-api.ts
@@ -29,7 +29,7 @@ import {
 } from './utils';
 
 export class H5GroveApi extends DataProviderApi {
-  /* API compatible with h5grove@0.0.16 */
+  /* API compatible with h5grove@1.0.0 */
   public constructor(
     url: string,
     filepath: string,
@@ -133,7 +133,12 @@ export class H5GroveApi extends DataProviderApi {
     const { data } = await this.cancellableFetchValue<ArrayBuffer>(
       '/data/',
       params,
-      { path: params.dataset.path, selection: params.selection, format: 'bin' },
+      {
+        path: params.dataset.path,
+        selection: params.selection,
+        format: 'bin',
+        dtype: 'safe',
+      },
       'arraybuffer'
     );
 


### PR DESCRIPTION
The only relevant change is the `dtype` argument change for binary data: https://github.com/silx-kit/h5grove/releases/tag/v1.0.0