### PR TITLE
Allow to hide left axis in histogram

### DIFF
--- a/apps/storybook/src/DomainSlider.stories.tsx
+++ b/apps/storybook/src/DomainSlider.stories.tsx
@@ -68,6 +68,19 @@ HistogramWithColorMap.args = {
   },
 };
 
+export const HistogramWithoutLeftAxis = Template.bind({});
+
+HistogramWithoutLeftAxis.args = {
+  ...Default.args,
+  histogram: {
+    values: [130, 92, 76, 68, 60, 52, 50, 26],
+    bins: [4, 53.5, 103, 152.5, 202, 251.5, 301, 350.5, 400],
+    showLeftAxis: false,
+    colorMap: 'Blues',
+    invertColorMap: true,
+  },
+};
+
 export const TypedHistogram = Template.bind({});
 
 TypedHistogram.args = {

--- a/apps/storybook/src/Histogram.stories.tsx
+++ b/apps/storybook/src/Histogram.stories.tsx
@@ -60,6 +60,13 @@ NonInteractive.args = {
   ...Default.args,
 };
 
+export const HideLeftAxis = Template.bind({});
+
+HideLeftAxis.args = {
+  ...Default.args,
+  showLeftAxis: false,
+};
+
 export default {
   title: 'Toolbar/Histogram',
   component: Histogram,

--- a/packages/lib/src/toolbar/controls/Histogram/Histogram.tsx
+++ b/packages/lib/src/toolbar/controls/Histogram/Histogram.tsx
@@ -27,7 +27,15 @@ interface Props extends HistogramParams {
 }
 
 function Histogram(props: Props) {
-  const { values, bins, scaleType, value, dataDomain, onChange } = props;
+  const {
+    values,
+    bins,
+    scaleType,
+    value,
+    dataDomain,
+    onChange,
+    showLeftAxis = true,
+  } = props;
   const { colorMap, invertColorMap } = props;
 
   const binDomain = useDomain(bins, scaleType) || DEFAULT_DOMAIN;
@@ -99,13 +107,15 @@ function Histogram(props: Props) {
           tickComponent={Tick}
           tickFormat={xScale.tickFormat(adaptedNumTicks(width), '.3~g')}
         />
-        <AxisLeft
-          scale={yScale.range([height, 0])}
-          numTicks={adaptedNumTicks(height)}
-          tickClassName={styles.tick}
-          tickComponent={Tick}
-          tickFormat={yScale.tickFormat(adaptedNumTicks(height), '.3~g')}
-        />
+        {showLeftAxis && (
+          <AxisLeft
+            scale={yScale.range([height, 0])}
+            numTicks={adaptedNumTicks(height)}
+            tickClassName={styles.tick}
+            tickComponent={Tick}
+            tickFormat={yScale.tickFormat(adaptedNumTicks(height), '.3~g')}
+          />
+        )}
       </svg>
     </div>
   );

--- a/packages/lib/src/vis/models.ts
+++ b/packages/lib/src/vis/models.ts
@@ -90,6 +90,7 @@ export type PrintableType =
 export interface HistogramParams {
   values: NumArray;
   bins: NumArray;
+  showLeftAxis?: boolean;
   colorMap?: ColorMap;
   invertColorMap?: boolean;
 }


### PR DESCRIPTION
Fix #1279 

In `Histogram`:
![image](https://user-images.githubusercontent.com/42204205/203294360-8045e11b-3db4-47c2-b74c-396a393a3252.png)

In `DomainSlider`:
![image](https://user-images.githubusercontent.com/42204205/203294433-8e1cd6cb-b8cb-4068-830b-0566d1b284c7.png)

The API is a bit clunky but with #1276 in the works, I thought we should not replicate the axis config API. Feedback welcome though.
