### PR TITLE
Fix stacking of domain slider tooltip

### DIFF
--- a/packages/lib/src/toolbar/Toolbar.module.css
+++ b/packages/lib/src/toolbar/Toolbar.module.css
@@ -1,6 +1,6 @@
 .toolbar {
   flex: 1 1 0%;
-  position: relative; /* for `z-index` below, in case parent doesn't have `display: flex`*/
+  position: relative; /* for `z-index` below, in case parent doesn't have `display: flex` */
   z-index: 1; /* for toolbar menus to appear above visualizations (overflow, selectors) */
   display: flex;
   min-width: 0;

--- a/packages/lib/src/toolbar/controls/DomainSlider/DomainTooltip.module.css
+++ b/packages/lib/src/toolbar/controls/DomainSlider/DomainTooltip.module.css
@@ -1,8 +1,11 @@
 .tooltip {
   composes: popup from '../../Toolbar.module.css';
   left: 50%;
-  /* FIX style ordering issue with Vite */
-  transform: translate(-50%, 100%) !important;
+  z-index: 2; /* above overflow and selector menus */
+  transform: translate(
+    -50%,
+    100%
+  ) !important; /* FIX style ordering issue with Vite */
   /* Add invisible padding around tooltip to extend hover area */
   /* (especially for when enabling auto-scaling hides an error message). */
   padding-left: 2rem;

--- a/packages/lib/src/toolbar/controls/Selector/Selector.module.css
+++ b/packages/lib/src/toolbar/controls/Selector/Selector.module.css
@@ -50,7 +50,7 @@
   top: calc(100% + 0.75rem);
   left: 50%;
   transform: translateX(-50%); /* center menu with button */
-  z-index: 1; /* above other selectors */
+  z-index: 1; /* above overflow menu */
   min-width: 100%;
   padding-top: 0.25rem;
   background-color: var(--h5w-selector-menu--bgColor, white);


### PR DESCRIPTION
It is now always above everything, since it can be opened on hover - i.e. when other menus are open. Also, you can't pin it and keep it open while opening another menu, so there's no need for another menu to appear above the domain slider tooltip.

![image](https://user-images.githubusercontent.com/2936402/196460832-502aae85-a515-43fa-975d-e53ba9759eec.png)

![image](https://user-images.githubusercontent.com/2936402/196460885-c8eb4f3e-3949-434b-b750-3db1a0646a56.png)

![image](https://user-images.githubusercontent.com/2936402/196460961-a3b0ce56-aaa8-4441-a129-c27b72018eae.png)
