### PR TITLE
Add SVG overlay and `SvgElement` helper

### DIFF
--- a/packages/lib/src/interactions/SelectionLine.tsx
+++ b/packages/lib/src/interactions/SelectionLine.tsx
@@ -2,8 +2,7 @@ import type { SVGProps } from 'react';
 import type { Vector2 } from 'three';
 
 import { useCameraState } from '../vis/hooks';
-import Overlay from '../vis/shared/Overlay';
-import { useVisCanvasContext } from '../vis/shared/VisCanvasProvider';
+import SvgElement from '../vis/shared/SvgElement';
 import { dataToHtml } from '../vis/utils';
 
 interface Props extends SVGProps<SVGLineElement> {
@@ -13,8 +12,6 @@ interface Props extends SVGProps<SVGLineElement> {
 
 function SelectionLine(props: Props) {
   const { startPoint, endPoint, stroke = 'black', ...restSvgProps } = props;
-
-  const { canvasSize } = useVisCanvasContext();
 
   const htmlSelection = useCameraState(
     (...args) => ({
@@ -28,18 +25,9 @@ function SelectionLine(props: Props) {
   const { x: x2, y: y2 } = htmlSelection.endPoint;
 
   return (
-    <Overlay>
-      <svg {...canvasSize}>
-        <line
-          x1={x1}
-          y1={y1}
-          x2={x2}
-          y2={y2}
-          stroke={stroke}
-          {...restSvgProps}
-        />
-      </svg>
-    </Overlay>
+    <SvgElement>
+      <line x1={x1} y1={y1} x2={x2} y2={y2} stroke={stroke} {...restSvgProps} />
+    </SvgElement>
   );
 }
 

--- a/packages/lib/src/interactions/SelectionRect.tsx
+++ b/packages/lib/src/interactions/SelectionRect.tsx
@@ -2,8 +2,7 @@ import type { SVGProps } from 'react';
 import type { Vector2 } from 'three';
 
 import { useCameraState } from '../vis/hooks';
-import Overlay from '../vis/shared/Overlay';
-import { useVisCanvasContext } from '../vis/shared/VisCanvasProvider';
+import SvgElement from '../vis/shared/SvgElement';
 import { dataToHtml } from '../vis/utils';
 
 interface Props extends SVGProps<SVGRectElement> {
@@ -20,8 +19,6 @@ function SelectionRect(props: Props) {
     ...restSvgProps
   } = props;
 
-  const { canvasSize } = useVisCanvasContext();
-
   const htmlSelection = useCameraState(
     (...args) => ({
       startPoint: dataToHtml(...args, startPoint),
@@ -34,19 +31,17 @@ function SelectionRect(props: Props) {
   const { x: x2, y: y2 } = htmlSelection.endPoint;
 
   return (
-    <Overlay>
-      <svg {...canvasSize}>
-        <rect
-          x={Math.min(x1, x2)}
-          y={Math.min(y1, y2)}
-          width={Math.abs(x2 - x1)}
-          height={Math.abs(y2 - y1)}
-          fill={fill}
-          fillOpacity={fillOpacity}
-          {...restSvgProps}
-        />
-      </svg>
-    </Overlay>
+    <SvgElement>
+      <rect
+        x={Math.min(x1, x2)}
+        y={Math.min(y1, y2)}
+        width={Math.abs(x2 - x1)}
+        height={Math.abs(y2 - y1)}
+        fill={fill}
+        fillOpacity={fillOpacity}
+        {...restSvgProps}
+      />
+    </SvgElement>
   );
 }
 

--- a/packages/lib/src/vis/shared/SvgElement.tsx
+++ b/packages/lib/src/vis/shared/SvgElement.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+
+import Html from './Html';
+import { useVisCanvasContext } from './VisCanvasProvider';
+
+interface Props {
+  children?: ReactNode;
+}
+
+function SvgElement(props: Props) {
+  const { children } = props;
+  const { svgOverlay } = useVisCanvasContext();
+
+  if (!svgOverlay) {
+    return null;
+  }
+
+  return <Html>{createPortal(children, svgOverlay)}</Html>;
+}
+
+export default SvgElement;

--- a/packages/lib/src/vis/shared/VisCanvas.module.css
+++ b/packages/lib/src/vis/shared/VisCanvas.module.css
@@ -9,10 +9,20 @@
   background-color: var(--h5w-canvas--bgColor, transparent);
 }
 
+.svgOverlay {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1; /* for SVG elements to appear above visualization */
+  pointer-events: none;
+}
+
 .floatingToolbar {
   position: absolute;
   right: 0;
   bottom: 0;
   display: flex;
-  z-index: 1; /* for toolbar items to appear above visualizations (overflow, selectors) */
+  z-index: 2; /* for toolbar items to appear above visualization and SVG elements */
 }

--- a/packages/lib/src/vis/shared/VisCanvas.tsx
+++ b/packages/lib/src/vis/shared/VisCanvas.tsx
@@ -45,6 +45,7 @@ function VisCanvas(props: PropsWithChildren<Props>) {
       })
     : NO_OFFSETS;
 
+  const [svgOverlay, setSvgOverlay] = useState<SVGSVGElement>();
   const [floatingToolbar, setFloatingToolbar] = useState<HTMLDivElement>();
 
   return (
@@ -62,6 +63,7 @@ function VisCanvas(props: PropsWithChildren<Props>) {
           visRatio={visRatio}
           abscissaConfig={abscissaConfig}
           ordinateConfig={ordinateConfig}
+          svgOverlay={svgOverlay}
           floatingToolbar={floatingToolbar}
         >
           <AxisSystem
@@ -76,6 +78,13 @@ function VisCanvas(props: PropsWithChildren<Props>) {
             <ThresholdAdjuster value={raycasterThreshold} />
           )}
         </VisCanvasProvider>
+
+        <Html>
+          <svg
+            ref={(elem) => setSvgOverlay(elem || undefined)}
+            className={styles.svgOverlay}
+          />
+        </Html>
         <Html>
           <div
             ref={(elem) => setFloatingToolbar(elem || undefined)}

--- a/packages/lib/src/vis/shared/VisCanvasProvider.tsx
+++ b/packages/lib/src/vis/shared/VisCanvasProvider.tsx
@@ -21,6 +21,7 @@ export interface VisCanvasContextValue {
   // For internal use only
   cameraToHtml: (cameraPt: Vector3) => Vector2;
   htmlToCamera: (htmlPt: Vector2) => Vector3;
+  svgOverlay: SVGSVGElement | undefined;
   floatingToolbar: HTMLDivElement | undefined;
 }
 
@@ -34,6 +35,7 @@ interface Props {
   visRatio: number | undefined;
   abscissaConfig: AxisConfig;
   ordinateConfig: AxisConfig;
+  svgOverlay: SVGSVGElement | undefined;
   floatingToolbar: HTMLDivElement | undefined;
 }
 
@@ -42,6 +44,7 @@ function VisCanvasProvider(props: PropsWithChildren<Props>) {
     visRatio,
     abscissaConfig,
     ordinateConfig,
+    svgOverlay,
     floatingToolbar,
     children,
   } = props;
@@ -112,6 +115,7 @@ function VisCanvasProvider(props: PropsWithChildren<Props>) {
         worldToData,
         cameraToHtml,
         htmlToCamera,
+        svgOverlay,
         floatingToolbar,
       }}
     >


### PR DESCRIPTION
Basically the replacement for SVG scene.

SVG elements wrapped in `SvgElement` get appended to this new global `svg` overlay container via a portal, similarly to floating toolbar controls. When it comes to naming, I hestiated with `SvgShape`, `Svg`, etc. but had issues with each. We can discuss this in person if you like @loichuder .