### PR TITLE
Use Cypress plugin to wait for stable DOM

### DIFF
--- a/cypress/plugins.ts
+++ b/cypress/plugins.ts
@@ -1,7 +1,7 @@
 import { addMatchImageSnapshotPlugin } from 'cypress-image-snapshot/plugin';
 
 const pluginConfig: Cypress.PluginConfig = (on, config) => {
-  addMatchImageSnapshotPlugin(on, config); // eslint-disable-line @typescript-eslint/no-unsafe-argument
+  addMatchImageSnapshotPlugin(on, config);
 };
 
 export default pluginConfig;

--- a/cypress/support.ts
+++ b/cypress/support.ts
@@ -1,43 +1,13 @@
-/* eslint-disable promise/no-nesting */
-/* eslint-disable promise/prefer-await-to-then */
 import '@testing-library/cypress/add-commands';
 import { addMatchImageSnapshotCommand } from 'cypress-image-snapshot/command';
+import { registerCommand as addWaitForStableDomCommand } from 'cypress-wait-for-stable-dom';
 
-const INTERVAL = 300; // more than debounce on slicing slider
-const TIMEOUT = 2000;
-const OBSERVER_CONFIG = {
-  subtree: true,
-  childList: true,
-  attributes: true,
-  attributeOldValue: true,
-  characterData: true,
-  characterDataOldValue: true,
-};
+addMatchImageSnapshotCommand();
 
-// Simplified version of https://github.com/narinluangrath/cypress-wait-for-stable-dom/ due to import issue
-function waitForStableDOM(iteration = 0) {
-  cy.document().then((document: Document) => {
-    let mutation: MutationRecord[];
-    const observer = new MutationObserver((m) => (mutation = m));
-    observer.observe(document, OBSERVER_CONFIG);
-
-    cy.wait(INTERVAL, { log: false }).then(() => {
-      if (!mutation) {
-        cy.log(`No changes detected for over ${INTERVAL}ms!`);
-        cy.log('Continuing with test...');
-        return;
-      } else if (iteration * INTERVAL < TIMEOUT) {
-        cy.log('Mutation detected... retrying...');
-        waitForStableDOM(iteration + 1);
-        return;
-      }
-
-      throw new Error('Timed out waiting for stable DOM');
-    });
-  });
-}
-
-Cypress.Commands.add('waitForStableDOM', waitForStableDOM);
+addWaitForStableDomCommand({
+  pollInterval: 300, // more than debounce on slicing slider
+  timeout: 2000,
+});
 
 Cypress.Commands.add('selectExplorerNode', (name: string) => {
   cy.findByRole('treeitem', {
@@ -50,5 +20,3 @@ Cypress.Commands.add('selectVisTab', (name: string) => {
   cy.findByRole('tab', { name }).click();
   cy.waitForStableDOM();
 });
-
-addMatchImageSnapshotCommand();

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/node": "16.11.7",
     "cypress": "9.5.0",
     "cypress-image-snapshot": "4.0.1",
+    "cypress-wait-for-stable-dom": "0.1.0",
     "eslint": "8.23.1",
     "eslint-config-galex": "4.2.2",
     "identity-obj-proxy": "3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ importers:
       '@types/node': 16.11.7
       cypress: 9.5.0
       cypress-image-snapshot: 4.0.1
+      cypress-wait-for-stable-dom: 0.1.0
       eslint: '>=8'
       eslint-config-galex: 4.2.2
       identity-obj-proxy: 3.0.0
@@ -32,6 +33,7 @@ importers:
       '@types/node': 16.11.7
       cypress: 9.5.0
       cypress-image-snapshot: 4.0.1_cypress@9.5.0+jest@27.5.1
+      cypress-wait-for-stable-dom: 0.1.0
       eslint: 8.23.1
       eslint-config-galex: 4.2.2_eslint@8.23.1+jest@27.5.1
       identity-obj-proxy: 3.0.0
@@ -7398,6 +7400,10 @@ packages:
       term-img: 4.1.0
     transitivePeerDependencies:
       - jest
+    dev: true
+
+  /cypress-wait-for-stable-dom/0.1.0:
+    resolution: {integrity: sha512-iVJc6CDzlu1xUnTcZph+zbkOlImaDelpvRv4G+3naugvjkF6b9EFpDmRCC/16xL1pqpkFq4rFyfhuNw4C3PQjw==}
     dev: true
 
   /cypress/9.5.0:


### PR DESCRIPTION
With PRs https://github.com/narinluangrath/cypress-wait-for-stable-dom/issues/4 and https://github.com/narinluangrath/cypress-wait-for-stable-dom/issues/5 now resolved, I'm able to use the plugin [cypress-wait-for-stable-dom](https://github.com/narinluangrath/cypress-wait-for-stable-dom).