### PR TITLE
Implement SelectToZoom for a single axis

### DIFF
--- a/apps/storybook/src/SelectToZoom.stories.tsx
+++ b/apps/storybook/src/SelectToZoom.stories.tsx
@@ -6,6 +6,7 @@ import {
   ResetZoomButton,
   HeatmapMesh,
   getDomain,
+  AxialSelectToZoom,
 } from '@h5web/lib';
 import type { ModifierKey as ModifierKeyType } from '@h5web/lib';
 import { mockValues, ScaleType } from '@h5web/shared';
@@ -33,10 +34,13 @@ function Image() {
 interface TemplateProps {
   modifierKey: ModifierKeyType;
   keepRatio?: boolean;
+  xAxisZoomModifierKey: ModifierKeyType;
+  yAxisZoomModifierKey: ModifierKeyType;
 }
 
 const Template: Story<TemplateProps> = (args) => {
-  const { keepRatio } = args;
+  const { keepRatio, modifierKey, xAxisZoomModifierKey, yAxisZoomModifierKey } =
+    args;
   return (
     <VisCanvas
       abscissaConfig={{ visDomain: [-5, 5], showGrid: true }}
@@ -45,7 +49,15 @@ const Template: Story<TemplateProps> = (args) => {
     >
       <Pan />
       <Zoom />
-      <SelectToZoom {...args} />
+      <SelectToZoom modifierKey={modifierKey} keepRatio={keepRatio} />
+      <AxialSelectToZoom
+        axis="x"
+        modifierKey={[modifierKey, xAxisZoomModifierKey]}
+      />
+      <AxialSelectToZoom
+        axis="y"
+        modifierKey={[modifierKey, yAxisZoomModifierKey]}
+      />
       <ResetZoomButton />
       <Image />
     </VisCanvas>
@@ -63,6 +75,13 @@ KeepRatio.args = {
   keepRatio: true,
 };
 
+export const AxialZoom = Template.bind({});
+AxialZoom.args = {
+  modifierKey: 'Control',
+  xAxisZoomModifierKey: 'Alt',
+  yAxisZoomModifierKey: 'Shift',
+};
+
 export default {
   title: 'Building Blocks/SelectToZoom',
   component: SelectToZoom,
@@ -70,6 +89,14 @@ export default {
   parameters: { layout: 'fullscreen' },
   argTypes: {
     modifierKey: {
+      control: { type: 'inline-radio' },
+      options: ['Alt', 'Control', 'Shift'],
+    },
+    xAxisZoomModifierKey: {
+      control: { type: 'inline-radio' },
+      options: ['Alt', 'Control', 'Shift'],
+    },
+    yAxisZoomModifierKey: {
       control: { type: 'inline-radio' },
       options: ['Alt', 'Control', 'Shift'],
     },

--- a/packages/app/src/vis-packs/core/utils.ts
+++ b/packages/app/src/vis-packs/core/utils.ts
@@ -20,6 +20,8 @@ export const INTERACTIONS_WITH_AXIAL_ZOOM = [
   ...BASE_INTERACTIONS,
   { shortcut: 'Alt+Wheel', description: 'Zoom in X' },
   { shortcut: 'Shift+Wheel', description: 'Zoom in Y' },
+  { shortcut: 'Ctrl+Alt+Drag', description: 'Select to zoom in X' },
+  { shortcut: 'Ctrl+Shift+Drag', description: 'Select to zoom in Y' },
 ];
 
 export function getBaseArray<T, U extends T[] | TypedArray | undefined>(

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -48,6 +48,7 @@ export { default as Zoom } from './interactions/Zoom';
 export { default as XAxisZoom } from './interactions/XAxisZoom';
 export { default as YAxisZoom } from './interactions/YAxisZoom';
 export { default as SelectToZoom } from './interactions/SelectToZoom';
+export { default as AxialSelectToZoom } from './interactions/AxialSelectToZoom';
 export { default as SelectionLine } from './interactions/SelectionLine';
 export { default as SelectionRect } from './interactions/SelectionRect';
 export { default as SelectionTool } from './interactions/SelectionTool';

--- a/packages/lib/src/interactions/AxialSelectToZoom.tsx
+++ b/packages/lib/src/interactions/AxialSelectToZoom.tsx
@@ -1,0 +1,92 @@
+import { useThree } from '@react-three/fiber';
+import { Vector2 } from 'three';
+
+import { useCameraState } from '../vis/hooks';
+import { useAxisSystemContext } from '../vis/shared/AxisSystemProvider';
+import { getVisibleDomains } from '../vis/utils';
+import SelectionRect from './SelectionRect';
+import SelectionTool from './SelectionTool';
+import { useMoveCameraTo } from './hooks';
+import type { ModifierKey, Selection } from './models';
+import { getEnclosedRectangle } from './utils';
+
+interface Props {
+  axis: 'x' | 'y';
+  disabled?: boolean;
+  modifierKey?: ModifierKey[] | ModifierKey;
+}
+
+function AxialSelectToZoom(props: Props) {
+  const { axis, modifierKey, disabled } = props;
+
+  const { dataToWorld } = useAxisSystemContext();
+  const moveCameraTo = useMoveCameraTo();
+
+  const { width, height } = useThree((state) => state.size);
+  const camera = useThree((state) => state.camera);
+
+  const { xVisibleDomain, yVisibleDomain } = useCameraState(
+    getVisibleDomains,
+    []
+  );
+
+  function getAxialSelection(selection: Selection): Selection {
+    const { startPoint: mouseStartPoint, endPoint: mouseEndPoint } = selection;
+    const startPoint =
+      axis === 'x'
+        ? new Vector2(mouseStartPoint.x, yVisibleDomain[0])
+        : new Vector2(xVisibleDomain[0], mouseStartPoint.y);
+    const endPoint =
+      axis === 'x'
+        ? new Vector2(mouseEndPoint.x, yVisibleDomain[1])
+        : new Vector2(xVisibleDomain[1], mouseEndPoint.y);
+
+    return {
+      startPoint,
+      endPoint,
+      worldStartPoint: dataToWorld(startPoint),
+      worldEndPoint: dataToWorld(endPoint),
+    };
+  }
+
+  function onSelectionEnd(selection: Selection) {
+    // Work in world coordinates as we need to act on the world camera
+    const { worldStartPoint, worldEndPoint } = getAxialSelection(selection);
+
+    if (
+      worldStartPoint.x === worldEndPoint.x ||
+      worldStartPoint.y === worldEndPoint.y
+    ) {
+      return;
+    }
+
+    const zoomRect = getEnclosedRectangle(worldStartPoint, worldEndPoint);
+    const { center: zoomRectCenter } = zoomRect;
+
+    // Change scale first so that moveCameraTo computes the updated camera bounds
+    camera.scale.set(zoomRect.width / width, zoomRect.height / height, 1);
+    camera.updateMatrixWorld();
+
+    moveCameraTo(zoomRectCenter.x, zoomRectCenter.y);
+  }
+
+  return (
+    <SelectionTool
+      onSelectionEnd={onSelectionEnd}
+      id={`AxialSelectToZoom${axis}`}
+      modifierKey={modifierKey}
+      disabled={disabled}
+    >
+      {(selection) => (
+        <SelectionRect
+          fill="white"
+          stroke="black"
+          fillOpacity={0.25}
+          {...getAxialSelection(selection)}
+        />
+      )}
+    </SelectionTool>
+  );
+}
+
+export default AxialSelectToZoom;

--- a/packages/lib/src/interactions/DefaultInteractions.tsx
+++ b/packages/lib/src/interactions/DefaultInteractions.tsx
@@ -5,6 +5,7 @@ import SelectToZoom from '../interactions/SelectToZoom';
 import XAxisZoom from '../interactions/XAxisZoom';
 import YAxisZoom from '../interactions/YAxisZoom';
 import Zoom from '../interactions/Zoom';
+import AxialSelectToZoom from './AxialSelectToZoom';
 import type { Interactions } from './models';
 import { getDefaultInteractions } from './utils';
 
@@ -43,6 +44,12 @@ function DefaultInteractions(props: Props) {
       {interactions.YAxisZoom && <YAxisZoom {...interactions.YAxisZoom} />}
       {interactions.SelectToZoom && (
         <SelectToZoom {...interactions.SelectToZoom} keepRatio={keepRatio} />
+      )}
+      {interactions.XSelectToZoom && (
+        <AxialSelectToZoom axis="x" {...interactions.XSelectToZoom} />
+      )}
+      {interactions.YSelectToZoom && (
+        <AxialSelectToZoom axis="y" {...interactions.YSelectToZoom} />
       )}
     </>
   );

--- a/packages/lib/src/interactions/InteractionsProvider.tsx
+++ b/packages/lib/src/interactions/InteractionsProvider.tsx
@@ -1,4 +1,3 @@
-import { assertDefined } from '@h5web/shared';
 import type { ReactNode } from 'react';
 import { createContext, useCallback, useContext, useState } from 'react';
 
@@ -44,7 +43,7 @@ function InteractionsProvider(props: { children: ReactNode }) {
     (interactionId: string, event: MouseEvent | WheelEvent) => {
       const registeredInteractions = [...interactionMap.values()];
 
-      function isButtonPressed(button?: MouseButton | 'Wheel') {
+      function isButtonPressed(button: MouseButton | 'Wheel') {
         if (event instanceof WheelEvent) {
           return button === 'Wheel';
         }
@@ -56,18 +55,13 @@ function InteractionsProvider(props: { children: ReactNode }) {
         return keys.every((k) => event.getModifierState(k));
       }
 
-      const params = interactionMap.get(interactionId);
-      assertDefined(params, `Interaction ${interactionId} is not registered.`);
-
-      const { disabled } = params;
-
-      if (disabled) {
-        return false;
+      if (!interactionMap.has(interactionId)) {
+        throw new Error(`Interaction ${interactionId} is not registered`);
       }
 
       const matchingInteractions = registeredInteractions.filter(
-        ({ modifierKeys: keys, button }) =>
-          isButtonPressed(button) && areKeysPressed(keys)
+        ({ modifierKeys: keys, button, disabled }) =>
+          !disabled && isButtonPressed(button) && areKeysPressed(keys)
       );
 
       if (matchingInteractions.length === 0) {

--- a/packages/lib/src/interactions/utils.ts
+++ b/packages/lib/src/interactions/utils.ts
@@ -55,6 +55,8 @@ export function getDefaultInteractions(
     XAxisZoom: { modifierKey: 'Alt', disabled: keepRatio },
     YAxisZoom: { modifierKey: 'Shift', disabled: keepRatio },
     SelectToZoom: { modifierKey: 'Control' },
+    XSelectToZoom: { modifierKey: ['Control', 'Alt'], disabled: keepRatio },
+    YSelectToZoom: { modifierKey: ['Control', 'Shift'], disabled: keepRatio },
   };
 }
 


### PR DESCRIPTION
Fix #1066

![Peek 2022-06-21 16-50](https://user-images.githubusercontent.com/42204205/174830315-3b75093d-30d1-4677-8a2a-1ea2a1fe37ca.gif)

This PR implements a specific component `AxialSelectToZoom` for drawing a selection to zoom on a single axis. Triggering this zoom mode can be done with  a specific combination of keys (thanks to #1144) rather than relying on the size of the rectangle (which can be fiddly).