### PR TITLE
Export additionnal types in h5web/lib

### DIFF
--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -133,6 +133,8 @@ export type {
   Size,
   AxisConfig,
   AxisParams,
+  VisScaleType,
+  HistogramParams,
 } from './vis/models';
 
 export type { D3Interpolator, ColorMap } from './vis/heatmap/models';


### PR DESCRIPTION
Here are my thoughts about what should be exported after reviewing https://gitlab.esrf.fr/ui/daiquiri-ui/-/tree/744d64aaac72c79ffafd61b779af93d71f04cc5b/src/components/h5web:
- `bootstrap/DefaultMouseModeOptions`: daiquiri-specific
- `items`: could stay in daiquiri for now
- `DefaultMouseInteraction`: daiquiri-specific
- `LinearVis...`: Used in `TiledHeatmapMesh` story. But apart from that, I don't think it should be exported by us
- `SelectionPoint`: Could be in H5Web but we have no use for it for now. Could be refactored using `useCanvasEvents` though.
- `SvgScene...`: Bound to disappear
- `VisSynchroniser` and `hooks`: daiquiri-specific
- `models`: no longer needed if `SelectionPoint` is refactored
- `utils`: **export `VisScaleType` and `HistogramParams` in H5Web**. `toScaleType` and `stripHistogram` are arguable. The first almost has an equivalent [in HeatmatMesh](https://github.com/silx-kit/h5web/blob/ef80dac22cf959af43eca53f76b3fb7e811c3287/packages/lib/src/vis/heatmap/HeatmapMesh.tsx#L85) and the second could be useful in Braggy. 