### PR TITLE
Make interaction components smart with regard to canvas aspect

### DIFF
--- a/apps/storybook/src/AxialSelectToZoom.stories.tsx
+++ b/apps/storybook/src/AxialSelectToZoom.stories.tsx
@@ -1,29 +1,31 @@
 import type { AxialSelectToZoomProps } from '@h5web/lib';
-import { mockValues, useDomain } from '@h5web/lib';
+import { useDomain } from '@h5web/lib';
+import { assertDefined } from '@h5web/lib';
+import { HeatmapMesh, ScaleType } from '@h5web/lib';
+import { mockValues } from '@h5web/lib';
 import { Zoom } from '@h5web/lib';
 import {
-  assertDefined,
   DataCurve,
-  getAxisValues,
   AxialSelectToZoom,
   Pan,
   ResetZoomButton,
   VisCanvas,
 } from '@h5web/lib';
 import type { Meta, Story } from '@storybook/react';
+import { range } from 'lodash';
 
 import FillHeight from './decorators/FillHeight';
+import { useMockData } from './hooks';
+
+const { oneD, twoD } = mockValues;
 
 const Template: Story<AxialSelectToZoomProps> = (args) => {
-  const domain = useDomain(mockValues.oneD);
+  const domain = useDomain(oneD);
   assertDefined(domain);
 
   return (
     <VisCanvas
-      abscissaConfig={{
-        visDomain: [0, mockValues.oneD.length],
-        showGrid: true,
-      }}
+      abscissaConfig={{ visDomain: [0, oneD.length], showGrid: true }}
       ordinateConfig={{ visDomain: domain, showGrid: true }}
     >
       <Pan />
@@ -32,9 +34,8 @@ const Template: Story<AxialSelectToZoomProps> = (args) => {
       <ResetZoomButton />
 
       <DataCurve
-        abscissas={getAxisValues(undefined, mockValues.oneD.length)}
-        ordinates={mockValues.oneD}
-        errors={mockValues.oneD_errors}
+        abscissas={range(oneD.length)}
+        ordinates={oneD}
         color="blue"
         showErrors
       />
@@ -64,6 +65,32 @@ export const Disabled = Template.bind({});
 Disabled.args = {
   axis: 'x',
   disabled: true,
+};
+
+export const DisabledInsideEqualAspectCanvas: Story<AxialSelectToZoomProps> = (
+  args
+) => {
+  const { values, domain } = useMockData(twoD, [20, 41]);
+
+  return (
+    <VisCanvas
+      abscissaConfig={{ visDomain: [0, 41], showGrid: true }}
+      ordinateConfig={{ visDomain: [0, 20], showGrid: true }}
+      aspect="equal"
+    >
+      <Pan />
+      <Zoom />
+      <AxialSelectToZoom {...args} />
+      <ResetZoomButton />
+
+      <HeatmapMesh
+        values={values}
+        domain={domain}
+        colorMap="Viridis"
+        scaleType={ScaleType.Linear}
+      />
+    </VisCanvas>
+  );
 };
 
 export default {

--- a/apps/storybook/src/DefaultInteractions.stories.tsx
+++ b/apps/storybook/src/DefaultInteractions.stories.tsx
@@ -1,14 +1,17 @@
 import { DefaultInteractions, ResetZoomButton, VisCanvas } from '@h5web/lib';
-import type { DefaultInteractionsProps } from '@h5web/lib/src/interactions/DefaultInteractions';
+import type { DefaultInteractionsConfig } from '@h5web/lib/src/interactions/DefaultInteractions';
 import type { Meta, Story } from '@storybook/react';
 
 import FillHeight from './decorators/FillHeight';
 
-const Template: Story<DefaultInteractionsProps> = (args) => {
+export const InsideAutoAspectCanvas: Story<DefaultInteractionsConfig> = (
+  args
+) => {
   return (
     <VisCanvas
-      abscissaConfig={{ visDomain: [-10, 0], showGrid: true }}
-      ordinateConfig={{ visDomain: [50, 100], showGrid: true }}
+      abscissaConfig={{ visDomain: [0, 10], showGrid: true }}
+      ordinateConfig={{ visDomain: [0, 10], showGrid: true }}
+      aspect="auto"
     >
       <DefaultInteractions {...args} />
       <ResetZoomButton />
@@ -16,7 +19,20 @@ const Template: Story<DefaultInteractionsProps> = (args) => {
   );
 };
 
-export const Default = Template.bind({});
+export const InsideEqualAspectCanvas: Story<DefaultInteractionsConfig> = (
+  args
+) => {
+  return (
+    <VisCanvas
+      abscissaConfig={{ visDomain: [0, 10], showGrid: true }}
+      ordinateConfig={{ visDomain: [0, 10], showGrid: true }}
+      aspect="equal"
+    >
+      <DefaultInteractions {...args} />
+      <ResetZoomButton />
+    </VisCanvas>
+  );
+};
 
 export default {
   title: 'Building Blocks/Interactions/DefaultInteractions',
@@ -24,7 +40,6 @@ export default {
   decorators: [FillHeight],
   parameters: { layout: 'fullscreen' },
   args: {
-    keepRatio: false,
     pan: {},
     zoom: {},
     xAxisZoom: { modifierKey: 'Alt' },
@@ -33,4 +48,4 @@ export default {
     xSelectToZoom: { modifierKey: ['Control', 'Alt'] },
     ySelectToZoom: { modifierKey: ['Control', 'Shift'] },
   },
-} as Meta<DefaultInteractionsProps>;
+} as Meta<DefaultInteractionsConfig>;

--- a/apps/storybook/src/SelectToZoom.stories.tsx
+++ b/apps/storybook/src/SelectToZoom.stories.tsx
@@ -4,41 +4,33 @@ import {
   SelectToZoom,
   ResetZoomButton,
   HeatmapMesh,
-  getDomain,
   Zoom,
 } from '@h5web/lib';
 import type { SelectToZoomProps } from '@h5web/lib';
 import { mockValues, ScaleType } from '@h5web/shared';
 import type { Meta, Story } from '@storybook/react';
-import ndarray from 'ndarray';
 
 import FillHeight from './decorators/FillHeight';
+import { useMockData } from './hooks';
 
-const cols = 41;
-const rows = 20;
-const values = ndarray(Float32Array.from(mockValues.twoD.flat()), [rows, cols]);
-const domain = getDomain(values);
+const { twoD } = mockValues;
 
 const Template: Story<SelectToZoomProps> = (args) => {
-  const { keepRatio, modifierKey, disabled } = args;
+  const { values, domain } = useMockData(twoD, [20, 41]);
+
   return (
     <VisCanvas
-      abscissaConfig={{ visDomain: [-5, 5], showGrid: true }}
-      ordinateConfig={{ visDomain: [-0.5, 1.5], showGrid: true }}
-      aspect={keepRatio ? 'equal' : 'auto'}
+      abscissaConfig={{ visDomain: [0, values.shape[1]], showGrid: true }}
+      ordinateConfig={{ visDomain: [0, values.shape[0]], showGrid: true }}
     >
       <Pan />
       <Zoom />
-      <SelectToZoom
-        modifierKey={modifierKey}
-        keepRatio={keepRatio}
-        disabled={disabled}
-      />
+      <SelectToZoom {...args} />
       <ResetZoomButton />
 
       <HeatmapMesh
         values={values}
-        domain={domain || [0, 1]}
+        domain={domain}
         colorMap="Viridis"
         scaleType={ScaleType.Linear}
       />
@@ -46,11 +38,30 @@ const Template: Story<SelectToZoomProps> = (args) => {
   );
 };
 
-export const Default = Template.bind({});
+export const InsideAutoAspectCanvas = Template.bind({});
 
-export const KeepRatio = Template.bind({});
-KeepRatio.args = {
-  keepRatio: true,
+export const InsideEqualAspectCanvas: Story<SelectToZoomProps> = (args) => {
+  const { values, domain } = useMockData(twoD, [20, 41]);
+
+  return (
+    <VisCanvas
+      abscissaConfig={{ visDomain: [0, values.shape[1]], showGrid: true }}
+      ordinateConfig={{ visDomain: [0, values.shape[0]], showGrid: true }}
+      aspect="equal"
+    >
+      <Pan />
+      <Zoom />
+      <SelectToZoom {...args} />
+      <ResetZoomButton />
+
+      <HeatmapMesh
+        values={values}
+        domain={domain}
+        colorMap="Viridis"
+        scaleType={ScaleType.Linear}
+      />
+    </VisCanvas>
+  );
 };
 
 export const ModifierKey = Template.bind({});
@@ -74,7 +85,6 @@ export default {
   decorators: [FillHeight],
   parameters: { layout: 'fullscreen' },
   args: {
-    keepRatio: false,
     modifierKey: [],
     disabled: false,
   },

--- a/apps/storybook/src/TiledHeatmapMesh.stories.tsx
+++ b/apps/storybook/src/TiledHeatmapMesh.stories.tsx
@@ -183,7 +183,7 @@ const Template: Story<TiledHeatmapStoryProps> = (args) => {
     >
       <Pan />
       <Zoom />
-      <SelectToZoom keepRatio modifierKey="Control" />
+      <SelectToZoom modifierKey="Control" />
       <ResetZoomButton />
       <group
         scale={[abscissaConfig.flip ? -1 : 1, ordinateConfig.flip ? -1 : 1, 1]}
@@ -309,7 +309,7 @@ export const WithTransforms: Story<TiledHeatmapStoryProps> = (args) => {
     >
       <Pan />
       <Zoom />
-      <SelectToZoom keepRatio modifierKey="Control" />
+      <SelectToZoom modifierKey="Control" />
       <ResetZoomButton />
       <LinearAxesGroup>
         <group position={[1, 1, 0]} rotation={[0, 0, Math.PI / 4]}>

--- a/apps/storybook/src/XAxisZoom.stories.tsx
+++ b/apps/storybook/src/XAxisZoom.stories.tsx
@@ -7,8 +7,8 @@ import FillHeight from './decorators/FillHeight';
 const Template: Story<XAxisZoomProps> = (args) => {
   return (
     <VisCanvas
-      abscissaConfig={{ visDomain: [-10, 0], showGrid: true }}
-      ordinateConfig={{ visDomain: [50, 100], showGrid: true }}
+      abscissaConfig={{ visDomain: [0, 10], showGrid: true }}
+      ordinateConfig={{ visDomain: [0, 10], showGrid: true }}
     >
       <Pan />
       <XAxisZoom {...args} />
@@ -32,6 +32,20 @@ MultipleModifierKeys.args = {
 export const Disabled = Template.bind({});
 Disabled.args = {
   disabled: true,
+};
+
+export const DisabledInsideEqualAspectCanvas: Story<XAxisZoomProps> = (
+  args
+) => {
+  return (
+    <VisCanvas
+      abscissaConfig={{ visDomain: [0, 10], showGrid: true }}
+      ordinateConfig={{ visDomain: [0, 10], showGrid: true }}
+      aspect="equal"
+    >
+      <XAxisZoom {...args} />
+    </VisCanvas>
+  );
 };
 
 export default {

--- a/apps/storybook/src/YAxisZoom.stories.tsx
+++ b/apps/storybook/src/YAxisZoom.stories.tsx
@@ -7,8 +7,8 @@ import FillHeight from './decorators/FillHeight';
 const Template: Story<YAxisZoomProps> = (args) => {
   return (
     <VisCanvas
-      abscissaConfig={{ visDomain: [-10, 0], showGrid: true }}
-      ordinateConfig={{ visDomain: [50, 100], showGrid: true }}
+      abscissaConfig={{ visDomain: [0, 10], showGrid: true }}
+      ordinateConfig={{ visDomain: [0, 10], showGrid: true }}
     >
       <Pan />
       <YAxisZoom {...args} />
@@ -32,6 +32,20 @@ MultipleModifierKeys.args = {
 export const Disabled = Template.bind({});
 Disabled.args = {
   disabled: true,
+};
+
+export const DisabledInsideEqualAspectCanvas: Story<YAxisZoomProps> = (
+  args
+) => {
+  return (
+    <VisCanvas
+      abscissaConfig={{ visDomain: [0, 10], showGrid: true }}
+      ordinateConfig={{ visDomain: [0, 10], showGrid: true }}
+      aspect="equal"
+    >
+      <YAxisZoom {...args} />
+    </VisCanvas>
+  );
 };
 
 export default {

--- a/apps/storybook/src/hooks.ts
+++ b/apps/storybook/src/hooks.ts
@@ -1,0 +1,21 @@
+import { useDomain } from '@h5web/lib';
+import type { ArrayShape, Domain } from '@h5web/shared';
+import type { NdArray } from 'ndarray';
+import ndarray from 'ndarray';
+import { useMemo } from 'react';
+
+type NestedNumArray = (number | NestedNumArray)[];
+
+export function useMockData(
+  mockNumArray: NestedNumArray,
+  shape: ArrayShape = [mockNumArray.length]
+): { values: NdArray<Float32Array>; domain: Domain } {
+  const values = useMemo(
+    () => ndarray(Float32Array.from(mockNumArray.flat() as number[]), shape),
+    [mockNumArray, shape]
+  );
+
+  const domain = useDomain(values) || [1, 2];
+
+  return { values, domain };
+}

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -64,10 +64,7 @@ export type { YAxisZoomProps } from './interactions/YAxisZoom';
 export type { SelectToZoomProps } from './interactions/SelectToZoom';
 export type { AxialSelectToZoomProps } from './interactions/AxialSelectToZoom';
 export type { SelectionProps } from './interactions/SelectionTool';
-export type {
-  DefaultInteractionsConfig,
-  DefaultInteractionsProps,
-} from './interactions/DefaultInteractions';
+export type { DefaultInteractionsConfig } from './interactions/DefaultInteractions';
 
 // Context
 export { useAxisSystemContext } from './vis/shared/AxisSystemProvider';

--- a/packages/lib/src/interactions/AxialSelectToZoom.tsx
+++ b/packages/lib/src/interactions/AxialSelectToZoom.tsx
@@ -1,5 +1,6 @@
 import { useThree } from '@react-three/fiber';
 
+import { useAxisSystemContext } from '../vis/shared/AxisSystemProvider';
 import AxialSelectionTool from './AxialSelectionTool';
 import SelectionRect from './SelectionRect';
 import { useMoveCameraTo } from './hooks';
@@ -13,6 +14,7 @@ interface Props extends CommonInteractionProps {
 function AxialSelectToZoom(props: Props) {
   const { axis, modifierKey, disabled } = props;
 
+  const { visRatio } = useAxisSystemContext();
   const moveCameraTo = useMoveCameraTo();
 
   const { width, height } = useThree((state) => state.size);
@@ -44,7 +46,7 @@ function AxialSelectToZoom(props: Props) {
       axis={axis}
       id={`${axis.toUpperCase()}SelectToZoom`}
       modifierKey={modifierKey}
-      disabled={disabled}
+      disabled={visRatio !== undefined || disabled}
       onSelectionEnd={onSelectionEnd}
     >
       {({ startPoint, endPoint }) => (

--- a/packages/lib/src/interactions/DefaultInteractions.tsx
+++ b/packages/lib/src/interactions/DefaultInteractions.tsx
@@ -16,17 +16,13 @@ export interface DefaultInteractionsConfig {
   zoom?: ZoomProps | false;
   xAxisZoom?: XAxisZoomProps | false;
   yAxisZoom?: YAxisZoomProps | false;
-  selectToZoom?: Omit<SelectToZoomProps, 'keepRatio'> | false;
+  selectToZoom?: SelectToZoomProps | false;
   xSelectToZoom?: Omit<AxialSelectToZoomProps, 'axis'> | false;
   ySelectToZoom?: Omit<AxialSelectToZoomProps, 'axis'> | false;
 }
 
-interface Props extends DefaultInteractionsConfig {
-  keepRatio?: boolean;
-}
-
-function DefaultInteractions(props: Props) {
-  const { keepRatio, ...interactions } = props;
+function DefaultInteractions(props: DefaultInteractionsConfig) {
+  const { ...interactions } = props;
 
   return (
     <>
@@ -34,32 +30,19 @@ function DefaultInteractions(props: Props) {
       {interactions.zoom !== false && <Zoom {...interactions.zoom} />}
 
       {interactions.xAxisZoom !== false && (
-        <XAxisZoom
-          modifierKey="Alt"
-          disabled={keepRatio}
-          {...interactions.xAxisZoom}
-        />
+        <XAxisZoom modifierKey="Alt" {...interactions.xAxisZoom} />
       )}
       {interactions.yAxisZoom !== false && (
-        <YAxisZoom
-          modifierKey="Shift"
-          disabled={keepRatio}
-          {...interactions.yAxisZoom}
-        />
+        <YAxisZoom modifierKey="Shift" {...interactions.yAxisZoom} />
       )}
 
       {interactions.selectToZoom !== false && (
-        <SelectToZoom
-          keepRatio={keepRatio}
-          modifierKey="Control"
-          {...interactions.selectToZoom}
-        />
+        <SelectToZoom modifierKey="Control" {...interactions.selectToZoom} />
       )}
       {interactions.xSelectToZoom !== false && (
         <AxialSelectToZoom
           axis="x"
           modifierKey={['Control', 'Alt']}
-          disabled={keepRatio}
           {...interactions.xSelectToZoom}
         />
       )}
@@ -67,7 +50,6 @@ function DefaultInteractions(props: Props) {
         <AxialSelectToZoom
           axis="y"
           modifierKey={['Control', 'Shift']}
-          disabled={keepRatio}
           {...interactions.ySelectToZoom}
         />
       )}
@@ -75,5 +57,4 @@ function DefaultInteractions(props: Props) {
   );
 }
 
-export type { Props as DefaultInteractionsProps };
 export default DefaultInteractions;

--- a/packages/lib/src/interactions/SelectToZoom.tsx
+++ b/packages/lib/src/interactions/SelectToZoom.tsx
@@ -9,14 +9,13 @@ import { useMoveCameraTo } from './hooks';
 import type { CommonInteractionProps, Selection } from './models';
 import { getEnclosedRectangle, getRatioRespectingRectangle } from './utils';
 
-interface Props extends CommonInteractionProps {
-  keepRatio?: boolean;
-}
+type Props = CommonInteractionProps;
 
 function SelectToZoom(props: Props) {
-  const { keepRatio, ...interactionProps } = props;
-
   const context = useAxisSystemContext();
+  const { visRatio } = context;
+  const keepRatio = visRatio !== undefined;
+
   const moveCameraTo = useMoveCameraTo();
 
   const { width, height } = useThree((state) => state.size);
@@ -59,11 +58,7 @@ function SelectToZoom(props: Props) {
   }
 
   return (
-    <SelectionTool
-      id="SelectToZoom"
-      onSelectionEnd={onSelectionEnd}
-      {...interactionProps}
-    >
+    <SelectionTool id="SelectToZoom" onSelectionEnd={onSelectionEnd} {...props}>
       {({ startPoint, endPoint }) => {
         const dataRatio = getDataRatio();
 

--- a/packages/lib/src/interactions/XAxisZoom.tsx
+++ b/packages/lib/src/interactions/XAxisZoom.tsx
@@ -1,3 +1,4 @@
+import { useAxisSystemContext } from '../vis/shared/AxisSystemProvider';
 import { useCanvasEvents, useInteraction, useZoomOnWheel } from './hooks';
 import type { CommonInteractionProps } from './models';
 import { getModifierKeyArray } from './utils';
@@ -6,9 +7,11 @@ type Props = CommonInteractionProps;
 
 function XAxisZoom(props: Props) {
   const { modifierKey, disabled } = props;
+  const { visRatio } = useAxisSystemContext();
+
   const shouldInteract = useInteraction('XAxisZoom', {
     modifierKeys: getModifierKeyArray(modifierKey),
-    disabled,
+    disabled: visRatio !== undefined || disabled,
     button: 'Wheel',
   });
 

--- a/packages/lib/src/interactions/YAxisZoom.tsx
+++ b/packages/lib/src/interactions/YAxisZoom.tsx
@@ -1,3 +1,4 @@
+import { useAxisSystemContext } from '../vis/shared/AxisSystemProvider';
 import { useCanvasEvents, useZoomOnWheel, useInteraction } from './hooks';
 import type { CommonInteractionProps } from './models';
 import { getModifierKeyArray } from './utils';
@@ -6,9 +7,11 @@ type Props = CommonInteractionProps;
 
 function YAxisZoom(props: Props) {
   const { modifierKey, disabled } = props;
+  const { visRatio } = useAxisSystemContext();
+
   const shouldInteract = useInteraction('YAxisZoom', {
     modifierKeys: getModifierKeyArray(modifierKey),
-    disabled,
+    disabled: visRatio !== undefined || disabled,
     button: 'Wheel',
   });
 

--- a/packages/lib/src/vis/heatmap/HeatmapVis.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapVis.tsx
@@ -97,7 +97,7 @@ function HeatmapVis(props: Props) {
           flip: flipYAxis,
         }}
       >
-        <DefaultInteractions keepRatio={aspect !== 'auto'} {...interactions} />
+        <DefaultInteractions {...interactions} />
         <ResetZoomButton />
 
         <TooltipMesh

--- a/packages/lib/src/vis/rgb/RgbVis.tsx
+++ b/packages/lib/src/vis/rgb/RgbVis.tsx
@@ -75,7 +75,7 @@ function RgbVis(props: Props) {
           label: ordinateLabel,
         }}
       >
-        <DefaultInteractions keepRatio={aspect !== 'auto'} {...interactions} />
+        <DefaultInteractions {...interactions} />
         <ResetZoomButton />
 
         <RgbMesh values={safeDataArray} bgr={imageType === ImageType.BGR} />

--- a/packages/lib/src/vis/shared/AxisSystemProvider.tsx
+++ b/packages/lib/src/vis/shared/AxisSystemProvider.tsx
@@ -8,6 +8,7 @@ import { getCanvasScale, getSizeToFit } from '../utils';
 
 export interface AxisSystemContextValue {
   visSize: Size;
+  visRatio: number | undefined;
   abscissaConfig: AxisConfig;
   ordinateConfig: AxisConfig;
   abscissaScale: AxisScale;
@@ -79,6 +80,7 @@ function AxisSystemProvider(props: PropsWithChildren<Props>) {
     <AxisSystemContext.Provider
       value={{
         visSize,
+        visRatio,
         abscissaConfig,
         ordinateConfig,
         abscissaScale,


### PR DESCRIPTION
⚠️ **Breaking change**: `DefaultInteractions` and `SelectToZoom` no longer accept a `keepRatio` prop. Each interaction component adjusts its behaviour automatically when used inside a canvas with an `'equal'` or custom `aspect`.

---

So far, the high-level visualisations had to compute a `keepRatio` flag and pass it to the various interaction components (via `DefaultInteractions`). Since #1284, this flag was computed based on the `aspect` prop passed to `VisCanvas`: `keepRatio={aspect !== 'auto'}`. In practice, this meant that consumers of the low-level components could very well mis-configure the interactions - e.g. by passing `aspect="equal"` to `VisCanvas` and then forgetting to disable axial-zoom interactions.

In this PR, I inject `visRatio` (which is computed internally by `VisCanvas`) via `AxisSystemContext` so that each interaction component can access it and configure itself accordingly when used inside a canvas with an equal-aspect ratio or a custom ratio:

- `XAxisZoom`, `YAxisZoom` and `AxialSelectToZoom` all disable themselves automatically;
- `SelectToZoom` configures itself to keep the canvas' ratio on zoom.

I've added stories to test this behaviour.