### PR TITLE
Pass dataset value to `getExportURL`

### DIFF
--- a/packages/app/src/providers/api.ts
+++ b/packages/app/src/providers/api.ts
@@ -4,8 +4,8 @@ import type {
   AttributeValues,
   Dataset,
   Entity,
-  NumericType,
   ProvidedEntity,
+  Value,
 } from '@h5web/shared';
 import type {
   AxiosInstance,
@@ -44,11 +44,12 @@ export abstract class DataProviderApi {
     this.client = axios.create(config);
   }
 
-  public getExportURL?(
-    dataset: Dataset<ArrayShape, NumericType>,
+  public getExportURL?<D extends Dataset<ArrayShape>>(
+    dataset: D,
     selection: string | undefined,
+    value: Value<D>,
     format: ExportFormat
-  ): string | undefined; // `undefined` if format is not supported
+  ): URL | undefined; // `undefined` if format is not supported
 
   public addProgressListener(cb: ProgressCallback): void {
     this.progressListeners.add(cb);

--- a/packages/app/src/vis-packs/core/compound/MappedCompoundMatrixVis.tsx
+++ b/packages/app/src/vis-packs/core/compound/MappedCompoundMatrixVis.tsx
@@ -9,6 +9,7 @@ import type {
 import { createPortal } from 'react-dom';
 
 import type { DimensionMapping } from '../../../dimension-mapper/models';
+import { useDataContext } from '../../../providers/DataProvider';
 import { useMappedArray, useSlicedDimsAndMapping } from '../hooks';
 import MatrixToolbar from '../matrix/MatrixToolbar';
 import type { MatrixVisConfig } from '../matrix/config';
@@ -43,14 +44,20 @@ function MappedCompoundMatrixVis(props: Props) {
     getFormatter(field, notation)
   );
 
+  const { getExportURL } = useDataContext();
+  const selection = getSliceSelection(dimMapping);
+
   return (
     <>
       {toolbarContainer &&
         createPortal(
           <MatrixToolbar
-            dataset={dataset}
-            selection={getSliceSelection(dimMapping)}
             cellWidth={cellWidth}
+            isSlice={selection !== undefined}
+            getExportURL={
+              getExportURL &&
+              ((format) => getExportURL(dataset, selection, value, format))
+            }
           />,
           toolbarContainer
         )}

--- a/packages/app/src/vis-packs/core/heatmap/HeatmapToolbar.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/HeatmapToolbar.tsx
@@ -12,10 +12,8 @@ import {
   ToggleBtn,
   Toolbar,
 } from '@h5web/lib';
-import type { ArrayShape, Dataset, NumericType } from '@h5web/shared';
 import { MdAspectRatio } from 'react-icons/md';
 
-import { useDataContext } from '../../../providers/DataProvider';
 import type { ExportFormat } from '../../../providers/models';
 import { getImageInteractions } from '../utils';
 import type { HeatmapConfig } from './config';
@@ -23,14 +21,14 @@ import type { HeatmapConfig } from './config';
 const EXPORT_FORMATS: ExportFormat[] = ['tiff', 'npy'];
 
 interface Props {
-  dataset: Dataset<ArrayShape, NumericType>;
   dataDomain: Domain;
-  selection: string | undefined;
+  isSlice: boolean;
   config: HeatmapConfig;
+  getExportURL: ((format: ExportFormat) => URL | undefined) | undefined;
 }
 
 function HeatmapToolbar(props: Props) {
-  const { dataset, dataDomain, selection, config } = props;
+  const { isSlice, dataDomain, config, getExportURL } = props;
   const {
     customDomain,
     colorMap,
@@ -47,15 +45,6 @@ function HeatmapToolbar(props: Props) {
     toggleColorMapInversion,
     toggleYAxisFlip,
   } = config;
-
-  const { getExportURL } = useDataContext();
-
-  const exportEntries =
-    getExportURL &&
-    EXPORT_FORMATS.map((format) => ({
-      format,
-      url: getExportURL(dataset, selection, format),
-    }));
 
   return (
     <Toolbar interactions={getImageInteractions(layout)}>
@@ -102,8 +91,14 @@ function HeatmapToolbar(props: Props) {
 
       <Separator />
 
-      {exportEntries && (
-        <ExportMenu entries={exportEntries} isSlice={selection !== undefined} />
+      {getExportURL && (
+        <ExportMenu
+          isSlice={isSlice}
+          entries={EXPORT_FORMATS.map((format) => ({
+            format,
+            url: getExportURL(format),
+          }))}
+        />
       )}
 
       <SnapshotBtn />

--- a/packages/app/src/vis-packs/core/heatmap/MappedHeatmapVis.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/MappedHeatmapVis.tsx
@@ -10,6 +10,7 @@ import type { TypedArray } from 'ndarray';
 import { createPortal } from 'react-dom';
 
 import type { DimensionMapping } from '../../../dimension-mapper/models';
+import { useDataContext } from '../../../providers/DataProvider';
 import { useMappedArray, useSlicedDimsAndMapping } from '../hooks';
 import { DEFAULT_DOMAIN, getSliceSelection } from '../utils';
 import HeatmapToolbar from './HeatmapToolbar';
@@ -59,15 +60,21 @@ function MappedHeatmapVis(props: Props) {
   const xDimIndex = dimMapping.indexOf('x');
   const yDimIndex = dimMapping.indexOf('y');
 
+  const { getExportURL } = useDataContext();
+  const selection = getSliceSelection(dimMapping);
+
   return (
     <>
       {toolbarContainer &&
         createPortal(
           <HeatmapToolbar
-            dataset={dataset}
             dataDomain={dataDomain}
-            selection={getSliceSelection(dimMapping)}
+            isSlice={selection !== undefined}
             config={config}
+            getExportURL={
+              getExportURL &&
+              ((format) => getExportURL(dataset, selection, value, format))
+            }
           />,
           toolbarContainer
         )}

--- a/packages/app/src/vis-packs/core/line/LineToolbar.tsx
+++ b/packages/app/src/vis-packs/core/line/LineToolbar.tsx
@@ -7,12 +7,10 @@ import {
   ToggleGroup,
   Toolbar,
 } from '@h5web/lib';
-import type { ArrayShape, Dataset, NumericType } from '@h5web/shared';
 import { ScaleType } from '@h5web/shared';
 import { FiItalic } from 'react-icons/fi';
 import { MdGridOn, MdDomain } from 'react-icons/md';
 
-import { useDataContext } from '../../../providers/DataProvider';
 import type { ExportFormat } from '../../../providers/models';
 import { INTERACTIONS_WITH_AXIAL_ZOOM } from '../utils';
 import type { LineConfig } from './config';
@@ -21,15 +19,17 @@ const SCALETYPE_OPTIONS = [ScaleType.Linear, ScaleType.Log, ScaleType.SymLog];
 const EXPORT_FORMATS: ExportFormat[] = ['npy', 'csv'];
 
 interface Props {
-  dataset?: Dataset<ArrayShape, NumericType>;
-  selection?: string | undefined;
+  isSlice: boolean;
   disableAutoScale: boolean;
   disableErrors: boolean;
   config: LineConfig;
+  getExportURL: ((format: ExportFormat) => URL | undefined) | undefined;
 }
 
 function LineToolbar(props: Props) {
-  const { dataset, selection, disableAutoScale, disableErrors, config } = props;
+  const { isSlice, disableAutoScale, disableErrors, config, getExportURL } =
+    props;
+
   const {
     curveType,
     setCurveType,
@@ -44,16 +44,6 @@ function LineToolbar(props: Props) {
     showErrors,
     toggleErrors,
   } = config;
-
-  const { getExportURL } = useDataContext();
-
-  const exportEntries =
-    getExportURL &&
-    dataset &&
-    EXPORT_FORMATS.map((format) => ({
-      format,
-      url: getExportURL(dataset, selection, format),
-    }));
 
   return (
     <Toolbar interactions={INTERACTIONS_WITH_AXIAL_ZOOM}>
@@ -116,12 +106,15 @@ function LineToolbar(props: Props) {
         <ToggleGroup.Btn label="Both" value={CurveType.LineAndGlyphs} />
       </ToggleGroup>
 
-      {exportEntries && dataset && (
+      {getExportURL && (
         <>
           <Separator />
           <ExportMenu
-            entries={exportEntries}
-            isSlice={selection !== undefined}
+            isSlice={isSlice}
+            entries={EXPORT_FORMATS.map((format) => ({
+              format,
+              url: getExportURL(format),
+            }))}
           />
         </>
       )}

--- a/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
+++ b/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
@@ -9,6 +9,7 @@ import type {
 import { createPortal } from 'react-dom';
 
 import type { DimensionMapping } from '../../../dimension-mapper/models';
+import { useDataContext } from '../../../providers/DataProvider';
 import {
   useMappedArrays,
   useMappedArray,
@@ -82,16 +83,22 @@ function MappedLineVis(props: Props) {
   const combinedDomain = useCombinedDomain([dataDomain, ...auxDomains]);
   const xDimIndex = dimMapping.indexOf('x');
 
+  const { getExportURL } = useDataContext();
+
   return (
     <>
       {toolbarContainer &&
         createPortal(
           <LineToolbar
-            dataset={dataset}
-            selection={selection}
+            isSlice={selection !== undefined}
             disableAutoScale={dims.length <= 1} // with 1D datasets, `baseArray` and `dataArray` are the same so auto-scaling is implied
             disableErrors={!errors}
             config={config}
+            getExportURL={
+              getExportURL &&
+              dataset &&
+              ((format) => getExportURL(dataset, selection, value, format))
+            }
           />,
           toolbarContainer
         )}

--- a/packages/app/src/vis-packs/core/matrix/MappedMatrixVis.tsx
+++ b/packages/app/src/vis-packs/core/matrix/MappedMatrixVis.tsx
@@ -8,6 +8,7 @@ import type {
 import { createPortal } from 'react-dom';
 
 import type { DimensionMapping } from '../../../dimension-mapper/models';
+import { useDataContext } from '../../../providers/DataProvider';
 import { useMappedArray, useSlicedDimsAndMapping } from '../hooks';
 import { getSliceSelection } from '../utils';
 import MatrixToolbar from './MatrixToolbar';
@@ -33,14 +34,20 @@ function MappedMatrixVis(props: Props) {
   const formatter = getFormatter(type, notation);
   const cellWidth = getCellWidth(type);
 
+  const { getExportURL } = useDataContext();
+  const selection = getSliceSelection(dimMapping);
+
   return (
     <>
       {toolbarContainer &&
         createPortal(
           <MatrixToolbar
-            dataset={dataset}
-            selection={getSliceSelection(dimMapping)}
             cellWidth={cellWidth}
+            isSlice={selection !== undefined}
+            getExportURL={
+              getExportURL &&
+              ((format) => getExportURL(dataset, selection, value, format))
+            }
           />,
           toolbarContainer
         )}

--- a/packages/app/src/vis-packs/core/matrix/MatrixToolbar.tsx
+++ b/packages/app/src/vis-packs/core/matrix/MatrixToolbar.tsx
@@ -6,25 +6,21 @@ import {
   ToggleBtn,
   Toolbar,
 } from '@h5web/lib';
-import type { ArrayShape, Dataset } from '@h5web/shared';
-import { hasNumericType } from '@h5web/shared';
 import { FiAnchor } from 'react-icons/fi';
 
-import { useDataContext } from '../../../providers/DataProvider';
 import type { ExportFormat } from '../../../providers/models';
 import { useMatrixConfig } from './config';
 
 const EXPORT_FORMATS: ExportFormat[] = ['npy', 'csv'];
 
 interface Props {
-  dataset: Dataset<ArrayShape>;
-  selection?: string | undefined;
   cellWidth: number;
+  isSlice: boolean;
+  getExportURL: ((format: ExportFormat) => URL | undefined) | undefined;
 }
 
 function MatrixToolbar(props: Props) {
-  const { dataset, selection, cellWidth } = props;
-  const { getExportURL } = useDataContext();
+  const { cellWidth, isSlice, getExportURL } = props;
 
   const {
     sticky,
@@ -34,14 +30,6 @@ function MatrixToolbar(props: Props) {
     notation,
     setNotation,
   } = useMatrixConfig();
-
-  const exportEntries =
-    getExportURL &&
-    hasNumericType(dataset) &&
-    EXPORT_FORMATS.map((format) => ({
-      format,
-      url: getExportURL(dataset, selection, format),
-    }));
 
   return (
     <Toolbar>
@@ -62,12 +50,15 @@ function MatrixToolbar(props: Props) {
         onToggle={toggleSticky}
       />
 
-      {exportEntries && (
+      {getExportURL && (
         <>
           <Separator />
           <ExportMenu
-            entries={exportEntries}
-            isSlice={selection !== undefined}
+            isSlice={isSlice}
+            entries={EXPORT_FORMATS.map((format) => ({
+              format,
+              url: getExportURL(format),
+            }))}
           />
         </>
       )}

--- a/packages/lib/src/toolbar/controls/ExportMenu.tsx
+++ b/packages/lib/src/toolbar/controls/ExportMenu.tsx
@@ -6,7 +6,7 @@ import styles from './Selector/Selector.module.css';
 
 export interface ExportEntry {
   format: string;
-  url: string | undefined;
+  url: URL | undefined;
 }
 
 interface Props {
@@ -40,7 +40,7 @@ function ExportMenu(props: Props) {
                 <a
                   key={format}
                   className={styles.linkOption}
-                  href={url}
+                  href={url.href}
                   target="_blank"
                   download={`data.${format}`}
                   rel="noreferrer"


### PR DESCRIPTION
Getting closer to #1063 

I pass the `value` of the dataset, which is available in the mapped vis, to the `getExportURL` method of the data provider. This will allow data providers to generate client-side exports without them having to call `valuesStore.get` (which is not doable outside of the `render` pipeline, as the exports will be generated on demand, when clicking on the `ExportMenu` options).