### PR TITLE
Use tuples to store selection rectangles

### DIFF
--- a/apps/storybook/src/Selection.stories.tsx
+++ b/apps/storybook/src/Selection.stories.tsx
@@ -1,4 +1,4 @@
-import type { Selection, ModifierKey, Axis } from '@h5web/lib';
+import type { ModifierKey, Axis, Selection, Rect2 } from '@h5web/lib';
 import { AxialSelectionTool } from '@h5web/lib';
 import {
   Pan,
@@ -12,9 +12,26 @@ import {
 import type { Meta, Story } from '@storybook/react';
 import { format } from 'd3-format';
 import { useState } from 'react';
-import type { Vector2 } from 'three';
 
 import FillHeight from './decorators/FillHeight';
+
+const formatCoord = format('.2f');
+
+function getTitle(selection: Rect2 | undefined) {
+  if (!selection) {
+    return 'No selection';
+  }
+
+  const [start, end] = selection;
+  return `Selection from (${formatCoord(start.x)}, ${formatCoord(
+    start.y
+  )}) to (${formatCoord(end.x)}, ${formatCoord(end.y)})`;
+}
+
+const SELECTION_COMPONENTS = {
+  line: SelectionLine,
+  rectangle: SelectionRect,
+};
 
 interface TemplateProps {
   selectionType: 'line' | 'rectangle';
@@ -24,18 +41,12 @@ interface TemplateProps {
   stroke?: string;
 }
 
-function vectorToStr(vec: Vector2) {
-  return `(${format('.2f')(vec.x)}, ${format('.2f')(vec.y)})`;
-}
-
 const Template: Story<TemplateProps> = (args) => {
   const { selectionType, selectionModifierKey, panModifierKey, ...svgProps } =
     args;
 
   const [activeSelection, setActiveSelection] = useState<Selection>();
-
-  const SelectionComponent =
-    selectionType === 'line' ? SelectionLine : SelectionRect;
+  const SelectionComponent = SELECTION_COMPONENTS[selectionType];
 
   if (selectionModifierKey === panModifierKey) {
     return (
@@ -48,13 +59,7 @@ const Template: Story<TemplateProps> = (args) => {
 
   return (
     <VisCanvas
-      title={
-        activeSelection
-          ? `Selection from ${vectorToStr(
-              activeSelection.startPoint
-            )} to ${vectorToStr(activeSelection.endPoint)}`
-          : 'No selection'
-      }
+      title={getTitle(activeSelection?.data)}
       abscissaConfig={{ visDomain: [-10, 0], showGrid: true }}
       ordinateConfig={{ visDomain: [50, 100], showGrid: true }}
     >
@@ -67,7 +72,13 @@ const Template: Story<TemplateProps> = (args) => {
         onSelectionEnd={() => setActiveSelection(undefined)}
         modifierKey={selectionModifierKey}
       >
-        {(selection) => <SelectionComponent {...selection} {...svgProps} />}
+        {({ data: [dataStart, dataEnd] }) => (
+          <SelectionComponent
+            startPoint={dataStart}
+            endPoint={dataEnd}
+            {...svgProps}
+          />
+        )}
       </SelectionTool>
     </VisCanvas>
   );
@@ -137,9 +148,7 @@ export const Persisted: Story<TemplateProps> = (args) => {
   const { selectionType, selectionModifierKey, panModifierKey } = args;
 
   const [persistedSelection, setPersistedSelection] = useState<Selection>();
-
-  const SelectionComponent =
-    selectionType === 'line' ? SelectionLine : SelectionRect;
+  const SelectionComponent = SELECTION_COMPONENTS[selectionType];
 
   if (selectionModifierKey === panModifierKey) {
     return (
@@ -152,13 +161,7 @@ export const Persisted: Story<TemplateProps> = (args) => {
 
   return (
     <VisCanvas
-      title={
-        persistedSelection
-          ? `Selection from ${vectorToStr(
-              persistedSelection.startPoint
-            )} to ${vectorToStr(persistedSelection.endPoint)}`
-          : 'No selection'
-      }
+      title={getTitle(persistedSelection?.data)}
       abscissaConfig={{ visDomain: [-10, 0], showGrid: true }}
       ordinateConfig={{ visDomain: [50, 100], showGrid: true }}
     >
@@ -167,20 +170,21 @@ export const Persisted: Story<TemplateProps> = (args) => {
       <ResetZoomButton />
 
       <SelectionTool
-        onSelectionStart={() => {
-          setPersistedSelection(undefined);
-        }}
+        onSelectionStart={() => setPersistedSelection(undefined)}
         onSelectionEnd={setPersistedSelection}
         modifierKey={selectionModifierKey}
       >
-        {(selection) =>
-          !persistedSelection && <SelectionComponent {...selection} />
+        {({ data: [dataStart, dataEnd] }) =>
+          !persistedSelection && (
+            <SelectionComponent startPoint={dataStart} endPoint={dataEnd} />
+          )
         }
       </SelectionTool>
+
       {persistedSelection && (
         <SelectionComponent
-          startPoint={persistedSelection.startPoint}
-          endPoint={persistedSelection.endPoint}
+          startPoint={persistedSelection.data[0]}
+          endPoint={persistedSelection.data[1]}
         />
       )}
     </VisCanvas>
@@ -212,9 +216,7 @@ export const AxialSelection: Story<TemplateProps & { axis: Axis }> = (args) => {
   } = args;
 
   const [activeSelection, setActiveSelection] = useState<Selection>();
-
-  const SelectionComponent =
-    selectionType === 'line' ? SelectionLine : SelectionRect;
+  const SelectionComponent = SELECTION_COMPONENTS[selectionType];
 
   if (selectionModifierKey === panModifierKey) {
     return (
@@ -227,13 +229,7 @@ export const AxialSelection: Story<TemplateProps & { axis: Axis }> = (args) => {
 
   return (
     <VisCanvas
-      title={
-        activeSelection
-          ? `Selection from ${vectorToStr(
-              activeSelection.startPoint
-            )} to ${vectorToStr(activeSelection.endPoint)}`
-          : 'No selection'
-      }
+      title={getTitle(activeSelection?.data)}
       abscissaConfig={{ visDomain: [-10, 0], showGrid: true }}
       ordinateConfig={{ visDomain: [50, 100], showGrid: true }}
     >
@@ -247,7 +243,13 @@ export const AxialSelection: Story<TemplateProps & { axis: Axis }> = (args) => {
         onSelectionEnd={() => setActiveSelection(undefined)}
         modifierKey={selectionModifierKey}
       >
-        {(selection) => <SelectionComponent {...selection} {...svgProps} />}
+        {({ data: [dataStart, dataEnd] }) => (
+          <SelectionComponent
+            startPoint={dataStart}
+            endPoint={dataEnd}
+            {...svgProps}
+          />
+        )}
       </AxialSelectionTool>
     </VisCanvas>
   );

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -119,6 +119,9 @@ export type {
   InteractionInfo,
   ModifierKey,
   Selection,
+  Rect,
+  Rect2,
+  Rect3,
   CanvasEvent,
   CanvasEventCallbacks,
 } from './interactions/models';

--- a/packages/lib/src/interactions/AxialSelectToZoom.tsx
+++ b/packages/lib/src/interactions/AxialSelectToZoom.tsx
@@ -22,17 +22,12 @@ function AxialSelectToZoom(props: Props) {
   const camera = useThree((state) => state.camera);
 
   function onSelectionEnd(selection: Selection) {
-    // Work in world coordinates as we need to act on the world camera
-    const { worldStartPoint, worldEndPoint } = selection;
-
-    if (
-      worldStartPoint.x === worldEndPoint.x ||
-      worldStartPoint.y === worldEndPoint.y
-    ) {
+    const [worldStart, worldEnd] = selection.world;
+    if (worldStart.x === worldEnd.x || worldStart.y === worldEnd.y) {
       return;
     }
 
-    const zoomRect = getEnclosedRectangle(worldStartPoint, worldEndPoint);
+    const zoomRect = getEnclosedRectangle(worldStart, worldEnd);
     const { center: zoomRectCenter } = zoomRect;
 
     // Change scale first so that moveCameraTo computes the updated camera bounds
@@ -50,13 +45,13 @@ function AxialSelectToZoom(props: Props) {
       disabled={visRatio !== undefined || disabled}
       onSelectionEnd={onSelectionEnd}
     >
-      {({ startPoint, endPoint }) => (
+      {({ data: [dataStart, dataEnd] }) => (
         <SelectionRect
           fill="white"
           stroke="black"
           fillOpacity={0.25}
-          startPoint={startPoint}
-          endPoint={endPoint}
+          startPoint={dataStart}
+          endPoint={dataEnd}
         />
       )}
     </AxialSelectionTool>

--- a/packages/lib/src/interactions/AxialSelectionTool.tsx
+++ b/packages/lib/src/interactions/AxialSelectionTool.tsx
@@ -1,13 +1,12 @@
 import type { Axis } from '@h5web/shared';
 import { useThree } from '@react-three/fiber';
-import { useCallback } from 'react';
 import { Vector3 } from 'three';
 
 import { useVisCanvasContext } from '../vis/shared/VisCanvasProvider';
 import { getWorldFOV } from '../vis/utils';
 import type { SelectionProps } from './SelectionTool';
 import SelectionTool from './SelectionTool';
-import type { Selection } from './models';
+import type { Rect2, Rect3, Selection } from './models';
 
 interface Props extends SelectionProps {
   axis: Axis;
@@ -26,30 +25,26 @@ function AxialSelectionTool(props: Props) {
   const { worldToData } = useVisCanvasContext();
   const camera = useThree((state) => state.camera);
 
-  const toAxialSelection = useCallback(
-    (selection: Selection): Selection => {
-      const { worldStartPoint, worldEndPoint } = selection;
-      const { bottomLeft, topRight } = getWorldFOV(camera);
+  function toAxialSelection(selection: Selection): Selection {
+    const [worldStart, worldEnd] = selection.world;
+    const { bottomLeft, topRight } = getWorldFOV(camera);
 
-      const axialWorldStartPoint =
-        axis === 'x'
-          ? new Vector3(worldStartPoint.x, bottomLeft.y, 0)
-          : new Vector3(bottomLeft.x, worldStartPoint.y, 0);
+    const axialWorldSelection: Rect3 =
+      axis === 'x'
+        ? [
+            new Vector3(worldStart.x, bottomLeft.y, 0),
+            new Vector3(worldEnd.x, topRight.y, 0),
+          ]
+        : [
+            new Vector3(bottomLeft.x, worldStart.y, 0),
+            new Vector3(topRight.x, worldEnd.y, 0),
+          ];
 
-      const axialWorldEndPoint =
-        axis === 'x'
-          ? new Vector3(worldEndPoint.x, topRight.y, 0)
-          : new Vector3(topRight.x, worldEndPoint.y, 0);
-
-      return {
-        startPoint: worldToData(axialWorldStartPoint),
-        endPoint: worldToData(axialWorldEndPoint),
-        worldStartPoint: axialWorldStartPoint,
-        worldEndPoint: axialWorldEndPoint,
-      };
-    },
-    [axis, camera, worldToData]
-  );
+    return {
+      world: axialWorldSelection,
+      data: axialWorldSelection.map(worldToData) as Rect2,
+    };
+  }
 
   return (
     <SelectionTool

--- a/packages/lib/src/interactions/SelectToZoom.tsx
+++ b/packages/lib/src/interactions/SelectToZoom.tsx
@@ -21,20 +21,16 @@ function SelectToZoom(props: Props) {
   const moveCameraTo = useMoveCameraTo();
 
   function onSelectionEnd(selection: Selection) {
-    const { startPoint: dataStartPoint, endPoint: dataEndPoint } = selection;
-
-    // Work in world coordinates as we need to act on the world camera
-    const [startPoint, endPoint] = getRatioRespectingRectangle(
-      dataStartPoint,
-      dataEndPoint,
+    const [worldStart, worldEnd] = getRatioRespectingRectangle(
+      ...selection.data,
       keepRatio ? canvasRatio : undefined
-    ).map(dataToWorld);
+    ).map(dataToWorld); // work in world coordinates as we need to act on the world camera
 
-    if (startPoint.x === endPoint.x || startPoint.y === endPoint.y) {
+    if (worldStart.x === worldEnd.x || worldStart.y === worldEnd.y) {
       return;
     }
 
-    const zoomRect = getEnclosedRectangle(startPoint, endPoint);
+    const zoomRect = getEnclosedRectangle(worldStart, worldEnd);
     const { center: zoomRectCenter } = zoomRect;
 
     // Change scale first so that moveCameraTo computes the updated camera bounds
@@ -46,11 +42,11 @@ function SelectToZoom(props: Props) {
 
   return (
     <SelectionTool id="SelectToZoom" onSelectionEnd={onSelectionEnd} {...props}>
-      {({ startPoint, endPoint }) => (
+      {({ data: [dataStart, dataEnd] }) => (
         <>
           <SelectionRect
-            startPoint={startPoint}
-            endPoint={endPoint}
+            startPoint={dataStart}
+            endPoint={dataEnd}
             fill="white"
             stroke="black"
             fillOpacity={keepRatio ? 0 : 0.25}
@@ -58,8 +54,8 @@ function SelectToZoom(props: Props) {
           />
           {keepRatio && (
             <RatioSelectionRect
-              startPoint={startPoint}
-              endPoint={endPoint}
+              startPoint={dataStart}
+              endPoint={dataEnd}
               ratio={canvasRatio}
               fillOpacity={0.25}
               fill="white"

--- a/packages/lib/src/interactions/SelectionTool.tsx
+++ b/packages/lib/src/interactions/SelectionTool.tsx
@@ -39,9 +39,7 @@ function SelectionTool(props: Props) {
   const { worldToData } = useVisCanvasContext();
 
   const [startEvt, setStartEvt] = useState<CanvasEvent<PointerEvent>>();
-  const [selection, setSelection] = useRafState<Selection | undefined>(
-    undefined
-  );
+  const [selection, setSelection] = useRafState<Selection>();
 
   const modifierKeys = getModifierKeyArray(modifierKey);
   const isModifierKeyPressed = useModifierKeyPressed(modifierKeys);
@@ -53,18 +51,16 @@ function SelectionTool(props: Props) {
   });
 
   const computeSelection = useCallback(
-    (evt: CanvasEvent<PointerEvent>) => {
+    (evt: CanvasEvent<PointerEvent>): Selection => {
       assertDefined(startEvt);
-      const { dataPt: startPoint, worldPt: worldStartPoint } = startEvt;
+      const { dataPt: dataStart, worldPt: worldStart } = startEvt;
 
-      const { worldPt: worldEndPt } = evt;
-      const boundWorldEndPoint = boundWorldPointToFOV(worldEndPt, camera);
+      const { worldPt: worldEnd } = evt;
+      const boundWorldEnd = boundWorldPointToFOV(worldEnd, camera);
 
       return {
-        startPoint,
-        endPoint: worldToData(boundWorldEndPoint),
-        worldStartPoint,
-        worldEndPoint: boundWorldEndPoint,
+        world: [worldStart, boundWorldEnd],
+        data: [dataStart, worldToData(boundWorldEnd)],
       };
     },
     [camera, startEvt, worldToData]
@@ -127,8 +123,8 @@ function SelectionTool(props: Props) {
       setSelection,
       onSelectionEnd,
       shouldInteract,
-      computeSelection,
       transformSelection,
+      computeSelection,
     ]
   );
 

--- a/packages/lib/src/interactions/models.ts
+++ b/packages/lib/src/interactions/models.ts
@@ -8,11 +8,13 @@ export enum MouseButton {
 }
 
 export interface Selection {
-  startPoint: Vector2;
-  endPoint: Vector2;
-  worldStartPoint: Vector3;
-  worldEndPoint: Vector3;
+  world: Rect3;
+  data: Rect2;
 }
+
+export type Rect<T extends Vector2 | Vector3> = [T, T];
+export type Rect2 = Rect<Vector2>;
+export type Rect3 = Rect<Vector3>;
 
 export interface CanvasEvent<T extends MouseEvent> {
   htmlPt: Vector2;


### PR DESCRIPTION
Not a huge win (at least for now) in terms of amount of code, but it does feel clearer and it definitely simplifies naming start/end points variables when destructuring, and opens the door to a few simplifications (e.g. one prop/parameter instead of two for `SelectionRect`, `getEnclosedRectangle`, etc.) I haven't made those simplifications yet to keep the PR concise.