### PR TITLE
Add docker and docker-compose support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# 
+# Build stage 1.
+#
+FROM node:16-alpine
+
+COPY . ./h5web/
+WORKDIR /h5web
+RUN npm install -g pnpm
+RUN pnpm install
+RUN pnpm build
+EXPOSE 80
+CMD pnpm serve
+
+#
+# Build stage 2.
+#
+
+FROM nginx:alpine
+COPY --from=0 /h5web/apps/demo/dist/ /usr/share/nginx/html/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,35 @@
+version: '3.1'
+
+services:
+    reverse-proxy:
+        image: traefik:2.5
+        command: --api.insecure=true --providers.docker=true --entrypoints.web.address=:80
+        ports:
+            - "80:80"
+        volumes:
+            - /var/run/docker.sock:/var/run/docker.sock
+           
+    h5web: 
+        #image: h5web:test   ... add this line once there is an official image ...
+        build:
+            #added build just to circumvent publishing an unofficial image
+            context: https://github.com/schreiber-lab/h5web.git#add_Docker
+            #before merge: change context from fork to main repo
+
+        labels:
+            - "traefik.http.routers.catanie.rule=PathPrefix(`/`)"
+            - "traefik.http.routers.catanie.entrypoints=web"
+    
+    h5grove:
+        #image: h5grove:test ... add this line once there is an official image ...
+        build:
+            #added build just to circumvent publishing an unofficial image
+            context: https://github.com/schreiber-lab/h5grove.git#add_Dockerfile
+            #before merge: change context from fork to main repo
+
+        labels:
+            - "traefik.http.routers.catamel.rule=PathPrefix(`/attr`,`/data`,`/meta`,`/stats` )"
+            - "traefik.http.routers.catamel.entrypoints=web"
+        #volumes:
+        # specify the path to data file/dir on host machine and mount it in /data 
+        #   - "/path/to/dataset/dataset.h5:/data/dataset.h5"


### PR DESCRIPTION
Together with https://github.com/silx-kit/h5grove/pull/70 this is a first attempt to add a Dockerfile to build a production-ready image of h5web and bundle it as h5grove as a stand-alone micro-service in docker-compose to illustrate the use-case.

since there are no official h5web and 5hgrove images in the docker registry yet the docker-compose build context is used to create the corresponding images on the spot.

```
docker-compose build
docker-compose up
```