### PR TITLE
Fix h5wasm file clean-up in strict mode ahead of React 18 upgrade

### DIFF
--- a/packages/h5wasm/src/H5WasmProvider.tsx
+++ b/packages/h5wasm/src/H5WasmProvider.tsx
@@ -1,7 +1,7 @@
 import { DataProvider } from '@h5web/app';
 import type { DataProviderApi } from '@h5web/app/src/providers/api';
 import type { PropsWithChildren } from 'react';
-import { useEffect, useMemo } from 'react';
+import { useState, useEffect } from 'react';
 
 import { H5WasmApi } from './h5wasm-api';
 
@@ -14,14 +14,18 @@ interface Props {
 function H5WasmProvider(props: PropsWithChildren<Props>) {
   const { filename, buffer, getExportURL, children } = props;
 
-  const api = useMemo(
-    () => new H5WasmApi(filename, buffer, getExportURL),
-    [filename, buffer, getExportURL]
-  );
+  const [api, setApi] = useState<H5WasmApi>();
 
   useEffect(() => {
-    return () => void api.cleanUp();
-  }, [api]);
+    const h5wasmApi = new H5WasmApi(filename, buffer, getExportURL);
+    setApi(h5wasmApi);
+
+    return () => void h5wasmApi.cleanUp();
+  }, [filename, buffer, getExportURL]);
+
+  if (!api) {
+    return null;
+  }
 
   return <DataProvider api={api}>{children}</DataProvider>;
 }


### PR DESCRIPTION
Cherry-picked from https://github.com/silx-kit/h5web/pull/1119