### PR TITLE
Add camera utilities `worldToHtml`, `htmlToWorld` and `htmlToData`

### DIFF
--- a/apps/storybook/src/Utilities.stories.mdx
+++ b/apps/storybook/src/Utilities.stories.mdx
@@ -194,7 +194,7 @@ Register event listeners on the `canvas` element. Useful to implement custom int
 useCanvasEvents(callbacks: CanvasEventCallbacks): void
 
 const handlePointerDown = useCallback((evt: CanvasEvent<PointerEvent>) => {
-  const { htmlPt, cameraPt, worldPt, dataPt, sourceEvent } = evt;
+  const { htmlPt, worldPt, dataPt, sourceEvent } = evt;
   // ...
 }, []);
 
@@ -234,12 +234,20 @@ To avoid unnecessary re-renders, it performs a deep comparison before updating t
 The utilities documented in this section require access to the R3F `camera` object. They are typically meant to be called inside
 [`useCameraState`](https://h5web-docs.panosc.eu/?path=/story/utilities--page#usecamerastate) callbacks or DOM event listeners.
 
-#### worldToCamera
+#### worldToHtml
 
-Convert a point from world space to camera space
+Convert a point from world space to HTML space
 
 ```ts
-dataToHtml(camera: Camera, worldPt: Vector2 | Vector3): Vector2
+worldToHtml(camera: Camera, context: VisCanvasContextValue, worldPt: Vector3): Vector2
+```
+
+#### htmlToWorld
+
+Convert a point from HTML space to world space
+
+```ts
+htmlToWorld(camera: Camera, context: VisCanvasContextValue, htmlPt: Vector2): Vector3
 ```
 
 #### dataToHtml
@@ -247,11 +255,15 @@ dataToHtml(camera: Camera, worldPt: Vector2 | Vector3): Vector2
 Convert a point from data space to HTML space.
 
 ```ts
-dataToHtml(
-  camera: Camera,
-  context: VisCanvasContextValue,
-  dataPt: Vector2 | Vector3
-): Vector2
+dataToHtml(camera: Camera, context: VisCanvasContextValue, dataPt: Vector2): Vector2
+```
+
+#### htmlToData
+
+Convert a point from HTML space to data space.
+
+```ts
+htmlToData(camera: Camera, context: VisCanvasContextValue, htmlPt: Vector2): Vector2
 ```
 
 #### getWorldFOV

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -79,8 +79,10 @@ export {
   getAxisValues,
   getAxisDomain,
   getValueToIndexScale,
-  worldToCamera,
+  worldToHtml,
+  htmlToWorld,
   dataToHtml,
+  htmlToData,
   getWorldFOV,
   getVisibleDomains,
 } from './vis/utils';

--- a/packages/lib/src/interactions/models.ts
+++ b/packages/lib/src/interactions/models.ts
@@ -16,7 +16,6 @@ export interface Selection {
 
 export interface CanvasEvent<T extends MouseEvent> {
   htmlPt: Vector2;
-  cameraPt: Vector3;
   worldPt: Vector3;
   dataPt: Vector2;
   sourceEvent: T;

--- a/packages/lib/src/interactions/utils.ts
+++ b/packages/lib/src/interactions/utils.ts
@@ -6,7 +6,7 @@ import type { Size } from '../vis/models';
 import { getWorldFOV } from '../vis/utils';
 import type { ModifierKey } from './models';
 
-export function boundPointToFOV(
+export function boundWorldPointToFOV(
   unboundedPoint: Vector3,
   camera: Camera
 ): Vector3 {

--- a/packages/lib/src/vis/utils.ts
+++ b/packages/lib/src/vis/utils.ts
@@ -350,8 +350,21 @@ export function toArray(arr: NumArray): number[] {
   return isTypedArray(arr) ? [...arr] : arr;
 }
 
-export function worldToCamera(camera: Camera, worldPt: Vector3) {
-  return worldPt.clone().project(camera);
+export function worldToHtml(
+  camera: Camera,
+  context: VisCanvasContextValue,
+  worldPt: Vector3
+) {
+  const cameraPt = worldPt.clone().project(camera);
+  return context.cameraToHtml(cameraPt);
+}
+
+export function htmlToWorld(
+  camera: Camera,
+  context: VisCanvasContextValue,
+  htmlPt: Vector2
+) {
+  return context.htmlToCamera(htmlPt).unproject(camera);
 }
 
 export function dataToHtml(
@@ -359,10 +372,17 @@ export function dataToHtml(
   context: VisCanvasContextValue,
   dataPt: Vector2
 ): Vector2 {
-  const { dataToWorld, cameraToHtml } = context;
-  const worldPt = dataToWorld(dataPt);
-  const cameraPt = worldToCamera(camera, worldPt);
-  return cameraToHtml(cameraPt);
+  const worldPt = context.dataToWorld(dataPt);
+  return worldToHtml(camera, context, worldPt);
+}
+
+export function htmlToData(
+  camera: Camera,
+  context: VisCanvasContextValue,
+  htmlPt: Vector2
+): Vector2 {
+  const worldPt = htmlToWorld(camera, context, htmlPt);
+  return context.worldToData(worldPt);
 }
 
 export function getWorldFOV(camera: Camera): {


### PR DESCRIPTION
We already had `dataToHtml`; I'm just adding the missing ones. This helps to extract some of the vector conversions and camera projections from the `useCanvasEvents`.