### PR TITLE
Make auxiliary labels optional in LineVis

### DIFF
--- a/apps/storybook/src/LineVis.stories.tsx
+++ b/apps/storybook/src/LineVis.stories.tsx
@@ -92,6 +92,12 @@ ErrorBars.args = {
 export const AuxiliaryArrays = Template.bind({});
 AuxiliaryArrays.args = {
   dataArray: primaryArray,
+  auxiliaries: [{ array: secondaryArray }, { array: tertiaryArray }],
+};
+
+export const AuxiliaryLabels = Template.bind({});
+AuxiliaryLabels.args = {
+  dataArray: primaryArray,
   auxiliaries: [
     { label: 'secondary', array: secondaryArray },
     { label: 'tertiary', array: tertiaryArray },

--- a/packages/lib/src/vis/line/LineVis.tsx
+++ b/packages/lib/src/vis/line/LineVis.tsx
@@ -73,8 +73,8 @@ function LineVis(props: Props) {
 
   assertLength(abscissaValue, dataArray.size, 'abscissa');
   assertLength(errorsArray, dataArray.size, 'error');
-  auxiliaries.forEach(({ label, array }) =>
-    assertLength(array, dataArray.size, `'${label}' auxiliary`)
+  auxiliaries.forEach(({ label, array }, index) =>
+    assertLength(array, dataArray.size, `'${label || index}' auxiliary`)
   );
 
   const abscissas = useAxisValues(abscissaValue, dataArray.size);
@@ -153,12 +153,13 @@ function LineVis(props: Props) {
                 </div>
 
                 {auxiliaries.map(({ label, array, errors }, index) => (
-                  <div className={styles.tooltipAux} key={label}>
+                  <div className={styles.tooltipAux} key={label || index}>
                     <span
                       className={styles.mark}
                       style={{ color: auxColors[index % auxColors.length] }}
                     />
-                    {label} = {formatTooltipVal(array.get(xi))}
+                    {label ? `${label} = ` : ''}
+                    {formatTooltipVal(array.get(xi))}
                     {errors && ` ±${formatTooltipErr(errors.get(xi))}`}
                   </div>
                 ))}

--- a/packages/lib/src/vis/line/models.ts
+++ b/packages/lib/src/vis/line/models.ts
@@ -21,7 +21,7 @@ export interface TooltipData {
 }
 
 export interface AuxiliaryParams {
-  label: string;
   array: NdArray<NumArray>;
+  label?: string;
   errors?: NdArray<NumArray>;
 }


### PR DESCRIPTION
Even though labels are always set when calling `LineVis` from `NxSpectrum`, it would be nice to lift this constraint for other uses (such as the example https://codesandbox.io/s/h5weblib-demo-multiple-curves-kwkli)