### PR TITLE
Prevent `onSelectionChange` from affecting selection tool performance

### DIFF
--- a/packages/lib/src/interactions/SelectionTool.tsx
+++ b/packages/lib/src/interactions/SelectionTool.tsx
@@ -1,7 +1,7 @@
 import { useKeyboardEvent, useRafState } from '@react-hookz/web';
 import { useThree } from '@react-three/fiber';
 import type { ReactNode } from 'react';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type { Vector2 } from 'three';
 
 import { useVisCanvasContext } from '../vis/shared/VisCanvasProvider';
@@ -77,28 +77,14 @@ function SelectionTool(props: Props) {
       const { worldPt } = evt;
       const dataEndPoint = worldToData(boundPointToFOV(worldPt, camera));
 
-      const newSelection = {
+      setSelection({
         startPoint,
         endPoint: dataEndPoint,
         worldStartPoint: dataToWorld(startPoint),
         worldEndPoint: dataToWorld(dataEndPoint),
-      };
-
-      setSelection(newSelection);
-
-      if (onSelectionChange && isModifierKeyPressed) {
-        onSelectionChange(newSelection);
-      }
+      });
     },
-    [
-      startPoint,
-      worldToData,
-      camera,
-      setSelection,
-      dataToWorld,
-      onSelectionChange,
-      isModifierKeyPressed,
-    ]
+    [startPoint, worldToData, camera, setSelection, dataToWorld]
   );
 
   const onPointerUp = useCallback(
@@ -147,6 +133,12 @@ function SelectionTool(props: Props) {
     [],
     { event: 'keydown' }
   );
+
+  useEffect(() => {
+    if (onSelectionChange && selection && isModifierKeyPressed) {
+      onSelectionChange(selection);
+    }
+  }, [selection, isModifierKeyPressed, onSelectionChange]);
 
   if (!selection || !isModifierKeyPressed) {
     return null;


### PR DESCRIPTION
`onSelectionChange` was called on every pointer move event, so it had the potential to affect the performance of the selection tool. I'm moving the call inside a `useEffect` so that it happens asynchronously, after the RAF selection state is updated and after the selection tool and its render prop have had time to re-render.