### PR TITLE
Fix overflow on raw and scalar vis

### DIFF
--- a/apps/demo/src/styles.css
+++ b/apps/demo/src/styles.css
@@ -9,6 +9,7 @@
 
 body {
   box-sizing: border-box;
+  min-width: 42em;
   font-family: var(--sans-serif);
   line-height: 1.2;
   color: #020402;

--- a/packages/lib/src/vis/raw/RawVis.module.css
+++ b/packages/lib/src/vis/raw/RawVis.module.css
@@ -1,6 +1,11 @@
+.root {
+  overflow: auto;
+}
+
 .raw {
-  padding: 1rem;
+  min-width: fit-content; /* fix missing padding-right */
   margin: 0;
+  padding: 1rem 1.5rem;
   color: inherit;
   font-family: var(--monospace);
   font-size: inherit;

--- a/packages/lib/src/vis/raw/RawVis.tsx
+++ b/packages/lib/src/vis/raw/RawVis.tsx
@@ -19,7 +19,11 @@ function RawVis(props: Props) {
     );
   }
 
-  return <pre className={styles.raw}>{valueAsStr}</pre>;
+  return (
+    <div className={styles.root}>
+      <pre className={styles.raw}>{valueAsStr}</pre>
+    </div>
+  );
 }
 
 export default RawVis;

--- a/packages/lib/src/vis/scalar/ScalarVis.module.css
+++ b/packages/lib/src/vis/scalar/ScalarVis.module.css
@@ -1,4 +1,9 @@
+.root {
+  overflow: auto;
+}
+
 .scalar {
+  width: fit-content; /* fix missing padding-right */
   margin: 0;
   padding: 1rem 1.5rem;
   color: inherit;

--- a/packages/lib/src/vis/scalar/ScalarVis.tsx
+++ b/packages/lib/src/vis/scalar/ScalarVis.tsx
@@ -9,7 +9,12 @@ interface Props {
 
 function ScalarVis(props: Props) {
   const { value, formatter } = props;
-  return <pre className={styles.scalar}>{formatter(value)}</pre>;
+
+  return (
+    <div className={styles.root}>
+      <pre className={styles.scalar}>{formatter(value)}</pre>
+    </div>
+  );
 }
 
 export default ScalarVis;


### PR DESCRIPTION
Fix #1223 

In the end, I added wrappers to avoid breaking the other vis. The challenge was keeping the padding on the right and bottom of the overflowing content... I've also added a `min-width` the demo to avoid breaking the layout -- I figure it's safer to let consumers deal with this than to enforce something in @h5web/app.

![image](https://user-images.githubusercontent.com/2936402/195098495-d5936191-5991-4668-8f65-b51617a4cf9e.png)

![image](https://user-images.githubusercontent.com/2936402/195098933-3ad699d8-06a2-4810-a67d-2b7a6d11ef27.png)

Note that I did not commit the changes to the mock values visible in the screenshots above.