### PR TITLE
Simplify props API of `ExportMenu`

### DIFF
--- a/packages/app/src/vis-packs/core/heatmap/HeatmapToolbar.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/HeatmapToolbar.tsx
@@ -50,6 +50,13 @@ function HeatmapToolbar(props: Props) {
 
   const { getExportURL } = useDataContext();
 
+  const exportEntries =
+    getExportURL &&
+    EXPORT_FORMATS.map((format) => ({
+      format,
+      url: getExportURL(dataset, selection, format),
+    }));
+
   return (
     <Toolbar interactions={getImageInteractions(layout)}>
       <DomainSlider
@@ -95,14 +102,8 @@ function HeatmapToolbar(props: Props) {
 
       <Separator />
 
-      {getExportURL && (
-        <ExportMenu
-          formats={EXPORT_FORMATS}
-          isSlice={selection !== undefined}
-          getFormatURL={(format: ExportFormat) =>
-            getExportURL(dataset, selection, format)
-          }
-        />
+      {exportEntries && (
+        <ExportMenu entries={exportEntries} isSlice={selection !== undefined} />
       )}
 
       <SnapshotBtn />

--- a/packages/app/src/vis-packs/core/line/LineToolbar.tsx
+++ b/packages/app/src/vis-packs/core/line/LineToolbar.tsx
@@ -47,6 +47,14 @@ function LineToolbar(props: Props) {
 
   const { getExportURL } = useDataContext();
 
+  const exportEntries =
+    getExportURL &&
+    dataset &&
+    EXPORT_FORMATS.map((format) => ({
+      format,
+      url: getExportURL(dataset, selection, format),
+    }));
+
   return (
     <Toolbar interactions={INTERACTIONS_WITH_AXIAL_ZOOM}>
       <ScaleSelector
@@ -108,15 +116,12 @@ function LineToolbar(props: Props) {
         <ToggleGroup.Btn label="Both" value={CurveType.LineAndGlyphs} />
       </ToggleGroup>
 
-      {getExportURL && dataset && (
+      {exportEntries && dataset && (
         <>
           <Separator />
           <ExportMenu
-            formats={EXPORT_FORMATS}
+            entries={exportEntries}
             isSlice={selection !== undefined}
-            getFormatURL={(format: ExportFormat) =>
-              getExportURL(dataset, selection, format)
-            }
           />
         </>
       )}

--- a/packages/app/src/vis-packs/core/matrix/MatrixToolbar.tsx
+++ b/packages/app/src/vis-packs/core/matrix/MatrixToolbar.tsx
@@ -35,6 +35,14 @@ function MatrixToolbar(props: Props) {
     setNotation,
   } = useMatrixConfig();
 
+  const exportEntries =
+    getExportURL &&
+    hasNumericType(dataset) &&
+    EXPORT_FORMATS.map((format) => ({
+      format,
+      url: getExportURL(dataset, selection, format),
+    }));
+
   return (
     <Toolbar>
       <CellWidthInput
@@ -54,15 +62,12 @@ function MatrixToolbar(props: Props) {
         onToggle={toggleSticky}
       />
 
-      {getExportURL && hasNumericType(dataset) && (
+      {exportEntries && (
         <>
           <Separator />
           <ExportMenu
-            formats={EXPORT_FORMATS}
+            entries={exportEntries}
             isSlice={selection !== undefined}
-            getFormatURL={(format: ExportFormat) =>
-              getExportURL(dataset, selection, format)
-            }
           />
         </>
       )}

--- a/packages/lib/src/toolbar/controls/ExportMenu.tsx
+++ b/packages/lib/src/toolbar/controls/ExportMenu.tsx
@@ -1,28 +1,28 @@
-import { isDefined } from '@h5web/shared';
 import { Button, Wrapper, Menu } from 'react-aria-menubutton';
 import { FiDownload } from 'react-icons/fi';
 import { MdArrowDropDown } from 'react-icons/md';
 
 import styles from './Selector/Selector.module.css';
 
-interface Props<F extends string> {
-  formats: F[];
-  isSlice: boolean;
-  getFormatURL: (format: F) => string | undefined; // `undefined` if format is not supported
+export interface ExportEntry {
+  format: string;
+  url: string | undefined;
 }
 
-function ExportMenu<F extends string>(props: Props<F>) {
-  const { formats, isSlice, getFormatURL } = props;
+interface Props {
+  entries: ExportEntry[];
+  isSlice: boolean;
+}
 
-  const urls = formats.map(getFormatURL);
-  const hasSupportedFormats = urls.some(isDefined);
+function ExportMenu(props: Props) {
+  const { entries, isSlice } = props;
 
   return (
     <Wrapper className={styles.wrapper}>
       <Button
         className={styles.btn}
         tag="button"
-        disabled={!hasSupportedFormats}
+        disabled={!entries.some(({ url }) => !!url)}
       >
         <div className={styles.btnLike}>
           <FiDownload className={styles.icon} />
@@ -34,13 +34,13 @@ function ExportMenu<F extends string>(props: Props<F>) {
       </Button>
       <Menu className={styles.menu}>
         <div className={styles.list}>
-          {formats.map(
-            (format, index) =>
-              urls[index] && (
+          {entries.map(({ format, url }) => {
+            return (
+              url && (
                 <a
                   key={format}
                   className={styles.linkOption}
-                  href={urls[index]}
+                  href={url}
                   target="_blank"
                   download={`data.${format}`}
                   rel="noreferrer"
@@ -50,7 +50,8 @@ function ExportMenu<F extends string>(props: Props<F>) {
                   >{`Export to ${format.toUpperCase()}`}</span>
                 </a>
               )
-          )}
+            );
+          })}
         </div>
       </Menu>
     </Wrapper>


### PR DESCRIPTION
Preparation for #1063 

The `getFormatURL`  prop was confusing. It made it look like the URLs were generated lazily, which isn't the case -- they're generated during render. Also, we used to end up with two arrays, `formats` and `urls`, so we had to access one by `index` in the `map` loop.