### PR TITLE
Allow to disable dark mode of App

### DIFF
--- a/apps/demo/src/H5GroveApp.tsx
+++ b/apps/demo/src/H5GroveApp.tsx
@@ -16,7 +16,11 @@ function H5GroveApp() {
       filepath={filepath}
       axiosConfig={{ params: { file: filepath } }}
     >
-      <App explorerOpen={!query.has('wide')} getFeedbackURL={getFeedbackURL} />
+      <App
+        explorerOpen={!query.has('wide')}
+        getFeedbackURL={getFeedbackURL}
+        disableDarkMode
+      />
     </H5GroveProvider>
   );
 }

--- a/packages/app/src/App.module.css
+++ b/packages/app/src/App.module.css
@@ -51,6 +51,9 @@
   --h5w-domainSlider-histogram--color: var(--secondary-dark);
   --h5w-domainSlider-histogram-indicator--color: var(--secondary-darker);
   --h5w-interactionHelp-shortcut--bgColor: var(--primary-light);
+
+  --h5w-line--color: darkblue;
+  --h5w-line--colorAux: orangered, forestgreen, red, mediumorchid, olive;
 }
 
 .root *,
@@ -72,7 +75,7 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  .root {
+  .root[data-allow-dark-mode] {
     filter: invert();
 
     /* Set shadows to lighter colors so they remain dark once inverted */
@@ -80,10 +83,14 @@
     --h5w-btnRaised-hover--shadowColor: #fff;
     --h5w-domainSlider-track--shadowColor: #f5f5f5;
     --h5w-domainSlider-dataTrack--shadowColor: #fff;
+
+    /* Change line colors for better contrast once inverted */
+    --h5w-line--color: deepskyblue;
+    --h5w-custom--line-colorAux: orange, lightgreen, red, violet, gold;
   }
 
-  .root [data-keep-colors],
-  .root [data-keep-canvas-colors] canvas {
+  .root[data-allow-dark-mode] [data-keep-colors],
+  .root[data-allow-dark-mode] [data-keep-canvas-colors] canvas {
     filter: invert(); /* invert back to normal colors */
   }
 }

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -20,6 +20,7 @@ interface Props {
   explorerOpen?: boolean;
   initialPath?: string;
   getFeedbackURL?: (context: FeedbackContext) => string;
+  disableDarkMode?: boolean;
 }
 
 function App(props: Props) {
@@ -27,6 +28,7 @@ function App(props: Props) {
     explorerOpen: initialExplorerOpen = true,
     initialPath = '/',
     getFeedbackURL,
+    disableDarkMode,
   } = props;
 
   const [selectedPath, setSelectedPath] = useState<string>(initialPath);
@@ -42,7 +44,11 @@ function App(props: Props) {
 
   return (
     <ErrorBoundary FallbackComponent={ErrorFallback}>
-      <ReflexContainer className={styles.root} orientation="vertical">
+      <ReflexContainer
+        className={styles.root}
+        data-allow-dark-mode={disableDarkMode ? undefined : ''}
+        orientation="vertical"
+      >
         <ReflexElement
           className={styles.explorer}
           style={{ display: isExplorerOpen ? undefined : 'none' }}

--- a/packages/lib/src/vis/hooks.ts
+++ b/packages/lib/src/vis/hooks.ts
@@ -1,6 +1,5 @@
 import { ScaleType, getBounds, getValidDomainForScale } from '@h5web/shared';
 import type { Domain, AnyNumArray } from '@h5web/shared';
-import { useMediaQuery } from '@react-hookz/web';
 import type { Camera } from '@react-three/fiber';
 import { useFrame, useThree } from '@react-three/fiber';
 import { useEffect, useCallback, useMemo, useState } from 'react';
@@ -78,7 +77,6 @@ export function useCameraState<T>(
 export function useCustomColors(
   colorDefs: CustomColor[]
 ): [string[], RefCallback<HTMLElement>] {
-  const isDark = useMediaQuery('(prefers-color-scheme: dark)');
   const [styles, setStyles] = useState<CSSStyleDeclaration>();
 
   // https://reactjs.org/docs/hooks-faq.html#how-can-i-measure-a-dom-node
@@ -92,12 +90,10 @@ export function useCustomColors(
     return [colorDefs.map(() => 'transparent'), refCallback];
   }
 
-  const colors = colorDefs.map(({ property, fallback, darkFallback }) => {
-    return (
-      styles.getPropertyValue(property).trim() ||
-      (isDark && darkFallback ? darkFallback : fallback)
-    );
-  });
+  const colors = colorDefs.map(
+    ({ property, fallback }) =>
+      styles.getPropertyValue(property).trim() || fallback
+  );
 
   return [colors, refCallback];
 }

--- a/packages/lib/src/vis/line/LineVis.tsx
+++ b/packages/lib/src/vis/line/LineVis.tsx
@@ -33,12 +33,10 @@ const COLORS: CustomColor[] = [
   {
     property: '--h5w-line--color',
     fallback: 'darkblue',
-    darkFallback: 'deepskyblue',
   },
   {
     property: '--h5w-line--colorAux',
     fallback: 'orangered, forestgreen, red, mediumorchid, olive',
-    darkFallback: 'orange, lightgreen, red, violet, gold',
   },
 ];
 

--- a/packages/lib/src/vis/models.ts
+++ b/packages/lib/src/vis/models.ts
@@ -95,5 +95,4 @@ export interface HistogramParams {
 export interface CustomColor {
   property: `--h5w-${string}`;
   fallback: string;
-  darkFallback?: string;
 }


### PR DESCRIPTION
While working to disable the dark mode in daiquiri, I had the thought that if the switch to dark mode is sometimes undesirable, there should be a way to disable it.

This would avoid the [CSS hack in jupyterlab-h5web](https://github.com/silx-kit/jupyterlab-h5web/blob/8543f67bb93bc6cb19198d5233d1df2c0779758a/style/index.css#L20).

Here is a proposal based on a `disableDarkMode` prop of `App` that gets translated in a `allow-dark-mode` CSS attribute so that CSS dark mode rules can be filtered. I am not convinced this is the best solution so I am drafting it for discussion.