### PR TITLE
Make H5Wasm demo more permissive

### DIFF
--- a/apps/demo/src/h5wasm/DropZone.tsx
+++ b/apps/demo/src/h5wasm/DropZone.tsx
@@ -31,7 +31,6 @@ function DropZone(props: Props) {
 
   const { getRootProps, getInputProps, open, isDragActive, fileRejections } =
     useDropzone({
-      accept: { 'application/x-hdf5': EXT },
       multiple: false,
       noClick: true,
       noKeyboard: true,
@@ -46,7 +45,7 @@ function DropZone(props: Props) {
         'data-disabled': isReadingFile || undefined,
       })}
     >
-      <input {...getInputProps()} />
+      <input {...getInputProps()} accept={EXT.join(',')} />
       <div className={styles.inner}>
         {isDragActive ? (
           <p className={styles.dropIt}>Drop it!</p>
@@ -58,12 +57,11 @@ function DropZone(props: Props) {
                 or use a file picker instead
               </button>
             </p>
-            <p
-              className={styles.hint}
-              role={fileRejections.length > 0 ? 'alert' : undefined}
-            >
-              Extensions allowed: <strong>{EXT.join(' ')}</strong>
-            </p>
+            {fileRejections.length > 1 && (
+              <p className={styles.hint} role="alert">
+                Please drop a single file
+              </p>
+            )}
           </>
         )}
       </div>

--- a/packages/h5wasm/src/h5wasm-api.ts
+++ b/packages/h5wasm/src/h5wasm-api.ts
@@ -33,22 +33,13 @@ import {
   isH5WasmSoftLink,
 } from './guards';
 import type { H5WasmAttributes, H5WasmEntity } from './models';
-import {
-  convertMetadataToDType,
-  convertSelectionToRanges,
-  isHDF5,
-} from './utils';
+import { convertMetadataToDType, convertSelectionToRanges } from './utils';
 
 export class H5WasmApi extends ProviderApi {
   private readonly file: Promise<H5WasmFile>;
 
   public constructor(filename: string, buffer: ArrayBuffer) {
     super(filename);
-
-    if (!isHDF5(buffer)) {
-      throw new Error('Expected valid HDF5 file');
-    }
-
     this.file = this.initFile(buffer);
   }
 
@@ -118,7 +109,10 @@ export class H5WasmApi extends ProviderApi {
     const file = await this.file;
 
     const h5wEntity = file.get(path);
-    assertNonNull(h5wEntity, `No entity found at ${path}`);
+    assertNonNull(
+      h5wEntity,
+      path === '/' ? `Expected valid HDF5 file` : `No entity found at ${path}`
+    );
 
     return h5wEntity;
   }

--- a/packages/h5wasm/src/utils.ts
+++ b/packages/h5wasm/src/utils.ts
@@ -13,15 +13,6 @@ import {
 } from './guards';
 import type { NumericMetadata } from './models';
 
-// https://www.loc.gov/preservation/digital/formats/fdd/fdd000229.shtml
-const HDF5_MAGIC_NUMBER = [0x89, 0x48, 0x44, 0x46, 0x0d, 0x0a, 0x1a, 0x0a]; // ASCII: \211 HDF \r \n \032 \n
-
-export function isHDF5(buffer: ArrayBuffer): boolean {
-  return new Uint8Array(buffer.slice(0, HDF5_MAGIC_NUMBER.length)).every(
-    (num, i) => num === HDF5_MAGIC_NUMBER[i]
-  );
-}
-
 export function convertNumericMetadataToDType(
   metadata: NumericMetadata
 ): NumericType {


### PR DESCRIPTION
- Allow files with any extensions to be dropped - fix #1126 
- Allow files that don't start with the HDF5 magic number (called the HDF5 File Signature in the spec), as per the HDF5 spec https://web.ics.purdue.edu/~aai/HDF5/html/H5.format.html