### PR TITLE
Leave `flip` handling out of TiledHeatmapMesh

### DIFF
--- a/apps/storybook/src/TiledHeatmapMesh.stories.tsx
+++ b/apps/storybook/src/TiledHeatmapMesh.stories.tsx
@@ -188,7 +188,11 @@ const Template: Story<TiledHeatmapStoryProps> = (args) => {
       <Zoom />
       <SelectToZoom keepRatio modifierKey="Control" />
       <ResetZoomButton />
-      <TiledHeatmapMesh {...tiledHeatmapProps} />
+      <group
+        scale={[abscissaConfig.flip ? -1 : 1, ordinateConfig.flip ? -1 : 1, 1]}
+      >
+        <TiledHeatmapMesh {...tiledHeatmapProps} />
+      </group>
       {showTooltip && <TiledTooltipMesh renderTooltip={renderTooltip} />}
     </VisCanvas>
   );
@@ -336,13 +340,13 @@ WithTransforms.args = {
     visDomain: [-2, 1.5],
     isIndexAxis: true,
     showGrid: false,
-    flip: false,
+    flip: true,
   },
   ordinateConfig: {
     visDomain: [0, 2],
     isIndexAxis: true,
     showGrid: false,
-    flip: false,
+    flip: true,
   },
 };
 

--- a/packages/lib/src/vis/tiles/TiledHeatmapMesh.tsx
+++ b/packages/lib/src/vis/tiles/TiledHeatmapMesh.tsx
@@ -9,13 +9,13 @@ import type { Size } from '../models';
 import { useAxisSystemContext } from '../shared/AxisSystemProvider';
 import TiledLayer from './TiledLayer';
 import type { TilesApi } from './api';
