### PR TITLE
Add doc on feature tests and make minor test improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,9 @@
   - [Fixing and formatting](#fixing-and-formatting)
   - [Editor integration](#editor-integration)
 - [Testing](#testing)
+  - [Feature tests](#feature-tests)
+    - [Fake timers](#fake-timers)
+    - [Debugging](#debugging)
   - [Visual regression](#visual-regression)
 - [Deployment](#deployment)
 - [Release process](#release-process)
@@ -205,6 +208,62 @@ install the recommended extensions.
 > [`projects` configuration](https://jestjs.io/docs/configuration#projects-arraystring--projectconfig)
 > located in `jest.config.json`. This results in a nicer terminal output when
 > running tests on the entire workspace.
+
+### Feature tests
+
+The `@h5web/app` package includes feature tests written with
+[React Testing Library](https://testing-library.com/docs/react-testing-library/intro).
+They are located under `src/__tests__`. Each file covers a particular subtree of
+components of H5Web.
+
+H5Web's feature tests typically consist in rendering the entire app with mock
+data (i.e. inside `MockProvider`), executing an action like a real user would
+(e.g. clicking on a button, pressing a key, etc.), and then expecting something
+to happen in the DOM as a result. Most tests, perform multiple actions and
+expectations consecutively to minimise the overhead of rendering the entire app
+again and again.
+
+`MockProvider` resolves most requests instantaneously to save time in tests, but
+its API's methods are still called asynchronously like other providers. This
+means that during tests, `Suspense` loading fallbacks render just like they
+would normally; they just don't stick around in the DOM for long.
+
+This adds a bit of complexity when testing, as React doesn't like when something
+happens after a test has completed. In fact, we have to ensure that every
+component that suspends inside a test **finishes loading before the end of that
+test**. This is where Testing Library's
+[asynchronous methods](https://testing-library.com/docs/dom-testing-library/api-async)
+come in.
+
+#### Fake timers
+
+To allow developing and testing loading interfaces, as well as features like
+cancel/retry, `MockProvider` adds an artificial delay of 3s (`SLOW_TIMEOUT`) to
+some requests, notably to value requests for datasets prefixed with `slow_`.
+
+In order for this artificial delay to not slow down feature tests, we must use
+[fake timers](https://testing-library.com/docs/using-fake-timers/). This is done
+by setting the `withFakeTimers` option when calling `renderApp()`:
+
+```ts
+renderApp({ withFakeTimers: true });
+```
+
+#### Debugging
+
+You can use Testing Library's
+[`prettyDOM` utility](https://testing-library.com/docs/dom-testing-library/api-debugging#prettydom)
+to log the state of the DOM anywhere in your tests:
+
+```ts
+console.debug(prettyDOM()); // if you use `console.log` without mocking it, the test will fail
+console.debug(prettyDOM(screen.getByText('foo'))); // you can also print out a specific element
+```
+
+To ensure that the entire DOM is printed out in the terminal, you may have to
+set environment variable `DEBUG_PRINT_LIMIT`
+[to a large value](https://testing-library.com/docs/dom-testing-library/api-debugging#automatic-logging)
+when calling `pnpm test`.
 
 ### Visual regression
 

--- a/apps/demo/.env
+++ b/apps/demo/.env
@@ -18,3 +18,13 @@ VITE_HSDS_FALLBACK_FILEPATH="water_224.h5"
 
 # Feedback email
 VITE_FEEDBACK_EMAIL="h5web@esrf.fr"
+
+
+#####
+# TESTING CONFIGURATION
+# Copy and configure the variables below in your own `.env.test.local` file
+#####
+
+# Testing Library's DOM logging limit
+# https://testing-library.com/docs/dom-testing-library/api-debugging/#automatic-logging
+DEBUG_PRINT_LIMIT=7000

--- a/packages/app/src/__tests__/CorePack.test.tsx
+++ b/packages/app/src/__tests__/CorePack.test.tsx
@@ -9,7 +9,7 @@ import {
 } from '../test-utils';
 import { Vis } from '../vis-packs/core/visualizations';
 
-test('visualise raw dataset', async () => {
+test('visualize raw dataset', async () => {
   await renderApp('/entities/raw');
 
   await expect(findVisTabs()).resolves.toEqual([Vis.Raw]);
@@ -25,7 +25,7 @@ test('log raw dataset to console if too large', async () => {
   expect(logSpy).toHaveBeenCalledWith(mockValues.raw_large);
 });
 
-test('visualise scalar dataset', async () => {
+test('visualize scalar dataset', async () => {
   // Integer scalar
   const { selectExplorerNode } = await renderApp('/entities/scalar_int');
 
@@ -78,7 +78,33 @@ test('visualize 2D datasets', async () => {
   expect(within(figure).getByText('4e+2')).toBeVisible(); // color bar limit
 });
 
-test('visualize 1D slice of a 3D dataset as Line with and without autoscale', async () => {
+test('visualize 2D complex dataset', async () => {
+  const { user } = await renderApp('/nD_datasets/twoD_cplx');
+
+  await expect(findVisTabs()).resolves.toEqual([
+    Vis.Matrix,
+    Vis.Line,
+    Vis.Heatmap,
+  ]);
+  await expect(findSelectedVisTab()).resolves.toBe(Vis.Heatmap);
+
+  const figure = await screen.findByRole('figure', {
+    name: 'twoD_cplx (amplitude)',
+  });
+  expect(figure).toBeVisible();
+  expect(within(figure).getByText('5e+0')).toBeVisible(); // color bar limit
+
+  const selector = screen.getByRole('button', { name: '𝓐 Amplitude' });
+  await user.click(selector);
+  const phaseItem = screen.getByRole('menuitem', { name: 'φ Phase' });
+  await user.click(phaseItem);
+
+  expect(
+    screen.getByRole('figure', { name: 'twoD_cplx (phase)' })
+  ).toBeVisible();
+});
+
+test('visualize 1D slice of 3D dataset as Line with and without autoscale', async () => {
   const { user } = await renderApp({
     initialPath: '/resilience/slow_slicing',
     preferredVis: Vis.Line,

--- a/packages/app/src/__tests__/DimensionMapper.test.tsx
+++ b/packages/app/src/__tests__/DimensionMapper.test.tsx
@@ -56,7 +56,7 @@ test('control mapping for X and Y axes when visualizing 2D dataset as Heatmap', 
   const yD0Button = within(yRadioGroup).getByRole('radio', { name: 'D0' });
   const yD1Button = within(yRadioGroup).getByRole('radio', { name: 'D1' });
 
-  // Ensure that default mapping is ['y', 'x']
+  // Ensure that the default mapping is ['y', 'x']
   expect(xD1Button).toBeChecked();
   expect(yD0Button).toBeChecked();
 

--- a/packages/app/src/__tests__/DomainSlider.test.tsx
+++ b/packages/app/src/__tests__/DomainSlider.test.tsx
@@ -1,18 +1,14 @@
-import { screen, waitFor, within } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 
 import { renderApp } from '../test-utils';
 
-test('show slider with two thumbs', async () => {
-  await renderApp('/nexus_entry/nx_process/nx_data');
+test('show slider with two thumbs and reveal tooltip on hover', async () => {
+  const { user } = await renderApp('/nexus_entry/nx_process/nx_data');
 
   const thumbs = await screen.findAllByRole('slider');
   expect(thumbs).toHaveLength(2);
   expect(thumbs[0]).toHaveAttribute('aria-valuenow', '20');
   expect(thumbs[1]).toHaveAttribute('aria-valuenow', '81');
-});
-
-test('show tooltip on hover', async () => {
-  const { user } = await renderApp('/nexus_entry/nx_process/nx_data');
 
   const editBtn = await screen.findByRole('button', { name: 'Edit domain' });
   const tooltip = screen.getByRole('dialog', { hidden: true });
@@ -20,14 +16,17 @@ test('show tooltip on hover', async () => {
   expect(editBtn).toHaveAttribute('aria-expanded', 'false');
   expect(tooltip).not.toBeVisible();
 
+  // Hover to show tooltip
   await user.hover(editBtn);
   expect(editBtn).toHaveAttribute('aria-expanded', 'true');
   expect(tooltip).toBeVisible();
 
+  // Unhover to hide tooltip
   await user.unhover(editBtn);
   expect(editBtn).toHaveAttribute('aria-expanded', 'false');
   expect(tooltip).not.toBeVisible();
 
+  // Hover and press escape to hide tooltip
   await user.hover(editBtn);
   await user.keyboard('{Escape}');
   expect(tooltip).not.toBeVisible();
@@ -36,6 +35,7 @@ test('show tooltip on hover', async () => {
 test('show min/max and data range in tooltip', async () => {
   const { user } = await renderApp('/nexus_entry/nx_process/nx_data');
 
+  // Hover edit button to reveal tooltip
   const editBtn = await screen.findByRole('button', { name: 'Edit domain' });
   await user.hover(editBtn);
 
@@ -52,7 +52,7 @@ test('show min/max and data range in tooltip', async () => {
   expect(within(range).getByTitle('400')).toHaveTextContent('4e+2');
 });
 
-test('update domain when moving thumbs (with keyboard)', async () => {
+test('move thumbs with keyboard to update domain', async () => {
   const { user } = await renderApp('/nexus_entry/nx_process/nx_data');
 
   // Hover min thumb to reveal tooltip
@@ -111,7 +111,7 @@ test('edit bounds manually', async () => {
   const cancelMinBtn = screen.getByRole('button', { name: 'Cancel min' });
   expect(applyMinBtn).toBeEnabled();
   expect(cancelMinBtn).toBeEnabled();
-  await waitFor(() => expect(minInput).toHaveFocus()); // input needs time to receive focus
+  expect(minInput).toHaveFocus();
 
   // Type '1' in min input field (at the end, after the current value)
   await user.type(minInput, '1');
@@ -196,7 +196,7 @@ test('control min/max autoscale behaviour', async () => {
   await user.click(maxBtn);
   expect(maxBtn).toHaveAttribute('aria-pressed', 'true');
   expect(minBtn).toHaveAttribute('aria-pressed', 'false'); // unaffected
-  await waitFor(() => expect(maxInput).toHaveValue('4e+2')); // input needs time to be reset
+  expect(maxInput).toHaveValue('4e+2');
 });
 
 test('handle empty domain', async () => {
@@ -262,8 +262,9 @@ test('handle min > max', async () => {
 test('handle min or max <= 0 in log scale', async () => {
   const { user } = await renderApp('/nexus_entry/image');
 
+  // Ensure the scale type is log
   await expect(
-    screen.findByRole('button', { name: 'Log' }) // wait for switch to log scale
+    screen.findByRole('button', { name: 'Log' })
   ).resolves.toBeVisible();
 
   const editBtn = screen.getByRole('button', { name: 'Edit domain' });

--- a/packages/app/src/__tests__/Explorer.test.tsx
+++ b/packages/app/src/__tests__/Explorer.test.tsx
@@ -37,14 +37,14 @@ test('toggle explorer sidebar', async () => {
 });
 
 test('navigate groups in explorer', async () => {
-  const { user } = await renderApp();
+  const { selectExplorerNode } = await renderApp();
 
   const groupBtn = await screen.findByRole('treeitem', { name: 'entities' });
   expect(groupBtn).toHaveAttribute('aria-selected', 'false');
   expect(groupBtn).toHaveAttribute('aria-expanded', 'false');
 
   // Expand `entities` group
-  await user.click(groupBtn);
+  await selectExplorerNode('entities');
 
   expect(groupBtn).toHaveAttribute('aria-selected', 'true');
   expect(groupBtn).toHaveAttribute('aria-expanded', 'true');
@@ -56,7 +56,7 @@ test('navigate groups in explorer', async () => {
   expect(childGroupBtn).toHaveAttribute('aria-expanded', 'false');
 
   // Expand `empty_group` child group
-  await user.click(childGroupBtn);
+  await selectExplorerNode('empty_group');
 
   expect(groupBtn).toHaveAttribute('aria-selected', 'false');
   expect(groupBtn).toHaveAttribute('aria-expanded', 'true');
@@ -64,20 +64,20 @@ test('navigate groups in explorer', async () => {
   expect(childGroupBtn).toHaveAttribute('aria-expanded', 'true');
 
   // Collapse `empty_group` child group
-  await user.click(childGroupBtn);
+  await selectExplorerNode('empty_group');
 
   expect(childGroupBtn).toHaveAttribute('aria-selected', 'true');
   expect(childGroupBtn).toHaveAttribute('aria-expanded', 'false');
 
   // Select `entities` group
-  await user.click(groupBtn);
+  await selectExplorerNode('entities');
 
   expect(groupBtn).toHaveAttribute('aria-selected', 'true');
   expect(groupBtn).toHaveAttribute('aria-expanded', 'true'); // remains expanded as it wasn't previously selected
   expect(childGroupBtn).toHaveAttribute('aria-selected', 'false');
 
   // Collapse `entities` group
-  await user.click(groupBtn);
+  await selectExplorerNode('entities');
 
   expect(
     screen.queryByRole('treeitem', { name: 'empty_group' })

--- a/packages/app/src/__tests__/MetadataViewer.test.tsx
+++ b/packages/app/src/__tests__/MetadataViewer.test.tsx
@@ -116,6 +116,7 @@ test('follow path attributes', async () => {
   const { user, selectExplorerNode } = await renderApp();
   await user.click(await screen.findByRole('tab', { name: 'Inspect' }));
 
+  // Follow relative `default` attribute
   await user.click(
     await screen.findByRole('button', { name: 'Inspect nexus_entry' })
   );

--- a/packages/app/src/__tests__/NexusPack.test.tsx
+++ b/packages/app/src/__tests__/NexusPack.test.tsx
@@ -259,7 +259,6 @@ test('cancel and retry slow fetch of NxSpectrum', async () => {
     withFakeTimers: true,
   });
 
-  // Select NXdata group with spectrum interpretation and start fetching dataset values
   await expect(screen.findByText(/Loading data/)).resolves.toBeVisible();
 
   // Cancel all fetches at once
@@ -286,7 +285,6 @@ test('cancel and retry slow fetch of NxImage', async () => {
     withFakeTimers: true,
   });
 
-  // Select NXdata group with image interpretation and start fetching dataset values
   await expect(screen.findByText(/Loading data/)).resolves.toBeVisible();
 
   // Cancel all fetches at once
@@ -311,7 +309,6 @@ test('retry fetching automatically when re-selecting NxSpectrum', async () => {
     withFakeTimers: true,
   });
 
-  // Select NXdata group with spectrum interpretation and start fetching dataset values
   await expect(screen.findByText(/Loading data/)).resolves.toBeVisible();
 
   // Cancel all fetches at once
@@ -325,7 +322,7 @@ test('retry fetching automatically when re-selecting NxSpectrum', async () => {
   await selectExplorerNode('entities');
   await expect(screen.findByText(/No visualization/)).resolves.toBeVisible();
 
-  // Select dataset again
+  // Select NXdata group again
   await selectExplorerNode('slow_nx_spectrum');
   await expect(screen.findByText(/Loading data/)).resolves.toBeVisible();
 
@@ -340,7 +337,6 @@ test('retry fetching automatically when selecting other NxImage slice', async ()
     withFakeTimers: true,
   });
 
-  // Select NXdata group with spectrum interpretation and start fetching dataset values
   await expect(screen.findByText(/Loading data/)).resolves.toBeVisible();
 
   // Cancel all fetches at once

--- a/packages/app/src/__tests__/VisSelector.test.tsx
+++ b/packages/app/src/__tests__/VisSelector.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from '@testing-library/react';
 
-import { renderApp } from '../test-utils';
+import { findSelectedVisTab, renderApp } from '../test-utils';
 import { Vis } from '../vis-packs/core/visualizations';
 
 test('switch between visualizations', async () => {
@@ -70,9 +70,10 @@ test('remember preferred visualization when switching between datasets', async (
     '/nD_datasets/twoD'
   );
 
-  /* Switch to Matrix vis. Since this is not the most advanced visualization
+  /* Switch to Matrix vis. Since this is _not_ the most advanced visualization
    * for `twoD`, it becomes the preferred visualization. */
   await selectVisTab(Vis.Matrix);
+  await expect(findSelectedVisTab()).resolves.toBe('Matrix');
 
   // Select another dataset for which the Matrix vis is not the most advanced visualization
   await selectExplorerNode('oneD');
@@ -81,6 +82,7 @@ test('remember preferred visualization when switching between datasets', async (
   await expect(
     screen.findByRole('tab', { name: 'Matrix' })
   ).resolves.toHaveAttribute('aria-selected', 'true');
+  await expect(findSelectedVisTab()).resolves.toBe('Matrix');
 
   /* Switch to Line vis. Since this _is_ the most advanced visualization for
    * `oneD`, the preferred visualization is cleared. */
@@ -93,4 +95,5 @@ test('remember preferred visualization when switching between datasets', async (
   await expect(
     screen.findByRole('tab', { name: 'RGB' })
   ).resolves.toHaveAttribute('aria-selected', 'true');
+  await expect(findSelectedVisTab()).resolves.toBe('RGB');
 });

--- a/packages/app/src/__tests__/Visualizer.test.tsx
+++ b/packages/app/src/__tests__/Visualizer.test.tsx
@@ -39,7 +39,6 @@ test('cancel and retry slow fetch of dataset value', async () => {
     withFakeTimers: true,
   });
 
-  // Select dataset and start fetching value
   await expect(screen.findByText(/Loading data/)).resolves.toBeVisible();
 
   // Cancel fetch
@@ -65,7 +64,6 @@ test('cancel and retry slow fetch of dataset slice', async () => {
     withFakeTimers: true,
   });
 
-  // Select dataset and start fetching first slice
   await expect(
     screen.findByText(/Loading current slice/)
   ).resolves.toBeVisible();
@@ -95,7 +93,6 @@ test('retry fetching automatically when re-selecting dataset', async () => {
     withFakeTimers: true,
   });
 
-  // Select dataset and start fetching
   await expect(screen.findByText(/Loading data/)).resolves.toBeVisible();
 
   // Cancel fetch
@@ -123,7 +120,6 @@ test('retry fetching dataset slice automatically when re-selecting slice', async
     withFakeTimers: true,
   });
 
-  // Select dataset and start fetching first slice
   await expect(
     screen.findByText(/Loading current slice/)
   ).resolves.toBeVisible();
@@ -164,7 +160,6 @@ test('cancel fetching dataset slice when changing entity', async () => {
     withFakeTimers: true,
   });
 
-  // Select dataset and start fetching first slice
   await expect(
     screen.findByText(/Loading current slice/)
   ).resolves.toBeVisible();
@@ -176,9 +171,10 @@ test('cancel fetching dataset slice when changing entity', async () => {
   // Let pending requests succeed
   jest.runAllTimers();
 
-  // Reselect dataset and check that it refetches the first slice
+  // Reselect initial dataset
   await selectExplorerNode('slow_slicing');
-  // The slice request was cancelled so it should be pending once again
+
+  // Ensure that fetching restarts (since it was cancelled)
   await expect(
     screen.findByText(/Loading current slice/)
   ).resolves.toBeVisible();
@@ -199,7 +195,7 @@ test('cancel fetching dataset slice when changing vis', async () => {
     screen.findByText(/Loading current slice/)
   ).resolves.toBeVisible();
 
-  // Switch to the Line vis to cancel the fetch
+  // Switch to Line visualization to cancel fetch
   await selectVisTab(Vis.Line);
   await expect(
     screen.findByText(/Loading current slice/)


### PR DESCRIPTION
Part six, and final, of bringing in test improvements from https://github.com/silx-kit/h5web/pull/1119

I diffed all the test files and brought a few more things over, including some of the documentation from: https://github.com/silx-kit/h5web/pull/1119/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055

Only thing that's left and that can't be ported is all the async `Suspense` stuff: waiting for all loaders to disappear; using `getBy` instead of `findBy` in tests with real timers; and using `findBy` with a timeout in tests with fake timers. This stuff requires upgrading  React Testing Library to v13, which requires upgrading React to v18.