### PR TITLE
Remove derived props in Mapped..Vis components

### DIFF
--- a/packages/app/src/vis-packs/core/heatmap/HeatmapVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/HeatmapVisContainer.tsx
@@ -22,7 +22,6 @@ function HeatmapVisContainer(props: VisContainerProps) {
 
   const { shape: dims } = entity;
   const [dimMapping, setDimMapping] = useDimMappingState(dims, 2);
-  const selection = getSliceSelection(dimMapping);
 
   return (
     <>
@@ -34,13 +33,11 @@ function HeatmapVisContainer(props: VisContainerProps) {
       <VisBoundary resetKey={dimMapping} loadingMessage="Loading current slice">
         <ValueFetcher
           dataset={entity}
-          selection={selection}
+          selection={getSliceSelection(dimMapping)}
           render={(value) => (
             <MappedHeatmapVis
               dataset={entity}
-              selection={selection}
               value={value}
-              dims={dims}
               dimMapping={dimMapping}
               title={entity.name}
               toolbarContainer={toolbarContainer}

--- a/packages/app/src/vis-packs/core/heatmap/MappedHeatmapVis.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/MappedHeatmapVis.tsx
@@ -12,15 +12,13 @@ import shallow from 'zustand/shallow';
 import type { DimensionMapping } from '../../../dimension-mapper/models';
 import { useMappedArray, useSlicedDimsAndMapping } from '../hooks';
 import type { AxisMapping } from '../models';
-import { DEFAULT_DOMAIN } from '../utils';
+import { DEFAULT_DOMAIN, getSliceSelection } from '../utils';
 import HeatmapToolbar from './HeatmapToolbar';
 import { useHeatmapConfig } from './config';
 
 interface Props {
   dataset: Dataset<ArrayShape, NumericType>;
-  selection: string | undefined;
   value: number[] | TypedArray;
-  dims: number[];
   dimMapping: DimensionMapping;
   axisMapping?: AxisMapping;
   title: string;
@@ -31,9 +29,7 @@ interface Props {
 function MappedHeatmapVis(props: Props) {
   const {
     dataset,
-    selection,
     value,
-    dims,
     dimMapping,
     axisMapping = [],
     title,
@@ -51,6 +47,7 @@ function MappedHeatmapVis(props: Props) {
     flipYAxis,
   } = useHeatmapConfig((state) => state, shallow);
 
+  const { shape: dims } = dataset;
   const [slicedDims, slicedMapping] = useSlicedDimsAndMapping(dims, dimMapping);
   const [dataArray] = useMappedArray(value, slicedDims, slicedMapping);
 
@@ -65,7 +62,7 @@ function MappedHeatmapVis(props: Props) {
           <HeatmapToolbar
             dataset={dataset}
             dataDomain={dataDomain}
-            selection={selection}
+            selection={getSliceSelection(dimMapping)}
             initialScaleType={colorScaleType}
           />,
           toolbarContainer

--- a/packages/app/src/vis-packs/core/matrix/MappedMatrixVis.tsx
+++ b/packages/app/src/vis-packs/core/matrix/MappedMatrixVis.tsx
@@ -10,28 +10,27 @@ import shallow from 'zustand/shallow';
 
 import type { DimensionMapping } from '../../../dimension-mapper/models';
 import { useMappedArray, useSlicedDimsAndMapping } from '../hooks';
+import { getSliceSelection } from '../utils';
 import MatrixToolbar from './MatrixToolbar';
 import { useMatrixConfig } from './config';
 import { getCellWidth, getFormatter } from './utils';
 
 interface Props {
   dataset: Dataset<ArrayShape, PrintableType>;
-  selection: string | undefined;
   value: ArrayValue<PrintableType>;
-  dims: number[];
   dimMapping: DimensionMapping;
   toolbarContainer: HTMLDivElement | undefined;
 }
 
 function MappedMatrixVis(props: Props) {
-  const { dataset, selection, value, dims, dimMapping, toolbarContainer } =
-    props;
+  const { dataset, value, dimMapping, toolbarContainer } = props;
 
   const { sticky, customCellWidth } = useMatrixConfig(
     (state) => state,
     shallow
   );
 
+  const { shape: dims } = dataset;
   const [slicedDims, slicedMapping] = useSlicedDimsAndMapping(dims, dimMapping);
   const [mappedArray] = useMappedArray(value, slicedDims, slicedMapping);
 
@@ -44,7 +43,7 @@ function MappedMatrixVis(props: Props) {
         createPortal(
           <MatrixToolbar
             dataset={dataset}
-            selection={selection}
+            selection={getSliceSelection(dimMapping)}
             cellWidth={cellWidth}
           />,
           toolbarContainer

--- a/packages/app/src/vis-packs/core/matrix/MatrixVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/matrix/MatrixVisContainer.tsx
@@ -21,7 +21,6 @@ function MatrixVisContainer(props: VisContainerProps) {
   const { shape: dims } = entity;
   const axesCount = Math.min(dims.length, 2);
   const [dimMapping, setDimMapping] = useDimMappingState(dims, axesCount);
-  const selection = getSliceSelection(dimMapping);
 
   return (
     <>
@@ -33,13 +32,11 @@ function MatrixVisContainer(props: VisContainerProps) {
       <VisBoundary resetKey={dimMapping} loadingMessage="Loading current slice">
         <ValueFetcher
           dataset={entity}
-          selection={selection}
+          selection={getSliceSelection(dimMapping)}
           render={(value) => (
             <MappedMatrixVis
               dataset={entity}
-              selection={selection}
               value={value}
-              dims={dims}
               dimMapping={dimMapping}
               toolbarContainer={toolbarContainer}
             />

--- a/packages/app/src/vis-packs/nexus/containers/NxImageContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxImageContainer.tsx
@@ -22,7 +22,6 @@ function NxImageContainer(props: VisContainerProps) {
 
   const { shape: dims } = signalDataset;
   const [dimMapping, setDimMapping] = useDimMappingState(dims, 2);
-  const selection = getSliceSelection(dimMapping);
 
   return (
     <>
@@ -34,16 +33,14 @@ function NxImageContainer(props: VisContainerProps) {
       <VisBoundary resetKey={dimMapping}>
         <NxValuesFetcher
           nxData={nxData}
-          selection={selection}
+          selection={getSliceSelection(dimMapping)}
           render={(nxValues) => {
             const { signal, axisMapping, title } = nxValues;
 
             return (
               <MappedHeatmapVis
                 dataset={signalDataset}
-                selection={selection}
                 value={signal}
-                dims={dims}
                 dimMapping={dimMapping}
                 axisMapping={axisMapping}
                 title={title}


### PR DESCRIPTION
See https://github.com/silx-kit/h5web/pull/1169#discussion_r919805775

Done for `Heatmap` and `Matrix`. `Line` is a bit more complicated:
- `selection` can be forced to `undefined` in the `Mapped..` component due to `autoscale` #445 
- `dataset` is optional for `ComplexLine` as the export is disabled

This would perhaps need a specific refactoring