### PR TITLE
Fix onSelectionChange not called in SelectionTool

### DIFF
--- a/packages/lib/src/interactions/SelectionTool.tsx
+++ b/packages/lib/src/interactions/SelectionTool.tsx
@@ -72,14 +72,14 @@ function SelectionTool(props: Props) {
         return;
       }
 
-      const { worldPt, sourceEvent } = evt;
+      const { worldPt } = evt;
       const dataEndPoint = worldToData(boundPointToFOV(worldPt, camera));
       setEndPoint(dataEndPoint);
 
       const worldEndPoint = dataToWorld(dataEndPoint);
       const worldStartPoint = dataToWorld(startPoint);
 
-      if (onSelectionChange && shouldInteract(sourceEvent)) {
+      if (onSelectionChange && isModifierKeyPressed) {
         onSelectionChange({
           startPoint,
           endPoint: dataEndPoint,
@@ -95,7 +95,7 @@ function SelectionTool(props: Props) {
       setEndPoint,
       dataToWorld,
       onSelectionChange,
-      shouldInteract,
+      isModifierKeyPressed,
     ]
   );
 


### PR DESCRIPTION
The `onSelectionChange` callback of `SelectionTool` is not called when the mouse moves (see https://h5web-docs.panosc.eu/?path=/story/building-blocks-selection--rectangle where the title should update when dragging a rectangle).

This is a quick fix as a discussion with @axelboc showed that a bigger refactoring could be envisionned to distinguish checks for starting the interaction and checks for continuing the interaction on pointer moves.