### PR TITLE
Extend interaction area of histogram marker to center it

### DIFF
--- a/apps/storybook/src/Histogram.stories.tsx
+++ b/apps/storybook/src/Histogram.stories.tsx
@@ -12,7 +12,7 @@ const Template: Story<Omit<HistogramProps, 'onChange'>> = (args) => {
   return (
     <div>
       <p>
-        Domain: [{domain[0]}, {domain[1]}]
+        Domain: [{domain[0].toFixed(2)}, {domain[1].toFixed(2)}]
       </p>
       <Histogram {...otherArgs} value={domain} onChange={setDomain} />
     </div>

--- a/packages/lib/src/toolbar/controls/Histogram/Marker.tsx
+++ b/packages/lib/src/toolbar/controls/Histogram/Marker.tsx
@@ -49,10 +49,10 @@ function Marker(props: Props) {
       {/* Add an invisible rectangle to help selection */}
       {dragState && (
         <rect
-          x={flipArrow ? x - ARROW_SIZE : x}
+          x={x - ARROW_SIZE}
           y={0}
           height="100%"
-          width={ARROW_SIZE}
+          width={2 * ARROW_SIZE}
           fill="transparent"
           fillOpacity={0}
           stroke="none"


### PR DESCRIPTION
Fix #1277 

**Before:** (interaction area in blue)
![Screen Shot 2022-11-14 at 09 19 29](https://user-images.githubusercontent.com/42204205/201609763-99c6eb9d-c511-4837-85ac-805c5f21902c.png)


**After:**
![Screen Shot 2022-11-14 at 09 18 18](https://user-images.githubusercontent.com/42204205/201609584-7eabf201-f33e-4f6a-a5bf-434ae5c99ab3.png)
