### PR TITLE
Make histogram interactive in DomainSlider

### DIFF
--- a/packages/lib/src/toolbar/controls/DomainSlider/DomainSlider.module.css
+++ b/packages/lib/src/toolbar/controls/DomainSlider/DomainSlider.module.css
@@ -1,6 +1,13 @@
 .root {
   position: relative;
   display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.sliderContainer {
+  display: flex;
+  flex: 1 1 0%;
   padding: 0 0.375rem;
   margin-right: -0.375rem;
 }

--- a/packages/lib/src/toolbar/controls/DomainSlider/DomainSlider.tsx
+++ b/packages/lib/src/toolbar/controls/DomainSlider/DomainSlider.tsx
@@ -70,37 +70,38 @@ function DomainSlider(props: Props) {
       onPointerEnter={() => toggleHovered(true)}
       onPointerLeave={() => toggleHovered(false)}
     >
-      <ScaledSlider
-        value={sliderDomain}
-        safeVisDomain={safeDomain}
-        dataDomain={dataDomain}
-        scaleType={scaleType}
-        errors={errors}
-        isAutoMin={isAutoMin}
-        isAutoMax={isAutoMax}
-        onChange={(newValue) => {
-          setSliderDomain(newValue);
-          toggleEditing(false);
-        }}
-        onAfterChange={(hasMinChanged, hasMaxChanged) => {
-          onCustomDomainChange([
-            hasMinChanged ? sliderDomain[0] : customDomain[0],
-            hasMaxChanged ? sliderDomain[1] : customDomain[1],
-          ]);
-        }}
-      />
+      <div className={styles.sliderContainer}>
+        <ScaledSlider
+          value={sliderDomain}
+          safeVisDomain={safeDomain}
+          dataDomain={dataDomain}
+          scaleType={scaleType}
+          errors={errors}
+          isAutoMin={isAutoMin}
+          isAutoMax={isAutoMax}
+          onChange={(newValue) => {
+            setSliderDomain(newValue);
+            toggleEditing(false);
+          }}
+          onAfterChange={(hasMinChanged, hasMaxChanged) => {
+            onCustomDomainChange([
+              hasMinChanged ? sliderDomain[0] : customDomain[0],
+              hasMaxChanged ? sliderDomain[1] : customDomain[1],
+            ]);
+          }}
+        />
 
-      <ToggleBtn
-        iconOnly
-        small
-        label="Edit domain"
-        aria-expanded={hovered || isEditing}
-        aria-controls={TOOLTIP_ID}
-        icon={FiEdit3}
-        value={isEditing}
-        onToggle={() => toggleEditing(!isEditing)}
-      />
-
+        <ToggleBtn
+          iconOnly
+          small
+          label="Edit domain"
+          aria-expanded={hovered || isEditing}
+          aria-controls={TOOLTIP_ID}
+          icon={FiEdit3}
+          value={isEditing}
+          onToggle={() => toggleEditing(!isEditing)}
+        />
+      </div>
       <DomainTooltip
         ref={tooltipRef}
         id={TOOLTIP_ID}
@@ -137,6 +138,7 @@ function DomainSlider(props: Props) {
             dataDomain={dataDomain}
             value={sliderDomain}
             scaleType={scaleType}
+            onChange={onCustomDomainChange}
             {...histogram}
           />
         )}

--- a/packages/lib/src/toolbar/controls/DomainSlider/DomainTooltip.module.css
+++ b/packages/lib/src/toolbar/controls/DomainSlider/DomainTooltip.module.css
@@ -1,11 +1,6 @@
 .tooltip {
   composes: popup from '../../Toolbar.module.css';
-  left: 50%;
   z-index: 2; /* above overflow and selector menus */
-  transform: translate(
-    -50%,
-    100%
-  ) !important; /* FIX style ordering issue with Vite */
   /* Add invisible padding around tooltip to extend hover area */
   /* (especially for when enabling auto-scaling hides an error message). */
   padding-left: 2rem;

--- a/packages/lib/src/toolbar/controls/Histogram/Marker.tsx
+++ b/packages/lib/src/toolbar/controls/Histogram/Marker.tsx
@@ -34,7 +34,7 @@ function Marker(props: Props) {
 
   return (
     <g
-      transform={dragState ? `translate(${dragState.dx}, 0)` : undefined}
+      transform={`translate(${dragState?.dx || 0}, 0)`}
       style={{ cursor: dragState ? 'ew-resize' : undefined }}
       {...handlers}
     >


### PR DESCRIPTION
That could have been as simple as adding [this line](https://github.com/silx-kit/h5web/compare/interactive-histogram-slider?expand=1#diff-1ddc4e75c70dd0e3279348964b72806822988ea30c61e19a69240832a32d4d65R141).

But due to https://github.com/airbnb/visx/issues/1174, the point positions when dragging are wrongly computed as the domain slider root div is translated via `transform`. This was to center the tooltip with respect to the slider.

To fix this, I reimplemented the centering by adding a flex container around the slider container and the tooltip to center them. This allows to remove `transform` from the histogram hierarchy of parents to work around https://github.com/airbnb/visx/issues/1174.