### PR TITLE
Allow viewing remote files in H5Wasm demo

### DIFF
--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -23,6 +23,8 @@
   "dependencies": {
     "@h5web/app": "workspace:*",
     "@h5web/h5wasm": "workspace:*",
+    "axios": "0.27.2",
+    "axios-hooks": "3.1.2",
     "normalize.css": "8.0.1",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/apps/demo/src/Home.tsx
+++ b/apps/demo/src/Home.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from 'react';
 import { FiChevronsRight } from 'react-icons/fi';
 import { Link } from 'react-router-dom';
 
@@ -130,6 +131,33 @@ function Home() {
               This demo allows you to <strong>open any HDF5 files</strong> on
               your computer with H5Web. Note that if your files contain external
               links, they will not be resolved.
+            </p>
+            <p>
+              You can also provide the URL of a file hosted on a{' '}
+              <strong>static server</strong>. For instance, try these files
+              hosted on{' '}
+              <a
+                href="http://www.silx.org/pub/h5web/"
+                target="_blank"
+                rel="noreferrer"
+              >
+                silx.org
+              </a>
+              :{' '}
+              {['water_224.h5', 'epics.h5', 'grove.h5', 'tall.h5 '].map(
+                (filename, index) => (
+                  <Fragment key={filename}>
+                    {index > 0 && ', '}
+                    <Link
+                      to={`h5wasm?url=${encodeURIComponent(
+                        `https://www.silx.org/pub/h5web/${filename}`
+                      )}`}
+                    >
+                      {filename}
+                    </Link>
+                  </Fragment>
+                )
+              )}
             </p>
           </section>
           <section>

--- a/apps/demo/src/h5wasm/DropZone.tsx
+++ b/apps/demo/src/h5wasm/DropZone.tsx
@@ -2,16 +2,18 @@ import { useCallback, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 
 import styles from './H5WasmApp.module.css';
+import UrlForm from './UrlForm';
 import type { H5File } from './models';
 
 const EXT = ['.h5', '.hdf5', '.hdf', '.nx', '.nx5', '.nexus', '.nxs', '.cxi'];
 
 interface Props {
-  onChange: (h5File: H5File) => void;
+  onH5File: (h5File: H5File) => void;
 }
 
 function DropZone(props: Props) {
-  const { onChange } = props;
+  const { onH5File } = props;
+
   const [isReadingFile, setReadingFile] = useState(false);
 
   const onDropAccepted = useCallback(
@@ -20,13 +22,13 @@ function DropZone(props: Props) {
       reader.addEventListener('abort', () => setReadingFile(false));
       reader.addEventListener('error', () => setReadingFile(false));
       reader.addEventListener('load', () => {
-        onChange({ filename: file.name, buffer: reader.result as ArrayBuffer });
+        onH5File({ filename: file.name, buffer: reader.result as ArrayBuffer });
       });
 
       reader.readAsArrayBuffer(file);
       setReadingFile(true);
     },
-    [onChange]
+    [onH5File]
   );
 
   const { getRootProps, getInputProps, open, isDragActive, fileRejections } =
@@ -47,23 +49,24 @@ function DropZone(props: Props) {
     >
       <input {...getInputProps()} accept={EXT.join(',')} />
       <div className={styles.inner}>
-        {isDragActive ? (
-          <p className={styles.dropIt}>Drop it!</p>
-        ) : (
-          <>
-            <p className={styles.content}>
-              Drop an HDF5 file here{' '}
-              <button className={styles.btn} type="button" onClick={open}>
-                or use a file picker instead
-              </button>
+        {isDragActive && <p className={styles.dropIt}>Drop it!</p>}
+        <div hidden={isDragActive}>
+          <p className={styles.drop}>
+            <span>Drop an HDF5 file here</span>{' '}
+            <button className={styles.browseBtn} type="button" onClick={open}>
+              or use a file picker instead
+            </button>
+          </p>
+          {fileRejections.length > 1 && (
+            <p className={styles.hint} role="alert">
+              Please drop a single file
             </p>
-            {fileRejections.length > 1 && (
-              <p className={styles.hint} role="alert">
-                Please drop a single file
-              </p>
-            )}
-          </>
-        )}
+          )}
+          <p className={styles.fromUrl}>
+            You may also provide a URL if your file is hosted remotely:
+          </p>
+          <UrlForm onH5File={onH5File} />
+        </div>
       </div>
     </div>
   );

--- a/apps/demo/src/h5wasm/H5WasmApp.module.css
+++ b/apps/demo/src/h5wasm/H5WasmApp.module.css
@@ -1,8 +1,10 @@
 .dropZone {
-  height: 100%;
+  display: flex;
+  min-height: 100%;
   padding: 2rem;
-  text-align: center;
   background-color: var(--primary-bg);
+  text-align: center;
+  font-size: 1.125rem;
 }
 
 .activeDropZone {
@@ -16,38 +18,84 @@
 }
 
 .inner {
+  flex: 1 1 0%;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: 100%;
-  padding-bottom: 3vh;
+  padding: 1.5rem;
   border: 3px dashed currentColor;
   border-radius: 2rem;
 }
 
-.content {
-  font-size: 2rem;
-  margin: 0;
+.drop {
+  margin: -2vh 0 0;
 }
 
-.btn {
+.drop > span {
+  font-size: 2rem;
+}
+
+.browseBtn {
   composes: btnClean from global;
   display: block;
   margin: 0.25rem auto 0;
   padding: 0.25rem 1rem;
   color: #444;
-  font-size: 1.125rem;
   text-decoration: underline;
 }
 
-.btn:hover,
-.btn:focus-visible {
+.browseBtn:hover,
+.browseBtn:focus-visible {
   text-decoration: none;
 }
 
+.fromUrl {
+  margin-top: 1.5rem;
+}
+
+.fromUrl::before {
+  content: '';
+  display: block;
+  width: 15rem;
+  margin: 0 auto 1.5rem;
+  border-top: 2px solid currentColor;
+}
+
+.urlForm {
+  display: flex;
+  align-self: stretch;
+  font-size: 1rem;
+}
+
+.urlForm > fieldset {
+  flex: 1 1 0%;
+  display: flex;
+  justify-content: center;
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+.urlInput {
+  flex: 1 1 0%;
+  max-width: 20rem;
+}
+
+.goBtn {
+  composes: btnClean from global;
+  composes: ctaBtn from '../Home.module.css';
+  margin-left: 0.5rem;
+  margin-right: 0;
+}
+
+.goLoader {
+  animation: spin 1s ease-in-out infinite;
+}
+
 .hint {
-  margin: 2rem 0 0;
+  margin: 0.5rem 0 0;
+  font-size: 1rem;
   font-style: italic;
 }
 
@@ -57,4 +105,10 @@
 
 .dropIt {
   font-size: 5rem;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(180deg);
+  }
 }

--- a/apps/demo/src/h5wasm/H5WasmApp.tsx
+++ b/apps/demo/src/h5wasm/H5WasmApp.tsx
@@ -12,7 +12,7 @@ function H5WasmApp() {
   const [h5File, setH5File] = useState<H5File>();
 
   if (!h5File) {
-    return <DropZone onChange={setH5File} />;
+    return <DropZone onH5File={setH5File} />;
   }
 
   return (

--- a/apps/demo/src/h5wasm/UrlForm.tsx
+++ b/apps/demo/src/h5wasm/UrlForm.tsx
@@ -1,0 +1,86 @@
+import useAxios from 'axios-hooks';
+import type { FormEvent } from 'react';
+import { useCallback } from 'react';
+import { useEffect } from 'react';
+import { FiLoader } from 'react-icons/fi';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+import styles from './H5WasmApp.module.css';
+import type { H5File } from './models';
+
+interface Props {
+  onH5File: (h5File: H5File) => void;
+}
+
+function UrlForm(props: Props) {
+  const { onH5File } = props;
+
+  const navigate = useNavigate();
+  const query = new URLSearchParams(useLocation().search);
+  const url = query.get('url') || '';
+
+  const [{ loading, error }, execute] = useAxios<ArrayBuffer>(
+    { url, responseType: 'arraybuffer' },
+    { manual: true }
+  );
+
+  const fetchFile = useCallback(async () => {
+    if (url) {
+      const { data } = await execute();
+      onH5File({ filename: url.slice(url.lastIndexOf('/') + 1), buffer: data });
+    }
+  }, [url, execute, onH5File]);
+
+  useEffect(() => {
+    void fetchFile();
+  }, [url, fetchFile]);
+
+  function handleUrlSubmit(evt: FormEvent<HTMLFormElement>) {
+    evt.preventDefault();
+    const formData = new FormData(evt.currentTarget);
+    const newUrl = formData.get('url') as string;
+
+    if (newUrl === url) {
+      void fetchFile(); // refetch
+    } else {
+      navigate(`?${new URLSearchParams({ url: newUrl }).toString()}`);
+    }
+  }
+
+  // Make sure loading state appears on first render if appropriate
+  const isLoading = loading || (!!url && !error);
+
+  return (
+    <>
+      <form className={styles.urlForm} onSubmit={handleUrlSubmit}>
+        <fieldset disabled={isLoading}>
+          <input
+            className={styles.urlInput}
+            name="url"
+            type="url"
+            defaultValue={url}
+            placeholder="https://example.com/my-file.h5"
+            aria-labelledby="h5wasm-go"
+            required
+          />
+          <button id="h5wasm-go" className={styles.goBtn} type="submit">
+            {isLoading ? (
+              <FiLoader className={styles.goLoader} aria-label="Loading..." />
+            ) : (
+              'Go'
+            )}
+          </button>
+        </fieldset>
+      </form>
+      {error && (
+        <p className={styles.hint} role="alert">
+          {error.isAxiosError
+            ? 'Sorry, your file could not be fetched'
+            : `An error occured: ${error.message}`}
+        </p>
+      )}
+    </>
+  );
+}
+
+export default UrlForm;

--- a/apps/demo/src/h5wasm/UrlForm.tsx
+++ b/apps/demo/src/h5wasm/UrlForm.tsx
@@ -63,7 +63,7 @@ function UrlForm(props: Props) {
             aria-labelledby="h5wasm-go"
             required
           />
-          <button id="h5wasm-go" className={styles.goBtn} type="submit">
+          <button id="h5wasm-url" className={styles.urlBtn} type="submit">
             {isLoading ? (
               <FiLoader className={styles.goLoader} aria-label="Loading..." />
             ) : (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,8 @@ importers:
       '@types/react-dom': 17.0.11
       '@types/react-router-dom': 5.3.3
       '@vitejs/plugin-react': 1.3.2
+      axios: 0.27.2
+      axios-hooks: 3.1.2
       eslint: '>=8'
       eslint-config-galex: 4.1.4
       normalize.css: 8.0.1
@@ -64,6 +66,8 @@ importers:
     dependencies:
       '@h5web/app': link:../../packages/app
       '@h5web/h5wasm': link:../../packages/h5wasm
+      axios: 0.27.2
+      axios-hooks: 3.1.2_axios@0.27.2+react@17.0.2
       normalize.css: 8.0.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -5560,6 +5564,19 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
+  /axios-hooks/3.1.2_axios@0.27.2+react@17.0.2:
+    resolution: {integrity: sha512-bkanFqlRZC3ZdLFy62mgw+LtyL5b/KCJbSR0oYcePQfZLbYYi1IKSGmL3pRzy6vKiUiRIFDHH71diQq3clt0eA==}
+    peerDependencies:
+      axios: '>=0.24.0'
+      react: ^16.8.0-0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.18.3
+      axios: 0.27.2
+      dequal: 2.0.2
+      lru-cache: 6.0.0
+      react: 17.0.2
+    dev: false
+
   /axios/0.27.2:
     resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
     dependencies:
@@ -7305,6 +7322,11 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
     dev: true
+
+  /dequal/2.0.2:
+    resolution: {integrity: sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==}
+    engines: {node: '>=6'}
+    dev: false
 
   /des.js/1.0.1:
     resolution: {integrity: sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==}
@@ -9565,7 +9587,7 @@ packages:
   /history/5.3.0:
     resolution: {integrity: sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==}
     dependencies:
-      '@babel/runtime': 7.17.9
+      '@babel/runtime': 7.18.3
     dev: false
 
   /hmac-drbg/1.0.1:
@@ -11366,7 +11388,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
-    dev: true
 
   /lz-string/1.4.4:
     resolution: {integrity: sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==}
@@ -15836,7 +15857,6 @@ packages:
 
   /yallist/4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-    dev: true
 
   /yaml/1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}


### PR DESCRIPTION
- I've added a form to the H5Wasm demo to allow specifying a URL
- When the form is submitted, the app navigates to `?url=<url>`, which fetches the file as an `ArrayBuffer`
- While fetching, the form is disabled and a spinner is shown
- Once fetched, the buffer is passed to `H5WasmProvider` and the viewer shows up
- The use of the `url` param allows refreshing (cf. GIF below), bookmarking and linking (e.g. from the H5Web homepage)

![h5wasm-url](https://user-images.githubusercontent.com/2936402/175554457-868e7dca-3f1f-49ff-8fd6-e06493389b8e.gif)
