### PR TITLE
Use shader in SurfaceVis

### DIFF
--- a/packages/lib/src/vis/heatmap/HeatmapMaterial.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapMaterial.tsx
@@ -1,0 +1,145 @@
+import type { Domain } from '@h5web/shared';
+import { ScaleType } from '@h5web/shared';
+import { rgb } from 'd3-color';
+import type { NdArray } from 'ndarray';
+import { memo, useMemo } from 'react';
+import type { TextureFilter } from 'three';
+import { DoubleSide } from 'three';
+import { DataTexture, RGBAFormat, UnsignedByteType } from 'three';
+
+import type { VisScaleType } from '../models';
+import type { VisMeshProps } from '../shared/VisMesh';
+import { DEFAULT_DOMAIN, getUniforms, VERTEX_SHADER } from '../utils';
+import { useDataTexture } from './hooks';
+import type { ColorMap, TextureSafeTypedArray } from './models';
+import { getInterpolator, scaleDomain } from './utils';
+
+interface Props extends VisMeshProps {
+  values: NdArray<TextureSafeTypedArray | Uint16Array>; // uint16 values are treated as half floats
+  domain: Domain;
+  scaleType: VisScaleType;
+  colorMap: ColorMap;
+  invertColorMap?: boolean;
+  magFilter?: TextureFilter;
+  alphaValues?: NdArray<TextureSafeTypedArray | Uint16Array>; // uint16 values are treated as half floats
+  alphaDomain?: Domain;
+}
+
+const CMAP_SIZE = 256;
+
+const IMPL_SCALE: Partial<Record<ScaleType, string>> = {
+  [ScaleType.Log]: 'log(value) * oneOverLog10',
+  [ScaleType.SymLog]: 'sign(value) * log(1. + abs(value)) * oneOverLog10',
+  [ScaleType.Sqrt]: 'sqrt(value)',
+};
+
+const IMPL_IS_SUPPORTED: Partial<Record<ScaleType, string>> = {
+  [ScaleType.Log]: 'value > 0.',
+  [ScaleType.Sqrt]: 'value >= 0.',
+};
+
+function HeatmapMaterial(props: Props) {
+  const {
+    values,
+    domain,
+    scaleType: visScaleType,
+    colorMap,
+    invertColorMap = false,
+    magFilter,
+    alphaValues,
+    alphaDomain = DEFAULT_DOMAIN,
+  } = props;
+
+  const dataTexture = useDataTexture(values, magFilter);
+  const alphaTexture = useDataTexture(alphaValues);
+
+  const colorMapTexture = useMemo(() => {
+    const interpolator = getInterpolator(colorMap, invertColorMap);
+
+    const colors = Array.from({ length: CMAP_SIZE }).flatMap((_, i) => {
+      const { r, g, b } = rgb(interpolator(i / (CMAP_SIZE - 1)));
+      return [r, g, b, 255];
+    });
+
+    const texture = new DataTexture(
+      Uint8Array.from(colors),
+      CMAP_SIZE,
+      1,
+      RGBAFormat,
+      UnsignedByteType
+    );
+    texture.needsUpdate = true;
+
+    return texture;
+  }, [colorMap, invertColorMap]);
+
+  const [scaleType, gammaExponent] = Array.isArray(visScaleType)
+    ? visScaleType
+    : [visScaleType as ScaleType, 1];
+
+  const scaledDomain = scaleDomain(domain, scaleType);
+
+  const shader = {
+    uniforms: getUniforms({
+      data: dataTexture,
+      colorMap: colorMapTexture,
+      min: scaledDomain[0],
+      oneOverRange: 1 / (scaledDomain[1] - scaledDomain[0]),
+      gammaExponent,
+      normRevertFactor: values.dtype === 'uint8' ? 255 : 1, // revert WebGL's automatic normalization of UNSIGNED_BYTE with RED format
+      alpha: alphaTexture,
+      withAlpha: alphaValues ? 1 : 0,
+      alphaMin: alphaDomain[0],
+      oneOverAlphaRange: 1 / (alphaDomain[1] - alphaDomain[0]),
+    }),
+    vertexShader: VERTEX_SHADER,
+    fragmentShader: `
+      uniform sampler2D data;
+      uniform sampler2D colorMap;
+
+      uniform float min;
+      uniform float oneOverRange;
+      uniform float gammaExponent;
+      uniform float normRevertFactor;
+
+      uniform sampler2D alpha;
+      uniform float alphaMin;
+      uniform float oneOverAlphaRange;
+      uniform int withAlpha;
+
+      const vec4 nanColor = vec4(255, 255, 255, 1);
+      const float oneOverLog10 = 0.43429448190325176;
+
+      varying vec2 coords;
+
+      bool isSupported(float value) {
+        return ${IMPL_IS_SUPPORTED[scaleType] || 'true'};
+      }
+
+      float scale(float value) {
+        return ${IMPL_SCALE[scaleType] || 'value'};
+      }
+
+      void main() {
+        float value = texture2D(data, coords).r * normRevertFactor;
+
+        if (isnan(value) || isinf(value) || !isSupported(value)) {
+          gl_FragColor = nanColor;
+        } else {
+          float scaledValue = scale(value);
+          float normalizedValue = clamp(oneOverRange * (scaledValue - min), 0., 1.);
+
+          gl_FragColor = texture2D(colorMap, vec2(pow(normalizedValue, gammaExponent), 0.5));
+
+          if (withAlpha == 1) {
+            gl_FragColor.a = oneOverAlphaRange * (texture2D(alpha, coords).r - alphaMin);
+          }
+        }
+      }
+    `,
+  };
+
+  return <shaderMaterial args={[shader]} side={DoubleSide} />;
+}
+
+export default memo(HeatmapMaterial);

