### PR TITLE
Improve compound dtype parsing in H5GroveProvider

### DIFF
--- a/packages/app/src/providers/h5grove/h5grove-api.ts
+++ b/packages/app/src/providers/h5grove/h5grove-api.ts
@@ -13,7 +13,7 @@ import { isString } from 'lodash';
 
 import { DataProviderApi } from '../api';
 import type { ExportFormat, ValuesStoreParams } from '../models';
-import { convertDtype, handleAxiosError } from '../utils';
+import { handleAxiosError } from '../utils';
 import type {
   H5GroveAttribute,
   H5GroveAttrValuesResponse,
@@ -26,10 +26,11 @@ import {
   isGroupResponse,
   isSoftLinkResponse,
   typedArrayFromDType,
+  convertH5GroveDtype,
 } from './utils';
 
 export class H5GroveApi extends DataProviderApi {
-  /* API compatible with h5grove@1.0.0 */
+  /* API compatible with h5grove@1.1.0 */
   public constructor(
     url: string,
     filepath: string,
@@ -194,7 +195,7 @@ export class H5GroveApi extends DataProviderApi {
         attributes,
         kind: EntityKind.Dataset,
         shape,
-        type: convertDtype(dtype),
+        type: convertH5GroveDtype(dtype),
         rawType: dtype,
         ...(chunks && { chunks }),
         ...(filters && { filters }),
@@ -244,7 +245,7 @@ export class H5GroveApi extends DataProviderApi {
     return attrsMetadata.map<Attribute>(({ name, dtype, shape }) => ({
       name,
       shape,
-      type: convertDtype(dtype),
+      type: convertH5GroveDtype(dtype),
     }));
   }
 }

--- a/packages/app/src/providers/h5grove/models.ts
+++ b/packages/app/src/providers/h5grove/models.ts
@@ -10,9 +10,15 @@ export interface H5GroveEntityResponse {
     | 'other';
 }
 
+export type H5GroveDtype =
+  | string
+  | {
+      [k: string]: H5GroveDtype;
+    };
+
 export interface H5GroveDatasetResponse extends H5GroveEntityResponse {
   type: EntityKind.Dataset;
-  dtype: string;
+  dtype: H5GroveDtype;
   shape: number[];
   attributes: H5GroveAttribute[];
   chunks: number[] | null;
@@ -37,7 +43,7 @@ export interface H5GroveExternalLinkResponse extends H5GroveEntityResponse {
 }
 
 export interface H5GroveAttribute {
-  dtype: string;
+  dtype: H5GroveDtype;
   name: string;
   shape: number[];
 }

--- a/packages/app/src/providers/h5grove/utils.test.ts
+++ b/packages/app/src/providers/h5grove/utils.test.ts
@@ -1,15 +1,15 @@
 import { DTypeClass, Endianness } from '@h5web/shared';
 
-import { convertDtype } from './utils';
+import { convertH5GroveDtype } from './utils';
 
-describe('convertDtype', () => {
+describe('convertH5GroveDtype', () => {
   it('should convert integer dtypes', () => {
-    expect(convertDtype('<i4')).toEqual({
+    expect(convertH5GroveDtype('<i4')).toEqual({
       class: DTypeClass.Integer,
       size: 32,
       endianness: Endianness.LE,
     });
-    expect(convertDtype('>u8')).toEqual({
+    expect(convertH5GroveDtype('>u8')).toEqual({
       class: DTypeClass.Unsigned,
       size: 64,
       endianness: Endianness.BE,
@@ -17,12 +17,12 @@ describe('convertDtype', () => {
   });
 
   it('should convert float dtypes', () => {
-    expect(convertDtype('<f4')).toEqual({
+    expect(convertH5GroveDtype('<f4')).toEqual({
       class: DTypeClass.Float,
       size: 32,
       endianness: Endianness.LE,
     });
-    expect(convertDtype('>f8')).toEqual({
+    expect(convertH5GroveDtype('>f8')).toEqual({
       class: DTypeClass.Float,
       size: 64,
       endianness: Endianness.BE,
@@ -30,7 +30,7 @@ describe('convertDtype', () => {
   });
 
   it('should convert complex dtypes', () => {
-    expect(convertDtype('<c8')).toEqual({
+    expect(convertH5GroveDtype('<c8')).toEqual({
       class: DTypeClass.Complex,
       realType: {
         class: DTypeClass.Float,
@@ -46,7 +46,7 @@ describe('convertDtype', () => {
   });
 
   it('should convert bytes string dtypes', () => {
-    expect(convertDtype('|S6')).toEqual({
+    expect(convertH5GroveDtype('|S6')).toEqual({
       class: DTypeClass.String,
       charSet: 'ASCII',
       length: 6,
@@ -54,25 +54,47 @@ describe('convertDtype', () => {
   });
 
   it('should interpret objects as strings', () => {
-    expect(convertDtype('|O')).toEqual({
+    expect(convertH5GroveDtype('|O')).toEqual({
       class: DTypeClass.String,
       charSet: 'UTF-8',
     });
   });
 
   it('should interpret |b1 as booleans', () => {
-    expect(convertDtype('|b1')).toEqual({ class: DTypeClass.Bool });
+    expect(convertH5GroveDtype('|b1')).toEqual({ class: DTypeClass.Bool });
   });
 
   it('should handle "not applicable" endianness symbol', () => {
-    expect(convertDtype('|f8')).toEqual({
+    expect(convertH5GroveDtype('|f8')).toEqual({
       class: DTypeClass.Float,
       size: 64,
       endianness: undefined,
     });
   });
 
+  it('should convert compound dtype', () => {
+    expect(convertH5GroveDtype({ country: '|S10', population: '<i4' })).toEqual(
+      {
+        class: DTypeClass.Compound,
+        fields: {
+          country: {
+            class: DTypeClass.String,
+            charSet: 'ASCII',
+            length: 10,
+          },
+          population: {
+            class: DTypeClass.Integer,
+            endianness: Endianness.LE,
+            size: 32,
+          },
+        },
+      }
+    );
+  });
+
   it('should handle unknown type', () => {
-    expect(convertDtype('>notAType')).toEqual({ class: DTypeClass.Unknown });
+    expect(convertH5GroveDtype('>notAType')).toEqual({
+      class: DTypeClass.Unknown,
+    });
   });
 });

--- a/packages/app/src/providers/h5grove/utils.ts
+++ b/packages/app/src/providers/h5grove/utils.ts
@@ -1,13 +1,25 @@
 import type { DType } from '@h5web/shared';
-import { DTypeClass, EntityKind, isNumericType } from '@h5web/shared';
+import {
+  DTypeClass,
+  Endianness,
+  EntityKind,
+  isNumericType,
+} from '@h5web/shared';
 
 import type {
   H5GroveDatasetResponse,
+  H5GroveDtype,
   H5GroveEntityResponse,
   H5GroveExternalLinkResponse,
   H5GroveGroupResponse,
   H5GroveSoftLinkResponse,
 } from './models';
+
+// https://numpy.org/doc/stable/reference/generated/numpy.dtype.byteorder.html#numpy.dtype.byteorder
+const ENDIANNESS_MAPPING: Record<string, Endianness> = {
+  '<': Endianness.LE,
+  '>': Endianness.BE,
+};
 
 export function isGroupResponse(
   response: H5GroveEntityResponse
@@ -79,4 +91,88 @@ export function typedArrayFromDType(dtype: DType) {
   }
 
   return undefined;
+}
+
+export function convertH5GroveDtype(dtype: H5GroveDtype): DType {
+  if (typeof dtype === 'string') {
+    return convertDtypeString(dtype);
+  }
+
+  return {
+    class: DTypeClass.Compound,
+    fields: Object.fromEntries(
+      Object.entries(dtype).map(([k, v]) => [k, convertH5GroveDtype(v)])
+    ),
+  };
+}
+
+function convertDtypeString(dtype: string): DType {
+  const regexp = /([<>=|])?([A-z])(\d*)/u;
+  const matches = regexp.exec(dtype);
+
+  if (matches === null) {
+    throw new Error(`Unknown dtype ${dtype}`);
+  }
+
+  const [, endianMatch, dataType, lengthMatch] = matches;
+
+  const length = lengthMatch ? Number.parseInt(lengthMatch, 10) : 0;
+  const endianness = ENDIANNESS_MAPPING[endianMatch] || undefined;
+
+  switch (dataType) {
+    case 'b':
+      // Booleans are stored as bytes but numpy represents them distinctly from "normal" bytes:
+      // `|b1` for booleans vs. `|i1` for normal bytes
+      // https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.bool
+      return { class: DTypeClass.Bool };
+
+    case 'f':
+      return {
+        class: DTypeClass.Float,
+        size: length * 8,
+        endianness,
+      };
+
+    case 'i':
+      return {
+        class: DTypeClass.Integer,
+        size: length * 8,
+        endianness,
+      };
+
+    case 'u':
+      return {
+        class: DTypeClass.Unsigned,
+        size: length * 8,
+        endianness,
+      };
+
+    case 'c':
+      return {
+        class: DTypeClass.Complex,
+        realType: {
+          class: DTypeClass.Float,
+          size: length * 4, // Bytes are equally distributed between real and imag
+          endianness,
+        },
+        imagType: {
+          class: DTypeClass.Float,
+          size: length * 4, // Bytes are equally distributed between real and imag
+          endianness,
+        },
+      };
+
+    case 'S':
+      return {
+        class: DTypeClass.String,
+        charSet: 'ASCII',
+        length,
+      };
+
+    case 'O':
+      return { class: DTypeClass.String, charSet: 'UTF-8' };
+
+    default:
+      return { class: DTypeClass.Unknown };
+  }
 }

--- a/packages/app/src/providers/utils.ts
+++ b/packages/app/src/providers/utils.ts
@@ -5,90 +5,13 @@ import type {
   Primitive,
   ScalarShape,
 } from '@h5web/shared';
-import { Endianness, DTypeClass, assertArray } from '@h5web/shared';
+import { assertArray } from '@h5web/shared';
 import { AxiosError } from 'axios';
 import ndarray from 'ndarray';
 
 import { applyMapping } from '../vis-packs/core/utils';
 
 export const CANCELLED_ERROR_MSG = 'Request cancelled';
-
-// https://numpy.org/doc/stable/reference/generated/numpy.dtype.byteorder.html#numpy.dtype.byteorder
-const ENDIANNESS_MAPPING: Record<string, Endianness> = {
-  '<': Endianness.LE,
-  '>': Endianness.BE,
-};
-
-export function convertDtype(dtype: string): DType {
-  const regexp = /([<>=|])?([A-z])(\d*)/u;
-  const matches = regexp.exec(dtype);
-
-  if (matches === null) {
-    throw new Error(`Unknown dtype ${dtype}`);
-  }
-
-  const [, endianMatch, dataType, lengthMatch] = matches;
-
-  const length = lengthMatch ? Number.parseInt(lengthMatch, 10) : 0;
-  const endianness = ENDIANNESS_MAPPING[endianMatch] || undefined;
-
-  switch (dataType) {
-    case 'b':
-      // Booleans are stored as bytes but numpy represents them distinctly from "normal" bytes:
-      // `|b1` for booleans vs. `|i1` for normal bytes
-      // https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.bool
-      return { class: DTypeClass.Bool };
-
-    case 'f':
-      return {
-        class: DTypeClass.Float,
-        size: length * 8,
-        endianness,
-      };
-
-    case 'i':
-      return {
-        class: DTypeClass.Integer,
-        size: length * 8,
-        endianness,
-      };
-
-    case 'u':
-      return {
-        class: DTypeClass.Unsigned,
-        size: length * 8,
-        endianness,
-      };
-
-    case 'c':
-      return {
-        class: DTypeClass.Complex,
-        realType: {
-          class: DTypeClass.Float,
-          size: length * 4, // Bytes are equally distributed between real and imag
-          endianness,
-        },
-        imagType: {
-          class: DTypeClass.Float,
-          size: length * 4, // Bytes are equally distributed between real and imag
-          endianness,
-        },
-      };
-
-    case 'S':
-      return {
-        class: DTypeClass.String,
-        charSet: 'ASCII',
-        length,
-      };
-
-    case 'O':
-      return { class: DTypeClass.String, charSet: 'UTF-8' };
-
-    default:
-      return { class: DTypeClass.Unknown };
-  }
-}
 
 export function flattenValue(
   value: unknown,


### PR DESCRIPTION
Following https://github.com/silx-kit/h5grove/pull/69 and early step for #1130 

Previously, compound dtypes were interpreted by `H5GroveProvider` as `Unknown`. Now, there are rightly shown as `Compound` and the raw inspection can show the fields

![image](https://user-images.githubusercontent.com/42204205/173796201-2c2fd645-b89c-4f77-91de-972adf59bf2d.png)
