### PR TITLE
Allow propagating errors through top-level error boundary

### DIFF
--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -140,6 +140,34 @@ form instead.
 />
 ```
 
+#### `disableDarkMode?: boolean` (optional)
+
+By default, the viewer follows your browser's and/or operating system's dark
+mode setting. This prop disables this beahviour by forcing the viewer into light
+mode.
+
+```tsx
+<App disableDarkMode />
+```
+
+#### `propagateErrors?: boolean` (optional)
+
+The viewer has a top-level `ErrorBoundary` that, by default, handles errors
+thrown outside of the visualization area. These include errors thrown by the
+data provider when fetching metadata for the explorer. If you prefer to
+implement your own error boundary, you may choose to let errors through the
+viewer's top-level boundary:
+
+```tsx
+import { ErrorBoundary } from 'react-error-boundary';
+
+<ErrorBoundary FallbackComponent={MyErrorFallback}>
+  <MockProvider>
+    <App propagateErrors />
+  </MockProvider>
+</ErrorBoundary>;
+```
+
 ### `H5GroveProvider`
 
 Data provider for [H5Grove](https://github.com/silx-kit/h5grove).

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -21,6 +21,7 @@ interface Props {
   initialPath?: string;
   getFeedbackURL?: (context: FeedbackContext) => string;
   disableDarkMode?: boolean;
+  propagateErrors?: boolean;
 }
 
 function App(props: Props) {
@@ -29,6 +30,7 @@ function App(props: Props) {
     initialPath = '/',
     getFeedbackURL,
     disableDarkMode,
+    propagateErrors,
   } = props;
 
   const [selectedPath, setSelectedPath] = useState<string>(initialPath);
@@ -43,7 +45,14 @@ function App(props: Props) {
   }
 
   return (
-    <ErrorBoundary FallbackComponent={ErrorFallback}>
+    <ErrorBoundary
+      FallbackComponent={ErrorFallback}
+      onError={(err) => {
+        if (propagateErrors) {
+          throw err;
+        }
+      }}
+    >
       <ReflexContainer
         className={styles.root}
         data-allow-dark-mode={disableDarkMode ? undefined : ''}


### PR DESCRIPTION
For consumers who want to implement their own error boundary, like in https://gitlab.esrf.fr/ui/myhdf5/-/merge_requests/11

I think this is more flexible than to allow consumers to override the top-level error fallback component, for instance.

Note that I also make `react-error-boundary` an optional peer dependency to reduce bundle size for consumers who do want to provide their own boundary.