### PR TITLE
Warn when trying to register two interactions with the same ID

### DIFF
--- a/packages/lib/src/interactions/InteractionsProvider.tsx
+++ b/packages/lib/src/interactions/InteractionsProvider.tsx
@@ -27,7 +27,11 @@ function InteractionsProvider(props: { children: ReactNode }) {
 
   const registerInteraction = useCallback(
     (id: string, value: InteractionEntry) => {
-      interactionMap.set(id, { id, ...value });
+      if (interactionMap.has(id)) {
+        console.warn(`An interaction with ID "${id}" is already registered.`); // eslint-disable-line no-console
+      } else {
+        interactionMap.set(id, { id, ...value });
+      }
     },
     [interactionMap]
   );


### PR DESCRIPTION
Now, when this occurs, the second interaction no longer replaces the first. See https://github.com/silx-kit/h5web/issues/1143#issuecomment-1164050717