### PR TITLE
Invoke selection start/end callbacks asynchronously

### DIFF
--- a/apps/storybook/src/Selection.stories.tsx
+++ b/apps/storybook/src/Selection.stories.tsx
@@ -178,11 +178,9 @@ export const Persisted: Story<TemplateProps> = (args) => {
         onSelectionStart={() => setPersistedSelection(undefined)}
         onSelectionEnd={setPersistedSelection}
       >
-        {({ data: [dataStart, dataEnd] }) =>
-          !persistedSelection && (
-            <SelectionComponent startPoint={dataStart} endPoint={dataEnd} />
-          )
-        }
+        {({ data: [dataStart, dataEnd] }) => (
+          <SelectionComponent startPoint={dataStart} endPoint={dataEnd} />
+        )}
       </SelectionTool>
 
       {persistedSelection && (
@@ -264,6 +262,7 @@ export const AxialSelection: Story<TemplateProps & { axis: Axis }> = (args) => {
 
 AxialSelection.args = {
   selectionType: 'rectangle',
+  selectionModifierKey: undefined,
   panModifierKey: 'Control',
   axis: 'x',
 };
@@ -272,9 +271,13 @@ AxialSelection.argTypes = {
     control: { type: 'inline-radio' },
     options: ['x', 'y'],
   },
+  selectionModifierKey: {
+    control: { type: 'inline-radio' },
+    options: ['Alt', 'Control', 'Shift', undefined],
+  },
   panModifierKey: {
     control: { type: 'inline-radio' },
-    options: ['Alt', 'Control', 'Shift'],
+    options: ['Alt', 'Control', 'Shift', undefined],
   },
 };
 


### PR DESCRIPTION
Now that the callbacks are stable, we can really embrace `useEffect`. This PR moves the calls to `onSelectionStart` and `onSelectionEnd` into the `useEffect`.

In addition to reducing the potential impact on performance of consumers doing something really heavy in the callbacks, it also allows me to easily fix two bugs:

1. `onSelectionStart` is now called only when the user actually starts dragging. So a simple click no longer creates a selection and no longer invokes any of the callbacks.
2. `onSelectionEnd` is now called _after_ the render prop, which means that if the consumer persists the selection in `onSelectionEnd` and displays it, we no longer see two selections stacked on top of each other for one render. This allows us to remove the workaround for this subtle bug from the `Persisted` selection story.