### PR TITLE
Allow to constrain interactions to a single button

### DIFF
--- a/packages/lib/src/interactions/InteractionsProvider.tsx
+++ b/packages/lib/src/interactions/InteractionsProvider.tsx
@@ -44,8 +44,12 @@ function InteractionsProvider(props: { children: ReactNode }) {
       const params = interactionMap.get(id);
       assertDefined(params, `Interaction ${id} is not registered.`);
 
-      const { disabled, modifierKey } = params;
+      const { disabled, modifierKey, button } = params;
       if (disabled) {
+        return false;
+      }
+
+      if (button !== undefined && event.button !== button) {
         return false;
       }
 

--- a/packages/lib/src/interactions/Pan.tsx
+++ b/packages/lib/src/interactions/Pan.tsx
@@ -8,13 +8,22 @@ import {
   useMoveCameraTo,
   useInteraction,
 } from './hooks';
+import { MouseButton } from './models';
 import type { CanvasEvent, Interaction } from './models';
 
-function Pan(props: Interaction) {
-  const { modifierKey } = props;
+interface Props extends Omit<Interaction, 'button'> {
+  button?: MouseButton;
+}
+
+function Pan(props: Props) {
+  const { button = MouseButton.Left, modifierKey, disabled } = props;
 
   const camera = useThree((state) => state.camera);
-  const shouldInteract = useInteraction('Pan', props);
+  const shouldInteract = useInteraction('Pan', {
+    button,
+    modifierKey,
+    disabled,
+  });
   const moveCameraTo = useMoveCameraTo();
 
   const startOffsetPosition = useRef<Vector3>(); // `useRef` to avoid re-renders

--- a/packages/lib/src/interactions/SelectToZoom.tsx
+++ b/packages/lib/src/interactions/SelectToZoom.tsx
@@ -10,7 +10,7 @@ import { useMoveCameraTo } from './hooks';
 import type { Interaction, Selection } from './models';
 import { getEnclosedRectangle, getRatioRespectingRectangle } from './utils';
 
-interface Props extends Interaction {
+interface Props extends Omit<Interaction, 'button'> {
   keepRatio?: boolean;
 }
 

--- a/packages/lib/src/interactions/SelectionTool.tsx
+++ b/packages/lib/src/interactions/SelectionTool.tsx
@@ -11,9 +11,10 @@ import {
   useInteraction,
 } from './hooks';
 import type { CanvasEvent, Interaction, Selection } from './models';
+import { MouseButton } from './models';
 import { boundPointToFOV } from './utils';
 
-interface Props extends Interaction {
+interface Props extends Omit<Interaction, 'button'> {
   onSelectionStart?: () => void;
   onSelectionChange?: (points: Selection) => void;
   onSelectionEnd?: (points: Selection) => void;
@@ -35,7 +36,11 @@ function SelectionTool(props: Props) {
 
   const camera = useThree((state) => state.camera);
   const { worldToData } = useAxisSystemContext();
-  const shouldInteract = useInteraction(id, { modifierKey, disabled });
+  const shouldInteract = useInteraction(id, {
+    button: MouseButton.Left,
+    modifierKey,
+    disabled,
+  });
 
   const [startPoint, setStartPoint] = useState<Vector2>();
   const [endPoint, setEndPoint] = useRafState<Vector2 | undefined>(undefined);

--- a/packages/lib/src/interactions/XAxisZoom.tsx
+++ b/packages/lib/src/interactions/XAxisZoom.tsx
@@ -1,7 +1,7 @@
 import { useCanvasEvents, useInteraction, useZoomOnWheel } from './hooks';
 import type { Interaction } from './models';
 
-function XAxisZoom(props: Interaction) {
+function XAxisZoom(props: Omit<Interaction, 'button'>) {
   const shouldInteract = useInteraction('XAxisZoom', props);
 
   const isZoomAllowed = (sourceEvent: WheelEvent) => ({

--- a/packages/lib/src/interactions/YAxisZoom.tsx
+++ b/packages/lib/src/interactions/YAxisZoom.tsx
@@ -1,7 +1,7 @@
 import { useCanvasEvents, useZoomOnWheel, useInteraction } from './hooks';
 import type { Interaction } from './models';
 
-function YAxisZoom(props: Interaction) {
+function YAxisZoom(props: Omit<Interaction, 'button'>) {
   const shouldInteract = useInteraction('YAxisZoom', props);
 
   const isZoomAllowed = (sourceEvent: WheelEvent) => ({

--- a/packages/lib/src/interactions/Zoom.tsx
+++ b/packages/lib/src/interactions/Zoom.tsx
@@ -1,7 +1,7 @@
 import { useCanvasEvents, useZoomOnWheel, useInteraction } from './hooks';
 import type { Interaction } from './models';
 
-function Zoom(props: Interaction) {
+function Zoom(props: Omit<Interaction, 'button'>) {
   const shouldInteract = useInteraction('Zoom', props);
 
   const isZoomAllowed = (sourceEvent: WheelEvent) => {

--- a/packages/lib/src/interactions/models.ts
+++ b/packages/lib/src/interactions/models.ts
@@ -2,6 +2,11 @@ import type { Vector2, Vector3 } from 'three';
 
 export type ModifierKey = 'Alt' | 'Control' | 'Shift';
 
+export enum MouseButton {
+  'Left' = 0,
+  'Middle' = 1,
+}
+
 export interface Selection {
   startPoint: Vector2;
   endPoint: Vector2;
@@ -28,6 +33,7 @@ export interface InteractionInfo {
 }
 
 export interface Interaction {
+  button?: MouseButton;
   modifierKey?: ModifierKey;
   disabled?: boolean;
 }


### PR DESCRIPTION
Looking at #1120 and #1121, I thought we could leverage our interaction registration process to be able to constrain interactions to a single button.

I tried to keep the changes minimal to give a basis of discussion so that when `button` is not given, the behaviour is the same as before (no constrain on button). Among future improvements, I can see:
- Give default values for `button` for the `Pan`
- Take `button` in account when looking at conflicting interactions in `shouldInteract`