### PR TITLE
Always use `Vector3` for world/camera and `Vector2` for data/html

### DIFF
--- a/packages/lib/src/interactions/AxialSelectToZoom.tsx
+++ b/packages/lib/src/interactions/AxialSelectToZoom.tsx
@@ -38,7 +38,7 @@ function AxialSelectToZoom(props: Props) {
     camera.scale.set(zoomRect.width / width, zoomRect.height / height, 1);
     camera.updateMatrixWorld();
 
-    moveCameraTo(zoomRectCenter.x, zoomRectCenter.y);
+    moveCameraTo(zoomRectCenter);
   }
 
   return (

--- a/packages/lib/src/interactions/Pan.tsx
+++ b/packages/lib/src/interactions/Pan.tsx
@@ -67,9 +67,7 @@ function Pan(props: Props) {
 
       const { worldPt } = evt;
       const delta = startOffsetPosition.current.clone().sub(worldPt);
-      const target = camera.position.clone().add(delta);
-
-      moveCameraTo(target.x, target.y);
+      moveCameraTo(camera.position.clone().add(delta));
     },
     [camera, isModifierKeyPressed, moveCameraTo]
   );

--- a/packages/lib/src/interactions/SelectToZoom.tsx
+++ b/packages/lib/src/interactions/SelectToZoom.tsx
@@ -41,7 +41,7 @@ function SelectToZoom(props: Props) {
     camera.scale.set(zoomRect.width / width, zoomRect.height / height, 1);
     camera.updateMatrixWorld();
 
-    moveCameraTo(zoomRectCenter.x, zoomRectCenter.y);
+    moveCameraTo(zoomRectCenter);
   }
 
   return (

--- a/packages/lib/src/interactions/SelectionTool.tsx
+++ b/packages/lib/src/interactions/SelectionTool.tsx
@@ -4,7 +4,6 @@ import { useThree } from '@react-three/fiber';
 import type { ReactNode } from 'react';
 import { useCallback, useEffect, useState } from 'react';
 import type { Vector3 } from 'three';
-import { Vector2 } from 'three';
 
 import { useVisCanvasContext } from '../vis/shared/VisCanvasProvider';
 import {
@@ -61,7 +60,7 @@ function SelectionTool(props: Props) {
       return {
         startPoint,
         endPoint: worldToData(boundWorldEndPoint),
-        worldStartPoint: new Vector2(worldStartPoint.x, worldStartPoint.y),
+        worldStartPoint,
         worldEndPoint: boundWorldEndPoint,
       };
     },

--- a/packages/lib/src/interactions/hooks.ts
+++ b/packages/lib/src/interactions/hooks.ts
@@ -26,7 +26,7 @@ export function useMoveCameraTo() {
   const invalidate = useThree((state) => state.invalidate);
 
   return useCallback(
-    (x: number, y: number) => {
+    (worldPt: Vector3) => {
       const { position } = camera;
 
       const { topRight, bottomLeft } = getWorldFOV(camera);
@@ -34,7 +34,7 @@ export function useMoveCameraTo() {
       const height = Math.abs(topRight.y - bottomLeft.y);
 
       const clampedPosition = clampPositionToArea(
-        new Vector2(x, y),
+        worldPt,
         { width, height },
         visSize
       );
@@ -90,15 +90,15 @@ export function useZoomOnWheel(
       }
       camera.updateMatrixWorld();
 
-      const oldPosition = worldPt.clone();
       // Scale the change in position according to the zoom
+      const oldPosition = worldPt.clone();
       const delta = camera.position.clone().sub(oldPosition);
       const scaledDelta =
         sourceEvent.deltaY < 0
           ? delta.multiply(zoomVector)
           : delta.divide(zoomVector);
-      const scaledPosition = oldPosition.add(scaledDelta);
-      moveCameraTo(scaledPosition.x, scaledPosition.y);
+
+      moveCameraTo(oldPosition.add(scaledDelta));
     },
     [camera, isZoomAllowed, moveCameraTo]
   );
@@ -123,7 +123,13 @@ export function useCanvasEvents(callbacks: CanvasEventCallbacks): void {
       const worldPt = cameraPt.clone().unproject(camera);
       const dataPt = worldToData(worldPt);
 
-      return { htmlPt, cameraPt, worldPt, dataPt, sourceEvent };
+      return {
+        htmlPt: new Vector2(htmlPt.x, htmlPt.y),
+        cameraPt,
+        worldPt,
+        dataPt,
+        sourceEvent,
+      };
     },
     [camera, cameraToHtmlMatrixInverse, worldToData]
   );

--- a/packages/lib/src/interactions/models.ts
+++ b/packages/lib/src/interactions/models.ts
@@ -10,12 +10,12 @@ export enum MouseButton {
 export interface Selection {
   startPoint: Vector2;
   endPoint: Vector2;
-  worldStartPoint: Vector2;
-  worldEndPoint: Vector2;
+  worldStartPoint: Vector3;
+  worldEndPoint: Vector3;
 }
 
 export interface CanvasEvent<T extends MouseEvent> {
-  htmlPt: Vector3;
+  htmlPt: Vector2;
   cameraPt: Vector3;
   worldPt: Vector3;
   dataPt: Vector2;

--- a/packages/lib/src/interactions/utils.ts
+++ b/packages/lib/src/interactions/utils.ts
@@ -1,20 +1,19 @@
 import type { Camera } from '@react-three/fiber';
 import { clamp } from 'lodash';
-import type { Vector3 } from 'three';
-import { Vector2 } from 'three';
+import { Vector2, Vector3 } from 'three';
 
 import type { Size } from '../vis/models';
 import { getWorldFOV } from '../vis/utils';
 import type { ModifierKey } from './models';
 
 export function boundPointToFOV(
-  unboundedPoint: Vector2 | Vector3,
+  unboundedPoint: Vector3,
   camera: Camera
-): Vector2 {
+): Vector3 {
   const { topRight, bottomLeft } = getWorldFOV(camera);
   const boundedX = clamp(unboundedPoint.x, bottomLeft.x, topRight.x);
   const boundedY = clamp(unboundedPoint.y, bottomLeft.y, topRight.y);
-  return new Vector2(boundedX, boundedY);
+  return new Vector3(boundedX, boundedY, 0);
 }
 
 export function getRatioRespectingRectangle(
@@ -50,7 +49,7 @@ export function getRatioRespectingRectangle(
   ];
 }
 
-export function getEnclosedRectangle(startPoint: Vector2, endPoint: Vector2) {
+export function getEnclosedRectangle(startPoint: Vector3, endPoint: Vector3) {
   // center = start + (end - start) / 2
   const center = endPoint
     .clone()
@@ -66,24 +65,25 @@ export function getEnclosedRectangle(startPoint: Vector2, endPoint: Vector2) {
 }
 
 export function clampPositionToArea(
-  center: Vector2,
+  center: Vector3,
   rectSize: Size,
   areaSize: Size
-): Vector2 {
+): Vector3 {
   const xBound = Math.max(areaSize.width / 2 - rectSize.width / 2, 0);
   const yBound = Math.max(areaSize.height / 2 - rectSize.height / 2, 0);
 
-  return new Vector2(
+  return new Vector3(
     clamp(center.x, -xBound, xBound),
-    clamp(center.y, -yBound, yBound)
+    clamp(center.y, -yBound, yBound),
+    0
   );
 }
 
 export function clampRectangleToVis(
-  startPoint: Vector2,
-  endPoint: Vector2,
+  startPoint: Vector3,
+  endPoint: Vector3,
   visSize: Size
-): [Vector2, Vector2] {
+): [Vector3, Vector3] {
   const { center, ...rectSize } = getEnclosedRectangle(startPoint, endPoint);
 
   const newCenter = clampPositionToArea(center, rectSize, visSize);

--- a/packages/lib/src/vis/shared/RatioEnforcer.tsx
+++ b/packages/lib/src/vis/shared/RatioEnforcer.tsx
@@ -18,7 +18,8 @@ function RatioEnforcer() {
     camera.scale.x = targetScale;
     camera.scale.y = targetScale;
     camera.updateMatrixWorld();
-    moveCameraTo(camera.position.x, camera.position.y);
+
+    moveCameraTo(camera.position);
   }, [camera, moveCameraTo, visRatio]);
 
   return null;

--- a/packages/lib/src/vis/shared/ViewportCenterer.tsx
+++ b/packages/lib/src/vis/shared/ViewportCenterer.tsx
@@ -19,8 +19,7 @@ function ViewportCenterer() {
   useEffect(() => {
     if (viewportCenter.current) {
       // On resize, move camera to the latest saved viewport center coordinates
-      const { x, y } = dataToWorld(viewportCenter.current);
-      moveCameraTo(x, y);
+      moveCameraTo(dataToWorld(viewportCenter.current));
     }
   }, [viewportCenter, moveCameraTo, dataToWorld, camera]);
 

--- a/packages/lib/src/vis/utils.ts
+++ b/packages/lib/src/vis/utils.ts
@@ -350,14 +350,14 @@ export function toArray(arr: NumArray): number[] {
   return isTypedArray(arr) ? [...arr] : arr;
 }
 
-export function worldToCamera(camera: Camera, worldPt: Vector2 | Vector3) {
-  return new Vector3(worldPt.x, worldPt.y, 0).project(camera);
+export function worldToCamera(camera: Camera, worldPt: Vector3) {
+  return worldPt.clone().project(camera);
 }
 
 export function dataToHtml(
   camera: Camera,
   context: VisCanvasContextValue,
-  dataPt: Vector2 | Vector3
+  dataPt: Vector2
 ): Vector2 {
   const { dataToWorld, cameraToHtml } = context;
   const worldPt = dataToWorld(dataPt);


### PR DESCRIPTION
I thought I'd try to bring the vector conversions under control a bit... Basically we need `Vector3` for camera projections, so I thought we could enforce the use of `Vector3` for points in world/camera space. In data/html space, it seems simpler to use `Vector2` as the `z` index makes less sense (in 2D at least...)