### PR TITLE
Fix infinite render loop in axial selection tool stories

### DIFF
--- a/apps/storybook/src/AxialSelectToZoom.stories.tsx
+++ b/apps/storybook/src/AxialSelectToZoom.stories.tsx
@@ -20,6 +20,7 @@ import { useMockData } from './hooks';
 const { oneD, twoD } = mockValues;
 
 const Template: Story<AxialSelectToZoomProps> = (args) => {
+  const { modifierKey } = args;
   const domain = useDomain(oneD);
   assertDefined(domain);
 
@@ -28,7 +29,7 @@ const Template: Story<AxialSelectToZoomProps> = (args) => {
       abscissaConfig={{ visDomain: [0, oneD.length], showGrid: true }}
       ordinateConfig={{ visDomain: domain, showGrid: true }}
     >
-      <Pan />
+      <Pan modifierKey={modifierKey?.length === 0 ? 'Control' : undefined} />
       <Zoom />
       <AxialSelectToZoom {...args} />
       <ResetZoomButton />
@@ -78,7 +79,7 @@ export const DisabledInsideEqualAspectCanvas: Story<AxialSelectToZoomProps> = (
       ordinateConfig={{ visDomain: [0, 20], showGrid: true }}
       aspect="equal"
     >
-      <Pan />
+      <Pan modifierKey="Control" />
       <Zoom />
       <AxialSelectToZoom {...args} />
       <ResetZoomButton />
@@ -91,6 +92,11 @@ export const DisabledInsideEqualAspectCanvas: Story<AxialSelectToZoomProps> = (
       />
     </VisCanvas>
   );
+};
+
+DisabledInsideEqualAspectCanvas.argTypes = {
+  modifierKey: { control: false },
+  disabled: { control: false },
 };
 
 export default {

--- a/apps/storybook/src/DefaultInteractions.stories.tsx
+++ b/apps/storybook/src/DefaultInteractions.stories.tsx
@@ -1,20 +1,39 @@
-import { DefaultInteractions, ResetZoomButton, VisCanvas } from '@h5web/lib';
+import {
+  DefaultInteractions,
+  HeatmapMesh,
+  mockValues,
+  ResetZoomButton,
+  ScaleType,
+  VisCanvas,
+} from '@h5web/lib';
 import type { DefaultInteractionsConfig } from '@h5web/lib/src/interactions/DefaultInteractions';
 import type { Meta, Story } from '@storybook/react';
 
 import FillHeight from './decorators/FillHeight';
+import { useMockData } from './hooks';
+
+const { twoD } = mockValues;
 
 export const InsideAutoAspectCanvas: Story<DefaultInteractionsConfig> = (
   args
 ) => {
+  const { values, domain } = useMockData(twoD, [20, 41]);
+
   return (
     <VisCanvas
-      abscissaConfig={{ visDomain: [0, 10], showGrid: true }}
-      ordinateConfig={{ visDomain: [0, 10], showGrid: true }}
+      abscissaConfig={{ visDomain: [0, values.shape[1]], showGrid: true }}
+      ordinateConfig={{ visDomain: [0, values.shape[0]], showGrid: true }}
       aspect="auto"
     >
       <DefaultInteractions {...args} />
       <ResetZoomButton />
+
+      <HeatmapMesh
+        values={values}
+        domain={domain}
+        colorMap="Viridis"
+        scaleType={ScaleType.Linear}
+      />
     </VisCanvas>
   );
 };
@@ -22,14 +41,23 @@ export const InsideAutoAspectCanvas: Story<DefaultInteractionsConfig> = (
 export const InsideEqualAspectCanvas: Story<DefaultInteractionsConfig> = (
   args
 ) => {
+  const { values, domain } = useMockData(twoD, [20, 41]);
+
   return (
     <VisCanvas
-      abscissaConfig={{ visDomain: [0, 10], showGrid: true }}
-      ordinateConfig={{ visDomain: [0, 10], showGrid: true }}
+      abscissaConfig={{ visDomain: [0, values.shape[1]], showGrid: true }}
+      ordinateConfig={{ visDomain: [0, values.shape[0]], showGrid: true }}
       aspect="equal"
     >
       <DefaultInteractions {...args} />
       <ResetZoomButton />
+
+      <HeatmapMesh
+        values={values}
+        domain={domain}
+        colorMap="Viridis"
+        scaleType={ScaleType.Linear}
+      />
     </VisCanvas>
   );
 };

--- a/apps/storybook/src/SelectToZoom.stories.tsx
+++ b/apps/storybook/src/SelectToZoom.stories.tsx
@@ -17,13 +17,14 @@ const { twoD } = mockValues;
 
 const Template: Story<SelectToZoomProps> = (args) => {
   const { values, domain } = useMockData(twoD, [20, 41]);
+  const { modifierKey } = args;
 
   return (
     <VisCanvas
       abscissaConfig={{ visDomain: [0, values.shape[1]], showGrid: true }}
       ordinateConfig={{ visDomain: [0, values.shape[0]], showGrid: true }}
     >
-      <Pan />
+      <Pan modifierKey={modifierKey?.length === 0 ? 'Control' : undefined} />
       <Zoom />
       <SelectToZoom {...args} />
       <ResetZoomButton />
@@ -42,6 +43,7 @@ export const InsideAutoAspectCanvas = Template.bind({});
 
 export const InsideEqualAspectCanvas: Story<SelectToZoomProps> = (args) => {
   const { values, domain } = useMockData(twoD, [20, 41]);
+  const { modifierKey } = args;
 
   return (
     <VisCanvas
@@ -49,7 +51,7 @@ export const InsideEqualAspectCanvas: Story<SelectToZoomProps> = (args) => {
       ordinateConfig={{ visDomain: [0, values.shape[0]], showGrid: true }}
       aspect="equal"
     >
-      <Pan />
+      <Pan modifierKey={modifierKey?.length === 0 ? 'Control' : undefined} />
       <Zoom />
       <SelectToZoom {...args} />
       <ResetZoomButton />

--- a/apps/storybook/src/Selection.stories.tsx
+++ b/apps/storybook/src/Selection.stories.tsx
@@ -9,6 +9,7 @@ import {
   Zoom,
   ResetZoomButton,
 } from '@h5web/lib';
+import { useThrottledState } from '@react-hookz/web';
 import type { Meta, Story } from '@storybook/react';
 import { format } from 'd3-format';
 import { useState } from 'react';
@@ -45,7 +46,10 @@ const Template: Story<TemplateProps> = (args) => {
   const { selectionType, selectionModifierKey, panModifierKey, ...svgProps } =
     args;
 
-  const [activeSelection, setActiveSelection] = useState<Selection>();
+  const [activeSelection, setActiveSelection] = useThrottledState<
+    Selection | undefined
+  >(undefined, 50);
+
   const SelectionComponent = SELECTION_COMPONENTS[selectionType];
 
   if (selectionModifierKey === panModifierKey) {
@@ -215,7 +219,10 @@ export const AxialSelection: Story<TemplateProps & { axis: Axis }> = (args) => {
     ...svgProps
   } = args;
 
-  const [activeSelection, setActiveSelection] = useState<Selection>();
+  const [activeSelection, setActiveSelection] = useThrottledState<
+    Selection | undefined
+  >(undefined, 50);
+
   const SelectionComponent = SELECTION_COMPONENTS[selectionType];
 
   if (selectionModifierKey === panModifierKey) {

--- a/apps/storybook/src/Selection.stories.tsx
+++ b/apps/storybook/src/Selection.stories.tsx
@@ -170,9 +170,9 @@ export const Persisted: Story<TemplateProps> = (args) => {
       <ResetZoomButton />
 
       <SelectionTool
+        modifierKey={selectionModifierKey}
         onSelectionStart={() => setPersistedSelection(undefined)}
         onSelectionEnd={setPersistedSelection}
-        modifierKey={selectionModifierKey}
       >
         {({ data: [dataStart, dataEnd] }) =>
           !persistedSelection && (
@@ -192,8 +192,8 @@ export const Persisted: Story<TemplateProps> = (args) => {
 };
 Persisted.args = {
   selectionType: 'rectangle',
-  selectionModifierKey: 'Control',
-  panModifierKey: undefined,
+  selectionModifierKey: undefined,
+  panModifierKey: 'Control',
 };
 Persisted.argTypes = {
   selectionModifierKey: {


### PR DESCRIPTION
**EDIT** The problem described below is still accurate, but the solutions I ended up with have changed -- cf. https://github.com/silx-kit/h5web/pull/1317#issuecomment-1344085794

---

Alright, so the axial selection tool stories had not been working for a few days, ever since I moved the `onSelectionChange` call in `SelectionTool` in a `useEffect` (89f5dac3eb1052ca279ef00bc1c00228afadc7bf). Then, the introduction of `transformSelection` made it worse (b3ff1b38f099233eb311f6b6da54ce62f0911b94)...

This is all because some of the selection stories have a state that is updated via `onSelectionChange` (to display the selection in the canvas' title), which means that when the selection changes, the entire `VisCanvas` gets re-rendered and this triggers an infinite render loop.

Obviously, in a real app, storing such a fast changing state at this level would be a very bad idea, but it's still not great that it leads to an infinite render loop. So let's start with identifying the cause of the render loop:

- Before I moved `onSelectionChange` to `useEffect` in `SelectionTool`, the `onSelectionChange` callback in `AxialSelectionTool` was not properly memoised: when the `onSelectionChange` prop was set (which is the case in the axial selection story), the callback would get a new reference on every render, and therefore on every mouse move. This was slow but not critical; `onSelectionChange` used to be called inside the mouse move handler in `SelectionTool`, so the handler was recreated and re-registered on every mouse move, but since a re-render doesn't trigger a mouse move, there was no risk of an infinite render loop.
- By moving the `onSelectionChange` call into `useEffect`, the effect started being called on every re-render and we ended up with an infinite render loop.

So the first solution is to **memoise `onSelectionChange` in `AxialSelectionTool`**.

However, this doesn't prevent an infinite render loop if the user forgets to memoise their own `onSelectionChange` callback! For this reason, I decided to **revert the move to `useEffect`** in `SelectionTool`. Sure, `onSelectionChange` can now again slow down the interaction if it's computationally-heavy (e.g. if it triggers a big re-render), but it's not as bad a risk as an infinite render loop. In other words, it's back to being an optimisation problem for the consumer rather than a debugging problem. To show one way of doing this optimisation properly, I changed `useState` in the stories with `useThrottledState`-- the improvement in fluidity of the selection interactions is significant.

As mentioned, `transformSelection` was also causing an infinite render loop, and for the same reason. Even though removing the `useEffect` resolved the issue, it still not great, because the event handlers still end up being recreated/re-registered on every render in the stories.

So I started by **reverting the "unmemoisation" of `toAxialSelection`** in `AxialSelectionTool` (from https://github.com/silx-kit/h5web/commit/59fbb27858f6bfaa82b55011245a39ea8900c826#diff-4541ea5f19d2f849664c8659e651c97bab5f81635e77388e24ac9fcd2b67fdfaL29). However this turned out not to be enough: `toAxialSelection` depends on `worldToData`, and `worldToData` is actually recreated on every render! That's because `worldToData` depends on the axis scales, which are themselves recreated on every render.

So basically, if we don't memoise the scales, we (or our users) risk running into an infinite loop issue again in the future! So I decided to go ahead and **memoise the scales**. I added a boolean to `createMemo` to perform a deep comparison of the dependencies (with react-hookz' `useDeepCompareMemo`), and I used it to create a memoised version of `getCanvasScale`. The reason for the deep comparison is that users are unlikely to want to memoise the axis config objects (`abscissaConfig` and `ordinateConfig`)...

As a bonus, I discovered a subtle bug when clicking quickly after finishing a selection. There was a race condition between the moment the `startEvt` state was reset in `onPointerUp` and the moment the next call to `onPointerMove` occurred. I fixed it by moving `startEvt` into a ref.