### PR TITLE
Fix serialisation of attributes for several dtypes in h5wasm

### DIFF
--- a/packages/h5wasm/src/h5wasm-api.ts
+++ b/packages/h5wasm/src/h5wasm-api.ts
@@ -7,28 +7,26 @@ import {
 } from '@h5web/app';
 import type {
   Attribute,
-  AttributeValues,
   ChildEntity,
   Entity,
   Group,
   ProvidedEntity,
   Shape,
 } from '@h5web/shared';
-import { hasArrayShape } from '@h5web/shared';
 import {
   assertNonNull,
   buildEntityPath,
-  DTypeClass,
   EntityKind,
+  hasArrayShape,
   hasBoolType,
 } from '@h5web/shared';
 import type { Attribute as H5WasmAttribute } from 'h5wasm';
 import { File as H5WasmFile, ready as h5wasmReady } from 'h5wasm';
 
-import { hasInt64Type } from './guards';
 import {
   assertH5WasmDataset,
   assertH5WasmEntityWithAttrs,
+  hasInt64Type,
   isH5WasmDataset,
   isH5WasmExternalLink,
   isH5WasmGroup,
@@ -75,18 +73,13 @@ export class H5WasmApi extends ProviderApi {
     return h5wDataset.value;
   }
 
-  public async getAttrValues(entity: Entity): Promise<AttributeValues> {
+  public async getAttrValues(entity: Entity) {
     const h5wEntity = await this.getH5WasmEntity(entity.path);
     assertH5WasmEntityWithAttrs(h5wEntity);
 
     return Object.fromEntries(
       Object.entries(h5wEntity.attrs).map(([name, attr]) => {
-        const { value, metadata } = attr;
-        const dtype = convertMetadataToDType(metadata);
-        return [
-          name,
-          dtype.class === DTypeClass.Bool ? attr.to_array() : value,
-        ];
+        return [name, attr.to_array()];
       })
     );
   }


### PR DESCRIPTION
Fix https://github.com/silx-kit/vscode-h5web/issues/15

As for #1179, I made use of [to_array](https://github.com/usnistgov/h5wasm/blob/main/README.md#reading) that converts into nested arrays of JSON-compatible values.

But, rather than adding a check like in #1179, I now use `to_array` for attribute values of **any dtype**. The reason is that attribute values get stringified by `JSON.stringify` in `AttributeInfo` so they should be JSON compatible.

This fixes the display of several dtypes:
- `int64` now works
- `float`: Arrays of floats were `TypedArrays` that were stringified as `{"0":4.2,"1":4.3, ...}`. Now, we have `[4.2, 4.3, ...]` with the proper array nesting.
- `complex`: nD (n>2) array were displayed as 1D. They now show the proper nesting.

Note that despite its name, `to_array` also works for scalar values so that we don't need to care about the shape of the attribute value. 

Also, using `to_array` leads to worse performances than using directly the values but as we don't expect huge arrays in attribute values, this is an acceptable drawback. 