### PR TITLE
Enforce stronger types for `DataProviderApi.getEntity()`

### DIFF
--- a/packages/app/src/explorer/EntityItem.tsx
+++ b/packages/app/src/explorer/EntityItem.tsx
@@ -1,5 +1,5 @@
 import { isGroup } from '@h5web/shared';
-import type { Entity } from '@h5web/shared';
+import type { ChildEntity } from '@h5web/shared';
 import { useToggle } from '@react-hookz/web';
 import type { CSSProperties } from 'react';
 import { Suspense, useEffect } from 'react';
@@ -13,7 +13,7 @@ import NxBadge from './NxBadge';
 
 interface Props {
   path: string;
-  entity: Entity;
+  entity: ChildEntity;
   level: number;
   selectedPath: string;
   onSelect: (path: string) => void;

--- a/packages/app/src/explorer/EntityList.tsx
+++ b/packages/app/src/explorer/EntityList.tsx
@@ -1,4 +1,4 @@
-import { assertGroupWithChildren, buildEntityPath } from '@h5web/shared';
+import { assertGroup, buildEntityPath } from '@h5web/shared';
 
 import { useDataContext } from '../providers/DataProvider';
 import EntityItem from './EntityItem';
@@ -16,7 +16,7 @@ function EntityList(props: Props) {
 
   const { entitiesStore } = useDataContext();
   const group = entitiesStore.get(parentPath);
-  assertGroupWithChildren(group);
+  assertGroup(group);
 
   if (group.children.length === 0) {
     return null;

--- a/packages/app/src/explorer/Icon.tsx
+++ b/packages/app/src/explorer/Icon.tsx
@@ -1,9 +1,7 @@
 import { isGroup, EntityKind } from '@h5web/shared';
-import type { Entity } from '@h5web/shared';
-import type { IconType } from 'react-icons';
+import type { ChildEntity } from '@h5web/shared';
 import {
   FiHash,
-  FiFolder,
   FiChevronDown,
   FiChevronRight,
   FiLayers,
@@ -12,15 +10,14 @@ import {
 
 import styles from './Explorer.module.css';
 
-const LEAF_ICONS: Record<EntityKind, IconType> = {
-  [EntityKind.Group]: FiFolder,
+const LEAF_ICONS = {
   [EntityKind.Dataset]: FiLayers,
   [EntityKind.Datatype]: FiHash,
   [EntityKind.Unresolved]: FiLink,
 };
 
 interface Props {
-  entity: Entity;
+  entity: ChildEntity;
   isExpanded: boolean;
 }
 

--- a/packages/app/src/explorer/NxBadge.tsx
+++ b/packages/app/src/explorer/NxBadge.tsx
@@ -1,11 +1,11 @@
-import type { Entity } from '@h5web/shared';
+import type { ChildEntity } from '@h5web/shared';
 
 import { useDataContext } from '../providers/DataProvider';
 import styles from './Explorer.module.css';
 import { needsNxBadge } from './utils';
 
 interface Props {
-  entity: Entity;
+  entity: ChildEntity;
 }
 
 function NxBadge(props: Props) {

--- a/packages/app/src/explorer/utils.ts
+++ b/packages/app/src/explorer/utils.ts
@@ -1,4 +1,4 @@
-import type { Entity } from '@h5web/shared';
+import type { ChildEntity } from '@h5web/shared';
 import { isGroup, assertStr } from '@h5web/shared';
 
 import type { AttrValuesStore } from '../providers/models';
@@ -7,7 +7,7 @@ import { hasAttribute } from '../utils';
 const SUPPORTED_NX_CLASSES = new Set(['NXdata', 'NXentry', 'NXprocess']);
 
 export function needsNxBadge(
-  entity: Entity,
+  entity: ChildEntity,
   attrValuesStore: AttrValuesStore
 ): boolean {
   if (!isGroup(entity)) {

--- a/packages/app/src/metadata-viewer/AttributesInfo.tsx
+++ b/packages/app/src/metadata-viewer/AttributesInfo.tsx
@@ -1,4 +1,4 @@
-import type { Entity } from '@h5web/shared';
+import type { ProvidedEntity } from '@h5web/shared';
 import { isComplexValue } from '@h5web/shared';
 
 import { useDataContext } from '../providers/DataProvider';
@@ -13,7 +13,7 @@ const FOLLOWABLE_ATTRS = new Set([
 ]);
 
 interface Props {
-  entity: Entity;
+  entity: ProvidedEntity;
   onFollowPath: (path: string) => void;
 }
 

--- a/packages/app/src/metadata-viewer/EntityInfo.tsx
+++ b/packages/app/src/metadata-viewer/EntityInfo.tsx
@@ -1,5 +1,5 @@
 import { isDataset, isDatatype } from '@h5web/shared';
-import type { Entity } from '@h5web/shared';
+import type { ProvidedEntity } from '@h5web/shared';
 
 import { useDataContext } from '../providers/DataProvider';
 import styles from './MetadataViewer.module.css';
@@ -7,7 +7,7 @@ import RawInspector from './RawInspector';
 import { renderType, renderShape } from './utils';
 
 interface Props {
-  entity: Entity;
+  entity: ProvidedEntity;
 }
 
 function EntityInfo(props: Props) {

--- a/packages/app/src/metadata-viewer/RawInspector.tsx
+++ b/packages/app/src/metadata-viewer/RawInspector.tsx
@@ -1,9 +1,9 @@
-import type { Entity } from '@h5web/shared';
+import type { ProvidedEntity } from '@h5web/shared';
 
 import styles from './RawInspector.module.css';
 
 interface Props {
-  entity: Entity;
+  entity: ProvidedEntity;
 }
 
 function RawInspector(props: Props) {

--- a/packages/app/src/providers/DataProvider.tsx
+++ b/packages/app/src/providers/DataProvider.tsx
@@ -1,5 +1,5 @@
-import type { Entity } from '@h5web/shared';
-import { assertGroupWithChildren, isGroup } from '@h5web/shared';
+import type { ChildEntity, Entity, Group } from '@h5web/shared';
+import { isGroup } from '@h5web/shared';
 import type { PropsWithChildren } from 'react';
 import { createContext, useContext, useMemo } from 'react';
 import { createFetchStore } from 'react-suspense-fetch';
@@ -43,25 +43,23 @@ function DataProvider(props: PropsWithChildren<Props>) {
   const { api, children } = props;
 
   const entitiesStore = useMemo(() => {
-    const childCache = new Map<string, Entity>();
+    const childCache = new Map<string, Exclude<ChildEntity, Group>>();
 
     const store = createFetchStore(async (path: string) => {
-      if (childCache.has(path)) {
-        return childCache.get(path) as Entity;
+      const cachedEntity = childCache.get(path);
+      if (cachedEntity) {
+        return cachedEntity;
       }
 
       const entity = await api.getEntity(path);
 
       if (isGroup(entity)) {
-        // Make sure `getEntity` doesn't return groups without `children` proprety
-        assertGroupWithChildren(entity);
-
         // Cache non-group children (datasets, datatypes and links)
-        entity.children
-          .filter((child) => !isGroup(child))
-          .forEach((child) => {
+        entity.children.forEach((child) => {
+          if (!isGroup(child)) {
             childCache.set(child.path, child);
-          });
+          }
+        });
       }
 
       return entity;

--- a/packages/app/src/providers/api.ts
+++ b/packages/app/src/providers/api.ts
@@ -5,6 +5,7 @@ import type {
   Dataset,
   Entity,
   NumericType,
+  ProvidedEntity,
 } from '@h5web/shared';
 import type {
   AxiosInstance,
@@ -108,7 +109,7 @@ export abstract class DataProviderApi {
     this.progressListeners.forEach((cb) => cb([...this.progress.values()]));
   }
 
-  public abstract getEntity(path: string): Promise<Entity>;
+  public abstract getEntity(path: string): Promise<ProvidedEntity>;
   public abstract getValue(params: ValuesStoreParams): Promise<unknown>;
   public abstract getAttrValues(entity: Entity): Promise<AttributeValues>;
 }

--- a/packages/app/src/providers/hsds/models.ts
+++ b/packages/app/src/providers/hsds/models.ts
@@ -66,6 +66,11 @@ interface HsdsSymbolicLink {
 /* ------------------- */
 /* ----- ENTITIES----- */
 
+export type BaseHsdsEntity = Pick<
+  HsdsEntity,
+  'id' | 'collection' | 'path' | 'name'
+>;
+
 export type HsdsEntity<T extends Entity = Entity> = T & {
   id: HsdsId;
   collection: HsdsCollection;

--- a/packages/app/src/providers/hsds/utils.ts
+++ b/packages/app/src/providers/hsds/utils.ts
@@ -26,7 +26,9 @@ export function isHsdsGroup(entity: HsdsEntity): entity is HsdsEntity<Group> {
   return isGroup(entity);
 }
 
-export function assertHsdsEntity(entity: Entity): asserts entity is HsdsEntity {
+export function assertHsdsEntity<T extends Entity>(
+  entity: T
+): asserts entity is HsdsEntity<T> {
   if (!('id' in entity)) {
     throw new Error('Expected entity to be HSDS entity');
   }

--- a/packages/app/src/providers/mock/mock-api.ts
+++ b/packages/app/src/providers/mock/mock-api.ts
@@ -2,6 +2,7 @@ import type {
   ArrayShape,
   AttributeValues,
   Entity,
+  ProvidedEntity,
   ScalarShape,
 } from '@h5web/shared';
 import {
@@ -29,7 +30,7 @@ export class MockApi extends DataProviderApi {
     super(mockFilepath);
   }
 
-  public async getEntity(path: string): Promise<Entity> {
+  public async getEntity(path: string): Promise<ProvidedEntity> {
     if (path.includes('slow_metadata')) {
       await new Promise<void>((resolve) => {
         setTimeout(() => resolve(), SLOW_TIMEOUT);

--- a/packages/app/src/providers/models.ts
+++ b/packages/app/src/providers/models.ts
@@ -4,13 +4,14 @@ import type {
   ArrayShape,
   Dataset,
   ScalarShape,
+  ProvidedEntity,
 } from '@h5web/shared';
 import type { FetchStore } from 'react-suspense-fetch';
 
 import type { ImageAttribute } from '../vis-packs/core/models';
 import type { NxAttribute } from '../vis-packs/nexus/models';
 
-export type EntitiesStore = FetchStore<Entity, string>;
+export type EntitiesStore = FetchStore<ProvidedEntity, string>;
 
 export interface ValuesStore extends FetchStore<unknown, ValuesStoreParams> {
   cancelOngoing: () => void;

--- a/packages/app/src/vis-packs/models.ts
+++ b/packages/app/src/vis-packs/models.ts
@@ -1,9 +1,9 @@
-import type { Entity } from '@h5web/shared';
+import type { ProvidedEntity } from '@h5web/shared';
 import type { ElementType, ReactNode } from 'react';
 import type { IconType } from 'react-icons';
 
 export interface VisContainerProps {
-  entity: Entity;
+  entity: ProvidedEntity;
   toolbarContainer: HTMLDivElement | undefined;
 }
 

--- a/packages/app/src/vis-packs/nexus/containers/NxComplexImageContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxComplexImageContainer.tsx
@@ -1,4 +1,4 @@
-import { assertGroupWithChildren, assertMinDims } from '@h5web/shared';
+import { assertGroup, assertMinDims } from '@h5web/shared';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useDimMappingState } from '../../../dimension-mapper/hooks';
@@ -12,7 +12,7 @@ import { assertComplexSignal } from '../utils';
 
 function NxComplexImageContainer(props: VisContainerProps) {
   const { entity, toolbarContainer } = props;
-  assertGroupWithChildren(entity);
+  assertGroup(entity);
 
   const nxData = useNxData(entity);
   assertComplexSignal(nxData);

--- a/packages/app/src/vis-packs/nexus/containers/NxComplexSpectrumContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxComplexSpectrumContainer.tsx
@@ -1,4 +1,4 @@
-import { assertGroupWithChildren } from '@h5web/shared';
+import { assertGroup } from '@h5web/shared';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useDimMappingState } from '../../../dimension-mapper/hooks';
@@ -13,7 +13,7 @@ import { useNxData } from '../hooks';
 
 function NxComplexSpectrumContainer(props: VisContainerProps) {
   const { entity, toolbarContainer } = props;
-  assertGroupWithChildren(entity);
+  assertGroup(entity);
 
   const nxData = useNxData(entity);
   assertComplexNxData(nxData);

--- a/packages/app/src/vis-packs/nexus/containers/NxImageContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxImageContainer.tsx
@@ -1,4 +1,4 @@
-import { assertGroupWithChildren, assertMinDims } from '@h5web/shared';
+import { assertGroup, assertMinDims } from '@h5web/shared';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useDimMappingState } from '../../../dimension-mapper/hooks';
@@ -12,7 +12,7 @@ import { assertNumericSignal } from '../utils';
 
 function NxImageContainer(props: VisContainerProps) {
   const { entity, toolbarContainer } = props;
-  assertGroupWithChildren(entity);
+  assertGroup(entity);
 
   const nxData = useNxData(entity);
   assertNumericSignal(nxData);

--- a/packages/app/src/vis-packs/nexus/containers/NxRgbContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxRgbContainer.tsx
@@ -1,4 +1,4 @@
-import { assertGroupWithChildren, assertNumDims } from '@h5web/shared';
+import { assertGroup, assertNumDims } from '@h5web/shared';
 
 import VisBoundary from '../../VisBoundary';
 import MappedRgbVis from '../../core/rgb/MappedRgbVis';
@@ -9,7 +9,7 @@ import { assertNumericSignal } from '../utils';
 
 function NxRgbContainer(props: VisContainerProps) {
   const { entity, toolbarContainer } = props;
-  assertGroupWithChildren(entity);
+  assertGroup(entity);
 
   const nxData = useNxData(entity);
   assertNumericSignal(nxData);

--- a/packages/app/src/vis-packs/nexus/containers/NxScatterContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxScatterContainer.tsx
@@ -1,8 +1,4 @@
-import {
-  assertDefined,
-  assertGroupWithChildren,
-  assertNumDims,
-} from '@h5web/shared';
+import { assertDefined, assertGroup, assertNumDims } from '@h5web/shared';
 import { isEqual } from 'lodash';
 
 import VisBoundary from '../../VisBoundary';
@@ -15,7 +11,7 @@ import { assertScatterAxisParams } from '../utils';
 
 function NxScatterContainer(props: VisContainerProps) {
   const { entity, toolbarContainer } = props;
-  assertGroupWithChildren(entity);
+  assertGroup(entity);
 
   const nxData = useNxData(entity);
   assertNumericNxData(nxData);

--- a/packages/app/src/vis-packs/nexus/containers/NxSpectrumContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxSpectrumContainer.tsx
@@ -1,4 +1,4 @@
-import { assertGroupWithChildren } from '@h5web/shared';
+import { assertGroup } from '@h5web/shared';
 import { isEqual } from 'lodash';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
@@ -14,7 +14,7 @@ import { useNxData } from '../hooks';
 
 function NxSpectrumContainer(props: VisContainerProps) {
   const { entity, toolbarContainer } = props;
-  assertGroupWithChildren(entity);
+  assertGroup(entity);
 
   const nxData = useNxData(entity);
   assertNumericNxData(nxData);

--- a/packages/app/src/visualizer/VisManager.tsx
+++ b/packages/app/src/visualizer/VisManager.tsx
@@ -1,4 +1,4 @@
-import type { Entity } from '@h5web/shared';
+import type { ProvidedEntity } from '@h5web/shared';
 import { assertDefined } from '@h5web/shared';
 import { useState } from 'react';
 
@@ -9,7 +9,7 @@ import styles from './Visualizer.module.css';
 import { useActiveVis } from './hooks';
 
 interface Props {
-  entity: Entity;
+  entity: ProvidedEntity;
   supportedVis: VisDef[];
 }
 

--- a/packages/app/src/visualizer/utils.ts
+++ b/packages/app/src/visualizer/utils.ts
@@ -1,6 +1,5 @@
-import type { Entity } from '@h5web/shared';
+import type { ChildEntity, ProvidedEntity } from '@h5web/shared';
 import {
-  assertGroupWithChildren,
   assertStr,
   buildEntityPath,
   hasComplexType,
@@ -27,7 +26,7 @@ export function resolvePath(
   path: string,
   entitiesStore: EntitiesStore,
   attrValueStore: AttrValuesStore
-): { entity: Entity; supportedVis: VisDef[] } | undefined {
+): { entity: ProvidedEntity; supportedVis: VisDef[] } | undefined {
   const entity = entitiesStore.get(path);
 
   const supportedVis = findSupportedVis(entity, attrValueStore);
@@ -44,7 +43,7 @@ export function resolvePath(
 }
 
 function findSupportedVis(
-  entity: Entity,
+  entity: ProvidedEntity,
   attrValueStore: AttrValuesStore
 ): VisDef[] {
   const nxVis = getSupportedNxVis(entity, attrValueStore);
@@ -56,7 +55,7 @@ function findSupportedVis(
 }
 
 function getNxDefaultPath(
-  entity: Entity,
+  entity: ProvidedEntity,
   attrValueStore: AttrValuesStore
 ): string | undefined {
   if (!isGroup(entity)) {
@@ -73,12 +72,11 @@ function getNxDefaultPath(
       : buildEntityPath(entity.path, defaultPath);
   }
 
-  assertGroupWithChildren(entity);
   return getImplicitDefaultChild(entity.children, attrValueStore)?.path;
 }
 
 function getSupportedCoreVis(
-  entity: Entity,
+  entity: ProvidedEntity,
   attrValueStore: AttrValuesStore
 ): CoreVisDef[] {
   const supportedVis = Object.values(CORE_VIS).filter(
@@ -91,14 +89,13 @@ function getSupportedCoreVis(
 }
 
 function getSupportedNxVis(
-  entity: Entity,
+  entity: ProvidedEntity,
   attrValuesStore: AttrValuesStore
 ): VisDef[] {
   if (!isGroup(entity)) {
     return [];
   }
 
-  assertGroupWithChildren(entity);
   if (!isNxDataGroup(entity, attrValuesStore)) {
     return [];
   }
@@ -144,9 +141,9 @@ function getSupportedNxVis(
 }
 
 function getImplicitDefaultChild(
-  children: Entity[],
+  children: ChildEntity[],
   attrValueStore: AttrValuesStore
-): Entity | undefined {
+): ChildEntity | undefined {
   const nxGroups = children
     .filter(isGroup)
     .filter((g) => hasAttribute(g, 'NX_class'));

--- a/packages/shared/src/guards.ts
+++ b/packages/shared/src/guards.ts
@@ -128,14 +128,20 @@ export function isGroup(entity: Entity): entity is Group {
   return entity.kind === EntityKind.Group;
 }
 
+export function assertGroup(entity: Entity): asserts entity is Group {
+  if (!isGroup(entity)) {
+    throw new Error('Expected group');
+  }
+}
+
 export function hasChildren(group: Group): group is GroupWithChildren {
   return 'children' in group;
 }
 
 export function assertGroupWithChildren(
-  entity: Entity
-): asserts entity is GroupWithChildren {
-  if (!isGroup(entity) || !hasChildren(entity)) {
+  group: Group
+): asserts group is GroupWithChildren {
+  if (!hasChildren(group)) {
     throw new Error('Expected group with children');
   }
 }

--- a/packages/shared/src/mock/metadata-utils.ts
+++ b/packages/shared/src/mock/metadata-utils.ts
@@ -17,6 +17,7 @@ import type {
   UnresolvedEntity,
   GroupWithChildren,
   PrintableCompoundType,
+  ChildEntity,
 } from '../models-hdf5';
 import { EntityKind, DTypeClass, Endianness } from '../models-hdf5';
 import type { NxInterpretation, SilxStyle } from '../models-nexus';
@@ -131,7 +132,7 @@ export function withImageAttributes<T extends Entity>(entity: T): T {
 /* ----- ENTITIES ----- */
 
 type EntityOpts = Partial<Pick<Entity, 'attributes' | 'link'>>;
-type GroupOpts = EntityOpts & { isRoot?: boolean; children?: Entity[] };
+type GroupOpts = EntityOpts & { isRoot?: boolean; children?: ChildEntity[] };
 type DatasetOpts = EntityOpts & { valueId?: MockValueId };
 
 function prefixChildrenPaths(
@@ -149,7 +150,7 @@ function prefixChildrenPaths(
 
 export function makeGroup(
   name: string,
-  children: Entity[] = [],
+  children: ChildEntity[] = [],
   opts: Omit<GroupOpts, 'children'> = {}
 ): GroupWithChildren {
   const { attributes = [], link, isRoot = false } = opts;
@@ -261,7 +262,7 @@ export function makeNxGroup(
   name: string,
   type: 'NXroot' | 'NXentry' | 'NXprocess' | 'NXdata',
   opts: { defaultPath?: string } & GroupOpts = {}
-): Group {
+): GroupWithChildren {
   const { defaultPath, children, ...groupOpts } = opts;
 
   return makeGroup(name, children, {

--- a/packages/shared/src/models-hdf5.ts
+++ b/packages/shared/src/models-hdf5.ts
@@ -18,12 +18,20 @@ export interface Entity {
   link?: Link;
 }
 
+export type ProvidedEntity =
+  | GroupWithChildren
+  | Dataset
+  | Datatype
+  | UnresolvedEntity;
+
+export type ChildEntity = Group | Dataset | Datatype | UnresolvedEntity;
+
 export interface Group extends Entity {
   kind: EntityKind.Group;
 }
 
 export interface GroupWithChildren extends Group {
-  children: Entity[];
+  children: ChildEntity[];
 }
 
 export interface Dataset<S extends Shape = Shape, T extends DType = DType>

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -4,7 +4,11 @@ import type { NdArray, TypedArray } from 'ndarray';
 import { assign } from 'ndarray-ops';
 
 import { assertLength, isNdArray, isTypedArray } from './guards';
-import type { Entity, GroupWithChildren, H5WebComplex } from './models-hdf5';
+import type {
+  ChildEntity,
+  GroupWithChildren,
+  H5WebComplex,
+} from './models-hdf5';
 import { ScaleType } from './models-vis';
 import type {
   Bounds,
@@ -55,7 +59,7 @@ export function toTypedNdArray<T extends TypedArrayConstructor>(
 export function getChildEntity(
   group: GroupWithChildren,
   entityName: string
-): Entity | undefined {
+): ChildEntity | undefined {
   return group.children.find((child) => child.name === entityName);
 }
 


### PR DESCRIPTION
Stems from #1180 

This PR enforces that `DataProviderApi.getEntity()` cannot return a `Group` without children by introducing a model called `ProvidedEntity`, which is a union of `GroupWithChildren`, `Dataset`, `Datatype` and `UnresolvedEntity`.

I also introduce a model called `ChildEntity`, which is similar but includes `Group` instead of `GroupWithChildren`.

These two models bring quite a bit of clarity throughout the app and allow simplifying a couple of things. For instance, to assert that a `ProvidedEntity` is a `GroupWithChildren`, we now need to check only if it's a group and can just skip the `children` check.