### PR TITLE
Do not display the compression filters table in h5wasm if no filter

### DIFF
--- a/packages/app/src/metadata-viewer/MetadataViewer.tsx
+++ b/packages/app/src/metadata-viewer/MetadataViewer.tsx
@@ -59,7 +59,7 @@ function MetadataViewer(props: Props) {
         </MetadataTable>
       )}
 
-      {isDataset(entity) && entity.filters && (
+      {isDataset(entity) && entity.filters && entity.filters.length > 0 && (
         <MetadataTable title="Compression filters">
           <FiltersInfo filters={entity.filters} />
         </MetadataTable>


### PR DESCRIPTION
A dataset loaded with h5wasm with no filter shows a disjointed _Compression filters_ header

![image](https://user-images.githubusercontent.com/42204205/201671962-adf709de-03ee-412a-908b-b9e8476ca782.png)

This PR removes the header if no filter is present