### PR TITLE
Update peer dep three of h5web/lib

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -41,7 +41,7 @@
     "@react-three/fiber": ">=6.0.14",
     "react": ">=16",
     "react-dom": ">=16",
-    "three": ">=0.120"
+    "three": ">=0.138"
   },
   "dependencies": {
     "@react-hookz/web": "14.2.2",


### PR DESCRIPTION
Oversight of https://github.com/silx-kit/h5web/pull/1170

Since we are dependant of the changes introduced in `138` (e.g. renaming from `DataTexture3D` to `Data3DTexture`), the version of `three` in `peerDependencies` should have been updated.