### PR TITLE
Support passing filename with slashes to H5WasmProvider

### DIFF
--- a/packages/h5wasm/package.json
+++ b/packages/h5wasm/package.json
@@ -38,7 +38,8 @@
     "react": ">=16"
   },
   "dependencies": {
-    "h5wasm": "0.4.4"
+    "h5wasm": "0.4.4",
+    "nanoid": "4.0.0"
   },
   "devDependencies": {
     "@h5web/app": "workspace:*",

--- a/packages/h5wasm/src/h5wasm-api.ts
+++ b/packages/h5wasm/src/h5wasm-api.ts
@@ -22,6 +22,7 @@ import {
 } from '@h5web/shared';
 import type { Attribute as H5WasmAttribute } from 'h5wasm';
 import { File as H5WasmFile, ready as h5wasmReady } from 'h5wasm';
+import { nanoid } from 'nanoid';
 
 import {
   assertH5WasmDataset,
@@ -98,9 +99,10 @@ export class H5WasmApi extends ProviderApi {
 
     // Write file to Emscripten virtual file system
     // https://emscripten.org/docs/api_reference/Filesystem-API.html#FS.writeFile
-    FS.writeFile(this.filepath, new Uint8Array(buffer), { flags: 'w+' });
+    const id = nanoid(); // use unique ID instead of `this.filepath` to avoid slashes and other unsupported characters
+    FS.writeFile(id, new Uint8Array(buffer), { flags: 'w+' });
 
-    return new H5WasmFile(this.filepath, 'r');
+    return new H5WasmFile(id, 'r');
   }
 
   private async getH5WasmEntity(path: string): Promise<H5WasmEntity> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,6 +257,7 @@ importers:
       eslint: '>=8'
       eslint-config-galex: 4.2.1
       h5wasm: 0.4.4
+      nanoid: 4.0.0
       react: 17.0.2
       rollup: 2.75.6
       rollup-plugin-dts: 4.2.2
@@ -264,6 +265,7 @@ importers:
       vite: 2.9.12
     dependencies:
       h5wasm: 0.4.4
+      nanoid: 4.0.0
     devDependencies:
       '@h5web/app': link:../app
       '@h5web/shared': link:../shared
@@ -3602,7 +3604,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       callsites: 3.1.0
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.10
       source-map: 0.6.1
     dev: true
 
@@ -3621,7 +3623,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/test-result': 27.5.1
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.10
       jest-haste-map: 27.5.1
       jest-runtime: 27.5.1
     transitivePeerDependencies:
@@ -7013,7 +7015,7 @@ packages:
       babel-plugin-istanbul: 6.1.1
       babel-preset-jest: 27.5.1_@babel+core@7.18.13
       chalk: 4.1.2
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.10
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
@@ -12372,7 +12374,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@types/node': 18.0.0
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.10
     dev: true
 
   /jest-snapshot/27.5.1:
@@ -12629,7 +12631,7 @@ packages:
   /jsonfile/4.0.0:
     resolution: {integrity: sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=}
     optionalDependencies:
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.10
     dev: true
 
   /jsonfile/6.1.0:
@@ -13389,6 +13391,12 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
     dev: true
+
+  /nanoid/4.0.0:
+    resolution: {integrity: sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg==}
+    engines: {node: ^14 || ^16 || >=18}
+    hasBin: true
+    dev: false
 
   /nanomatch/1.2.13:
     resolution: {integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==}
@@ -16681,6 +16689,7 @@ packages:
   /unified/9.2.0:
     resolution: {integrity: sha512-vx2Z0vY+a3YoTj8+pttM3tiJHCwY5UFbYdiWrwBEbHmK8pvsPj2rtAX2BFfgXen8T39CJWblWRDT4L5WGXtDdg==}
     dependencies:
+      '@types/unist': 2.0.6
       bail: 1.0.5
       extend: 3.0.2
       is-buffer: 2.0.5


### PR DESCRIPTION
Emscripten's `FS.writeFile` throws an `FS Error` when called with a filename that contains slashes. This is an unnecessary restriction, since the filename can be anything really -- like a URL.

I workaround the issue by generating a unique ID with https://github.com/ai/nanoid