### PR TITLE
Store full start event in state in `SelectionTool`

### DIFF
--- a/packages/lib/src/interactions/AxialSelectionTool.tsx
+++ b/packages/lib/src/interactions/AxialSelectionTool.tsx
@@ -31,21 +31,21 @@ function AxialSelectionTool(props: Props) {
       context
     );
 
-    const { startPoint: mouseStartPoint, endPoint: mouseEndPoint } = selection;
-    const startPoint =
+    const { startPoint, endPoint } = selection;
+    const axialStartPoint =
       axis === 'x'
-        ? new Vector2(mouseStartPoint.x, yVisibleDomain[0])
-        : new Vector2(xVisibleDomain[0], mouseStartPoint.y);
-    const endPoint =
+        ? new Vector2(startPoint.x, yVisibleDomain[0])
+        : new Vector2(xVisibleDomain[0], startPoint.y);
+    const axialEndPoint =
       axis === 'x'
-        ? new Vector2(mouseEndPoint.x, yVisibleDomain[1])
-        : new Vector2(xVisibleDomain[1], mouseEndPoint.y);
+        ? new Vector2(endPoint.x, yVisibleDomain[1])
+        : new Vector2(xVisibleDomain[1], endPoint.y);
 
     return {
-      startPoint,
-      endPoint,
-      worldStartPoint: context.dataToWorld(startPoint),
-      worldEndPoint: context.dataToWorld(endPoint),
+      startPoint: axialStartPoint,
+      endPoint: axialEndPoint,
+      worldStartPoint: context.dataToWorld(axialStartPoint),
+      worldEndPoint: context.dataToWorld(axialEndPoint),
     };
   }
 

--- a/packages/lib/src/interactions/RatioSelectionRect.tsx
+++ b/packages/lib/src/interactions/RatioSelectionRect.tsx
@@ -15,22 +15,19 @@ function RatioSelectionRect(props: Props) {
   const { startPoint, endPoint, ratio, ...svgProps } = props;
   const { visSize, dataToWorld, worldToData } = useVisCanvasContext();
 
-  const [dataStartPoint, dataEndPoint] = getRatioRespectingRectangle(
-    startPoint,
-    endPoint,
-    ratio
-  ).map(dataToWorld);
+  const [ratioWorldStartPoint, ratioWorldEndPoint] =
+    getRatioRespectingRectangle(startPoint, endPoint, ratio).map(dataToWorld);
 
-  const [worldStartPoint, worldEndPoint] = clampRectangleToVis(
-    dataStartPoint,
-    dataEndPoint,
+  const [clampedDataStartPoint, clampedDataEndPoint] = clampRectangleToVis(
+    ratioWorldStartPoint,
+    ratioWorldEndPoint,
     visSize
   ).map(worldToData);
 
   return (
     <SelectionRect
-      startPoint={worldStartPoint}
-      endPoint={worldEndPoint}
+      startPoint={clampedDataStartPoint}
+      endPoint={clampedDataEndPoint}
       {...svgProps}
     />
   );


### PR DESCRIPTION
The goal is twofold:

1. Keep a reference to the start `htmlPt` for #1296 to avoid having to compute it back from the data point.
2. Keep a reference to the start `worldPt` to avoid having to compute it back from the data point in both `onPointerMove` and `onPointerUp`.

I also fix a couple of naming issues. See comments.