### PR TITLE
Support axis mapping of scale types in `SILX_style`

### DIFF
--- a/packages/app/src/vis-packs/core/complex/MappedComplexLineVis.tsx
+++ b/packages/app/src/vis-packs/core/complex/MappedComplexLineVis.tsx
@@ -1,9 +1,8 @@
-import type { H5WebComplex, NumArray } from '@h5web/shared';
+import type { AxisMapping, H5WebComplex, NumArray } from '@h5web/shared';
 import { useMemo } from 'react';
 import { createPortal } from 'react-dom';
 
 import type { DimensionMapping } from '../../../dimension-mapper/models';
-import type { AxisMapping } from '../../nexus/models';
 import MappedLineVis from '../line/MappedLineVis';
 import type { LineConfig } from '../line/config';
 import ComplexLineToolbar from './ComplexLineToolbar';

--- a/packages/app/src/vis-packs/core/complex/MappedComplexVis.tsx
+++ b/packages/app/src/vis-packs/core/complex/MappedComplexVis.tsx
@@ -4,12 +4,11 @@ import {
   useValidDomainForScale,
   useVisDomain,
 } from '@h5web/lib';
-import type { H5WebComplex, NumArray } from '@h5web/shared';
+import type { AxisMapping, H5WebComplex, NumArray } from '@h5web/shared';
 import { useMemo } from 'react';
 import { createPortal } from 'react-dom';
 
 import type { DimensionMapping } from '../../../dimension-mapper/models';
-import type { AxisMapping } from '../../nexus/models';
 import type { HeatmapConfig } from '../heatmap/config';
 import {
   useBaseArray,

--- a/packages/app/src/vis-packs/core/heatmap/MappedHeatmapVis.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/MappedHeatmapVis.tsx
@@ -1,10 +1,15 @@
 import { HeatmapVis, useDomain, useSafeDomain, useVisDomain } from '@h5web/lib';
-import type { ArrayShape, Dataset, NumArray, NumericType } from '@h5web/shared';
+import type {
+  ArrayShape,
+  AxisMapping,
+  Dataset,
+  NumArray,
+  NumericType,
+} from '@h5web/shared';
 import type { TypedArray } from 'ndarray';
 import { createPortal } from 'react-dom';
 
 import type { DimensionMapping } from '../../../dimension-mapper/models';
-import type { AxisMapping } from '../../nexus/models';
 import { useMappedArray, useSlicedDimsAndMapping } from '../hooks';
 import { DEFAULT_DOMAIN, getSliceSelection } from '../utils';
 import HeatmapToolbar from './HeatmapToolbar';

--- a/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
+++ b/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
@@ -1,9 +1,15 @@
 import { LineVis, useCombinedDomain, useDomain, useDomains } from '@h5web/lib';
-import type { ArrayShape, Dataset, NumArray, NumericType } from '@h5web/shared';
+import type {
+  ArrayShape,
+  AxisMapping,
+  Dataset,
+  NumArray,
+  NumericType,
+} from '@h5web/shared';
 import { createPortal } from 'react-dom';
 
 import type { DimensionMapping } from '../../../dimension-mapper/models';
-import type { Auxiliary, AxisMapping } from '../../nexus/models';
+import type { Auxiliary } from '../../nexus/models';
 import {
   useMappedArrays,
   useMappedArray,

--- a/packages/app/src/vis-packs/core/scatter/MappedScatterVis.tsx
+++ b/packages/app/src/vis-packs/core/scatter/MappedScatterVis.tsx
@@ -1,9 +1,8 @@
 import { ScatterVis, useDomain, useSafeDomain, useVisDomain } from '@h5web/lib';
-import type { NumArray } from '@h5web/shared';
+import type { AxisMapping, NumArray } from '@h5web/shared';
 import { assertDefined } from '@h5web/shared';
 import { createPortal } from 'react-dom';
 
-import type { AxisMapping } from '../../nexus/models';
 import { useBaseArray } from '../hooks';
 import { DEFAULT_DOMAIN } from '../utils';
 import ScatterToolbar from './ScatterToolbar';

--- a/packages/app/src/vis-packs/nexus/hooks.ts
+++ b/packages/app/src/vis-packs/nexus/hooks.ts
@@ -1,4 +1,5 @@
 import type {
+  AxisMapping,
   GroupWithChildren,
   NumArray,
   NumArrayDataset,
@@ -7,7 +8,7 @@ import { isDefined } from '@h5web/shared';
 
 import { useDataContext } from '../../providers/DataProvider';
 import { useDatasetValues } from '../core/hooks';
-import type { AuxDatasets, Auxiliary, AxisMapping, NxData } from './models';
+import type { AuxDatasets, Auxiliary, NxData } from './models';
 import {
   assertNxDataGroup,
   findAssociatedDatasets,

--- a/packages/app/src/vis-packs/nexus/models.ts
+++ b/packages/app/src/vis-packs/nexus/models.ts
@@ -1,6 +1,7 @@
 import type {
   ArrayShape,
   ArrayValue,
+  AxisMapping,
   ComplexType,
   Dataset,
   NumArray,
@@ -47,8 +48,6 @@ export interface NxValues<T extends NumericType | ComplexType> {
   auxiliaries?: Auxiliary[];
   title: string;
 }
-
-export type AxisMapping<T> = (T | undefined)[];
 
 export interface SilxStyle {
   signalScaleType?: ScaleType;

--- a/packages/app/src/vis-packs/nexus/utils.ts
+++ b/packages/app/src/vis-packs/nexus/utils.ts
@@ -220,10 +220,9 @@ export function getSilxStyle(
       signalScaleType: isScaleType(signal_scale_type)
         ? signal_scale_type
         : undefined,
-      axisScaleTypes:
-        Array.isArray(axisScaleTypes) && axisScaleTypes.every(isScaleType)
-          ? axisScaleTypes
-          : undefined,
+      axisScaleTypes: Array.isArray(axisScaleTypes)
+        ? axisScaleTypes.map((type) => (isScaleType(type) ? type : undefined))
+        : undefined,
     };
   } catch {
     console.warn(`Malformed 'SILX_style' attribute: ${silxStyle}`); // eslint-disable-line no-console

--- a/packages/shared/src/models-nexus.ts
+++ b/packages/shared/src/models-nexus.ts
@@ -8,5 +8,7 @@ export enum NxInterpretation {
 
 export interface SilxStyle {
   signalScaleType?: ScaleType;
-  axisScaleTypes?: ScaleType[];
+  axisScaleTypes?: AxisMapping<ScaleType>;
 }
+
+export type AxisMapping<T> = (T | undefined)[];


### PR DESCRIPTION
Fix #1214

Most basic fix to let the `axisScaleTypes` array be parsed if it contains `null` values (or `'.'` or whatever -- anything else than a valid scale type is parsed as `undefined`).

This lets the spectrum visualization use the suggested axis scale type for the selected dimension on 2D+ datasets. As you pointed out in #1214, @loichuder, this does not fix the issue of updating the suggested scale type when selecting another dimension. But we agreed this isn't worth fixing until we actually encounter the use case.