### PR TITLE
Update react-slider to 2.0.4

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -53,7 +53,7 @@
     "react-error-boundary": "3.1.4",
     "react-icons": "4.4.0",
     "react-reflex": "4.0.9",
-    "react-slider": "2.0.1",
+    "react-slider": "2.0.4",
     "react-suspense-fetch": "0.4.1",
     "react-use": "17.4.0",
     "three": "0.141.0",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -63,7 +63,7 @@
     "react-icons": "4.4.0",
     "react-keyed-flatten-children": "1.3.0",
     "react-measure": "2.5.2",
-    "react-slider": "2.0.1",
+    "react-slider": "2.0.4",
     "react-use": "17.4.0",
     "react-window": "1.8.7"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,7 +194,7 @@ importers:
       react-error-boundary: 3.1.4
       react-icons: 4.4.0
       react-reflex: 4.0.9
-      react-slider: 2.0.1
+      react-slider: 2.0.4
       react-suspense-fetch: 0.4.1
       react-use: 17.4.0
       rollup: 2.75.6
@@ -215,7 +215,7 @@ importers:
       react-error-boundary: 3.1.4_react@17.0.2
       react-icons: 4.4.0_react@17.0.2
       react-reflex: 4.0.9_sfoxds7t5ydpegc3knd667wn6m
-      react-slider: 2.0.1_react@17.0.2
+      react-slider: 2.0.4_react@17.0.2
       react-suspense-fetch: 0.4.1
       react-use: 17.4.0_sfoxds7t5ydpegc3knd667wn6m
       three: 0.141.0
@@ -327,7 +327,7 @@ importers:
       react-icons: 4.4.0
       react-keyed-flatten-children: 1.3.0
       react-measure: 2.5.2
-      react-slider: 2.0.1
+      react-slider: 2.0.4
       react-use: 17.4.0
       react-window: 1.8.7
       rollup: 2.75.6
@@ -355,7 +355,7 @@ importers:
       react-icons: 4.4.0_react@17.0.2
       react-keyed-flatten-children: 1.3.0_react@17.0.2
       react-measure: 2.5.2_sfoxds7t5ydpegc3knd667wn6m
-      react-slider: 2.0.1_react@17.0.2
+      react-slider: 2.0.4_react@17.0.2
       react-use: 17.4.0_sfoxds7t5ydpegc3knd667wn6m
       react-window: 1.8.7_sfoxds7t5ydpegc3knd667wn6m
     devDependencies:
@@ -447,11 +447,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/highlight': 7.18.6
-    dev: true
-
-  /@babel/compat-data/7.18.13:
-    resolution: {integrity: sha512-5yUzC5LqyTFp2HLmDoxGQelcdYgSpP9xsnMWBphAscOdFrHSAVbLNzWiy32sVNDqJRDiJK6klfDnAgu6PAGSHw==}
-    engines: {node: '>=6.9.0'}
     dev: true
 
   /@babel/compat-data/7.18.5:
@@ -688,7 +683,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/compat-data': 7.18.13
+      '@babel/compat-data': 7.19.0
       '@babel/core': 7.18.13
       '@babel/helper-validator-option': 7.18.6
       browserslist: 4.21.3
@@ -14919,8 +14914,8 @@ packages:
       react: 17.0.2
     dev: false
 
-  /react-slider/2.0.1_react@17.0.2:
-    resolution: {integrity: sha512-EnPLeyPGQcgpU9i+OvdD6W1Fk+rHg7LOVGvREXqLnbSngYvnE+d++nus0iHho1kcDw6NzF1OXzqWXAEs2Nbl4Q==}
+  /react-slider/2.0.4_react@17.0.2:
+    resolution: {integrity: sha512-sWwQD01n6v+MbeLCYthJGZPc0kzOyhQHyd0bSo0edg+IAxTVQmj3Oy4SBK65eX6gNwS9meUn6Z5sIBUVmwAd9g==}
     peerDependencies:
       react: ^16 || ^17 || ^18
     dependencies:


### PR DESCRIPTION
CodeSandboxes are broken for a while due to a failure in the import of `react-slider`.

I hope that the update to [2.0.4](https://github.com/zillow/react-slider/releases/tag/v2.0.4) will fix this.