--- a/packages/lib/src/vis/heatmap/HeatmapMesh.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapMesh.tsx
@@ -1,17 +1,12 @@
 import type { Domain } from '@h5web/shared';
-import { ScaleType } from '@h5web/shared';
-import { rgb } from 'd3-color';
 import type { NdArray } from 'ndarray';
-import { memo, useMemo } from 'react';
 import type { TextureFilter } from 'three';
-import { DataTexture, RGBAFormat, UnsignedByteType } from 'three';
 
 import type { VisScaleType } from '../models';
 import type { VisMeshProps } from '../shared/VisMesh';
 import VisMesh from '../shared/VisMesh';
-import { DEFAULT_DOMAIN, getUniforms, VERTEX_SHADER } from '../utils';
+import HeatmapMaterial from './HeatmapMaterial';
 import type { ColorMap, TextureSafeTypedArray } from './models';
-import { getDataTexture, getInterpolator, scaleDomain } from './utils';
 
 interface Props extends VisMeshProps {
   values: NdArray<TextureSafeTypedArray | Uint16Array>; // uint16 values are treated as half floats
@@ -24,136 +19,34 @@ interface Props extends VisMeshProps {
   alphaDomain?: Domain;
 }
 
-const CMAP_SIZE = 256;
-
-const IMPL_SCALE: Partial<Record<ScaleType, string>> = {
-  [ScaleType.Log]: 'log(value) * oneOverLog10',
-  [ScaleType.SymLog]: 'sign(value) * log(1. + abs(value)) * oneOverLog10',
-  [ScaleType.Sqrt]: 'sqrt(value)',
-};
-
-const IMPL_IS_SUPPORTED: Partial<Record<ScaleType, string>> = {
-  [ScaleType.Log]: 'value > 0.',
-  [ScaleType.Sqrt]: 'value >= 0.',
-};
-
 function HeatmapMesh(props: Props) {
   const {
     values,
     domain,
-    scaleType: visScaleType,
+    scaleType,
     colorMap,
-    invertColorMap = false,
+    invertColorMap,
     magFilter,
     alphaValues,
-    alphaDomain = DEFAULT_DOMAIN,
+    alphaDomain,
     ...visMeshProps
   } = props;
 
-  const dataTexture = useMemo(
-    () => getDataTexture(values, magFilter),
-    [magFilter, values]
-  );
-
-  const alphaTexture = useMemo(
-    () => alphaValues && getDataTexture(alphaValues),
-    [alphaValues]
-  );
-
-  const colorMapTexture = useMemo(() => {
-    const interpolator = getInterpolator(colorMap, invertColorMap);
-
-    const colors = Uint8Array.from(
-      Array.from({ length: CMAP_SIZE }).flatMap((_, i) => {
-        const { r, g, b } = rgb(interpolator(i / (CMAP_SIZE - 1)));
-        return [r, g, b, 255];
-      })
-    );
-
-    const texture = new DataTexture(
-      colors,
-      CMAP_SIZE,
-      1,
-      RGBAFormat,
-      UnsignedByteType
-    );
-    texture.needsUpdate = true;
-
-    return texture;
-  }, [colorMap, invertColorMap]);
-
-  const [scaleType, gammaExponent] = Array.isArray(visScaleType)
-    ? visScaleType
-    : [visScaleType as ScaleType, 1];
-
-  const scaledDomain = scaleDomain(domain, scaleType);
-
-  const shader = {
-    uniforms: getUniforms({
-      data: dataTexture,
-      colorMap: colorMapTexture,
-      min: scaledDomain[0],
-      oneOverRange: 1 / (scaledDomain[1] - scaledDomain[0]),
-      gammaExponent,
-      normRevertFactor: values.dtype === 'uint8' ? 255 : 1, // revert WebGL's automatic normalization of UNSIGNED_BYTE with RED format
-      alpha: alphaTexture,
-      withAlpha: alphaValues ? 1 : 0,
-      alphaMin: alphaDomain[0],
-      oneOverAlphaRange: 1 / (alphaDomain[1] - alphaDomain[0]),
-    }),
-    vertexShader: VERTEX_SHADER,
-    fragmentShader: `
-      uniform sampler2D data;
-      uniform sampler2D colorMap;
-
-      uniform float min;
-      uniform float oneOverRange;
-      uniform float gammaExponent;
-      uniform float normRevertFactor;
-
-      uniform sampler2D alpha;
-      uniform float alphaMin;
-      uniform float oneOverAlphaRange;
-      uniform int withAlpha;
-
-      const vec4 nanColor = vec4(255, 255, 255, 1);
-      const float oneOverLog10 = 0.43429448190325176;
-
-      varying vec2 coords;
-
-      bool isSupported(float value) {
-        return ${IMPL_IS_SUPPORTED[scaleType] || 'true'};
-      }
-
-      float scale(float value) {
-        return ${IMPL_SCALE[scaleType] || 'value'};
-      }
-
-      void main() {
-        float value = texture2D(data, coords).r * normRevertFactor;
-
-        if (isnan(value) || isinf(value) || !isSupported(value)) {
-          gl_FragColor = nanColor;
-        } else {
-          float scaledValue = scale(value);
-          float normalizedValue = clamp(oneOverRange * (scaledValue - min), 0., 1.);
-
-          gl_FragColor = texture2D(colorMap, vec2(pow(normalizedValue, gammaExponent), 0.5));
-
-          if (withAlpha == 1) {
-            gl_FragColor.a = oneOverAlphaRange * (texture2D(alpha, coords).r - alphaMin);
-          }
-        }
-      }
-    `,
-  };
-
   return (
     <VisMesh {...visMeshProps}>
-      <shaderMaterial args={[shader]} />
+      <HeatmapMaterial
+        values={values}
+        domain={domain}
+        scaleType={scaleType}
+        colorMap={colorMap}
+        invertColorMap={invertColorMap}
+        magFilter={magFilter}
+        alphaValues={alphaValues}
+        alphaDomain={alphaDomain}
+      />
     </VisMesh>
   );
 }
 
 export type { Props as HeatmapMeshProps };
-export default memo(HeatmapMesh);
+export default HeatmapMesh;

--- a/packages/lib/src/vis/heatmap/hooks.ts
+++ b/packages/lib/src/vis/heatmap/hooks.ts
@@ -5,9 +5,11 @@ import {
   getSafeDomain,
   getPixelEdgeValues,
   toTextureSafeNdArray,
+  getDataTexture,
 } from './utils';
 
 export const useVisDomain = createMemo(getVisDomain);
 export const useSafeDomain = createMemo(getSafeDomain);
 export const usePixelEdgeValues = createMemo(getPixelEdgeValues);
 export const useTextureSafeNdArray = createMemo(toTextureSafeNdArray);
+export const useDataTexture = createMemo(getDataTexture);

--- a/packages/lib/src/vis/heatmap/utils.ts
+++ b/packages/lib/src/vis/heatmap/utils.ts
@@ -2,6 +2,7 @@ import type { Domain, NumArray } from '@h5web/shared';
 import { getDims, ScaleType, toTypedNdArray } from '@h5web/shared';
 import { range } from 'lodash';
 import type { NdArray } from 'ndarray';
+import type { TextureFilter } from 'three';
 import {
   ClampToEdgeWrapping,
   DataTexture,
@@ -163,8 +164,23 @@ export function toTextureSafeNdArray(
  */
 export function getDataTexture(
   values: NdArray<TextureSafeTypedArray | Uint16Array>,
-  magFilter = NearestFilter
-): DataTexture {
+  magFilter?: TextureFilter
+): DataTexture;
+export function getDataTexture(
+  values: undefined,
+  magFilter?: TextureFilter
+): undefined;
+export function getDataTexture(
+  values: NdArray<TextureSafeTypedArray | Uint16Array> | undefined,
+  magFilter?: TextureFilter
+): DataTexture | undefined;
+export function getDataTexture(
+  values: NdArray<TextureSafeTypedArray | Uint16Array> | undefined,
+  magFilter: TextureFilter = NearestFilter
+): DataTexture | undefined {
+  if (!values) {
+    return undefined;
+  }
   const { rows, cols } = getDims(values);
 
   const texture = new DataTexture(

--- a/packages/lib/src/vis/hooks.ts
+++ b/packages/lib/src/vis/hooks.ts
@@ -7,16 +7,12 @@ import {
 import type { Domain, AnyNumArray } from '@h5web/shared';
 import type { Camera } from '@react-three/fiber';
 import { useFrame, useThree } from '@react-three/fiber';
-import { rgb } from 'd3-color';
 import { useEffect, useCallback, useMemo, useState } from 'react';
 import type { RefCallback } from 'react';
 
-import type { ColorMap } from './heatmap/models';
-import { getInterpolator } from './heatmap/utils';
 import { useVisCanvasContext } from './shared/VisCanvasProvider';
 import type { VisCanvasContextValue } from './shared/VisCanvasProvider';
 import {
-  createAxisScale,
   getAxisDomain,
   getAxisValues,
   getCombinedDomain,
@@ -100,23 +96,4 @@ export function useCssColors(
   const colors = colorProperties.map((p) => styles.getPropertyValue(p).trim());
 
   return [colors, refCallback];
-}
-
-export function useDataToColorScale(
-  scaleType: ScaleType,
-  domain: Domain,
-  colorMap: ColorMap,
-  invertColorMap: boolean
-): (v: number) => [number, number, number] {
-  return useMemo(() => {
-    const numScale = createAxisScale(scaleType, {
-      domain,
-      range: [0, 1],
-    });
-    const interpolator = getInterpolator(colorMap, invertColorMap);
-    return (value: number) => {
-      const color = rgb(interpolator(numScale(value)));
-      return [color.r, color.g, color.b];
-    };
-  }, [colorMap, domain, invertColorMap, scaleType]);
 }

--- a/packages/lib/src/vis/scatter/ScatterPoints.tsx
+++ b/packages/lib/src/vis/scatter/ScatterPoints.tsx
@@ -5,9 +5,9 @@ import { useCallback, useLayoutEffect, useState } from 'react';
 import { BufferAttribute, BufferGeometry } from 'three';
 
 import type { ColorMap } from '../heatmap/models';
-import { useDataToColorScale } from '../hooks';
 import GlyphMaterial from '../line/GlyphMaterial';
 import { GlyphType } from '../line/models';
+import { useDataToColorScale } from './hooks';
 import { useBufferAttributes } from './hooks';
 
 interface Props {

--- a/packages/lib/src/vis/scatter/hooks.ts
+++ b/packages/lib/src/vis/scatter/hooks.ts
@@ -1,7 +1,11 @@
-import type { NumArray } from '@h5web/shared';
+import type { Domain, NumArray, ScaleType } from '@h5web/shared';
+import { rgb } from 'd3-color';
 import { useMemo } from 'react';
 
+import type { ColorMap } from '../heatmap/models';
+import { getInterpolator } from '../heatmap/utils';
 import { useVisCanvasContext } from '../shared/VisCanvasProvider';
+import { createAxisScale } from '../utils';
 
 const CAMERA_FAR = 1000; // R3F's default
 
@@ -40,4 +44,23 @@ export function useBufferAttributes(
     ordinateScale,
     ordinates,
   ]);
+}
+
+export function useDataToColorScale(
+  scaleType: ScaleType,
+  domain: Domain,
+  colorMap: ColorMap,
+  invertColorMap: boolean
+): (v: number) => [number, number, number] {
+  return useMemo(() => {
+    const numScale = createAxisScale(scaleType, {
+      domain,
+      range: [0, 1],
+    });
+    const interpolator = getInterpolator(colorMap, invertColorMap);
+    return (value: number) => {
+      const color = rgb(interpolator(numScale(value)));
+      return [color.r, color.g, color.b];
+    };
+  }, [colorMap, domain, invertColorMap, scaleType]);
 }

--- a/packages/lib/src/vis/surface/hooks.ts
+++ b/packages/lib/src/vis/surface/hooks.ts
@@ -2,31 +2,28 @@ import type { NumArray } from '@h5web/shared';
 import { getDims } from '@h5web/shared';
 import type { NdArray } from 'ndarray';
 import { useMemo } from 'react';
-import { Float32BufferAttribute, Uint8BufferAttribute } from 'three';
+import { Float32BufferAttribute } from 'three';
 
-export function useBufferAttributes(
-  dataArray: NdArray<NumArray>,
-  dataToColorScale: (val: number) => [number, number, number]
-) {
-  const { position, color } = useMemo(() => {
+export function useBufferAttributes(dataArray: NdArray<NumArray>) {
+  const { position, uv } = useMemo(() => {
     const { rows, cols } = getDims(dataArray);
 
     const positions: number[] = [];
-    const colors: number[] = [];
+    const uvs: number[] = [];
 
     for (let row = 0; row < rows; row++) {
       for (let col = 0; col < cols; col++) {
         const value = dataArray.get(row, col);
         positions.push(col, row, value);
-        colors.push(...dataToColorScale(value));
+        uvs.push((col + 0.5) / cols, (row + 0.5) / rows);
       }
     }
 
     return {
       position: new Float32BufferAttribute(positions, 3),
-      color: new Uint8BufferAttribute(colors, 3, true),
+      uv: new Float32BufferAttribute(uvs, 2),
     };
-  }, [dataArray, dataToColorScale]);
+  }, [dataArray]);
 
   const index = useMemo(() => {
     const { rows, cols } = getDims(dataArray);
@@ -56,5 +53,5 @@ export function useBufferAttributes(
     return indices;
   }, [dataArray]);
 
-  return { position, color, index };
+  return { position, index, uv };
 }


### PR DESCRIPTION
`SurfaceMesh` now uses the same shader as the `HeatmapMesh` (now in a `HeatmapMaterial` to be reusable). This avoids recomputing `BufferAttributes` when changing color map settings.

As a reminder, this shader relies on texture coordinates `uv` to look up the data value in the data texture to then compute the appropriate color. 

**This works in `HeatmapMesh` because the use of a plane geometry means that `uv` are essentially normalized coordinates of the geometry**. As `SurfaceMesh` uses a more complex geometry (an indexed `BufferGeometry`), **this postulate is no longer true**. 

To work around this and still be able to reuse the shader as-is, I now set the `uv` "manually" as attributes of the buffer geometry so that they contain the normalized coordinates expected by the shader. 

_Three.js has an example doing exactly this but for [normals](https://github.com/mrdoob/three.js/blob/309b00afb6dcbc5e6c58e72f10eaa8d2e8888c83/examples/webgl_buffergeometry_indexed.html) (see relevant discussion [here](https://discourse.threejs.org/t/indexed-buffer-geometry-normals/3679))._

After discussion with @t20100, we came up with several alternatives:
- Passing the `value` directly as `BufferAttribute` to save a lookup table and avoid computing `uv`
- Leverage in the shader the fact that `value` is in fact simply `position.z`. This may change in the future as we don't want the 3D display to be over-reliant on the data amplitude.

Unfortunately, all of them mean we would have to write more specific shader code. Since coding (and debugging) shaders and abstractions around them can be very challenging, I would make a strong point to keep the shader code minimal and the most reusable possible. Meaning I am relatively happy with the solution presented in this PR.