### PR TITLE
Fix floating toolbar and interactions help regressions

### DIFF
--- a/packages/app/src/__tests__/CorePack.test.tsx
+++ b/packages/app/src/__tests__/CorePack.test.tsx
@@ -140,3 +140,34 @@ test('visualize 1D slice of a 3D dataset with and without autoscale', async () =
   jest.runOnlyPendingTimers();
   jest.useRealTimers();
 });
+
+test('show interactions help for heatmap according to "keep ratio"', async () => {
+  const { user } = await renderApp();
+
+  const helpBtn = await screen.findByRole('button', { name: 'Show help' });
+  const keepRatioBtn = await screen.findByRole('button', {
+    name: 'Keep ratio',
+  });
+
+  // By default, "keep ratio" should be enabled
+  expect(keepRatioBtn).toHaveAttribute('aria-pressed', 'true');
+
+  // Since "keep ratio" is enabled, only basic interactions should be available (no axial-zoom interactions)
+  await user.click(helpBtn);
+
+  await expect(screen.findByText('Pan')).resolves.toBeVisible();
+  await expect(screen.findByText('Select to zoom')).resolves.toBeVisible();
+  await expect(screen.findByText('Zoom')).resolves.toBeVisible();
+
+  expect(screen.queryByText(/zoom in x/i)).not.toBeInTheDocument();
+  expect(screen.queryByText(/zoom in y/i)).not.toBeInTheDocument();
+
+  // Toggle "keep ratio" and check that axial-zoom interactions are now available
+  await user.click(keepRatioBtn);
+  await user.click(helpBtn);
+
+  await expect(screen.findByText('Zoom in X')).resolves.toBeVisible();
+  await expect(screen.findByText('Zoom in Y')).resolves.toBeVisible();
+  await expect(screen.findByText('Select to zoom in X')).resolves.toBeVisible();
+  await expect(screen.findByText('Select to zoom in Y')).resolves.toBeVisible();
+});

--- a/packages/app/src/vis-packs/core/utils.ts
+++ b/packages/app/src/vis-packs/core/utils.ts
@@ -81,5 +81,5 @@ export function getSliceSelection(
 }
 
 export function getImageInteractions(keepRatio: boolean) {
-  return keepRatio ? INTERACTIONS_WITH_AXIAL_ZOOM : BASE_INTERACTIONS;
+  return keepRatio ? BASE_INTERACTIONS : INTERACTIONS_WITH_AXIAL_ZOOM;
 }

--- a/packages/lib/src/vis/shared/AxisSystem.tsx
+++ b/packages/lib/src/vis/shared/AxisSystem.tsx
@@ -25,7 +25,7 @@ function AxisSystem(props: Props) {
   );
 
   return (
-    // Append to `canvasWrapper` instead of default container `r3fRoot`, which hides overflow
+    // Append to `canvasWrapper` instead of `r3fRoot`
     <Html overflowCanvas>
       <div
         className={styles.axisSystem}

--- a/packages/lib/src/vis/shared/AxisSystemProvider.tsx
+++ b/packages/lib/src/vis/shared/AxisSystemProvider.tsx
@@ -19,7 +19,7 @@ export interface AxisSystemContextValue {
   cameraToHtmlMatrix: Matrix4;
   cameraToHtmlMatrixInverse: Matrix4;
   cameraToHtml: (vec: Vector2 | Vector3) => Vector2;
-  floatingToolbar: HTMLDivElement | null;
+  floatingToolbar: HTMLDivElement | undefined;
 }
 
 const AxisSystemContext = createContext({} as AxisSystemContextValue);
@@ -32,7 +32,7 @@ interface Props {
   visRatio: number | undefined;
   abscissaConfig: AxisConfig;
   ordinateConfig: AxisConfig;
-  floatingToolbar: HTMLDivElement | null;
+  floatingToolbar: HTMLDivElement | undefined;
 }
 
 function AxisSystemProvider(props: PropsWithChildren<Props>) {

--- a/packages/lib/src/vis/shared/Html.tsx
+++ b/packages/lib/src/vis/shared/Html.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react';
 import ReactDOM from 'react-dom';
 
 interface Props {
-  overflowCanvas?: boolean;
+  overflowCanvas?: boolean; // allow children to overflow above axes
   container?: HTMLElement;
   children?: ReactNode;
 }
@@ -19,8 +19,8 @@ function Html(props: Props) {
   const r3fRoot = useThree((state) => state.gl.domElement.parentElement);
   const canvasWrapper = r3fRoot?.parentElement;
 
-  // Choose DOM container in which to append `renderTarget` to control overflow
-  // (`r3fRoot` means `Html` children won't be allowed to overflow above the axes)
+  // Choose DOM container to which to append `renderTarget`
+  // (with `canvasWrapper`, `Html` children are allowed to overflow above the axes)
   const container =
     customContainer || (overflowCanvas ? canvasWrapper : r3fRoot);
 

--- a/packages/lib/src/vis/shared/VisCanvas.tsx
+++ b/packages/lib/src/vis/shared/VisCanvas.tsx
@@ -1,12 +1,13 @@
 import { Canvas } from '@react-three/fiber';
 import type { PropsWithChildren } from 'react';
-import { useRef } from 'react';
+import { useState } from 'react';
 
 import InteractionsProvider from '../../interactions/InteractionsProvider';
 import type { Aspect, AxisConfig } from '../models';
 import { getAxisOffsets, getVisRatio } from '../utils';
 import AxisSystem from './AxisSystem';
 import AxisSystemProvider from './AxisSystemProvider';
+import Html from './Html';
 import RatioEnforcer from './RatioEnforcer';
 import ThresholdAdjuster from './ThresholdAdjuster';
 import ViewportCenterer from './ViewportCenterer';
@@ -44,7 +45,7 @@ function VisCanvas(props: PropsWithChildren<Props>) {
       })
     : NO_OFFSETS;
 
-  const floatingToolbarRef = useRef<HTMLDivElement>(null);
+  const [floatingToolbar, setFloatingToolbar] = useState<HTMLDivElement>();
 
   return (
     <div
@@ -71,7 +72,7 @@ function VisCanvas(props: PropsWithChildren<Props>) {
           visRatio={visRatio}
           abscissaConfig={abscissaConfig}
           ordinateConfig={ordinateConfig}
-          floatingToolbar={floatingToolbarRef.current}
+          floatingToolbar={floatingToolbar}
         >
           <InteractionsProvider>
             <AxisSystem
@@ -87,9 +88,13 @@ function VisCanvas(props: PropsWithChildren<Props>) {
             )}
           </InteractionsProvider>
         </AxisSystemProvider>
+        <Html>
+          <div
+            ref={(elem) => setFloatingToolbar(elem || undefined)}
+            className={styles.floatingToolbar}
+          />
+        </Html>
       </Canvas>
-
-      <div ref={floatingToolbarRef} className={styles.floatingToolbar} />
     </div>
   );
 }


### PR DESCRIPTION
Regressions introduced in #1283 and #1284:

- The floating toolbar was no longer rendered in some cases, so I reverted the switch from `useRef` to `useState`.
- The floating toolbar was overlapping the bottom axis, since it is relative to `canvasWrapper`, which now has the axes' padding. I simply moved it inside an `Html` element inside `VisCanvas` so it gets rendered inside `r3fRoot`.
- The interactions help for the heatmap-based visualizations was showing axial-zoom interactions with "keep ratio" enabled instead of disabled. I've inverted the logic and added a feature test.