### PR TITLE
Fix experimental vis not appearing

### DIFF
--- a/packages/app/src/vis-packs/core/visualizations.ts
+++ b/packages/app/src/vis-packs/core/visualizations.ts
@@ -44,9 +44,6 @@ import {
 import SurfaceVisContainer from './surface/SurfaceVisContainer';
 import { SurfaceConfigProvider } from './surface/config';
 
-// @ts-expect-error
-const enableSurfaceVis = window.H5WEB_EXPERIMENTAL;
-
 export enum Vis {
   Raw = 'Raw',
   Scalar = 'Scalar',
@@ -179,6 +176,9 @@ export const CORE_VIS: Record<Vis, CoreVisDef> = {
     Container: SurfaceVisContainer,
     ConfigProvider: SurfaceConfigProvider,
     supportsDataset: (dataset) => {
+      // @ts-expect-error
+      const enableSurfaceVis = window.H5WEB_EXPERIMENTAL;
+
       return (
         enableSurfaceVis &&
         hasNumericType(dataset) &&

--- a/packages/app/src/visualizer/utils.ts
+++ b/packages/app/src/visualizer/utils.ts
@@ -83,8 +83,8 @@ function getSupportedCoreVis(
     (vis) => isDataset(entity) && vis.supportsDataset(entity, attrValueStore)
   );
 
-  return supportedVis.length > 1 && supportedVis[0].name === Vis.Raw
-    ? supportedVis.slice(1)
+  return supportedVis.length > 1
+    ? supportedVis.filter((vis) => vis.name !== Vis.Raw)
     : supportedVis;
 }
 


### PR DESCRIPTION
I think our process for enabling experimenal vis was not working properly: the SurfaceVis did appear only when hot-reloading a dev version of the project.

I think this is due to the fact that `window.H5WEB_EXPERIMENTAL` is read before it is set by the `DemoApp` component. Since `window.H5WEB_EXPERIMENTAL` is `undefined`, the SurfaceVis is not enabled (expect if the reading of the variable is triggerred by a hot reloading).

To fix this, I now read `window.H5WEB_EXPERIMENTAL` in the `supportsDataset` function of the SurfaceVis so that its value is always up to date.