### PR TITLE
Make ScatterVis colorMap prop optional

### DIFF
--- a/apps/storybook/src/ScatterVis.stories.tsx
+++ b/apps/storybook/src/ScatterVis.stories.tsx
@@ -68,6 +68,12 @@ MarkerSize.args = {
   size: 20,
 };
 
+export const ColorMap = Template.bind({});
+ColorMap.args = {
+  ...Default.args,
+  colorMap: 'Rainbow',
+};
+
 export const ColorScaleType = Template.bind({});
 ColorScaleType.args = {
   ...Default.args,

--- a/packages/lib/src/vis/scatter/ScatterVis.tsx
+++ b/packages/lib/src/vis/scatter/ScatterVis.tsx
@@ -28,7 +28,7 @@ interface Props {
   ordinateParams: ScatterAxisParams;
   dataArray: NdArray<NumArray>;
   domain: Domain;
-  colorMap: ColorMap;
+  colorMap?: ColorMap;
   invertColorMap?: boolean;
   scaleType?: ScaleType;
   showGrid?: boolean;
@@ -45,7 +45,7 @@ function ScatterVis(props: Props) {
     ordinateParams,
     dataArray,
     domain,
-    colorMap,
+    colorMap = 'Viridis',
     invertColorMap = false,
     scaleType = ScaleType.Linear,
     showGrid = true,


### PR DESCRIPTION
For consistency with [`HeatmapVis`](https://github.com/silx-kit/h5web/blob/fc409b37725e76f0cb0fcf2ac84a9dc039ccb40a/packages/lib/src/vis/heatmap/HeatmapVis.tsx#L48)

