### PR TITLE
Abstract away enabling fake timers in tests

### DIFF
--- a/packages/app/src/__tests__/CorePack.test.tsx
+++ b/packages/app/src/__tests__/CorePack.test.tsx
@@ -79,10 +79,10 @@ test('visualize 2D datasets', async () => {
 });
 
 test('visualize 1D slice of a 3D dataset as Line with and without autoscale', async () => {
-  jest.useFakeTimers();
   const { user } = await renderApp({
     initialPath: '/resilience/slow_slicing',
     preferredVis: Vis.Line,
+    withFakeTimers: true,
   });
 
   // Wait for slice loader to appear (since autoscale is on by default, only the first slice gets fetched)
@@ -128,10 +128,9 @@ test('visualize 1D slice of a 3D dataset as Line with and without autoscale', as
 
   // Wait for new slicing to apply to Line visualization to confirm that no more slow fetching is performed
   await expect(screen.findByTestId('2,0,x', undefined)).resolves.toBeVisible();
-  d0Slider.blur(); // remove focus to avoid state update after unmount
 
-  jest.runOnlyPendingTimers();
-  jest.useRealTimers();
+  d0Slider.blur(); // remove focus to avoid state update after unmount
+  jest.runAllTimers();
 });
 
 test('show interactions help for heatmap according to "keep ratio"', async () => {

--- a/packages/app/src/__tests__/Explorer.test.tsx
+++ b/packages/app/src/__tests__/Explorer.test.tsx
@@ -87,8 +87,10 @@ test('navigate groups in explorer', async () => {
 });
 
 test('show spinner when group metadata is slow to fetch', async () => {
-  jest.useFakeTimers();
-  await renderApp('/resilience/slow_metadata');
+  await renderApp({
+    initialPath: '/resilience/slow_metadata',
+    withFakeTimers: true,
+  });
 
   await expect(screen.findByText(/Loading/)).resolves.toBeVisible();
   expect(screen.getByLabelText(/Loading group metadata/)).toBeVisible();
@@ -99,7 +101,4 @@ test('show spinner when group metadata is slow to fetch', async () => {
       screen.queryByLabelText(/Loading group metadata/)
     ).not.toBeInTheDocument();
   });
-
-  jest.runOnlyPendingTimers();
-  jest.useRealTimers();
 });

--- a/packages/app/src/__tests__/NexusPack.test.tsx
+++ b/packages/app/src/__tests__/NexusPack.test.tsx
@@ -254,8 +254,10 @@ test('ignore malformed `SILX_style` attribute', async () => {
 });
 
 test('cancel and retry slow fetch of NxSpectrum', async () => {
-  jest.useFakeTimers();
-  const { user } = await renderApp('/resilience/slow_nx_spectrum');
+  const { user } = await renderApp({
+    initialPath: '/resilience/slow_nx_spectrum',
+    withFakeTimers: true,
+  });
 
   // Select NXdata group with spectrum interpretation and start fetching dataset values
   await expect(screen.findByText(/Loading data/)).resolves.toBeVisible();
@@ -276,14 +278,13 @@ test('cancel and retry slow fetch of NxSpectrum', async () => {
   jest.runAllTimers();
 
   await expect(screen.findByRole('figure')).resolves.toBeVisible();
-
-  jest.runOnlyPendingTimers();
-  jest.useRealTimers();
 });
 
 test('cancel and retry slow fetch of NxImage', async () => {
-  jest.useFakeTimers();
-  const { user } = await renderApp('/resilience/slow_nx_image');
+  const { user } = await renderApp({
+    initialPath: '/resilience/slow_nx_image',
+    withFakeTimers: true,
+  });
 
   // Select NXdata group with image interpretation and start fetching dataset values
   await expect(screen.findByText(/Loading data/)).resolves.toBeVisible();
@@ -302,16 +303,13 @@ test('cancel and retry slow fetch of NxImage', async () => {
   // Let fetches succeed
   jest.runAllTimers();
   await expect(screen.findByRole('figure')).resolves.toBeVisible();
-
-  jest.runOnlyPendingTimers();
-  jest.useRealTimers();
 });
 
 test('retry fetching automatically when re-selecting NxSpectrum', async () => {
-  jest.useFakeTimers();
-  const { user, selectExplorerNode } = await renderApp(
-    '/resilience/slow_nx_spectrum'
-  );
+  const { user, selectExplorerNode } = await renderApp({
+    initialPath: '/resilience/slow_nx_spectrum',
+    withFakeTimers: true,
+  });
 
   // Select NXdata group with spectrum interpretation and start fetching dataset values
   await expect(screen.findByText(/Loading data/)).resolves.toBeVisible();
@@ -334,14 +332,13 @@ test('retry fetching automatically when re-selecting NxSpectrum', async () => {
   // Let fetches succeed
   jest.runAllTimers();
   await expect(screen.findByRole('figure')).resolves.toBeVisible();
-
-  jest.runOnlyPendingTimers();
-  jest.useRealTimers();
 });
 
 test('retry fetching automatically when selecting other NxImage slice', async () => {
-  jest.useFakeTimers();
-  const { user } = await renderApp('/resilience/slow_nx_image');
+  const { user } = await renderApp({
+    initialPath: '/resilience/slow_nx_image',
+    withFakeTimers: true,
+  });
 
   // Select NXdata group with spectrum interpretation and start fetching dataset values
   await expect(screen.findByText(/Loading data/)).resolves.toBeVisible();
@@ -370,7 +367,4 @@ test('retry fetching automatically when selecting other NxImage slice', async ()
   jest.runAllTimers();
   await expect(screen.findByRole('figure')).resolves.toBeVisible();
   d0Slider.blur(); // remove focus to avoid state update after unmount
-
-  jest.runOnlyPendingTimers();
-  jest.useRealTimers();
 });

--- a/packages/app/src/__tests__/Visualizer.test.tsx
+++ b/packages/app/src/__tests__/Visualizer.test.tsx
@@ -9,16 +9,15 @@ test('show fallback message when no visualization is supported', async () => {
 });
 
 test('show loader while fetching dataset value', async () => {
-  jest.useFakeTimers();
-  await renderApp('/resilience/slow_value');
+  await renderApp({
+    initialPath: '/resilience/slow_value',
+    withFakeTimers: true,
+  });
 
   await expect(screen.findByText(/Loading data/)).resolves.toBeVisible();
 
   jest.runAllTimers(); // resolve slow fetch right away
   await expect(screen.findByText(/42/)).resolves.toBeVisible();
-
-  jest.runOnlyPendingTimers();
-  jest.useRealTimers();
 });
 
 test("show error when dataset value can't be fetched", async () => {
@@ -35,8 +34,10 @@ test("show error when dataset value can't be fetched", async () => {
 });
 
 test('cancel and retry slow fetch of dataset value', async () => {
-  jest.useFakeTimers();
-  const { user } = await renderApp('/resilience/slow_value');
+  const { user } = await renderApp({
+    initialPath: '/resilience/slow_value',
+    withFakeTimers: true,
+  });
 
   // Select dataset and start fetching value
   await expect(screen.findByText(/Loading data/)).resolves.toBeVisible();
@@ -56,14 +57,13 @@ test('cancel and retry slow fetch of dataset value', async () => {
   // Let fetch succeed
   jest.runAllTimers();
   await expect(screen.findByText(/42/)).resolves.toBeVisible();
-
-  jest.runOnlyPendingTimers();
-  jest.useRealTimers();
 });
 
 test('cancel and retry slow fetch of dataset slice', async () => {
-  jest.useFakeTimers();
-  const { user } = await renderApp('/resilience/slow_slicing');
+  const { user } = await renderApp({
+    initialPath: '/resilience/slow_slicing',
+    withFakeTimers: true,
+  });
 
   // Select dataset and start fetching first slice
   await expect(
@@ -87,16 +87,13 @@ test('cancel and retry slow fetch of dataset slice', async () => {
   // Let fetch of first slice succeed
   jest.runAllTimers();
   await expect(screen.findByRole('figure')).resolves.toBeVisible();
-
-  jest.runOnlyPendingTimers();
-  jest.useRealTimers();
 });
 
 test('retry fetching automatically when re-selecting dataset', async () => {
-  jest.useFakeTimers();
-  const { user, selectExplorerNode } = await renderApp(
-    '/resilience/slow_value'
-  );
+  const { user, selectExplorerNode } = await renderApp({
+    initialPath: '/resilience/slow_value',
+    withFakeTimers: true,
+  });
 
   // Select dataset and start fetching
   await expect(screen.findByText(/Loading data/)).resolves.toBeVisible();
@@ -118,14 +115,13 @@ test('retry fetching automatically when re-selecting dataset', async () => {
   // Let fetch succeed
   jest.runAllTimers();
   await expect(screen.findByText(/42/)).resolves.toBeVisible();
-
-  jest.runOnlyPendingTimers();
-  jest.useRealTimers();
 });
 
 test('retry fetching dataset slice automatically when re-selecting slice', async () => {
-  jest.useFakeTimers();
-  const { user } = await renderApp('/resilience/slow_slicing');
+  const { user } = await renderApp({
+    initialPath: '/resilience/slow_slicing',
+    withFakeTimers: true,
+  });
 
   // Select dataset and start fetching first slice
   await expect(
@@ -160,14 +156,13 @@ test('retry fetching dataset slice automatically when re-selecting slice', async
   // Let fetch of first slice succeed
   jest.runAllTimers();
   await expect(screen.findByRole('figure')).resolves.toBeVisible();
-
-  jest.runOnlyPendingTimers();
-  jest.useRealTimers();
 });
 
 test('cancel fetching dataset slice when changing entity', async () => {
-  jest.useFakeTimers();
-  const { selectExplorerNode } = await renderApp('/resilience/slow_slicing');
+  const { selectExplorerNode } = await renderApp({
+    initialPath: '/resilience/slow_slicing',
+    withFakeTimers: true,
+  });
 
   // Select dataset and start fetching first slice
   await expect(
@@ -191,14 +186,13 @@ test('cancel fetching dataset slice when changing entity', async () => {
   // Let fetch of first slice succeed
   jest.runAllTimers();
   await expect(screen.findByRole('figure')).resolves.toBeVisible();
-
-  jest.runOnlyPendingTimers();
-  jest.useRealTimers();
 });
 
 test('cancel fetching dataset slice when changing vis', async () => {
-  jest.useFakeTimers();
-  const { selectVisTab } = await renderApp('/resilience/slow_slicing');
+  const { selectVisTab } = await renderApp({
+    initialPath: '/resilience/slow_slicing',
+    withFakeTimers: true,
+  });
 
   // Select dataset and start fetching the slice
   await expect(
@@ -226,7 +220,4 @@ test('cancel fetching dataset slice when changing vis', async () => {
   // Let fetch of slice succeed
   jest.runAllTimers();
   await expect(screen.findByRole('figure')).resolves.toBeVisible();
-
-  jest.runOnlyPendingTimers();
-  jest.useRealTimers();
 });

--- a/packages/app/src/setupTests.ts
+++ b/packages/app/src/setupTests.ts
@@ -65,4 +65,10 @@ const errorSpy = mockConsoleMethod('error');
 errorSpy.mockRestore(); // optional if end of test
 `);
   }
+
+  // Restore real timers if applicable (if fake modern timers were used)
+  // eslint-disable-next-line prefer-object-has-own
+  if (Object.prototype.hasOwnProperty.call(setTimeout, 'clock')) {
+    jest.useRealTimers();
+  }
 });

--- a/packages/app/src/test-utils.tsx
+++ b/packages/app/src/test-utils.tsx
@@ -17,13 +17,14 @@ type InitialPath = `/${string}`;
 interface RenderAppOpts {
   initialPath?: InitialPath;
   preferredVis?: Vis | undefined;
+  withFakeTimers?: boolean;
 }
 
 export async function renderApp(
   opts: InitialPath | RenderAppOpts = '/'
 ): Promise<RenderAppResult> {
   const optsObj = typeof opts === 'string' ? { initialPath: opts } : opts;
-  const { initialPath, preferredVis }: RenderAppOpts = {
+  const { initialPath, preferredVis, withFakeTimers }: RenderAppOpts = {
     initialPath: '/',
     ...optsObj,
   };
@@ -35,7 +36,14 @@ export async function renderApp(
     );
   }
 
-  const user = userEvent.setup({ delay: null }); // https://github.com/testing-library/user-event/issues/833
+  if (withFakeTimers) {
+    jest.useFakeTimers();
+  }
+
+  const user = userEvent.setup(
+    withFakeTimers ? { advanceTimers: jest.advanceTimersByTime } : undefined
+  );
+
   const renderResult = render(
     <MockProvider>
       <App initialPath={initialPath} />


### PR DESCRIPTION
Part five of bringing in test improvements from https://github.com/silx-kit/h5web/pull/1119