### PR TITLE
Remove `contain` layout and `canvasRatio` prop

### DIFF
--- a/apps/storybook/src/HeatmapVis.stories.tsx
+++ b/apps/storybook/src/HeatmapVis.stories.tsx
@@ -142,7 +142,7 @@ export default {
     },
     layout: {
       control: { type: 'inline-radio' },
-      options: ['contain', 'cover', 'fill'],
+      options: ['cover', 'fill'],
     },
   },
 } as Meta;

--- a/apps/storybook/src/HeatmapVisDisplay.stories.tsx
+++ b/apps/storybook/src/HeatmapVisDisplay.stories.tsx
@@ -22,13 +22,6 @@ Fill.args = {
   layout: 'fill',
 };
 
-export const Contain = Template.bind({});
-Contain.args = {
-  dataArray,
-  domain,
-  layout: 'contain',
-};
-
 export const FlipYAxis = Template.bind({});
 FlipYAxis.args = {
   dataArray,

--- a/apps/storybook/src/VisCanvas.stories.tsx
+++ b/apps/storybook/src/VisCanvas.stories.tsx
@@ -34,9 +34,9 @@ LogScales.args = {
 
 export const AspectRatio = Template.bind({});
 AspectRatio.args = {
-  abscissaConfig: { visDomain: [0, 16], showGrid: true, isIndexAxis: true },
+  abscissaConfig: { visDomain: [0, 20], showGrid: true, isIndexAxis: true },
   ordinateConfig: { visDomain: [0, 10], showGrid: true, isIndexAxis: true },
-  canvasRatio: 16 / 10,
+  visRatio: 20 / 10,
 };
 
 export const NoGrid = Template.bind({});

--- a/packages/app/src/vis-packs/core/heatmap/config.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/config.tsx
@@ -1,4 +1,4 @@
-import type { CustomDomain } from '@h5web/lib';
+import type { CustomDomain, Layout } from '@h5web/lib';
 import { isDefined, ScaleType } from '@h5web/shared';
 import { useMap } from '@react-hookz/web';
 import type { StoreApi } from 'zustand';
@@ -7,7 +7,7 @@ import createContext from 'zustand/context';
 import { persist } from 'zustand/middleware';
 
 import type { ConfigProviderProps } from '../../models';
-import type { ColorMap, Layout } from './models';
+import type { ColorMap } from './models';
 
 export interface HeatmapConfig {
   customDomain: CustomDomain;

--- a/packages/app/src/vis-packs/core/heatmap/models.ts
+++ b/packages/app/src/vis-packs/core/heatmap/models.ts
@@ -1,5 +1,3 @@
 import type { INTERPOLATORS } from '@h5web/lib';
 
 export type ColorMap = keyof typeof INTERPOLATORS;
-
-export type Layout = 'contain' | 'cover' | 'fill';

--- a/packages/app/src/vis-packs/core/rgb/config.tsx
+++ b/packages/app/src/vis-packs/core/rgb/config.tsx
@@ -1,3 +1,4 @@
+import type { Layout } from '@h5web/lib';
 import { ImageType } from '@h5web/lib';
 import type { StoreApi } from 'zustand';
 import create from 'zustand';
@@ -5,7 +6,6 @@ import createContext from 'zustand/context';
 import { persist } from 'zustand/middleware';
 
 import type { ConfigProviderProps } from '../../models';
-import type { Layout } from '../heatmap/models';
 
 export interface RgbVisConfig {
   showGrid: boolean;

--- a/packages/app/src/vis-packs/core/utils.ts
+++ b/packages/app/src/vis-packs/core/utils.ts
@@ -1,3 +1,4 @@
+import type { Layout } from '@h5web/lib';
 import type { Domain } from '@h5web/shared';
 import { createArrayFromView } from '@h5web/shared';
 import { isNumber } from 'lodash';
@@ -6,7 +7,6 @@ import ndarray from 'ndarray';
 
 import type { Axis, DimensionMapping } from '../../dimension-mapper/models';
 import { isAxis } from '../../dimension-mapper/utils';
-import type { Layout } from './heatmap/models';
 
 export const DEFAULT_DOMAIN: Domain = [0.1, 1];
 

--- a/packages/app/src/vis-packs/nexus/utils.ts
+++ b/packages/app/src/vis-packs/nexus/utils.ts
@@ -1,3 +1,4 @@
+import type { Layout } from '@h5web/lib';
 import {
   assertArray,
   assertArrayShape,
@@ -26,7 +27,6 @@ import type {
 
 import type { AttrValuesStore } from '../../providers/models';
 import { hasAttribute } from '../../utils';
-import type { Layout } from '../core/heatmap/models';
 import type { AxisDef, DatasetInfo, NxData, SilxStyle } from './models';
 
 export function isNxDataGroup(

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -137,7 +137,7 @@ export type {
   HistogramParams,
 } from './vis/models';
 
-export type { D3Interpolator, ColorMap } from './vis/heatmap/models';
+export type { D3Interpolator, ColorMap, Layout } from './vis/heatmap/models';
 export type { ScatterAxisParams } from './vis/scatter/models';
 
 // Mock data and utilities

--- a/packages/lib/src/vis/heatmap/HeatmapVis.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapVis.tsx
@@ -84,7 +84,6 @@ function HeatmapVis(props: Props) {
     <figure className={styles.root} aria-label={title} data-keep-canvas-colors>
       <VisCanvas
         title={title}
-        canvasRatio={layout === 'contain' ? cols / rows : undefined}
         visRatio={keepRatio ? cols / rows : undefined}
         abscissaConfig={{
           visDomain: abscissaDomain,

--- a/packages/lib/src/vis/heatmap/models.ts
+++ b/packages/lib/src/vis/heatmap/models.ts
@@ -4,7 +4,7 @@ export type D3Interpolator = (t: number) => string;
 
 export type ColorMap = keyof typeof INTERPOLATORS;
 
-export type Layout = 'contain' | 'cover' | 'fill';
+export type Layout = 'cover' | 'fill';
 
 export interface TooltipData {
   abscissa: number;

--- a/packages/lib/src/vis/rgb/RgbVis.tsx
+++ b/packages/lib/src/vis/rgb/RgbVis.tsx
@@ -63,7 +63,6 @@ function RgbVis(props: Props) {
     <figure className={styles.root} aria-label={title} data-keep-canvas-colors>
       <VisCanvas
         title={title}
-        canvasRatio={layout === 'contain' ? cols / rows : undefined}
         visRatio={keepRatio ? cols / rows : undefined}
         abscissaConfig={{
           visDomain: abscissaDomain,

--- a/packages/lib/src/vis/shared/AxisSystem.module.css
+++ b/packages/lib/src/vis/shared/AxisSystem.module.css
@@ -1,5 +1,9 @@
 .axisSystem {
   position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
   pointer-events: none;
   display: grid;
   grid-template-areas:

--- a/packages/lib/src/vis/shared/AxisSystem.tsx
+++ b/packages/lib/src/vis/shared/AxisSystem.tsx
@@ -17,10 +17,7 @@ interface Props {
 function AxisSystem(props: Props) {
   const { axisOffsets, title, showAxes } = props;
 
-  const gl = useThree((state) => state.gl);
   const canvasSize = useThree((state) => state.size);
-  const { width, height } = canvasSize;
-
   const { abscissaConfig, ordinateConfig } = useAxisSystemContext();
   const { xVisibleDomain, yVisibleDomain } = useCameraState(
     getVisibleDomains,
@@ -29,15 +26,10 @@ function AxisSystem(props: Props) {
 
   return (
     // Append to `canvasWrapper` instead of default container `r3fRoot`, which hides overflow
-    <Html container={gl.domElement.parentElement?.parentElement || undefined}>
+    <Html overflowCanvas>
       <div
         className={styles.axisSystem}
         style={{
-          // Take over space reserved for axis by VisCanvas
-          top: -axisOffsets.top,
-          left: -axisOffsets.left,
-          width: width + axisOffsets.left + axisOffsets.right,
-          height: height + axisOffsets.bottom + axisOffsets.top,
           gridTemplateColumns: `${axisOffsets.left}px 1fr ${axisOffsets.right}px`,
           gridTemplateRows: `${axisOffsets.top}px 1fr ${axisOffsets.bottom}px`,
         }}

--- a/packages/lib/src/vis/shared/AxisSystemProvider.tsx
+++ b/packages/lib/src/vis/shared/AxisSystemProvider.tsx
@@ -19,7 +19,7 @@ export interface AxisSystemContextValue {
   cameraToHtmlMatrix: Matrix4;
   cameraToHtmlMatrixInverse: Matrix4;
   cameraToHtml: (vec: Vector2 | Vector3) => Vector2;
-  floatingToolbar: HTMLDivElement | undefined;
+  floatingToolbar: HTMLDivElement | null;
 }
 
 const AxisSystemContext = createContext({} as AxisSystemContextValue);
@@ -32,7 +32,7 @@ interface Props {
   visRatio: number | undefined;
   abscissaConfig: AxisConfig;
   ordinateConfig: AxisConfig;
-  floatingToolbar: HTMLDivElement | undefined;
+  floatingToolbar: HTMLDivElement | null;
 }
 
 function AxisSystemProvider(props: PropsWithChildren<Props>) {

--- a/packages/lib/src/vis/shared/Html.tsx
+++ b/packages/lib/src/vis/shared/Html.tsx
@@ -19,8 +19,8 @@ function Html(props: Props) {
   const r3fRoot = useThree((state) => state.gl.domElement.parentElement);
   const canvasWrapper = r3fRoot?.parentElement;
 
-  // Choose DOM container in which to append `renderTarget`
-  // (`r3fRoot` hides overflow but its parent, `canvasWrapper`, does not -- cf. `VisCanvas`)
+  // Choose DOM container in which to append `renderTarget` to control overflow
+  // (`r3fRoot` means `Html` children won't be allowed to overflow above the axes)
   const container =
     customContainer || (overflowCanvas ? canvasWrapper : r3fRoot);
 

--- a/packages/lib/src/vis/shared/VisCanvas.module.css
+++ b/packages/lib/src/vis/shared/VisCanvas.module.css
@@ -1,15 +1,8 @@
-.canvasArea {
-  position: relative;
+.canvasWrapper {
   flex: 1 1 0%;
   overflow: hidden; /* prevent overflow when resizing */
-}
-
-.canvasWrapper {
   position: relative; /* for axis system */
-  width: 100%; /* fill container by default (unless size is passed in JSX) */
-  height: 100%;
-  margin: 0 auto;
-  z-index: 0; /* To create a stacking context for the floatingToolbar */
+  z-index: 0; /* stacking context for `.floatingToolbar` */
 }
 
 .r3fRoot {

--- a/packages/lib/src/vis/shared/VisCanvas.tsx
+++ b/packages/lib/src/vis/shared/VisCanvas.tsx
@@ -12,6 +12,8 @@ import ThresholdAdjuster from './ThresholdAdjuster';
 import ViewportCenterer from './ViewportCenterer';
 import styles from './VisCanvas.module.css';
 
+const NO_OFFSETS = { left: 0, right: 0, top: 0, bottom: 0 };
+
 interface Props {
   title?: string;
   visRatio?: number | undefined;
@@ -38,13 +40,13 @@ function VisCanvas(props: PropsWithChildren<Props>) {
         bottom: !!abscissaConfig.label,
         top: !!title,
       })
-    : { left: 0, right: 0, top: 0, bottom: 0 };
+    : NO_OFFSETS;
 
   const floatingToolbarRef = useRef<HTMLDivElement>(null);
 
   return (
     <div
-      className={styles.canvasArea}
+      className={styles.canvasWrapper}
       style={{
         paddingBottom: axisOffsets.bottom,
         paddingLeft: axisOffsets.left,
@@ -52,42 +54,40 @@ function VisCanvas(props: PropsWithChildren<Props>) {
         paddingRight: axisOffsets.right,
       }}
     >
-      <div className={styles.canvasWrapper}>
-        <Canvas
-          className={styles.r3fRoot}
-          orthographic
-          linear // disable automatic color encoding and gamma correction
-          flat // disable tone mapping
-          frameloop="demand" // disable game loop
-          dpr={[1, 3]} // https://discoverthreejs.com/tips-and-tricks/#performance
-          gl={{ preserveDrawingBuffer: true }} // for screenshot feature
-          resize={{ debounce: { scroll: 20, resize: 200 }, scroll: false }} // https://github.com/pmndrs/react-three-fiber/discussions/1906
+      <Canvas
+        className={styles.r3fRoot}
+        orthographic
+        linear // disable automatic color encoding and gamma correction
+        flat // disable tone mapping
+        frameloop="demand" // disable game loop
+        dpr={[1, 3]} // https://discoverthreejs.com/tips-and-tricks/#performance
+        gl={{ preserveDrawingBuffer: true }} // for screenshot feature
+        resize={{ debounce: { scroll: 20, resize: 200 }, scroll: false }} // https://github.com/pmndrs/react-three-fiber/discussions/1906
+      >
+        <ambientLight />
+        <AxisSystemProvider
+          visRatio={visRatio}
+          abscissaConfig={abscissaConfig}
+          ordinateConfig={ordinateConfig}
+          floatingToolbar={floatingToolbarRef.current}
         >
-          <ambientLight />
-          <AxisSystemProvider
-            visRatio={visRatio}
-            abscissaConfig={abscissaConfig}
-            ordinateConfig={ordinateConfig}
-            floatingToolbar={floatingToolbarRef.current}
-          >
-            <InteractionsProvider>
-              <AxisSystem
-                axisOffsets={axisOffsets}
-                title={title}
-                showAxes={showAxes}
-              />
-              {children}
-              <ViewportCenterer />
-              <RatioEnforcer visRatio={visRatio} />
-              {raycasterThreshold !== undefined && (
-                <ThresholdAdjuster value={raycasterThreshold} />
-              )}
-            </InteractionsProvider>
-          </AxisSystemProvider>
-        </Canvas>
+          <InteractionsProvider>
+            <AxisSystem
+              axisOffsets={axisOffsets}
+              title={title}
+              showAxes={showAxes}
+            />
+            {children}
+            <ViewportCenterer />
+            <RatioEnforcer visRatio={visRatio} />
+            {raycasterThreshold !== undefined && (
+              <ThresholdAdjuster value={raycasterThreshold} />
+            )}
+          </InteractionsProvider>
+        </AxisSystemProvider>
+      </Canvas>
 
-        <div ref={floatingToolbarRef} className={styles.floatingToolbar} />
-      </div>
+      <div ref={floatingToolbarRef} className={styles.floatingToolbar} />
     </div>
   );
 }

--- a/packages/lib/src/vis/shared/VisCanvas.tsx
+++ b/packages/lib/src/vis/shared/VisCanvas.tsx
@@ -1,11 +1,10 @@
-import { useMeasure } from '@react-hookz/web';
 import { Canvas } from '@react-three/fiber';
 import type { PropsWithChildren } from 'react';
-import { useState } from 'react';
+import { useRef } from 'react';
 
 import InteractionsProvider from '../../interactions/InteractionsProvider';
 import type { AxisConfig } from '../models';
-import { getSizeToFit, getAxisOffsets } from '../utils';
+import { getAxisOffsets } from '../utils';
 import AxisSystem from './AxisSystem';
 import AxisSystemProvider from './AxisSystemProvider';
 import RatioEnforcer from './RatioEnforcer';
@@ -15,7 +14,6 @@ import styles from './VisCanvas.module.css';
 
 interface Props {
   title?: string;
-  canvasRatio?: number | undefined;
   visRatio?: number | undefined;
   abscissaConfig: AxisConfig;
   ordinateConfig: AxisConfig;
@@ -26,7 +24,6 @@ interface Props {
 function VisCanvas(props: PropsWithChildren<Props>) {
   const {
     title,
-    canvasRatio,
     visRatio,
     abscissaConfig,
     ordinateConfig,
@@ -34,10 +31,6 @@ function VisCanvas(props: PropsWithChildren<Props>) {
     showAxes = true,
     children,
   } = props;
-
-  const shouldMeasure = !!canvasRatio;
-  const [areaSize, areaRef] = useMeasure<HTMLDivElement>(shouldMeasure);
-  const canvasSize = areaSize && getSizeToFit(areaSize, canvasRatio);
 
   const axisOffsets = showAxes
     ? getAxisOffsets({
@@ -47,11 +40,10 @@ function VisCanvas(props: PropsWithChildren<Props>) {
       })
     : { left: 0, right: 0, top: 0, bottom: 0 };
 
-  const [floatingToolbar, setFloatingToolbar] = useState<HTMLDivElement>();
+  const floatingToolbarRef = useRef<HTMLDivElement>(null);
 
   return (
     <div
-      ref={areaRef}
       className={styles.canvasArea}
       style={{
         paddingBottom: axisOffsets.bottom,
@@ -60,50 +52,42 @@ function VisCanvas(props: PropsWithChildren<Props>) {
         paddingRight: axisOffsets.right,
       }}
     >
-      {(!shouldMeasure || canvasSize) && (
-        <div
-          className={styles.canvasWrapper}
-          style={shouldMeasure ? canvasSize : undefined}
+      <div className={styles.canvasWrapper}>
+        <Canvas
+          className={styles.r3fRoot}
+          orthographic
+          linear // disable automatic color encoding and gamma correction
+          flat // disable tone mapping
+          frameloop="demand" // disable game loop
+          dpr={[1, 3]} // https://discoverthreejs.com/tips-and-tricks/#performance
+          gl={{ preserveDrawingBuffer: true }} // for screenshot feature
+          resize={{ debounce: { scroll: 20, resize: 200 }, scroll: false }} // https://github.com/pmndrs/react-three-fiber/discussions/1906
         >
-          <Canvas
-            className={styles.r3fRoot}
-            orthographic
-            linear // disable automatic color encoding and gamma correction
-            flat // disable tone mapping
-            frameloop="demand" // disable game loop
-            dpr={[1, 3]} // https://discoverthreejs.com/tips-and-tricks/#performance
-            gl={{ preserveDrawingBuffer: true }} // for screenshot feature
-            resize={{ debounce: { scroll: 20, resize: 200 }, scroll: false }} // https://github.com/pmndrs/react-three-fiber/discussions/1906
+          <ambientLight />
+          <AxisSystemProvider
+            visRatio={visRatio}
+            abscissaConfig={abscissaConfig}
+            ordinateConfig={ordinateConfig}
+            floatingToolbar={floatingToolbarRef.current}
           >
-            <ambientLight />
-            <AxisSystemProvider
-              visRatio={visRatio}
-              abscissaConfig={abscissaConfig}
-              ordinateConfig={ordinateConfig}
-              floatingToolbar={floatingToolbar}
-            >
-              <InteractionsProvider>
-                <AxisSystem
-                  axisOffsets={axisOffsets}
-                  title={title}
-                  showAxes={showAxes}
-                />
-                {children}
-                <ViewportCenterer />
-                <RatioEnforcer visRatio={visRatio} />
-                {raycasterThreshold !== undefined && (
-                  <ThresholdAdjuster value={raycasterThreshold} />
-                )}
-              </InteractionsProvider>
-            </AxisSystemProvider>
-          </Canvas>
+            <InteractionsProvider>
+              <AxisSystem
+                axisOffsets={axisOffsets}
+                title={title}
+                showAxes={showAxes}
+              />
+              {children}
+              <ViewportCenterer />
+              <RatioEnforcer visRatio={visRatio} />
+              {raycasterThreshold !== undefined && (
+                <ThresholdAdjuster value={raycasterThreshold} />
+              )}
+            </InteractionsProvider>
+          </AxisSystemProvider>
+        </Canvas>
 
-          <div
-            ref={(elem) => setFloatingToolbar(elem || undefined)}
-            className={styles.floatingToolbar}
-          />
-        </div>
-      )}
+        <div ref={floatingToolbarRef} className={styles.floatingToolbar} />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Part of #1275. Simplifies a lot of things! As discussed someone who wants to get the axes flush against an orthonormal heatmap can always compute the right width/height to give to the canvas' parent element with hard-coded axis offset values.