### PR TITLE
Allow H5Wasm entities to be null (e.g. datatype)

### DIFF
--- a/packages/h5wasm/src/h5wasm-api.ts
+++ b/packages/h5wasm/src/h5wasm-api.ts
@@ -124,7 +124,7 @@ export class H5WasmApi extends ProviderApi {
     return new H5WasmFile(id, 'r');
   }
 
-  private async getH5WasmEntity(path: string): Promise<H5WasmEntity> {
+  private async getH5WasmEntity(path: string) {
     const file = await this.file;
 
     const h5wEntity = file.get(path);
@@ -173,7 +173,6 @@ export class H5WasmApi extends ProviderApi {
         ...baseGroup,
         children: h5wEntity.keys().map((childName) => {
           const h5wChild = h5wEntity.get(childName);
-          assertNonNull(h5wChild);
 
           const childPath = buildEntityPath(path, childName);
           return this.processH5WasmEntity(childName, childPath, h5wChild, true);

--- a/packages/h5wasm/src/models.ts
+++ b/packages/h5wasm/src/models.ts
@@ -4,7 +4,7 @@ import type {
   CompoundTypeMetadata,
 } from 'h5wasm/src/hdf5_util_helpers';
 
-export type H5WasmEntity = NonNullable<ReturnType<H5WasmGroup['get']>>;
+export type H5WasmEntity = ReturnType<H5WasmGroup['get']>;
 
 export type H5WasmAttributes = H5WasmGroup['attrs'];
 


### PR DESCRIPTION
Before https://github.com/usnistgov/h5wasm/pull/32 is released, entities from h5wasm can be `null` which raises an error in the Provider.

This makes the `null` entities fall back to `Unresolved`.