### PR TITLE
Specify pnpm scripts required in every projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,10 @@
       "ignoreMissing": [
         "require-from-string"
       ]
-    }
+    },
+    "requiredScripts": [
+      "lint:eslint",
+      "lint:tsc"
+    ]
   }
 }


### PR DESCRIPTION
Added in pnpm 7.19: https://pnpm.io/package_json#pnpmrequiredscripts

Note that it only makes sense for linting scripts, which are run with `pnpm run --recursive` (`pnpm -r`). There is a `build` script in every project, but we run those on a per project basis or with a `--filter`.