### PR TITLE
Fix `Value<D>` and export `getExportURL` function type

### DIFF
--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -1,3 +1,5 @@
+import type { DataProviderApi } from './providers/api';
+
 export { default as App } from './App';
 
 export { default as MockProvider } from './providers/mock/MockProvider';
@@ -7,6 +9,7 @@ export { default as H5GroveProvider } from './providers/h5grove/H5GroveProvider'
 export { getFeedbackMailto } from './breadcrumbs/utils';
 export type { FeedbackContext } from './breadcrumbs/models';
 export type { ExportFormat, ExportURL } from './providers/models';
+export type GetExportURL = NonNullable<DataProviderApi['getExportURL']>;
 
 // Context
 export { useDataContext } from './providers/DataProvider';

--- a/packages/app/src/providers/hsds/hsds-api.ts
+++ b/packages/app/src/providers/hsds/hsds-api.ts
@@ -8,7 +8,6 @@ import type {
   ChildEntity,
   ProvidedEntity,
   ArrayShape,
-  DType,
   Value,
 } from '@h5web/shared';
 import { assertGroup } from '@h5web/shared';
@@ -152,7 +151,7 @@ export class HsdsApi extends DataProviderApi {
     );
   }
 
-  public getExportURL<D extends Dataset<ArrayShape, DType>>(
+  public getExportURL<D extends Dataset<ArrayShape>>(
     format: ExportFormat,
     dataset: D,
     selection: string | undefined,

--- a/packages/h5wasm/src/h5wasm-api.ts
+++ b/packages/h5wasm/src/h5wasm-api.ts
@@ -12,7 +12,6 @@ import type {
   Attribute,
   ChildEntity,
   Dataset,
-  DType,
   Entity,
   Group,
   ProvidedEntity,
@@ -95,7 +94,7 @@ export class H5WasmApi extends ProviderApi {
     );
   }
 
-  public getExportURL<D extends Dataset<ArrayShape, DType>>(
+  public getExportURL<D extends Dataset<ArrayShape>>(
     format: ExportFormat,
     dataset: D,
     selection: string | undefined,

--- a/packages/shared/src/models-hdf5.ts
+++ b/packages/shared/src/models-hdf5.ts
@@ -175,10 +175,12 @@ export type ArrayValue<T extends DType> =
   | Primitive<T>[]
   | (T extends NumericType ? TypedArray : never);
 
-export type Value<D extends Dataset> = D['shape'] extends ScalarShape
-  ? Primitive<D['type']>
-  : D['shape'] extends ArrayShape
-  ? ArrayValue<D['type']>
+export type Value<D extends Dataset> = D extends Dataset<infer S, infer T>
+  ? S extends ScalarShape
+    ? Primitive<T>
+    : S extends ArrayShape
+    ? ArrayValue<T>
+    : never
   : never;
 
 export type AttributeValues = Record<string, unknown>;


### PR DESCRIPTION
Partial fix for [#1063 ](https://github.com/silx-kit/h5web/issues/1063#issuecomment-1293771087)

There was a problem with the `Value<D>` type. In advanced cases, like the one identified by @bmaranville, the shape and dtype of the `Dataset` generic was not properly inferred.

`getExportURL` is only called with array-shaped datasets (`Dataset<ArrayShape>`), but `Value<D>` was not being narrowed down at all. Now, `Value<D>` is properly narrowed down to `unknown[] | TypedArray` (if we go down to the barest types).

```tsx
getExportURL={(format, dataset, selection, value) => async () => {
  value.forEach((val) => { /* ... */ }); // `forEach` now works because it is available on both arrays and typed arrays
}}
```

---

I'm also exporting the type of the `getExportURL` function in `@h5web/app` so one can extract the function outside of the JSX:

```tsx
const getExportURL: GetExportURL = (format, dataset, selection, value) => { ... };
```

I'm usually not a fan of function expressions, but in this case, replicating the signature would require exporting a lot of types and would be prone to mistakes. Indeed, with a function declaration, given the permissive nature of TS, consumers may not end up typing the function as strictly as they could and therefore struggle to implement it.