-import { useLayerScales, useTooltipOnMoveHandler } from './hooks';
+import { useTooltipOnMoveHandler } from './hooks';
 import type { ColorMapProps } from './models';
 import {
   getNdcToObject3DMatrix,
   getObject3DPixelSize,
   getObject3DVisibleBox,
-  scaleBox,
+  scaleBoxToLayer,
 } from './utils';
 
 interface Props extends ColorMapProps {
@@ -47,8 +47,7 @@ function TiledHeatmapMesh(props: Props) {
   );
   const visibleBox = getObject3DVisibleBox(ndcToLocalMatrix);
 
-  const { xScale, yScale } = useLayerScales(baseLayerSize, meshSize);
-  const bounds = scaleBox(visibleBox, xScale, yScale);
+  const bounds = scaleBoxToLayer(visibleBox, baseLayerSize, meshSize);
 
   let layers: number[] = [];
   if (!bounds.isEmpty()) {

--- a/packages/lib/src/vis/tiles/TiledLayer.tsx
+++ b/packages/lib/src/vis/tiles/TiledLayer.tsx
@@ -4,12 +4,14 @@ import { LinearFilter, NearestFilter, Vector2 } from 'three';
 import type { Box3 } from 'three';
 
 import type { Size } from '../models';
-import { useAxisSystemContext } from '../shared/AxisSystemProvider';
 import Tile from './Tile';
 import type { TilesApi } from './api';
-import { useLayerScales } from './hooks';
 import type { ColorMapProps, TileArray } from './models';
-import { getTileOffsets, scaleBox, sortTilesByDistanceTo } from './utils';
+import {
+  getTileOffsets,
+  scaleBoxToLayer,
+  sortTilesByDistanceTo,
+} from './utils';
 
 interface Props extends ColorMapProps {
   api: TilesApi;
@@ -25,14 +27,12 @@ function TiledLayer(props: Props) {
 
   const { baseLayerIndex, numLayers, tileSize } = api;
   const layerSize = api.layerSizes[layer];
-  const { xScale, yScale } = useLayerScales(layerSize, meshSize);
-  const { abscissaConfig, ordinateConfig } = useAxisSystemContext();
 
   if (visibleBox.isEmpty()) {
     return null;
   }
 
-  const bounds = scaleBox(visibleBox, xScale, yScale);
+  const bounds = scaleBoxToLayer(visibleBox, layerSize, meshSize);
   const tileOffsets = getTileOffsets(bounds, tileSize);
   // Sort tiles from closest to vis center to farthest away
   sortTilesByDistanceTo(tileOffsets, tileSize, bounds.getCenter(new Vector2()));
@@ -40,36 +40,26 @@ function TiledLayer(props: Props) {
   return (
     // Transforms to use level of details layer array coordinates
     <group
-      scale={[abscissaConfig.flip ? -1 : 1, ordinateConfig.flip ? -1 : 1, 1]}
+      position={[-meshSize.width / 2, -meshSize.height / 2, layer / numLayers]}
+      scale={[
+        meshSize.width / layerSize.width,
+        meshSize.height / layerSize.height,
+        1,
+      ]}
     >
-      <group
-        position={[
-          -meshSize.width / 2,
-          -meshSize.height / 2,
-          layer / numLayers,
-        ]}
-        scale={[
-          meshSize.width / layerSize.width,
-          meshSize.height / layerSize.height,
-          1,
-        ]}
-      >
-        {tileOffsets.map((offset) => (
-          <Suspense key={`${offset.x},${offset.y}`} fallback={null}>
-            <Tile
-              api={api}
-              layer={layer}
-              x={offset.x}
-              y={offset.y}
-              {...colorMapProps}
-              magFilter={
-                layer === baseLayerIndex ? NearestFilter : LinearFilter
-              }
-              onPointerMove={onPointerMove}
-            />
-          </Suspense>
-        ))}
-      </group>
+      {tileOffsets.map((offset) => (
+        <Suspense key={`${offset.x},${offset.y}`} fallback={null}>
+          <Tile
+            api={api}
+            layer={layer}
+            x={offset.x}
+            y={offset.y}
+            {...colorMapProps}
+            magFilter={layer === baseLayerIndex ? NearestFilter : LinearFilter}
+            onPointerMove={onPointerMove}
+          />
+        </Suspense>
+      ))}
     </group>
   );
 }

--- a/packages/lib/src/vis/tiles/hooks.ts
+++ b/packages/lib/src/vis/tiles/hooks.ts
@@ -1,32 +1,9 @@
-import { ScaleType } from '@h5web/shared';
 import type { ThreeEvent } from '@react-three/fiber';
 import { useCallback } from 'react';
 
-import type { Size } from '../models';
 import { useAxisSystemContext } from '../shared/AxisSystemProvider';
-import { createAxisScale } from '../utils';
 import type { TileArray } from './models';
 import { useTooltipStore } from './store';
-
-export function useLayerScales(layerSize: Size, meshSize: Size) {
-  const { abscissaConfig, ordinateConfig } = useAxisSystemContext();
-
-  const xScale = createAxisScale(ScaleType.Linear, {
-    domain: [-meshSize.width / 2, meshSize.width / 2],
-    range: [0, layerSize.width],
-    reverse: abscissaConfig.flip,
-    clamp: true,
-  });
-
-  const yScale = createAxisScale(ScaleType.Linear, {
-    domain: [-meshSize.height / 2, meshSize.height / 2],
-    range: [0, layerSize.height],
-    reverse: ordinateConfig.flip,
-    clamp: true,
-  });
-
-  return { xScale, yScale };
-}
 
 export function useTooltipOnMoveHandler() {
   const setTooltipValue = useTooltipStore((state) => state.setTooltipValue);

--- a/packages/lib/src/vis/tiles/utils.ts
+++ b/packages/lib/src/vis/tiles/utils.ts
@@ -1,9 +1,11 @@
+import { ScaleType } from '@h5web/shared';
 import type { Camera } from '@react-three/fiber';
 import type { RefObject } from 'react';
 import type { Matrix4, Object3D } from 'three';
 import { Box2, Box3, Vector2, Vector3 } from 'three';
 
-import type { AxisScale, Size } from '../models';
+import type { Size } from '../models';
+import { createAxisScale } from '../utils';
 
 export function getTileOffsets(box: Box2, tileSize: Size): Vector2[] {
   const { width, height } = tileSize;
@@ -86,14 +88,32 @@ export function getObject3DVisibleBox(
   return NDC_BOX.clone().applyMatrix4(ndcToObject3DMatrix);
 }
 
-export function scaleBox(
+function getLayerScales(layerSize: Size, meshSize: Size) {
+  const xScale = createAxisScale(ScaleType.Linear, {
+    domain: [-meshSize.width / 2, meshSize.width / 2],
+    range: [0, layerSize.width],
+    clamp: true,
+  });
+
+  const yScale = createAxisScale(ScaleType.Linear, {
+    domain: [-meshSize.height / 2, meshSize.height / 2],
+    range: [0, layerSize.height],
+    clamp: true,
+  });
+
+  return { xScale, yScale };
+}
+
+export function scaleBoxToLayer(
   box: Box3,
-  xScale: AxisScale,
-  yScale: AxisScale
+  layerSize: Size,
+  meshSize: Size
 ): Box2 {
   if (box.isEmpty()) {
     return new Box2();
   }
+
+  const { xScale, yScale } = getLayerScales(layerSize, meshSize);
 
   const pt1 = new Vector2(xScale(box.min.x), yScale(box.min.y));
   const pt2 = new Vector2(xScale(box.max.x), yScale(box.max.y));


### PR DESCRIPTION
In https://github.com/silx-kit/h5web/pull/1193, I moved the handling of the `flip` of the axes inside the `TiledHeatmapMesh` (more specifically at the `TiledLayer` level) to avoid flipping the new `TooltipMesh` that was part of `TiledHeatmapMesh`.

But:
- `TiledTooltipMesh` is now out of `TiledHeatmapMesh`
- In daiquiri-tomo, the `flip` was already handled by a higher-order component (`LinearVisGroup`, also demonstrated in the `WithTransform` story in H5Web). **The flip of axes was therefore applied twice for tiled layers.**
- In `HeatmapMesh`, the `flip` is handled outside of the component and I think we want the two components to behave similarly.

For all these reasons, I moved the handling of `flip` out of `TiledHeatmapMesh` reverting part of #1193.