### PR TITLE
Get all units and labels as part of `useNxData`

### DIFF
--- a/packages/app/src/vis-packs/core/hooks.ts
+++ b/packages/app/src/vis-packs/core/hooks.ts
@@ -54,17 +54,28 @@ export function useDatasetValue<D extends Dataset<ArrayShape | ScalarShape>>(
 export function useDatasetValues<D extends Dataset<ArrayShape | ScalarShape>>(
   datasets: D[],
   selection?: string
-): Record<string, Value<D>> {
+): Value<D>[];
+
+export function useDatasetValues<D extends Dataset<ArrayShape | ScalarShape>>(
+  datasets: (D | undefined)[],
+  selection?: string
+): (Value<D> | undefined)[];
+
+export function useDatasetValues<D extends Dataset<ArrayShape | ScalarShape>>(
+  datasets: (D | undefined)[],
+  selection?: string
+): (Value<D> | undefined)[] {
   const { valuesStore } = useDataContext();
 
-  return Object.fromEntries(
-    datasets.map((dataset) => {
-      const value = valuesStore.get({ dataset, selection });
-      assertDatasetValue(value, dataset);
+  return datasets.map((dataset) => {
+    if (!dataset) {
+      return undefined;
+    }
 
-      return [dataset.name, value];
-    })
-  );
+    const value = valuesStore.get({ dataset, selection });
+    assertDatasetValue(value, dataset);
+    return value;
+  });
 }
 
 export function useBaseArray<T, U extends T[] | TypedArray | undefined>(

--- a/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
+++ b/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
@@ -9,7 +9,6 @@ import type {
 import { createPortal } from 'react-dom';
 
 import type { DimensionMapping } from '../../../dimension-mapper/models';
-import type { Auxiliary } from '../../nexus/models';
 import {
   useMappedArrays,
   useMappedArray,
@@ -26,7 +25,9 @@ interface Props {
   value: NumArray;
   valueLabel?: string;
   errors?: NumArray;
-  auxiliaries?: Auxiliary[];
+  auxLabels?: string[];
+  auxValues?: NumArray[];
+  auxErrors?: (NumArray | undefined)[];
   dims: number[];
   dimMapping: DimensionMapping;
   axisLabels?: AxisMapping<string>;
@@ -43,7 +44,9 @@ function MappedLineVis(props: Props) {
     value,
     valueLabel,
     errors,
-    auxiliaries = [],
+    auxLabels = [],
+    auxValues = [],
+    auxErrors = [],
     dims,
     dimMapping,
     axisLabels,
@@ -64,12 +67,9 @@ function MappedLineVis(props: Props) {
 
   const [dataArray, dataForDomain] = useMappedArray(value, ...hookArgs);
   const [errorArray, errorsForDomain] = useMappedArray(errors, ...hookArgs);
-  const [auxArrays, auxForDomain] = useMappedArrays(
-    auxiliaries.map((aux) => aux.values),
-    ...hookArgs
-  );
+  const [auxArrays, auxForDomain] = useMappedArrays(auxValues, ...hookArgs);
   const [auxErrorsArrays, auxErrorsForDomain] = useMappedArrays(
-    auxiliaries.map((aux) => aux.errors),
+    auxErrors,
     ...hookArgs
   );
 
@@ -112,9 +112,9 @@ function MappedLineVis(props: Props) {
         dtype={dataset?.type}
         errorsArray={errorArray}
         showErrors={showErrors}
-        auxiliaries={auxiliaries.map(({ label }, i) => ({
-          label,
-          array: auxArrays[i],
+        auxiliaries={auxArrays.map((array, i) => ({
+          label: auxLabels[i],
+          array,
           errors: auxErrorsArrays[i],
         }))}
       />

--- a/packages/app/src/vis-packs/nexus/NxValuesFetcher.tsx
+++ b/packages/app/src/vis-packs/nexus/NxValuesFetcher.tsx
@@ -1,11 +1,12 @@
 import type { NumericType, ComplexType } from '@h5web/shared';
 import type { ReactNode } from 'react';
 
-import { useDataContext } from '../../providers/DataProvider';
-import { useDatasetValue, usePrefetchValues } from '../core/hooks';
-import { useAuxiliaries, useAxisValues } from './hooks';
+import {
+  useDatasetValue,
+  useDatasetValues,
+  usePrefetchValues,
+} from '../core/hooks';
 import type { NxData, NxValues } from './models';
-import { getDatasetLabel } from './utils';
 
 interface Props<T extends NumericType | ComplexType> {
   nxData: NxData<T>;
@@ -15,36 +16,32 @@ interface Props<T extends NumericType | ComplexType> {
 
 function NxValuesFetcher<T extends NumericType | ComplexType>(props: Props<T>) {
   const { nxData, selection, render } = props;
-  const {
-    signalDataset,
-    errorDataset,
-    axisDatasets,
-    auxDatasets,
-    titleDataset,
-  } = nxData;
+  const { signalDef, axisDefs, auxDefs, titleDataset } = nxData;
 
+  const axisDatasets = axisDefs.map((def) => def?.dataset);
+  const auxDatasets = auxDefs.map((def) => def?.dataset);
+  const auxErrorDatasets = auxDefs.map((def) => def?.errorDataset);
+
+  usePrefetchValues([titleDataset, ...axisDatasets]);
   usePrefetchValues(
     [
-      signalDataset,
-      errorDataset,
-      ...auxDatasets.flatMap((d) => [d.signal, d.errors]),
+      signalDef.dataset,
+      signalDef.errorDataset,
+      ...auxDatasets,
+      ...auxErrorDatasets,
     ],
     selection
   );
-  usePrefetchValues([...axisDatasets, titleDataset]);
 
-  const { attrValuesStore } = useDataContext();
-  const signal = useDatasetValue(signalDataset, selection);
-  const signalLabel = getDatasetLabel(signalDataset, attrValuesStore);
-  const errors = useDatasetValue(errorDataset, selection);
-  const axisValues = useAxisValues(axisDatasets);
-  const auxiliaries = useAuxiliaries(auxDatasets, selection);
-  const title = useDatasetValue(titleDataset) || signalLabel;
+  const title = useDatasetValue(titleDataset) || signalDef.label;
+  const signal = useDatasetValue(signalDef.dataset, selection);
+  const errors = useDatasetValue(signalDef.errorDataset, selection);
+  const auxValues = useDatasetValues(auxDatasets, selection);
+  const auxErrors = useDatasetValues(auxErrorDatasets, selection);
+  const axisValues = useDatasetValues(axisDatasets);
 
   return (
-    <>
-      {render({ signal, signalLabel, errors, axisValues, auxiliaries, title })}
-    </>
+    <>{render({ title, signal, errors, auxValues, auxErrors, axisValues })}</>
   );
 }
 

--- a/packages/app/src/vis-packs/nexus/containers/NxComplexImageContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxComplexImageContainer.tsx
@@ -19,10 +19,10 @@ function NxComplexImageContainer(props: VisContainerProps) {
   const nxData = useNxData(entity);
   assertComplexSignal(nxData);
 
-  const { signalDataset, axisLabels, silxStyle } = nxData;
-  assertMinDims(signalDataset, 2);
+  const { signalDef, axisDefs, silxStyle } = nxData;
+  assertMinDims(signalDef.dataset, 2);
 
-  const { shape: dims } = signalDataset;
+  const { shape: dims } = signalDef.dataset;
   const [dimMapping, setDimMapping] = useDimMappingState(dims, 2);
 
   const config = useComplexConfig();
@@ -49,7 +49,7 @@ function NxComplexImageContainer(props: VisContainerProps) {
                 value={signal}
                 dims={dims}
                 dimMapping={dimMapping}
-                axisLabels={axisLabels}
+                axisLabels={axisDefs.map((def) => def?.label)}
                 axisValues={axisValues}
                 title={title}
                 toolbarContainer={toolbarContainer}

--- a/packages/app/src/vis-packs/nexus/containers/NxComplexSpectrumContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxComplexSpectrumContainer.tsx
@@ -18,9 +18,8 @@ function NxComplexSpectrumContainer(props: VisContainerProps) {
 
   const nxData = useNxData(entity);
   assertComplexNxData(nxData);
-  const { signalDataset, axisLabels, silxStyle } = nxData;
-
-  const signalDims = signalDataset.shape;
+  const { signalDef, axisDefs, silxStyle } = nxData;
+  const signalDims = signalDef.dataset.shape;
 
   const [dimMapping, setDimMapping] = useDimMappingState(signalDims, 1);
   const xDimIndex = dimMapping.indexOf('x');
@@ -45,15 +44,15 @@ function NxComplexSpectrumContainer(props: VisContainerProps) {
           nxData={nxData}
           selection={autoScale ? getSliceSelection(dimMapping) : undefined}
           render={(nxValues) => {
-            const { signal, signalLabel, axisValues, title } = nxValues;
+            const { signal, axisValues, title } = nxValues;
 
             return (
               <MappedComplexLineVis
                 value={signal}
-                valueLabel={signalLabel}
+                valueLabel={signalDef.label}
                 dims={signalDims}
                 dimMapping={dimMapping}
-                axisLabels={axisLabels}
+                axisLabels={axisDefs.map((def) => def?.label)}
                 axisValues={axisValues}
                 title={title}
                 toolbarContainer={toolbarContainer}

--- a/packages/app/src/vis-packs/nexus/containers/NxImageContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxImageContainer.tsx
@@ -18,10 +18,10 @@ function NxImageContainer(props: VisContainerProps) {
   const nxData = useNxData(entity);
   assertNumericSignal(nxData);
 
-  const { signalDataset, axisLabels, silxStyle } = nxData;
-  assertMinDims(signalDataset, 2);
+  const { signalDef, axisDefs, silxStyle } = nxData;
+  assertMinDims(signalDef.dataset, 2);
 
-  const { shape: dims } = signalDataset;
+  const { shape: dims } = signalDef.dataset;
   const [dimMapping, setDimMapping] = useDimMappingState(dims, 2);
 
   const config = useHeatmapConfig({ scaleType: silxStyle.signalScaleType });
@@ -42,10 +42,10 @@ function NxImageContainer(props: VisContainerProps) {
 
             return (
               <MappedHeatmapVis
-                dataset={signalDataset}
+                dataset={signalDef.dataset}
                 value={signal}
                 dimMapping={dimMapping}
-                axisLabels={axisLabels}
+                axisLabels={axisDefs.map((def) => def?.label)}
                 axisValues={axisValues}
                 title={title}
                 toolbarContainer={toolbarContainer}

--- a/packages/app/src/vis-packs/nexus/containers/NxRgbContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxRgbContainer.tsx
@@ -15,10 +15,10 @@ function NxRgbContainer(props: VisContainerProps) {
   const nxData = useNxData(entity);
   assertNumericSignal(nxData);
 
-  const { signalDataset } = nxData;
-  assertNumDims(signalDataset, 3);
+  const { signalDef } = nxData;
+  assertNumDims(signalDef.dataset, 3);
 
-  const { shape: dims } = signalDataset;
+  const { shape: dims } = signalDef.dataset;
   const config = useRgbConfig();
 
   return (

--- a/packages/app/src/vis-packs/nexus/containers/NxScatterContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxScatterContainer.tsx
@@ -15,16 +15,16 @@ function NxScatterContainer(props: VisContainerProps) {
 
   const nxData = useNxData(entity);
   assertNumericNxData(nxData);
-  const { signalDataset, axisDatasets, axisLabels, silxStyle } = nxData;
+  const { signalDef, axisDefs, silxStyle } = nxData;
 
-  assertNumDims(signalDataset, 1);
-  const signalDims = signalDataset.shape;
+  assertNumDims(signalDef.dataset, 1);
+  const signalDims = signalDef.dataset.shape;
 
-  const [xDataset, yDataset] = axisDatasets;
+  const [xDataset, yDataset] = axisDefs;
   assertDefined(xDataset);
   assertDefined(yDataset);
-  const xDims = xDataset.shape;
-  const yDims = yDataset.shape;
+  const xDims = xDataset.dataset.shape;
+  const yDims = yDataset.dataset.shape;
 
   if (!isEqual(xDims, signalDims) || !isEqual(yDims, signalDims)) {
     const dimsStr = JSON.stringify({ signalDims, xDims, yDims });
@@ -49,7 +49,7 @@ function NxScatterContainer(props: VisContainerProps) {
           return (
             <MappedScatterVis
               value={signal}
-              axisLabels={axisLabels}
+              axisLabels={axisDefs.map((def) => def?.label)}
               axisValues={axisValues}
               title={title}
               toolbarContainer={toolbarContainer}

--- a/packages/app/src/vis-packs/nexus/containers/NxSpectrumContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxSpectrumContainer.tsx
@@ -18,10 +18,10 @@ function NxSpectrumContainer(props: VisContainerProps) {
 
   const nxData = useNxData(entity);
   assertNumericNxData(nxData);
-  const { signalDataset, errorDataset, axisLabels, silxStyle } = nxData;
+  const { signalDef, axisDefs, auxDefs, silxStyle } = nxData;
 
-  const signalDims = signalDataset.shape;
-  const errorDims = errorDataset?.shape;
+  const signalDims = signalDef.dataset.shape;
+  const errorDims = signalDef.errorDataset?.shape;
 
   if (errorDims && !isEqual(signalDims, errorDims)) {
     const dimsStr = JSON.stringify({ signalDims, errorsDims: errorDims });
@@ -51,26 +51,22 @@ function NxSpectrumContainer(props: VisContainerProps) {
           nxData={nxData}
           selection={selection}
           render={(nxValues) => {
-            const {
-              signal,
-              signalLabel,
-              errors,
-              axisValues,
-              auxiliaries,
-              title,
-            } = nxValues;
+            const { signal, errors, axisValues, auxValues, auxErrors, title } =
+              nxValues;
 
             return (
               <MappedLineVis
-                dataset={signalDataset}
+                dataset={signalDef.dataset}
                 selection={selection}
                 value={signal}
-                valueLabel={signalLabel}
+                valueLabel={signalDef.label}
                 errors={errors}
-                auxiliaries={auxiliaries}
+                auxLabels={auxDefs.map((def) => def?.label)}
+                auxValues={auxValues}
+                auxErrors={auxErrors}
                 dims={signalDims}
                 dimMapping={dimMapping}
-                axisLabels={axisLabels}
+                axisLabels={axisDefs.map((def) => def?.label)}
                 axisValues={axisValues}
                 title={title}
                 toolbarContainer={toolbarContainer}

--- a/packages/app/src/vis-packs/nexus/guards.ts
+++ b/packages/app/src/vis-packs/nexus/guards.ts
@@ -6,13 +6,13 @@ import type { NxData } from './models';
 export function assertNumericNxData(
   nxData: NxData
 ): asserts nxData is NxData<NumericType> {
-  const { signalDataset } = nxData;
-  assertNumericType(signalDataset);
+  const { signalDef } = nxData;
+  assertNumericType(signalDef.dataset);
 }
 
 export function assertComplexNxData(
   nxData: NxData
 ): asserts nxData is NxData<ComplexType> {
-  const { signalDataset } = nxData;
-  assertComplexType(signalDataset);
+  const { signalDef } = nxData;
+  assertComplexType(signalDef.dataset);
 }

--- a/packages/app/src/vis-packs/nexus/hooks.ts
+++ b/packages/app/src/vis-packs/nexus/hooks.ts
@@ -1,14 +1,8 @@
-import type {
-  AxisMapping,
-  GroupWithChildren,
-  NumArray,
-  NumArrayDataset,
-} from '@h5web/shared';
+import type { GroupWithChildren } from '@h5web/shared';
 import { isDefined } from '@h5web/shared';
 
 import { useDataContext } from '../../providers/DataProvider';
-import { useDatasetValues } from '../core/hooks';
-import type { AuxDatasets, Auxiliary, NxData } from './models';
+import type { NxData } from './models';
 import {
   assertNxDataGroup,
   findAssociatedDatasets,
@@ -17,8 +11,8 @@ import {
   findSignalDataset,
   findAuxErrorDataset,
   findTitleDataset,
-  getDatasetLabel,
   getSilxStyle,
+  getDatasetInfo,
 } from './utils';
 
 export function useNxData(group: GroupWithChildren): NxData {
@@ -26,55 +20,29 @@ export function useNxData(group: GroupWithChildren): NxData {
 
   assertNxDataGroup(group, attrValuesStore);
   const signalDataset = findSignalDataset(group, attrValuesStore);
-  const errorDataset = findErrorDataset(group, signalDataset.name);
   const axisDatasets = findAxesDatasets(group, signalDataset, attrValuesStore);
   const auxSignals = findAssociatedDatasets(
     group,
     'auxiliary_signals',
     attrValuesStore
   ).filter(isDefined);
-  const auxDatasets = auxSignals.map((auxSignal) => ({
-    signal: auxSignal,
-    errors: findAuxErrorDataset(group, auxSignal.name),
-  }));
 
   return {
-    signalDataset,
-    errorDataset,
-    axisDatasets,
-    axisLabels: axisDatasets.map(
-      (dataset) => dataset && getDatasetLabel(dataset, attrValuesStore)
-    ),
     titleDataset: findTitleDataset(group),
+    signalDef: {
+      dataset: signalDataset,
+      errorDataset: findErrorDataset(group, signalDataset.name),
+      ...getDatasetInfo(signalDataset, attrValuesStore),
+    },
+    auxDefs: auxSignals.map((auxSignal) => ({
+      dataset: auxSignal,
+      errorDataset: findAuxErrorDataset(group, auxSignal.name),
+      ...getDatasetInfo(auxSignal, attrValuesStore),
+    })),
+    axisDefs: axisDatasets.map(
+      (dataset) =>
+        dataset && { dataset, ...getDatasetInfo(dataset, attrValuesStore) }
+    ),
     silxStyle: getSilxStyle(group, attrValuesStore),
-    auxDatasets,
   };
-}
-
-export function useAxisValues(
-  axisDatasets: AxisMapping<NumArrayDataset>
-): AxisMapping<NumArray> {
-  const axisValues = useDatasetValues(axisDatasets.filter(isDefined));
-  return axisDatasets.map((dataset) => dataset && axisValues[dataset.name]);
-}
-
-export function useAuxiliaries(
-  auxDatasets: AuxDatasets,
-  selection: string | undefined
-): Auxiliary[] {
-  const { attrValuesStore } = useDataContext();
-
-  const auxValues = useDatasetValues(
-    [
-      ...auxDatasets.map((d) => d.signal),
-      ...auxDatasets.map((d) => d.errors).filter(isDefined),
-    ],
-    selection
-  );
-
-  return auxDatasets.map(({ signal, errors }) => ({
-    label: getDatasetLabel(signal, attrValuesStore),
-    values: auxValues[signal.name],
-    errors: errors ? auxValues[errors.name] : undefined,
-  }));
 }

--- a/packages/app/src/vis-packs/nexus/models.ts
+++ b/packages/app/src/vis-packs/nexus/models.ts
@@ -23,39 +23,43 @@ export type NxAttribute =
   | 'SILX_style'
   | 'auxiliary_signals';
 
-export type AuxDatasets = {
-  signal: NumArrayDataset;
-  errors?: NumArrayDataset;
-}[];
+export interface DatasetInfo {
+  label: string;
+  unit: string | undefined;
+}
 
-export interface NxData<
+interface DatasetDef<
   T extends NumericType | ComplexType = NumericType | ComplexType
-> {
-  signalDataset: Dataset<ArrayShape, T>;
-  errorDataset?: NumArrayDataset;
-  axisDatasets: AxisMapping<NumArrayDataset>;
-  axisLabels: AxisMapping<string>;
-  auxDatasets: AuxDatasets;
-  titleDataset?: Dataset<ScalarShape, StringType>;
-  silxStyle: SilxStyle;
+> extends DatasetInfo {
+  dataset: Dataset<ArrayShape, T>;
 }
 
-export interface NxValues<T extends NumericType | ComplexType> {
-  signal: ArrayValue<T>;
-  signalLabel: string;
-  errors?: NumArray;
-  axisValues: AxisMapping<NumArray>;
-  auxiliaries?: Auxiliary[];
-  title: string;
-}
+type WithError<T extends DatasetDef> = T & {
+  errorDataset?: NumArrayDataset;
+};
+
+export type AuxDef = WithError<DatasetDef<NumericType>>;
 
 export interface SilxStyle {
   signalScaleType?: ScaleType;
   axisScaleTypes?: AxisMapping<ScaleType>;
 }
 
-export interface Auxiliary {
-  label: string;
-  values: NumArray;
+export interface NxData<
+  T extends NumericType | ComplexType = NumericType | ComplexType
+> {
+  titleDataset?: Dataset<ScalarShape, StringType>;
+  signalDef: WithError<DatasetDef<T>>;
+  auxDefs: AuxDef[];
+  axisDefs: AxisMapping<DatasetDef<NumericType>>;
+  silxStyle: SilxStyle;
+}
+
+export interface NxValues<T extends NumericType | ComplexType> {
+  title: string;
+  signal: ArrayValue<T>;
   errors?: NumArray;
+  auxValues: NumArray[];
+  auxErrors: (NumArray | undefined)[];
+  axisValues: AxisMapping<NumArray>;
 }

--- a/packages/app/src/vis-packs/nexus/utils.ts
+++ b/packages/app/src/vis-packs/nexus/utils.ts
@@ -26,7 +26,7 @@ import type {
 
 import type { AttrValuesStore } from '../../providers/models';
 import { hasAttribute } from '../../utils';
-import type { NxData, SilxStyle } from './models';
+import type { DatasetInfo, NxData, SilxStyle } from './models';
 
 export function isNxDataGroup(
   group: GroupWithChildren,
@@ -230,31 +230,31 @@ export function getSilxStyle(
   }
 }
 
-export function getDatasetLabel(
+export function getDatasetInfo(
   dataset: Dataset,
   attrValuesStore: AttrValuesStore
-): string {
-  const longName = attrValuesStore.getSingle(dataset, 'long_name');
-  if (longName && typeof longName === 'string') {
-    return longName;
-  }
+): DatasetInfo {
+  const rawLongName = attrValuesStore.getSingle(dataset, 'long_name');
+  const longName =
+    rawLongName && typeof rawLongName === 'string' ? rawLongName : undefined;
 
-  const units = attrValuesStore.getSingle(dataset, 'units');
-  if (units && typeof units === 'string') {
-    return `${dataset.name} (${units})`;
-  }
+  const rawUnits = attrValuesStore.getSingle(dataset, 'units');
+  const units = rawUnits && typeof rawUnits === 'string' ? rawUnits : undefined;
 
-  return dataset.name;
+  return {
+    label: longName || (units ? `${dataset.name} (${units})` : dataset.name),
+    unit: units,
+  };
 }
 
 export function assertNumericSignal(
   nxData: NxData
 ): asserts nxData is NxData<NumericType> {
-  assertNumericType(nxData.signalDataset);
+  assertNumericType(nxData.signalDef.dataset);
 }
 
 export function assertComplexSignal(
   nxData: NxData
 ): asserts nxData is NxData<ComplexType> {
-  assertComplexType(nxData.signalDataset);
+  assertComplexType(nxData.signalDef.dataset);
 }


### PR DESCRIPTION
In preparation for #1198, labels and units are now retrieved once and for all when calling `useNxData`. We no longer compute labels/retrieves units from `NxValuesFetcher`. This will allow us to access units inside the container in order to pass an initial `layout` value to the heatmap config hook.