### PR TITLE
Inject `canvasSize` and `canvasRatio` via context and simplify `SelectToZoom` logic

### DIFF
--- a/apps/storybook/src/Context.stories.mdx
+++ b/apps/storybook/src/Context.stories.mdx
@@ -5,7 +5,7 @@ import { Meta } from '@storybook/addon-docs';
 ## Context
 
 Children of `VisCanvas` have access to `AxisSystemContext`, which provides helpful utilities to convert vectors from data space to world space and back.
-It also exposes the size of the visualization and the axis configs passed to `VisCanvas` for convenience.
+It also exposes the size and ratio of the canvas and of the visualization, as well as the axis configs passed to `VisCanvas`.
 
 Consumers of `AxisSystemContext` re-render **whenever the size of the canvas changes**.
 
@@ -15,14 +15,17 @@ useAxisSystemContext(): AxisSystemContextValue
 const { visSize, dataToWorld, worldToData } = useAxisSystemContext();
 ```
 
-| Name             | Description                                                                                                        | Type                                                  |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
-| `visSize`        | Visualization size (different from canvas size on ratio-constrained visualizations, like `HeatmapVis`)             | <code>Size</code>                                     |
-| `abscissaConfig` | Abscissa configuration object passed to `VisCanvas`                                                                | <code>AxisConfig</code>                               |
-| `ordinateConfig` | Ordinate configuration object passed to `VisCanvas`                                                                | <code>AxisConfig</code>                               |
-| `abscissaScale`  | Computes the X coordinate in world space of a given abscissa value (or the opposite with `abscissaScale.invert()`) | <code>AxisScale</code>                                |
-| `ordinateScale`  | Computes the Y coordinate in world space of a given ordinate value (or the opposite with `ordinateScale.invert()`) | <code>AxisScale</code>                                |
-| `dataToWorld`    | Converts a vector from data space to world space (calls `abscissaScale()` and `ordinateScale`)                     | <code>(vec: Vector2 &#124; Vector3) => Vector2</code> |
-| `worldToData`    | Converts a vector from world space to data space (calls `abscissaScale.invert()` and `ordinateScale.invert`)       | <code>(vec: Vector2 &#124; Vector3) => Vector2</code> |
+| Name             | Description                                                                                                                                                       | Type                                                  |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `canvasSize`     | Canvas size (equivalent to `useThree((state) => state.size)`)                                                                                                     | <code>Size</code>                                     |
+| `canvasRatio`    | Canvas ratio (i.e. `width / height`)                                                                                                                              | <code>number</code>                                   |
+| `visRatio`       | Visualization ratio: defined when `VisCanvas` receives `aspect="equal"` or `aspect={number}` (e.g. `HeatmapVis` with "keep ratio" enabled); `undefined` otherwise | <code>number &#124; undefined</code>                  |
+| `visSize`        | Visualization size (different from canvas size when `visRatio` is defined)                                                                                        | <code>Size</code>                                     |
+| `abscissaConfig` | Abscissa configuration object passed to `VisCanvas`                                                                                                               | <code>AxisConfig</code>                               |
+| `ordinateConfig` | Ordinate configuration object passed to `VisCanvas`                                                                                                               | <code>AxisConfig</code>                               |
+| `abscissaScale`  | Computes the X coordinate in world space of a given abscissa value (or the opposite with `abscissaScale.invert()`)                                                | <code>AxisScale</code>                                |
+| `ordinateScale`  | Computes the Y coordinate in world space of a given ordinate value (or the opposite with `ordinateScale.invert()`)                                                | <code>AxisScale</code>                                |
+| `dataToWorld`    | Converts a vector from data space to world space (calls `abscissaScale()` and `ordinateScale`)                                                                    | <code>(vec: Vector2 &#124; Vector3) => Vector2</code> |
+| `worldToData`    | Converts a vector from world space to data space (calls `abscissaScale.invert()` and `ordinateScale.invert`)                                                      | <code>(vec: Vector2 &#124; Vector3) => Vector2</code> |
 
 > This table is not exhaustive. Please consider any undocumented property as experimental or meant for internal use only.

--- a/packages/lib/src/interactions/AxialSelectToZoom.tsx
+++ b/packages/lib/src/interactions/AxialSelectToZoom.tsx
@@ -14,10 +14,10 @@ interface Props extends CommonInteractionProps {
 function AxialSelectToZoom(props: Props) {
   const { axis, modifierKey, disabled } = props;
 
-  const { visRatio } = useAxisSystemContext();
+  const { canvasSize, visRatio } = useAxisSystemContext();
   const moveCameraTo = useMoveCameraTo();
 
-  const { width, height } = useThree((state) => state.size);
+  const { width, height } = canvasSize;
   const camera = useThree((state) => state.camera);
 
   function onSelectionEnd(selection: Selection) {

--- a/packages/lib/src/interactions/RatioSelectionRect.tsx
+++ b/packages/lib/src/interactions/RatioSelectionRect.tsx
@@ -13,24 +13,24 @@ interface Props extends SVGProps<SVGRectElement> {
 
 function RatioSelectionRect(props: Props) {
   const { startPoint, endPoint, ratio, ...svgProps } = props;
+  const { visSize, dataToWorld, worldToData } = useAxisSystemContext();
 
-  const { dataToWorld, worldToData, visSize } = useAxisSystemContext();
-
-  const [ratioStartPoint, ratioEndPoint] = getRatioRespectingRectangle(
+  const [dataStartPoint, dataEndPoint] = getRatioRespectingRectangle(
     startPoint,
     endPoint,
     ratio
-  );
-  const [newStartPoint, newEndPoint] = clampRectangleToVis(
-    dataToWorld(ratioStartPoint),
-    dataToWorld(ratioEndPoint),
+  ).map(dataToWorld);
+
+  const [worldStartPoint, worldEndPoint] = clampRectangleToVis(
+    dataStartPoint,
+    dataEndPoint,
     visSize
-  );
+  ).map(worldToData);
 
   return (
     <SelectionRect
-      startPoint={worldToData(newStartPoint)}
-      endPoint={worldToData(newEndPoint)}
+      startPoint={worldStartPoint}
+      endPoint={worldEndPoint}
       {...svgProps}
     />
   );

--- a/packages/lib/src/interactions/SelectToZoom.tsx
+++ b/packages/lib/src/interactions/SelectToZoom.tsx
@@ -11,24 +11,24 @@ import { getEnclosedRectangle, getRatioRespectingRectangle } from './utils';
 type Props = CommonInteractionProps;
 
 function SelectToZoom(props: Props) {
-  const context = useAxisSystemContext();
-  const { visRatio, canvasRatio } = context;
+  const { canvasSize, canvasRatio, visRatio, dataToWorld } =
+    useAxisSystemContext();
+
+  const { width, height } = canvasSize;
   const keepRatio = visRatio !== undefined;
 
-  const moveCameraTo = useMoveCameraTo();
-
-  const { width, height } = useThree((state) => state.size);
   const camera = useThree((state) => state.camera);
+  const moveCameraTo = useMoveCameraTo();
 
   function onSelectionEnd(selection: Selection) {
     const { startPoint: dataStartPoint, endPoint: dataEndPoint } = selection;
 
     // Work in world coordinates as we need to act on the world camera
-    const [startPoint, endPoint] = (
-      keepRatio
-        ? getRatioRespectingRectangle(dataStartPoint, dataEndPoint, canvasRatio)
-        : [dataStartPoint, dataEndPoint]
-    ).map(context.dataToWorld);
+    const [startPoint, endPoint] = getRatioRespectingRectangle(
+      dataStartPoint,
+      dataEndPoint,
+      keepRatio ? canvasRatio : undefined
+    ).map(dataToWorld);
 
     if (startPoint.x === endPoint.x && startPoint.y === endPoint.y) {
       return;

--- a/packages/lib/src/interactions/SelectToZoom.tsx
+++ b/packages/lib/src/interactions/SelectToZoom.tsx
@@ -1,7 +1,6 @@
 import { useThree } from '@react-three/fiber';
 
 import { useAxisSystemContext } from '../vis/shared/AxisSystemProvider';
-import { getVisibleDomains } from '../vis/utils';
 import RatioSelectionRect from './RatioSelectionRect';
 import SelectionRect from './SelectionRect';
 import SelectionTool from './SelectionTool';
@@ -13,7 +12,7 @@ type Props = CommonInteractionProps;
 
 function SelectToZoom(props: Props) {
   const context = useAxisSystemContext();
-  const { visRatio } = context;
+  const { visRatio, canvasRatio } = context;
   const keepRatio = visRatio !== undefined;
 
   const moveCameraTo = useMoveCameraTo();
@@ -21,25 +20,13 @@ function SelectToZoom(props: Props) {
   const { width, height } = useThree((state) => state.size);
   const camera = useThree((state) => state.camera);
 
-  function getDataRatio() {
-    const { xVisibleDomain, yVisibleDomain } = getVisibleDomains(
-      camera,
-      context
-    );
-    return Math.abs(
-      (xVisibleDomain[1] - xVisibleDomain[0]) /
-        (yVisibleDomain[1] - yVisibleDomain[0])
-    );
-  }
-
   function onSelectionEnd(selection: Selection) {
     const { startPoint: dataStartPoint, endPoint: dataEndPoint } = selection;
-    const dataRatio = getDataRatio();
 
     // Work in world coordinates as we need to act on the world camera
     const [startPoint, endPoint] = (
       keepRatio
-        ? getRatioRespectingRectangle(dataStartPoint, dataEndPoint, dataRatio)
+        ? getRatioRespectingRectangle(dataStartPoint, dataEndPoint, canvasRatio)
         : [dataStartPoint, dataEndPoint]
     ).map(context.dataToWorld);
 
@@ -59,32 +46,28 @@ function SelectToZoom(props: Props) {
 
   return (
     <SelectionTool id="SelectToZoom" onSelectionEnd={onSelectionEnd} {...props}>
-      {({ startPoint, endPoint }) => {
-        const dataRatio = getDataRatio();
-
-        return (
-          <>
-            <SelectionRect
+      {({ startPoint, endPoint }) => (
+        <>
+          <SelectionRect
+            startPoint={startPoint}
+            endPoint={endPoint}
+            fill="white"
+            stroke="black"
+            fillOpacity={keepRatio ? 0 : 0.25}
+            strokeDasharray={keepRatio ? '4' : undefined}
+          />
+          {keepRatio && (
+            <RatioSelectionRect
               startPoint={startPoint}
               endPoint={endPoint}
+              ratio={canvasRatio}
+              fillOpacity={0.25}
               fill="white"
               stroke="black"
-              fillOpacity={keepRatio ? 0 : 0.25}
-              strokeDasharray={keepRatio ? '4' : undefined}
             />
-            {keepRatio && (
-              <RatioSelectionRect
-                startPoint={startPoint}
-                endPoint={endPoint}
-                ratio={dataRatio}
-                fillOpacity={0.25}
-                fill="white"
-                stroke="black"
-              />
-            )}
-          </>
-        );
-      }}
+          )}
+        </>
+      )}
     </SelectionTool>
   );
 }

--- a/packages/lib/src/interactions/SelectionLine.tsx
+++ b/packages/lib/src/interactions/SelectionLine.tsx
@@ -1,8 +1,8 @@
-import { useThree } from '@react-three/fiber';
 import type { SVGProps } from 'react';
 import type { Vector2 } from 'three';
 
 import { useCameraState } from '../vis/hooks';
+import { useAxisSystemContext } from '../vis/shared/AxisSystemProvider';
 import Overlay from '../vis/shared/Overlay';
 import { dataToHtml } from '../vis/utils';
 
@@ -14,7 +14,7 @@ interface Props extends SVGProps<SVGLineElement> {
 function SelectionLine(props: Props) {
   const { startPoint, endPoint, stroke = 'black', ...restSvgProps } = props;
 
-  const { width, height } = useThree((state) => state.size);
+  const { canvasSize } = useAxisSystemContext();
 
   const htmlSelection = useCameraState(
     (...args) => ({
@@ -29,7 +29,7 @@ function SelectionLine(props: Props) {
 
   return (
     <Overlay>
-      <svg width={width} height={height}>
+      <svg {...canvasSize}>
         <line
           x1={x1}
           y1={y1}

--- a/packages/lib/src/interactions/SelectionRect.tsx
+++ b/packages/lib/src/interactions/SelectionRect.tsx
@@ -1,8 +1,8 @@
-import { useThree } from '@react-three/fiber';
 import type { SVGProps } from 'react';
 import type { Vector2 } from 'three';
 
 import { useCameraState } from '../vis/hooks';
+import { useAxisSystemContext } from '../vis/shared/AxisSystemProvider';
 import Overlay from '../vis/shared/Overlay';
 import { dataToHtml } from '../vis/utils';
 
@@ -20,7 +20,7 @@ function SelectionRect(props: Props) {
     ...restSvgProps
   } = props;
 
-  const { width, height } = useThree((state) => state.size);
+  const { canvasSize } = useAxisSystemContext();
 
   const htmlSelection = useCameraState(
     (...args) => ({
@@ -35,7 +35,7 @@ function SelectionRect(props: Props) {
 
   return (
     <Overlay>
-      <svg width={width} height={height}>
+      <svg {...canvasSize}>
         <rect
           x={Math.min(x1, x2)}
           y={Math.min(y1, y2)}

--- a/packages/lib/src/interactions/utils.ts
+++ b/packages/lib/src/interactions/utils.ts
@@ -20,8 +20,12 @@ export function boundPointToFOV(
 export function getRatioRespectingRectangle(
   startPoint: Vector2,
   endPoint: Vector2,
-  ratio: number
+  ratio: number | undefined
 ) {
+  if (ratio === undefined) {
+    return [startPoint, endPoint];
+  }
+
   const widthSign = Math.sign(endPoint.x - startPoint.x);
   const width = Math.abs(endPoint.x - startPoint.x);
 

--- a/packages/lib/src/vis/shared/AxisSystem.tsx
+++ b/packages/lib/src/vis/shared/AxisSystem.tsx
@@ -1,5 +1,3 @@
-import { useThree } from '@react-three/fiber';
-
 import { useCameraState } from '../hooks';
 import type { AxisOffsets } from '../models';
 import { getVisibleDomains } from '../utils';
@@ -17,8 +15,7 @@ interface Props {
 function AxisSystem(props: Props) {
   const { axisOffsets, title, showAxes } = props;
 
-  const canvasSize = useThree((state) => state.size);
-  const { abscissaConfig, ordinateConfig } = useAxisSystemContext();
+  const { canvasSize, abscissaConfig, ordinateConfig } = useAxisSystemContext();
   const { xVisibleDomain, yVisibleDomain } = useCameraState(
     getVisibleDomains,
     []

--- a/packages/lib/src/vis/shared/AxisSystemProvider.tsx
+++ b/packages/lib/src/vis/shared/AxisSystemProvider.tsx
@@ -7,9 +7,10 @@ import type { AxisConfig, AxisScale, Size } from '../models';
 import { getCanvasScale, getSizeToFit } from '../utils';
 
 export interface AxisSystemContextValue {
-  visSize: Size;
-  visRatio: number | undefined;
+  canvasSize: Size;
   canvasRatio: number;
+  visRatio: number | undefined;
+  visSize: Size;
   abscissaConfig: AxisConfig;
   ordinateConfig: AxisConfig;
   abscissaScale: AxisScale;
@@ -46,10 +47,10 @@ function AxisSystemProvider(props: PropsWithChildren<Props>) {
     children,
   } = props;
 
-  const availableSize = useThree((state) => state.size);
-  const visSize = getSizeToFit(availableSize, visRatio);
+  const canvasSize = useThree((state) => state.size);
+  const visSize = getSizeToFit(canvasSize, visRatio);
 
-  const { width, height } = availableSize;
+  const { width, height } = canvasSize;
   const canvasRatio = width / height;
 
   const abscissaScale = getCanvasScale(abscissaConfig, visSize.width);
@@ -82,9 +83,10 @@ function AxisSystemProvider(props: PropsWithChildren<Props>) {
   return (
     <AxisSystemContext.Provider
       value={{
-        visSize,
-        visRatio,
+        canvasSize,
         canvasRatio,
+        visRatio,
+        visSize,
         abscissaConfig,
         ordinateConfig,
         abscissaScale,

--- a/packages/lib/src/vis/shared/AxisSystemProvider.tsx
+++ b/packages/lib/src/vis/shared/AxisSystemProvider.tsx
@@ -9,6 +9,7 @@ import { getCanvasScale, getSizeToFit } from '../utils';
 export interface AxisSystemContextValue {
   visSize: Size;
   visRatio: number | undefined;
+  canvasRatio: number;
   abscissaConfig: AxisConfig;
   ordinateConfig: AxisConfig;
   abscissaScale: AxisScale;
@@ -48,6 +49,9 @@ function AxisSystemProvider(props: PropsWithChildren<Props>) {
   const availableSize = useThree((state) => state.size);
   const visSize = getSizeToFit(availableSize, visRatio);
 
+  const { width, height } = availableSize;
+  const canvasRatio = width / height;
+
   const abscissaScale = getCanvasScale(abscissaConfig, visSize.width);
   const ordinateScale = getCanvasScale(ordinateConfig, visSize.height);
 
@@ -57,11 +61,10 @@ function AxisSystemProvider(props: PropsWithChildren<Props>) {
     new Vector2(abscissaScale(vec.x), ordinateScale(vec.y));
 
   const cameraToHtmlMatrix = useMemo(() => {
-    const { width, height } = availableSize;
     return new Matrix4()
       .makeScale(width / 2, -height / 2, 1) // scale from normalized camera space to HTML space
       .setPosition(width / 2, height / 2, 0); // account for shift of (0,0) position (center for camera, top-left for HTML)
-  }, [availableSize]);
+  }, [width, height]);
 
   const cameraToHtmlMatrixInverse = useMemo(() => {
     return cameraToHtmlMatrix.clone().invert();
@@ -81,6 +84,7 @@ function AxisSystemProvider(props: PropsWithChildren<Props>) {
       value={{
         visSize,
         visRatio,
+        canvasRatio,
         abscissaConfig,
         ordinateConfig,
         abscissaScale,

--- a/packages/lib/src/vis/shared/Overlay.tsx
+++ b/packages/lib/src/vis/shared/Overlay.tsx
@@ -1,6 +1,6 @@
-import { useThree } from '@react-three/fiber';
 import type { ReactNode, CSSProperties } from 'react';
 
+import { useAxisSystemContext } from './AxisSystemProvider';
 import Html from './Html';
 
 interface Props {
@@ -11,8 +11,7 @@ interface Props {
 
 function Overlay(props: Props) {
   const { children, style, className } = props;
-
-  const { width, height } = useThree((state) => state.size);
+  const { canvasSize } = useAxisSystemContext();
 
   return (
     <Html>
@@ -22,9 +21,8 @@ function Overlay(props: Props) {
           position: 'absolute',
           top: 0,
           left: 0,
-          width,
-          height,
           pointerEvents: 'none',
+          ...canvasSize,
           ...style,
         }}
       >

--- a/packages/lib/src/vis/shared/TooltipMesh.tsx
+++ b/packages/lib/src/vis/shared/TooltipMesh.tsx
@@ -1,4 +1,3 @@
-import { useThree } from '@react-three/fiber';
 import type { ThreeEvent } from '@react-three/fiber';
 import { useTooltip } from '@visx/tooltip';
 import { useCallback } from 'react';
@@ -17,11 +16,8 @@ interface Props {
 
 function TooltipMesh(props: Props) {
   const { guides, renderTooltip, size } = props;
-
-  const { width, height } = useThree((state) => state.size);
-
-  // Scales to compute data coordinates from unprojected mesh coordinates
-  const { worldToData } = useAxisSystemContext();
+  const { canvasSize, worldToData } = useAxisSystemContext();
+  const { width, height } = canvasSize;
 
   const {
     tooltipOpen,

--- a/packages/lib/src/vis/shared/TooltipOverlay.tsx
+++ b/packages/lib/src/vis/shared/TooltipOverlay.tsx
@@ -1,8 +1,8 @@
-import { useThree } from '@react-three/fiber';
 import { Line } from '@visx/shape';
 import { TooltipWithBounds } from '@visx/tooltip';
 import type { ReactNode } from 'react';
 
+import { useAxisSystemContext } from './AxisSystemProvider';
 import Overlay from './Overlay';
 import styles from './TooltipMesh.module.css';
 
@@ -17,7 +17,8 @@ interface Props {
 function TooltipOverlay(props: Props) {
   const { tooltipOpen, tooltipLeft, tooltipTop, guides, children } = props;
 
-  const { width, height } = useThree((state) => state.size);
+  const { canvasSize } = useAxisSystemContext();
+  const { width, height } = canvasSize;
 
   return (
     <Overlay>

--- a/packages/lib/src/vis/tiles/TiledHeatmapMesh.tsx
+++ b/packages/lib/src/vis/tiles/TiledHeatmapMesh.tsx
@@ -1,4 +1,3 @@
-import { useThree } from '@react-three/fiber';
 import { clamp, range } from 'lodash';
 import { useRef } from 'react';
 import type { Object3D } from 'three';
@@ -35,8 +34,7 @@ function TiledHeatmapMesh(props: Props) {
   } = props;
   const { baseLayerIndex, baseLayerSize } = api;
 
-  const canvasSize = useThree((state) => state.size);
-  const { visSize } = useAxisSystemContext();
+  const { canvasSize, visSize } = useAxisSystemContext();
   const meshSize = size ?? visSize;
 
   const groupRef = useRef<Object3D>(null);


### PR DESCRIPTION
`SelectToZoom` was computing the "ratio to respect" from the visible domains. I came to the realisation that this ratio was always the exact same as the ratio of the canvas, which seems obvious now -- we probably missed it because this wasn't the case when the feature was first developed as we had to iterate quite a bit to get to the current behaviour.

So I decided to inject `canvasRatio` via `AxisSystemContext` and use that directly in `SelectToZoom`. I also decided to inject `canvasSize` for convenience, to avoid using both `useThree` and `useAxisSystemContext` in some places.