### PR TITLE
Fix rolled-up types

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,7 +144,10 @@ The build process of `@h5web/lib` works as follows:
      consumers who use TypeScript. This is a two step process: first we generate
      type declarations for all TS files in the `dist-ts` folder with `tsc`, then
      we use Rollup to merge all the declarations into a single file:
-     `dist/index.d.ts`, which is referenced from `package.json`.
+     `dist/index.d.ts`, which is referenced from `package.json`. Note that since
+     `@h5web/shared` is not a published package, it cannot be marked as an
+     external dependency; its types must therefore be inlined into
+     `dist/index.d.ts`, so we make sure to tell Rollup where to find them.
 
 The build process of `@h5web/app` is the same with one exception: in addition to
 importing the package's global styles, `src/styles.ts` also imports the `lib`
@@ -156,6 +159,10 @@ import.
 The build process of`@h5web/h5wasm` is also the same as the lib's, but since the
 package does not include any styles, `vite build` does not generate a
 `style.css` file and there's not `build:css` script.
+
+Finally, since `@h5web/shared` is not a published package, it does not need to
+be built with Vite. However, its types do need to be built with `tsc` so that
+other packages can inline them in their own `dist/index.d.ts`.
 
 ## Code quality
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -61,6 +61,7 @@
   },
   "devDependencies": {
     "@h5web/shared": "workspace:*",
+    "@rollup/plugin-alias": "3.1.9",
     "@testing-library/dom": "8.13.0",
     "@testing-library/jest-dom": "5.16.4",
     "@testing-library/react": "12.1.5",

--- a/packages/app/rollup.config.js
+++ b/packages/app/rollup.config.js
@@ -1,3 +1,4 @@
+import alias from '@rollup/plugin-alias';
 import dts from 'rollup-plugin-dts';
 
 import { externals } from './vite.config';
@@ -7,7 +8,18 @@ const config = {
   input: './dist-ts/index.d.ts',
   output: [{ file: 'dist/index.d.ts', format: 'es' }],
   external: [...externals, /\.css$/u],
-  plugins: [dts({ respectExternal: true })],
+  plugins: [
+    alias({
+      entries: [
+        {
+          // Make sure rollup-plugin-dts can find shared types
+          find: '@h5web/shared',
+          replacement: '../shared/dist-ts/index.d.ts',
+        },
+      ],
+    }),
+    dts({ respectExternal: true }),
+  ],
 };
 
 export default config;

--- a/packages/h5wasm/package.json
+++ b/packages/h5wasm/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@h5web/app": "workspace:*",
     "@h5web/shared": "workspace:*",
+    "@rollup/plugin-alias": "3.1.9",
     "@types/react": "17.0.39",
     "eslint": "8.9.0",
     "eslint-config-galex": "3.6.5",

--- a/packages/h5wasm/rollup.config.js
+++ b/packages/h5wasm/rollup.config.js
@@ -1,3 +1,4 @@
+import alias from '@rollup/plugin-alias';
 import dts from 'rollup-plugin-dts';
 
 import { externals } from './vite.config';
@@ -7,7 +8,18 @@ const config = {
   input: './dist-ts/index.d.ts',
   output: [{ file: 'dist/index.d.ts', format: 'es' }],
   external: [...externals, /\.css$/u],
-  plugins: [dts({ respectExternal: true })],
+  plugins: [
+    alias({
+      entries: [
+        {
+          // Make sure rollup-plugin-dts can find shared types
+          find: '@h5web/shared',
+          replacement: '../shared/dist-ts/index.d.ts',
+        },
+      ],
+    }),
+    dts({ respectExternal: true }),
+  ],
 };
 
 export default config;

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -70,6 +70,7 @@
   "devDependencies": {
     "@h5web/shared": "workspace:*",
     "@react-three/fiber": "7.0.26",
+    "@rollup/plugin-alias": "3.1.9",
     "@types/d3-array": "3.0.2",
     "@types/d3-color": "3.0.2",
     "@types/d3-format": "3.0.1",

--- a/packages/lib/rollup.config.js
+++ b/packages/lib/rollup.config.js
@@ -1,3 +1,4 @@
+import alias from '@rollup/plugin-alias';
 import dts from 'rollup-plugin-dts';
 
 import { externals } from './vite.config';
@@ -7,7 +8,18 @@ const config = {
   input: './dist-ts/index.d.ts',
   output: [{ file: 'dist/index.d.ts', format: 'es' }],
   external: [...externals, /\.css$/u],
-  plugins: [dts({ respectExternal: true })],
+  plugins: [
+    alias({
+      entries: [
+        {
+          // Make sure rollup-plugin-dts can find shared types
+          find: '@h5web/shared',
+          replacement: '../shared/dist-ts/index.d.ts',
+        },
+      ],
+    }),
+    dts({ respectExternal: true }),
+  ],
 };
 
 export default config;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,6 +13,7 @@
   "sideEffects": false,
   "main": "src/index.ts",
   "scripts": {
+    "build": "run-p build:*",
     "build:dts": "tsc --build tsconfig.build.json",
     "lint:eslint": "eslint \"**/*.{js,cjs,ts,tsx}\" --max-warnings=0",
     "lint:tsc": "tsc --noEmit"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,7 @@ importers:
       '@h5web/shared': workspace:*
       '@react-hookz/web': 14.2.2
       '@react-three/fiber': 7.0.26
+      '@rollup/plugin-alias': 3.1.9
       '@testing-library/dom': 8.13.0
       '@testing-library/jest-dom': 5.16.4
       '@testing-library/react': 12.1.5
@@ -208,6 +209,7 @@ importers:
       zustand: 4.0.0-rc.1_react@17.0.2
     devDependencies:
       '@h5web/shared': link:../shared
+      '@rollup/plugin-alias': 3.1.9_rollup@2.68.0
       '@testing-library/dom': 8.13.0
       '@testing-library/jest-dom': 5.16.4
       '@testing-library/react': 12.1.5_sfoxds7t5ydpegc3knd667wn6m
@@ -235,6 +237,7 @@ importers:
     specifiers:
       '@h5web/app': workspace:*
       '@h5web/shared': workspace:*
+      '@rollup/plugin-alias': 3.1.9
       '@types/react': 17.0.39
       eslint: '>=8'
       eslint-config-galex: 3.6.5
@@ -249,6 +252,7 @@ importers:
     devDependencies:
       '@h5web/app': link:../app
       '@h5web/shared': link:../shared
+      '@rollup/plugin-alias': 3.1.9_rollup@2.68.0
       '@types/react': 17.0.39
       eslint: 8.9.0
       eslint-config-galex: 3.6.5_eslint@8.9.0
@@ -263,6 +267,7 @@ importers:
       '@h5web/shared': workspace:*
       '@react-hookz/web': 14.2.2
       '@react-three/fiber': 7.0.26
+      '@rollup/plugin-alias': 3.1.9
       '@types/d3-array': 3.0.2
       '@types/d3-color': 3.0.2
       '@types/d3-format': 3.0.1
@@ -337,6 +342,7 @@ importers:
     devDependencies:
       '@h5web/shared': link:../shared
       '@react-three/fiber': 7.0.26_apkfqzawxbvyaakrxvzzbm6zli
+      '@rollup/plugin-alias': 3.1.9_rollup@2.68.0
       '@types/d3-array': 3.0.2
       '@types/d3-color': 3.0.2
       '@types/d3-format': 3.0.1
@@ -2635,6 +2641,16 @@ packages:
       use-asset: 1.0.4_react@17.0.2
       utility-types: 3.10.0
       zustand: 3.7.0_react@17.0.2
+
+  /@rollup/plugin-alias/3.1.9_rollup@2.68.0:
+    resolution: {integrity: sha512-QI5fsEvm9bDzt32k39wpOwZhVzRcL5ydcffUHMyLVaVaLeC70I8TJZ17F1z1eMoLu4E/UOcH9BWVkKpIKdrfiw==}
+    engines: {node: '>=8.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0
+    dependencies:
+      rollup: 2.68.0
+      slash: 3.0.0
+    dev: true
 
   /@rollup/pluginutils/4.1.2:
     resolution: {integrity: sha512-ROn4qvkxP9SyPeHaf7uQC/GPFY6L/OWy9+bd9AwcjOAWQwxRscoEyAUD8qCY5o5iL4jqQwoLk2kaTKJPb/HwzQ==}
@@ -6470,7 +6486,7 @@ packages:
     dev: true
 
   /color-name/1.1.3:
-    resolution: {integrity: sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=}
+    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
     dev: true
 
   /color-name/1.1.4:
@@ -7801,7 +7817,7 @@ packages:
     dev: true
 
   /escape-string-regexp/1.0.5:
-    resolution: {integrity: sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=}
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
     dev: true
 
@@ -9249,7 +9265,7 @@ packages:
     dev: true
 
   /has-flag/3.0.0:
-    resolution: {integrity: sha1-tdRU3CGZriJWmfNGfloH87lVuv0=}
+    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
     dev: true
 


### PR DESCRIPTION
Fix #1099 

Here is the trick: I build the shared types with `tsc` to `packages/shared/dist-ts`, and then in the other packages, when the time comes to merge all the types into a single file with Rollup, I tell Rollup that `@h5web/shared` is an alias for `../shared/dist-ts/index.d.ts`! :tada: 

In `dist/index.d.ts`, the enums are now properly prefixed with `declare`, the `mockMetadata` object is no longer inlined, etc.

![image](https://user-images.githubusercontent.com/2936402/173076659-27d6b877-6312-4c37-9079-1aa5fe5eef3a.png)

This can only be good for package consumers, even when no errors were reported. If anything it will save the TypeScript engine some work in VSCode.

Also, `pnpm packages` used to output warnings like this one:

![image](https://user-images.githubusercontent.com/2936402/173079217-674136d7-97b4-42dd-a070-f4a57a868765.png)

Now the output is clean:

![image](https://user-images.githubusercontent.com/2936402/173079441-887f6e9e-5d1d-4b25-8f1c-23f1ee5f33ea.png)
