### PR TITLE
Allow rendering app with preferred vis in tests and improve testing of vis tabs

### DIFF
--- a/packages/app/src/__tests__/CorePack.test.tsx
+++ b/packages/app/src/__tests__/CorePack.test.tsx
@@ -72,60 +72,56 @@ test('visualize 2D datasets', async () => {
   ).resolves.toBeVisible();
 });
 
-test('visualize 1D slice of a 3D dataset with and without autoscale', async () => {
+test('visualize 1D slice of a 3D dataset as Line with and without autoscale', async () => {
   jest.useFakeTimers();
-  const { user } = await renderApp('/resilience/slow_slicing');
-
-  // Heatmap is selected by default and fetches a 2D slice.
-  await expect(
-    screen.findByText(/Loading current slice/)
-  ).resolves.toBeVisible();
-
-  // Let the 2D slice fetch succeed
-  jest.runAllTimers();
-  await expect(screen.findByRole('figure')).resolves.toBeVisible();
-
-  // Select the LineVis. The autoscale is on by default: it should fetch a 1D slice.
-  await user.click(await screen.findByRole('tab', { name: Vis.Line }));
-  await expect(
-    screen.findByText(/Loading current slice/)
-  ).resolves.toBeVisible();
-
-  // Let the 1D slice fetch succeed
-  jest.runAllTimers();
-  await expect(screen.findByRole('figure')).resolves.toBeVisible();
-
-  // Check that autoscale is truly on
-  const autoScaleBtn = await screen.findByRole('button', {
-    name: 'Auto-scale',
+  const { user } = await renderApp({
+    initialPath: '/resilience/slow_slicing',
+    preferredVis: Vis.Line,
   });
+
+  // Wait for slice loader to appear (since autoscale is on by default, only the first slice gets fetched)
+  await expect(
+    screen.findByText(/Loading current slice/)
+  ).resolves.toBeVisible();
+
+  // Wait for fetch of first slice to succeed
+  jest.runAllTimers();
+  await expect(screen.findByRole('figure')).resolves.toBeVisible();
+
+  // Confirm that autoscale is indeed on
+  const autoScaleBtn = screen.getByRole('button', { name: 'Auto-scale' });
   expect(autoScaleBtn).toHaveAttribute('aria-pressed', 'true');
 
-  // Move to other slice to fetch new slice
+  // Move to next slice
   const d0Slider = screen.getByRole('slider', { name: 'D0' });
   await user.type(d0Slider, '{ArrowUp}');
+
+  // Wait for slice loader to re-appear after debounce
   await expect(
     screen.findByText(/Loading current slice/)
   ).resolves.toBeVisible();
 
-  // Let the new slice fetch succeed
+  // Wait for fetch of second slice to succeed
   jest.runAllTimers();
   await expect(screen.findByRole('figure')).resolves.toBeVisible();
 
-  // Activate autoscale. It should trigger the fetch of the entire dataset.
+  // Activate autoscale
   await user.click(autoScaleBtn);
+
+  // Now, the entire dataset gets fetched
   await expect(
     screen.findByText(/Loading entire dataset/)
   ).resolves.toBeVisible();
 
-  // Let the dataset fetch succeed
+  // Wait for fetch of entire dataset to succeed
   jest.runAllTimers();
   await expect(screen.findByRole('figure')).resolves.toBeVisible();
 
-  // Move to third slice to check that entire dataset is fetched
+  // Move to third slice
   await user.type(d0Slider, '{ArrowUp}');
 
-  await expect(screen.findByRole('figure')).resolves.toBeVisible();
+  // Wait for new slicing to apply to Line visualization to confirm that no more slow fetching is performed
+  await expect(screen.findByTestId('2,0,x', undefined)).resolves.toBeVisible();
   d0Slider.blur(); // remove focus to avoid state update after unmount
 
   jest.runOnlyPendingTimers();

--- a/packages/app/src/__tests__/MetadataViewer.test.tsx
+++ b/packages/app/src/__tests__/MetadataViewer.test.tsx
@@ -1,14 +1,12 @@
 import { screen } from '@testing-library/react';
 
-import { queryVisSelector, renderApp } from '../test-utils';
+import { renderApp } from '../test-utils';
 
 test('switch between "display" and "inspect" modes', async () => {
   const { user } = await renderApp();
 
   // Switch to "inspect" mode
   await user.click(screen.getByRole('tab', { name: 'Inspect' }));
-
-  expect(queryVisSelector()).not.toBeInTheDocument();
   expect(screen.getByRole('row', { name: /^Path/ })).toBeVisible();
 
   // Switch back to "display" mode

--- a/packages/app/src/__tests__/MetadataViewer.test.tsx
+++ b/packages/app/src/__tests__/MetadataViewer.test.tsx
@@ -8,10 +8,14 @@ test('switch between "display" and "inspect" modes', async () => {
   // Switch to "inspect" mode
   await user.click(screen.getByRole('tab', { name: 'Inspect' }));
   expect(screen.getByRole('row', { name: /^Path/ })).toBeVisible();
+  expect(
+    screen.queryByRole('tablist', { name: 'Visualization' })
+  ).not.toBeInTheDocument();
 
   // Switch back to "display" mode
   await user.click(screen.getByRole('tab', { name: 'Display' }));
   expect(screen.queryByRole('row', { name: /^Path/ })).not.toBeInTheDocument();
+  expect(screen.getByRole('tablist', { name: 'Visualization' })).toBeVisible();
 });
 
 test('inspect group', async () => {

--- a/packages/app/src/__tests__/NexusPack.test.tsx
+++ b/packages/app/src/__tests__/NexusPack.test.tsx
@@ -1,7 +1,8 @@
 import { screen } from '@testing-library/react';
 
 import {
-  findVisSelectorTabs,
+  findVisTabs,
+  findSelectedVisTab,
   mockConsoleMethod,
   renderApp,
 } from '../test-utils';
@@ -10,9 +11,7 @@ import { NexusVis } from '../vis-packs/nexus/visualizations';
 test('visualize NXdata group with "spectrum" interpretation', async () => {
   await renderApp('/nexus_entry/spectrum');
 
-  const tabs = await findVisSelectorTabs();
-  expect(tabs).toHaveLength(1);
-  expect(tabs[0]).toHaveTextContent(NexusVis.NxSpectrum);
+  await expect(findVisTabs()).resolves.toEqual([NexusVis.NxSpectrum]);
 
   await expect(
     screen.findByRole('figure', { name: 'twoD_spectrum (arb. units)' }) // signal name + `units` attribute
@@ -22,9 +21,7 @@ test('visualize NXdata group with "spectrum" interpretation', async () => {
 test('visualize NXdata group with "image" interpretation', async () => {
   await renderApp('/nexus_entry/image');
 
-  const tabs = await findVisSelectorTabs();
-  expect(tabs).toHaveLength(1);
-  expect(tabs[0]).toHaveTextContent(NexusVis.NxImage);
+  await expect(findVisTabs()).resolves.toEqual([NexusVis.NxImage]);
 
   await expect(
     screen.findByRole('figure', { name: 'Interference fringes' }) // `long_name` attribute
@@ -34,10 +31,11 @@ test('visualize NXdata group with "image" interpretation', async () => {
 test('visualize NXdata group with 2D signal', async () => {
   await renderApp('/nexus_entry/nx_process/nx_data');
 
-  const tabs = await findVisSelectorTabs();
-  expect(tabs).toHaveLength(2);
-  expect(tabs[0]).toHaveTextContent(NexusVis.NxSpectrum);
-  expect(tabs[1]).toHaveTextContent(NexusVis.NxImage);
+  await expect(findVisTabs()).resolves.toEqual([
+    NexusVis.NxSpectrum,
+    NexusVis.NxImage,
+  ]);
+  await expect(findSelectedVisTab()).resolves.toBe(NexusVis.NxImage);
 
   await expect(
     screen.findByRole('figure', { name: 'NeXus 2D' }) // `title` dataset
@@ -47,9 +45,7 @@ test('visualize NXdata group with 2D signal', async () => {
 test('visualize NXdata group with 1D signal and two 1D axes of same length', async () => {
   await renderApp('/nexus_entry/scatter');
 
-  const tabs = await findVisSelectorTabs();
-  expect(tabs).toHaveLength(1);
-  expect(tabs[0]).toHaveTextContent(NexusVis.NxScatter);
+  await expect(findVisTabs()).resolves.toEqual([NexusVis.NxScatter]);
 
   await expect(
     screen.findByRole('figure', { name: 'scatter_data' })
@@ -59,10 +55,11 @@ test('visualize NXdata group with 1D signal and two 1D axes of same length', asy
 test('visualize NXentry group with relative path to 2D default signal', async () => {
   await renderApp('/nexus_entry');
 
-  const tabs = await findVisSelectorTabs();
-  expect(tabs).toHaveLength(2);
-  expect(tabs[0]).toHaveTextContent(NexusVis.NxSpectrum);
-  expect(tabs[1]).toHaveTextContent(NexusVis.NxImage);
+  await expect(findVisTabs()).resolves.toEqual([
+    NexusVis.NxSpectrum,
+    NexusVis.NxImage,
+  ]);
+  await expect(findSelectedVisTab()).resolves.toBe(NexusVis.NxImage);
 
   await expect(
     screen.findByRole('figure', { name: 'NeXus 2D' }) // `title` dataset
@@ -72,10 +69,11 @@ test('visualize NXentry group with relative path to 2D default signal', async ()
 test('visualize NXentry group with absolute path to 2D default signal', async () => {
   await renderApp('/nexus_entry/nx_process/absolute_default_path');
 
-  const tabs = await findVisSelectorTabs();
-  expect(tabs).toHaveLength(2);
-  expect(tabs[0]).toHaveTextContent(NexusVis.NxSpectrum);
-  expect(tabs[1]).toHaveTextContent(NexusVis.NxImage);
+  await expect(findVisTabs()).resolves.toEqual([
+    NexusVis.NxSpectrum,
+    NexusVis.NxImage,
+  ]);
+  await expect(findSelectedVisTab()).resolves.toBe(NexusVis.NxImage);
 
   await expect(
     screen.findByRole('figure', { name: 'NeXus 2D' }) // `title` dataset
@@ -85,10 +83,11 @@ test('visualize NXentry group with absolute path to 2D default signal', async ()
 test('visualize NXentry group with old-style signal', async () => {
   await renderApp('/nexus_entry/old-style');
 
-  const tabs = await findVisSelectorTabs();
-  expect(tabs).toHaveLength(2);
-  expect(tabs[0]).toHaveTextContent(NexusVis.NxSpectrum);
-  expect(tabs[1]).toHaveTextContent(NexusVis.NxImage);
+  await expect(findVisTabs()).resolves.toEqual([
+    NexusVis.NxSpectrum,
+    NexusVis.NxImage,
+  ]);
+  await expect(findSelectedVisTab()).resolves.toBe(NexusVis.NxImage);
 
   await expect(
     screen.findByRole('figure', { name: 'twoD' }) // name of dataset with `signal` attribute
@@ -98,10 +97,11 @@ test('visualize NXentry group with old-style signal', async () => {
 test('visualize NXroot group with 2D default signal', async () => {
   await renderApp();
 
-  const tabs = await findVisSelectorTabs();
-  expect(tabs).toHaveLength(2);
-  expect(tabs[0]).toHaveTextContent(NexusVis.NxSpectrum);
-  expect(tabs[1]).toHaveTextContent(NexusVis.NxImage);
+  await expect(findVisTabs()).resolves.toEqual([
+    NexusVis.NxSpectrum,
+    NexusVis.NxImage,
+  ]);
+  await expect(findSelectedVisTab()).resolves.toBe(NexusVis.NxImage);
 
   await expect(
     screen.findByRole('figure', { name: 'NeXus 2D' }) // `title` dataset
@@ -111,10 +111,11 @@ test('visualize NXroot group with 2D default signal', async () => {
 test('visualize NXdata group with 2D complex signal', async () => {
   await renderApp('/nexus_entry/complex');
 
-  const tabs = await findVisSelectorTabs();
-  expect(tabs).toHaveLength(2);
-  expect(tabs[0]).toHaveTextContent(NexusVis.NxSpectrum);
-  expect(tabs[1]).toHaveTextContent(NexusVis.NxImage);
+  await expect(findVisTabs()).resolves.toEqual([
+    NexusVis.NxSpectrum,
+    NexusVis.NxImage,
+  ]);
+  await expect(findSelectedVisTab()).resolves.toBe(NexusVis.NxImage);
 
   await expect(
     screen.findByRole('figure', { name: 'twoD_complex (amplitude)' }) // signal name + complex visualization type
@@ -124,9 +125,7 @@ test('visualize NXdata group with 2D complex signal', async () => {
 test('visualize NXdata group with 2D complex signal and "spectrum" interpretation', async () => {
   await renderApp('/nexus_entry/complex_spectrum');
 
-  const tabs = await findVisSelectorTabs();
-  expect(tabs).toHaveLength(1);
-  expect(tabs[0]).toHaveTextContent(NexusVis.NxSpectrum);
+  await expect(findVisTabs()).resolves.toEqual([NexusVis.NxSpectrum]);
 
   await expect(
     screen.findByRole('figure', { name: 'twoD_complex' }) // signal name (complex vis type is displayed as ordinate label)
@@ -136,9 +135,7 @@ test('visualize NXdata group with 2D complex signal and "spectrum" interpretatio
 test('visualize NXdata group with "rgb-image" interpretation', async () => {
   await renderApp('/nexus_entry/rgb-image');
 
-  const tabs = await findVisSelectorTabs();
-  expect(tabs).toHaveLength(1);
-  expect(tabs[0]).toHaveTextContent(NexusVis.NxRGB);
+  await expect(findVisTabs()).resolves.toEqual([NexusVis.NxRGB]);
 
   await expect(
     screen.findByRole('figure', { name: 'RGB CMY DGW' }) // `long_name` attribute
@@ -155,9 +152,7 @@ test('follow SILX styles when visualizing NXdata group', async () => {
 test('visualize NXentry group with implicit default child NXdata group', async () => {
   await renderApp('/nexus_no_default');
 
-  const tabs = await findVisSelectorTabs();
-  expect(tabs).toHaveLength(1);
-  expect(tabs[0]).toHaveTextContent(NexusVis.NxSpectrum);
+  await expect(findVisTabs()).resolves.toEqual([NexusVis.NxSpectrum]);
 
   await expect(
     screen.findByRole('figure', { name: 'oneD' }) // signal name of NXdata group "spectrum"
@@ -241,10 +236,11 @@ test('show fallback message when NXdata group has no `signal` attribute', async 
 test('visualize NXdata group with unknown interpretation', async () => {
   await renderApp('/nexus_malformed/interpretation_unknown');
 
-  const tabs = await findVisSelectorTabs();
-  expect(tabs).toHaveLength(2); // support check falls back to signal dataset dimensions (4D supports both Image and Spectrum)
-  expect(tabs[0]).toHaveTextContent(NexusVis.NxSpectrum);
-  expect(tabs[1]).toHaveTextContent(NexusVis.NxImage);
+  await expect(findVisTabs()).resolves.toEqual([
+    NexusVis.NxSpectrum,
+    NexusVis.NxImage,
+  ]);
+  await expect(findSelectedVisTab()).resolves.toBe(NexusVis.NxImage);
 
   await expect(
     screen.findByRole('figure', { name: 'fourD' }) // signal name
@@ -254,9 +250,7 @@ test('visualize NXdata group with unknown interpretation', async () => {
 test('visualize NXdata group with "rgb-image" interpretation but incompatible signal', async () => {
   await renderApp('/nexus_malformed/rgb-image_incompatible');
 
-  const tabs = await findVisSelectorTabs();
-  expect(tabs).toHaveLength(1); // support check falls back to signal dataset dimensions (1D supports only Spectrum)
-  expect(tabs[0]).toHaveTextContent(NexusVis.NxSpectrum);
+  await expect(findVisTabs()).resolves.toEqual([NexusVis.NxSpectrum]);
 
   await expect(
     screen.findByRole('figure', { name: 'oneD' }) // signal name
@@ -268,9 +262,7 @@ test('ignore unknown `SILX_style` options and invalid values', async () => {
 
   const errorSpy = mockConsoleMethod('error');
 
-  const tabs = await findVisSelectorTabs();
-  expect(tabs).toHaveLength(1);
-  expect(tabs[0]).toHaveTextContent(NexusVis.NxSpectrum);
+  await expect(findVisTabs()).resolves.toEqual([NexusVis.NxSpectrum]);
 
   const scaleSelectors = await screen.findAllByRole('button', {
     name: 'Linear', // the scales of both axes remain unchanged
@@ -285,9 +277,7 @@ test('warn in console when `SILX_style` attribute is not valid JSON', async () =
   const warningSpy = mockConsoleMethod('warn');
   await renderApp('/nexus_malformed/silx_style_malformed');
 
-  const tabs = await findVisSelectorTabs();
-  expect(tabs).toHaveLength(1);
-  expect(tabs[0]).toHaveTextContent(NexusVis.NxSpectrum);
+  await expect(findVisTabs()).resolves.toEqual([NexusVis.NxSpectrum]);
 
   expect(warningSpy).toHaveBeenCalledWith(
     "Malformed 'SILX_style' attribute: {"

--- a/packages/app/src/__tests__/VisSelector.test.tsx
+++ b/packages/app/src/__tests__/VisSelector.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from '@testing-library/react';
 
 import { renderApp } from '../test-utils';
+import { Vis } from '../vis-packs/core/visualizations';
 
 test('switch between visualizations', async () => {
   const { user } = await renderApp('/nD_datasets/oneD');
@@ -27,10 +28,10 @@ test('switch between visualizations', async () => {
 });
 
 test('restore active visualization when switching to inspect mode and back', async () => {
-  const { user } = await renderApp('/nD_datasets/twoD');
+  const { user, selectVisTab } = await renderApp('/nD_datasets/twoD');
 
   // Switch to Line visualization
-  await user.click(await screen.findByRole('tab', { name: 'Line' }));
+  await selectVisTab(Vis.Line);
 
   // Switch to inspect mode and back
   await user.click(await screen.findByRole('tab', { name: 'Inspect' }));
@@ -65,11 +66,13 @@ test('choose most advanced visualization when switching between datasets', async
 });
 
 test('remember preferred visualization when switching between datasets', async () => {
-  const { user, selectExplorerNode } = await renderApp('/nD_datasets/twoD');
+  const { user, selectExplorerNode, selectVisTab } = await renderApp(
+    '/nD_datasets/twoD'
+  );
 
   /* Switch to Matrix vis. Since this is not the most advanced visualization
    * for `twoD`, it becomes the preferred visualization. */
-  await user.click(await screen.findByRole('tab', { name: 'Matrix' }));
+  await selectVisTab(Vis.Matrix);
 
   // Select another dataset for which the Matrix vis is not the most advanced visualization
   await selectExplorerNode('oneD');

--- a/packages/app/src/__tests__/Visualizer.test.tsx
+++ b/packages/app/src/__tests__/Visualizer.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from '@testing-library/react';
 
 import { mockConsoleMethod, queryVisSelector, renderApp } from '../test-utils';
+import { Vis } from '../vis-packs/core/visualizations';
 
 test('show fallback message when no visualization is supported', async () => {
   await renderApp('/entities'); // simple group
@@ -201,7 +202,7 @@ test('cancel fetching dataset slice when changing entity', async () => {
 
 test('cancel fetching dataset slice when changing vis', async () => {
   jest.useFakeTimers();
-  const { user } = await renderApp('/resilience/slow_slicing');
+  const { user, selectVisTab } = await renderApp('/resilience/slow_slicing');
 
   // Select dataset and start fetching the slice
   await expect(
@@ -209,7 +210,7 @@ test('cancel fetching dataset slice when changing vis', async () => {
   ).resolves.toBeVisible();
 
   // Switch to the Line vis to cancel the fetch
-  await user.click(screen.getByRole('tab', { name: 'Line' }));
+  await selectVisTab(Vis.Line);
   await expect(
     screen.findByText(/Loading current slice/)
   ).resolves.toBeVisible();
@@ -218,14 +219,15 @@ test('cancel fetching dataset slice when changing vis', async () => {
   jest.runAllTimers();
   await expect(screen.findByRole('figure')).resolves.toBeVisible();
 
-  // Switch back to Heatmap and check that it refetches the slice
-  await user.click(screen.getByRole('tab', { name: 'Heatmap' }));
-  // The slice request was cancelled so it should be pending once again
+  // Switch back to Heatmap visualization
+  await selectVisTab(Vis.Heatmap);
+
+  // Ensure that fetching restarts (since it was cancelled)
   await expect(
     screen.findByText(/Loading current slice/)
   ).resolves.toBeVisible();
 
-  // Let fetch of the slice succeed
+  // Let fetch of slice succeed
   jest.runAllTimers();
   await expect(screen.findByRole('figure')).resolves.toBeVisible();
 

--- a/packages/app/src/__tests__/Visualizer.test.tsx
+++ b/packages/app/src/__tests__/Visualizer.test.tsx
@@ -198,7 +198,7 @@ test('cancel fetching dataset slice when changing entity', async () => {
 
 test('cancel fetching dataset slice when changing vis', async () => {
   jest.useFakeTimers();
-  const { user, selectVisTab } = await renderApp('/resilience/slow_slicing');
+  const { selectVisTab } = await renderApp('/resilience/slow_slicing');
 
   // Select dataset and start fetching the slice
   await expect(

--- a/packages/app/src/__tests__/Visualizer.test.tsx
+++ b/packages/app/src/__tests__/Visualizer.test.tsx
@@ -1,15 +1,11 @@
 import { screen } from '@testing-library/react';
 
-import { mockConsoleMethod, queryVisSelector, renderApp } from '../test-utils';
+import { mockConsoleMethod, renderApp } from '../test-utils';
 import { Vis } from '../vis-packs/core/visualizations';
 
 test('show fallback message when no visualization is supported', async () => {
   await renderApp('/entities'); // simple group
-
-  await expect(
-    screen.findByText('No visualization available for this entity.')
-  ).resolves.toBeInTheDocument();
-  expect(queryVisSelector()).not.toBeInTheDocument();
+  expect(screen.getByText(/No visualization available/)).toBeVisible();
 });
 
 test('show loader while fetching dataset value', async () => {

--- a/packages/app/src/test-utils.tsx
+++ b/packages/app/src/test-utils.tsx
@@ -1,3 +1,4 @@
+import { assertDefined, assertNonNull } from '@h5web/shared';
 import type { RenderResult } from '@testing-library/react';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -62,10 +63,27 @@ export async function renderApp(
   };
 }
 
-export async function findVisSelectorTabs(): Promise<HTMLElement[]> {
-  return within(
-    await screen.findByRole('tablist', { name: 'Visualization' })
-  ).getAllByRole('tab');
+async function findVisSelector(): Promise<HTMLElement> {
+  return screen.findByRole('tablist', { name: 'Visualization' });
+}
+
+export async function findVisTabs(): Promise<string[]> {
+  return within(await findVisSelector())
+    .getAllByRole('tab')
+    .map((tab) => {
+      assertNonNull(tab.textContent);
+      return tab.textContent;
+    });
+}
+
+export async function findSelectedVisTab(): Promise<string> {
+  const selectedTab = within(await findVisSelector())
+    .getAllByRole('tab')
+    .find((tab) => tab.getAttribute('aria-selected') === 'true');
+
+  assertDefined(selectedTab);
+  assertNonNull(selectedTab.textContent);
+  return selectedTab.textContent;
 }
 
 /**

--- a/packages/app/src/test-utils.tsx
+++ b/packages/app/src/test-utils.tsx
@@ -15,16 +15,24 @@ interface RenderAppResult extends RenderResult {
 type InitialPath = `/${string}`;
 interface RenderAppOpts {
   initialPath?: InitialPath;
+  preferredVis?: Vis | undefined;
 }
 
 export async function renderApp(
   opts: InitialPath | RenderAppOpts = '/'
 ): Promise<RenderAppResult> {
   const optsObj = typeof opts === 'string' ? { initialPath: opts } : opts;
-  const { initialPath }: RenderAppOpts = {
+  const { initialPath, preferredVis }: RenderAppOpts = {
     initialPath: '/',
     ...optsObj,
   };
+
+  if (preferredVis) {
+    window.localStorage.setItem(
+      'h5web:preferredVis',
+      JSON.stringify(preferredVis)
+    );
+  }
 
   const user = userEvent.setup({ delay: null }); // https://github.com/testing-library/user-event/issues/833
   const renderResult = render(

--- a/packages/app/src/test-utils.tsx
+++ b/packages/app/src/test-utils.tsx
@@ -62,10 +62,6 @@ export async function renderApp(
   };
 }
 
-export function queryVisSelector(): HTMLElement | null {
-  return screen.queryByRole('tablist', { name: 'Visualization' });
-}
-
 export async function findVisSelectorTabs(): Promise<HTMLElement[]> {
   return within(
     await screen.findByRole('tablist', { name: 'Visualization' })

--- a/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
+++ b/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
@@ -118,6 +118,7 @@ function MappedLineVis(props: Props) {
           array,
           errors: auxErrorsArrays[i],
         }))}
+        testid={dimMapping.toString()}
       />
     </>
   );

--- a/packages/lib/src/vis/line/LineVis.tsx
+++ b/packages/lib/src/vis/line/LineVis.tsx
@@ -44,6 +44,7 @@ interface Props {
   renderTooltip?: (data: TooltipData) => ReactElement;
   children?: ReactNode;
   interactions?: DefaultInteractionsConfig;
+  testid?: string;
 }
 
 function LineVis(props: Props) {
@@ -63,6 +64,7 @@ function LineVis(props: Props) {
     renderTooltip,
     children,
     interactions,
+    testid,
   } = props;
 
   const {
@@ -101,6 +103,7 @@ function LineVis(props: Props) {
       className={styles.root}
       aria-label={title}
       data-keep-canvas-colors
+      data-testid={testid}
     >
       <VisCanvas
         title={title}


### PR DESCRIPTION
Part three of bringing in test improvements from https://github.com/silx-kit/h5web/pull/1119