### PR TITLE
Implement own createMemo that preserves original function's overrides

### DIFF
--- a/packages/app/src/vis-packs/core/hooks.ts
+++ b/packages/app/src/vis-packs/core/hooks.ts
@@ -121,12 +121,14 @@ export function useMappedArrays(
   mapping: DimensionMapping,
   autoScale?: boolean
 ): [NdArray<NumArray>[], NdArray<NumArray>[]];
+
 export function useMappedArrays(
   values: (NumArray | undefined)[],
   dims: number[],
   mapping: DimensionMapping,
   autoScale?: boolean
 ): [(NdArray<NumArray> | undefined)[], (NdArray<NumArray> | undefined)[]];
+
 export function useMappedArrays(
   values: (NumArray | undefined)[],
   dims: number[],

--- a/packages/lib/src/vis/heatmap/hooks.ts
+++ b/packages/lib/src/vis/heatmap/hooks.ts
@@ -1,9 +1,5 @@
-import type { NumArray } from '@h5web/shared';
-import type { NdArray } from 'ndarray';
-import { useMemo } from 'react';
-import { createMemo } from 'react-use';
+import { createMemo } from '@h5web/shared';
 
-import type { TextureSafeTypedArray } from './models';
 import {
   getVisDomain,
   getSafeDomain,
@@ -14,19 +10,4 @@ import {
 export const useVisDomain = createMemo(getVisDomain);
 export const useSafeDomain = createMemo(getSafeDomain);
 export const usePixelEdgeValues = createMemo(getPixelEdgeValues);
-
-export function useTextureSafeNdArray(
-  ndArr: NdArray<NumArray>
-): NdArray<TextureSafeTypedArray>;
-
-export function useTextureSafeNdArray(
-  ndArr: NdArray<NumArray> | undefined
-): NdArray<TextureSafeTypedArray> | undefined;
-
-export function useTextureSafeNdArray(
-  ndArr: NdArray<NumArray> | undefined
-): NdArray<TextureSafeTypedArray> | undefined {
-  return useMemo(() => {
-    return ndArr && toTextureSafeNdArray(ndArr);
-  }, [ndArr]);
-}
+export const useTextureSafeNdArray = createMemo(toTextureSafeNdArray);

--- a/packages/lib/src/vis/heatmap/utils.ts
+++ b/packages/lib/src/vis/heatmap/utils.ts
@@ -132,7 +132,19 @@ export function scaleDomain(
 
 export function toTextureSafeNdArray(
   ndArr: NdArray<NumArray>
-): NdArray<TextureSafeTypedArray> {
+): NdArray<TextureSafeTypedArray>;
+
+export function toTextureSafeNdArray(
+  ndArr: NdArray<NumArray> | undefined
+): NdArray<TextureSafeTypedArray> | undefined;
+
+export function toTextureSafeNdArray(
+  ndArr: NdArray<NumArray> | undefined
+): NdArray<TextureSafeTypedArray> | undefined {
+  if (!ndArr) {
+    return undefined;
+  }
+
   if (ndArr.dtype === 'float32' || ndArr.dtype.startsWith('uint8')) {
     return ndArr as NdArray<TextureSafeTypedArray>;
   }

--- a/packages/lib/src/vis/hooks.ts
+++ b/packages/lib/src/vis/hooks.ts
@@ -1,10 +1,14 @@
-import { ScaleType, getBounds, getValidDomainForScale } from '@h5web/shared';
+import {
+  ScaleType,
+  getBounds,
+  getValidDomainForScale,
+  createMemo,
+} from '@h5web/shared';
 import type { Domain, AnyNumArray } from '@h5web/shared';
 import type { Camera } from '@react-three/fiber';
 import { useFrame, useThree } from '@react-three/fiber';
 import { useEffect, useCallback, useMemo, useState } from 'react';
 import type { RefCallback } from 'react';
-import { createMemo } from 'react-use';
 
 import { useAxisSystemContext } from './shared/AxisSystemProvider';
 import type { AxisSystemContextValue } from './shared/AxisSystemProvider';

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -2,6 +2,7 @@ import { format } from 'd3-format';
 import ndarray from 'ndarray';
 import type { NdArray, TypedArray } from 'ndarray';
 import { assign } from 'ndarray-ops';
+import { useMemo } from 'react';
 
 import { assertLength, isNdArray, isTypedArray } from './guards';
 import type {
@@ -181,4 +182,15 @@ export function getValidDomainForScale(
 export function getDims(dataArray: NdArray): Dims {
   const [rows, cols] = dataArray.shape;
   return { rows, cols };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function createMemo<P extends any[], R, T extends (...args: P) => R>(
+  fn: T
+): T;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function createMemo<P extends any[], R, T extends (...args: P) => R>(
+  fn: T
+) {
+  return (...args: P) => useMemo<R>(() => fn(...args), args); // eslint-disable-line react-hooks/exhaustive-deps
 }


### PR DESCRIPTION
Three reasons for this:

1. `createMemo` comes from `react-use`, so bring it in helps us move away from this unmaintained library.
2. The implementation is very short, so it's low-risk, low-maintenance.
3. `react-use`'s version was not playing well with functions with overrides: the memoised function would lose the overrides altogether, which prevented memoising some utility functions. I only found one such example, which I've refactored, but perhaps we had worked around other cases or had moved away from using `createMemo` for other reasons (e.g. `useDomain` cannot use `createMemo(getDomain)` because the two internal calls need to be memoised independently.)