### PR TITLE
Avoid duplicate computations in `SelectionTool`

### DIFF
--- a/apps/storybook/src/Selection.stories.tsx
+++ b/apps/storybook/src/Selection.stories.tsx
@@ -173,7 +173,9 @@ export const Persisted: Story<TemplateProps> = (args) => {
         onSelectionEnd={setPersistedSelection}
         modifierKey={selectionModifierKey}
       >
-        {(selection) => <SelectionComponent {...selection} />}
+        {(selection) =>
+          !persistedSelection && <SelectionComponent {...selection} />
+        }
       </SelectionTool>
       {persistedSelection && (
         <SelectionComponent


### PR DESCRIPTION
For #1296, I'm gonna need access to the selection start/end points in HTML space. Before I can get there, I need to refactor a few things so it doesn't become a huge mess. I'm gonna try to split things up to avoid regressions and make reviewing easier.

First up, I'm storing the entire `selection` in a state inside `SelectionTool` instead of just the `endPoint`. This avoids recomputing `worldStart/EndPoint` during render.

I'm also fixing a very subtle bug in the persisted selection story, where the active and persisted selections would both be visible for one render.