### PR TITLE
Allow transforming selection in `SelectionTool`

### DIFF
--- a/apps/storybook/src/Selection.stories.tsx
+++ b/apps/storybook/src/Selection.stories.tsx
@@ -1,4 +1,4 @@
-import type { Selection, ModifierKey } from '@h5web/lib';
+import type { Selection, ModifierKey, Axis } from '@h5web/lib';
 import { AxialSelectionTool } from '@h5web/lib';
 import {
   Pan,
@@ -202,9 +202,7 @@ Persisted.argTypes = {
   },
 };
 
-export const AxialSelection: Story<TemplateProps & { axis: 'x' | 'y' }> = (
-  args
-) => {
+export const AxialSelection: Story<TemplateProps & { axis: Axis }> = (args) => {
   const {
     selectionType,
     selectionModifierKey,

--- a/packages/app/src/dimension-mapper/AxisMapper.tsx
+++ b/packages/app/src/dimension-mapper/AxisMapper.tsx
@@ -1,8 +1,9 @@
 import { ToggleGroup } from '@h5web/lib';
+import type { Axis } from '@h5web/shared';
 import { isNumber } from 'lodash';
 
 import styles from './DimensionMapper.module.css';
-import type { Axis, DimensionMapping } from './models';
+import type { DimensionMapping } from './models';
 
 interface Props {
   axis: Axis;

--- a/packages/app/src/dimension-mapper/models.ts
+++ b/packages/app/src/dimension-mapper/models.ts
@@ -1,2 +1,3 @@
-export type Axis = 'x' | 'y';
+import type { Axis } from '@h5web/shared';
+
 export type DimensionMapping = (number | Axis)[];

--- a/packages/app/src/dimension-mapper/utils.ts
+++ b/packages/app/src/dimension-mapper/utils.ts
@@ -1,6 +1,5 @@
+import type { Axis } from '@h5web/shared';
 import { isNumber } from 'lodash';
-
-import type { Axis } from './models';
 
 export function isAxis(elem: number | Axis): elem is Axis {
   return !isNumber(elem);

--- a/packages/app/src/vis-packs/core/utils.ts
+++ b/packages/app/src/vis-packs/core/utils.ts
@@ -1,10 +1,10 @@
-import type { Domain } from '@h5web/shared';
+import type { Axis, Domain } from '@h5web/shared';
 import { createArrayFromView } from '@h5web/shared';
 import { isNumber } from 'lodash';
 import type { NdArray, TypedArray } from 'ndarray';
 import ndarray from 'ndarray';
 
-import type { Axis, DimensionMapping } from '../../dimension-mapper/models';
+import type { DimensionMapping } from '../../dimension-mapper/models';
 import { isAxis } from '../../dimension-mapper/utils';
 
 export const DEFAULT_DOMAIN: Domain = [0.1, 1];

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -122,7 +122,7 @@ export type {
 } from './interactions/models';
 export { MouseButton } from './interactions/models';
 
-export type { Domain, Dims } from '@h5web/shared';
+export type { Domain, Dims, Axis } from '@h5web/shared';
 
 export type {
   Aspect,

--- a/packages/lib/src/interactions/AxialSelectToZoom.tsx
+++ b/packages/lib/src/interactions/AxialSelectToZoom.tsx
@@ -1,3 +1,4 @@
+import type { Axis } from '@h5web/shared';
 import { useThree } from '@react-three/fiber';
 
 import { useVisCanvasContext } from '../vis/shared/VisCanvasProvider';
@@ -8,7 +9,7 @@ import type { Selection, CommonInteractionProps } from './models';
 import { getEnclosedRectangle } from './utils';
 
 interface Props extends CommonInteractionProps {
-  axis: 'x' | 'y';
+  axis: Axis;
 }
 
 function AxialSelectToZoom(props: Props) {

--- a/packages/shared/src/models-vis.ts
+++ b/packages/shared/src/models-vis.ts
@@ -15,6 +15,7 @@ export type TypedArrayConstructor =
   | Float64ArrayConstructor;
 
 export type Domain = [number, number];
+export type Axis = 'x' | 'y';
 
 export enum ScaleType {
   Linear = 'linear',


### PR DESCRIPTION
- I add a prop called `transformSelection` to `SelectionTool`, which allows transforming the selection before it gets passed to `onSelectionChange`, `onSelectionEnd` and the `children` render prop. This cleans up the code of `AxialSelectionTool` quite a bit, since we no longer have to monkey-patch those three props in order to turn the user's selection into an axial selection.
- I change the way `AxialSelectionTool` transforms the user's selection into an axial selection. Instead of doing `data -> world -> data`, we now just do `world -> data`. See comments.
- I move the dimension mapper's `Axis` type (`'x' | 'y'`) into `@h5web/shared` so I can re-use it everywhere. The name technically conflicts with our `Axis` component, but it doesn't seem to be a problem for now.