### PR TITLE
Use single cache for both pnpm store and Cypress binaries in CI

### DIFF
--- a/.github/workflows/approve-snapshots.yml
+++ b/.github/workflows/approve-snapshots.yml
@@ -22,22 +22,25 @@ jobs:
         with:
           ref: ${{ steps.getBranchName.outputs.branch }}
 
+      - name: Use Node 16 🕹️
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: 'package.json'
+
       - name: Install pnpm ⚙️
         uses: pnpm/action-setup@v2
         with:
           version: 7.x
 
-      - name: Use Node 16 🕹️
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: 'package.json'
-          cache: 'pnpm'
-
-      - name: Cache Cypress binary 📌
+      - name: Restore cache 📌
         uses: actions/cache@v3
         with:
-          path: ~/.cache/Cypress
-          key: cypress-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          path: |
+            ~/setup-pnpm/node_modules/.bin/store
+            ~/.cache/Cypress
+          key: cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-
 
       - name: Install dependencies ⚙️
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -16,22 +16,25 @@ jobs:
       - name: Checkout 🏷️
         uses: actions/checkout@v3
 
+      - name: Use Node 16 🕹️
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: 'package.json'
+
       - name: Install pnpm ⚙️
         uses: pnpm/action-setup@v2
         with:
           version: 7.x
 
-      - name: Use Node 16 🕹️
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: 'package.json'
-          cache: 'pnpm'
-
-      - name: Cache Cypress binary 📌
+      - name: Restore cache 📌
         uses: actions/cache@v3
         with:
-          path: ~/.cache/Cypress
-          key: cypress-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          path: |
+            ~/setup-pnpm/node_modules/.bin/store
+            ~/.cache/Cypress
+          key: cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-
 
       - name: Install dependencies ⚙️
         run: pnpm install --frozen-lockfile
@@ -48,22 +51,25 @@ jobs:
       - name: Checkout 🏷️
         uses: actions/checkout@v3
 
+      - name: Use Node 16 🕹️
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: 'package.json'
+
       - name: Install pnpm ⚙️
         uses: pnpm/action-setup@v2
         with:
           version: 7.x
 
-      - name: Use Node 16 🕹️
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: 'package.json'
-          cache: 'pnpm'
-
-      - name: Cache Cypress binary 📌
+      - name: Restore cache 📌
         uses: actions/cache@v3
         with:
-          path: ~/.cache/Cypress
-          key: cypress-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          path: |
+            ~/setup-pnpm/node_modules/.bin/store
+            ~/.cache/Cypress
+          key: cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-
 
       - name: Install dependencies ⚙️
         run: pnpm install --frozen-lockfile
@@ -82,22 +88,25 @@ jobs:
       - name: Checkout 🏷️
         uses: actions/checkout@v3
 
+      - name: Use Node 16 🕹️
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: 'package.json'
+
       - name: Install pnpm ⚙️
         uses: pnpm/action-setup@v2
         with:
           version: 7.x
 
-      - name: Use Node 16 🕹️
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: 'package.json'
-          cache: 'pnpm'
-
-      - name: Cache Cypress binary 📌
+      - name: Restore cache 📌
         uses: actions/cache@v3
         with:
-          path: ~/.cache/Cypress
-          key: cypress-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          path: |
+            ~/setup-pnpm/node_modules/.bin/store
+            ~/.cache/Cypress
+          key: cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-
 
       - name: Install dependencies ⚙️
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,23 +18,26 @@ jobs:
         with:
           TAG_PREFIX: v
 
-      - name: Install pnpm ⚙️
-        uses: pnpm/action-setup@v2
-        with:
-          version: 7.x
-
       - name: Use Node 16 🕹️
         uses: actions/setup-node@v3
         with:
           node-version-file: 'package.json'
           registry-url: 'https://registry.npmjs.org'
-          cache: 'pnpm'
 
-      - name: Cache Cypress binary 📌
+      - name: Install pnpm ⚙️
+        uses: pnpm/action-setup@v2
+        with:
+          version: 7.x
+
+      - name: Restore cache 📌
         uses: actions/cache@v3
         with:
-          path: ~/.cache/Cypress
-          key: cypress-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          path: |
+            ~/setup-pnpm/node_modules/.bin/store
+            ~/.cache/Cypress
+          key: cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-
 
       - name: Install dependencies ⚙️
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
`actions/setup-node` does not and will not provide a way to pass additional paths to its internal `actions/cache` instance, so I move caching into a separate step that takes care of caching both the pnpm store and Cypress binaries.