### PR TITLE
Upgrade GitHub actions

### DIFF
--- a/.github/workflows/approve-snapshots.yml
+++ b/.github/workflows/approve-snapshots.yml
@@ -22,25 +22,24 @@ jobs:
         with:
           ref: ${{ steps.getBranchName.outputs.branch }}
 
-      - name: Install ⚙️
+      - name: Install pnpm ⚙️
         uses: pnpm/action-setup@v2
         with:
           version: 7.x
 
       - name: Use Node 16 🕹️
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 16
-          registry-url: 'https://registry.npmjs.org'
+          node-version-file: 'package.json'
           cache: 'pnpm'
 
       - name: Cache Cypress binary 📌
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/Cypress
-          key: cypress-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: cypress-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
-      - name: Install ⚙️
+      - name: Install dependencies ⚙️
         run: pnpm install --frozen-lockfile
 
       - name: Build packages 📦
@@ -58,7 +57,7 @@ jobs:
           CYPRESS_TAKE_SNAPSHOTS: true
 
       - name: Upload debug screenshots and diffs on failure 🖼️
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress
@@ -67,7 +66,7 @@ jobs:
             cypress/snapshots/**/__diff_output__/
 
       - name: Open PR to update reference snapshots 🎁
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.USER_TOKEN }}
           branch: update-snapshots

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -16,19 +16,18 @@ jobs:
       - name: Checkout 🏷️
         uses: actions/checkout@v3
 
-      - name: Install ⚙️
+      - name: Install pnpm ⚙️
         uses: pnpm/action-setup@v2
         with:
           version: 7.x
 
       - name: Use Node 16 🕹️
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 16
-          registry-url: 'https://registry.npmjs.org'
+          node-version-file: 'package.json'
           cache: 'pnpm'
 
-      - name: Install ⚙️
+      - name: Install dependencies ⚙️
         run: pnpm install --frozen-lockfile
 
       - name: Lint 🤓
@@ -43,19 +42,18 @@ jobs:
       - name: Checkout 🏷️
         uses: actions/checkout@v3
 
-      - name: Install ⚙️
+      - name: Install pnpm ⚙️
         uses: pnpm/action-setup@v2
         with:
           version: 7.x
 
       - name: Use Node 16 🕹️
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 16
-          registry-url: 'https://registry.npmjs.org'
+          node-version-file: 'package.json'
           cache: 'pnpm'
 
-      - name: Install ⚙️
+      - name: Install dependencies ⚙️
         run: pnpm install --frozen-lockfile
 
       - name: Test 👓
@@ -72,25 +70,24 @@ jobs:
       - name: Checkout 🏷️
         uses: actions/checkout@v3
 
-      - name: Install ⚙️
+      - name: Install pnpm ⚙️
         uses: pnpm/action-setup@v2
         with:
           version: 7.x
 
       - name: Use Node 16 🕹️
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 16
-          registry-url: 'https://registry.npmjs.org'
+          node-version-file: 'package.json'
           cache: 'pnpm'
 
       - name: Cache Cypress binary 📌
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/Cypress
           key: cypress-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
-      - name: Install ⚙️
+      - name: Install dependencies ⚙️
         run: pnpm install --frozen-lockfile
 
       - name: Build packages 📦
@@ -108,7 +105,7 @@ jobs:
           CYPRESS_TAKE_SNAPSHOTS: true
 
       - name: Upload debug screenshots and diffs on failure 🖼️
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,23 +14,23 @@ jobs:
 
       - name: Match tag to package version 🧐
         id: packageVersion
-        uses: geritol/match-tag-to-package-version@0.1.0
-        env:
-          TAG_PREFIX: refs/tags/v
+        uses: geritol/match-tag-to-package-version@0.2.0
+        with:
+          TAG_PREFIX: v
 
-      - name: Install ⚙️
+      - name: Install pnpm ⚙️
         uses: pnpm/action-setup@v2
         with:
           version: 7.x
 
       - name: Use Node 16 🕹️
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version-file: 'package.json'
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 
-      - name: Install ⚙️
+      - name: Install dependencies ⚙️
         run: pnpm install --frozen-lockfile
 
       - name: Build packages 📦
@@ -84,9 +84,7 @@ jobs:
         run: pnpm build:storybook
 
       - name: Deploy Storybook 🚀
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+        uses: JamesIves/github-pages-deploy-action@4.4.1
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: apps/storybook/build
-          CLEAN: true
+          folder: apps/storybook/build
+          clean: true


### PR DESCRIPTION
I was trying to fix a caching issue in the CI related to Cypress binaries, and ended up upgrading all the actions:

- https://github.com/actions/setup-node
- https://github.com/actions/cache/releases
- https://github.com/actions/upload-artifact/releases
- https://github.com/JamesIves/github-pages-deploy-action/releases
- https://github.com/geritol/match-tag-to-package-version/releases