### PR TITLE
Change H5GroveProvider to supply axios config and not only params

### DIFF
--- a/apps/demo/src/H5GroveApp.tsx
+++ b/apps/demo/src/H5GroveApp.tsx
@@ -14,7 +14,7 @@ function H5GroveApp() {
     <H5GroveProvider
       url={URL}
       filepath={filepath}
-      axiosParams={{ file: filepath }}
+      axiosConfig={{ params: { file: filepath } }}
     >
       <App explorerOpen={!query.has('wide')} getFeedbackURL={getFeedbackURL} />
     </H5GroveProvider>

--- a/packages/app/src/providers/h5grove/H5GroveProvider.tsx
+++ b/packages/app/src/providers/h5grove/H5GroveProvider.tsx
@@ -1,3 +1,4 @@
+import type { AxiosRequestConfig } from 'axios';
 import type { PropsWithChildren } from 'react';
 import { useMemo } from 'react';
 
@@ -7,15 +8,15 @@ import { H5GroveApi } from './h5grove-api';
 interface Props {
   url: string;
   filepath: string;
-  axiosParams?: Record<string, string>;
+  axiosConfig?: AxiosRequestConfig;
 }
 
 function H5GroveProvider(props: PropsWithChildren<Props>) {
-  const { url, filepath, axiosParams, children } = props;
+  const { url, filepath, axiosConfig, children } = props;
 
   const api = useMemo(
-    () => new H5GroveApi(url, filepath, axiosParams),
-    [filepath, url, axiosParams]
+    () => new H5GroveApi(url, filepath, axiosConfig),
+    [filepath, url, axiosConfig]
   );
 
   return <DataProvider api={api}>{children}</DataProvider>;

--- a/packages/app/src/providers/h5grove/h5grove-api.ts
+++ b/packages/app/src/providers/h5grove/h5grove-api.ts
@@ -9,6 +9,7 @@ import type {
   NumericType,
 } from '@h5web/shared';
 import { hasScalarShape, buildEntityPath, EntityKind } from '@h5web/shared';
+import type { AxiosRequestConfig } from 'axios';
 import { isString } from 'lodash';
 
 import { DataProviderApi } from '../api';
@@ -34,9 +35,9 @@ export class H5GroveApi extends DataProviderApi {
   public constructor(
     url: string,
     filepath: string,
-    axiosParams?: Record<string, string>
+    axiosConfig?: AxiosRequestConfig
   ) {
-    super(filepath, { baseURL: url, params: axiosParams });
+    super(filepath, { baseURL: url, ...axiosConfig });
   }
 
   public async getEntity(path: string): Promise<Entity> {


### PR DESCRIPTION
Needed for daiquiri implementation as headers will need to be added on the top of query params