### PR TITLE
Invoke `SelectionTool` render prop and callbacks with transformed selection

### DIFF
--- a/packages/lib/src/interactions/AxialSelectToZoom.tsx
+++ b/packages/lib/src/interactions/AxialSelectToZoom.tsx
@@ -3,8 +3,7 @@ import type { Axis } from '@h5web/shared';
 import SvgRect from '../svg/SvgRect';
 import { useVisCanvasContext } from '../vis/shared/VisCanvasProvider';
 import AxialSelectionTool from './AxialSelectionTool';
-import Box from './box';
-import { useZoomOnBox } from './hooks';
+import { useZoomOnSelection } from './hooks';
 import type { Selection, CommonInteractionProps } from './models';
 
 interface Props extends CommonInteractionProps {
@@ -15,15 +14,15 @@ function AxialSelectToZoom(props: Props) {
   const { axis, modifierKey, disabled } = props;
 
   const { visRatio } = useVisCanvasContext();
-  const zoomOnBox = useZoomOnBox();
+  const zoomOnSelection = useZoomOnSelection();
 
-  function onSelectionEnd({ world: worldSelection }: Selection) {
-    const [worldStart, worldEnd] = worldSelection;
+  function onSelectionEnd(selection: Selection) {
+    const [worldStart, worldEnd] = selection.world;
     if (worldStart.x === worldEnd.x || worldStart.y === worldEnd.y) {
       return;
     }
 
-    zoomOnBox(Box.fromPoints(...worldSelection));
+    zoomOnSelection(selection);
   }
 
   return (

--- a/packages/lib/src/interactions/SelectionTool.tsx
+++ b/packages/lib/src/interactions/SelectionTool.tsx
@@ -22,7 +22,7 @@ import { boundWorldPointToFOV, getModifierKeyArray } from './utils';
 interface Props extends CommonInteractionProps {
   id?: string;
   transformSelection?: (selection: Selection) => Selection;
-  onSelectionStart?: (selection: Selection) => void;
+  onSelectionStart?: () => void;
   onSelectionChange?: (selection: Selection | undefined) => void;
   onSelectionEnd?: (selection: Selection) => void;
   children: (selection: Selection) => ReactNode;
@@ -132,7 +132,7 @@ function SelectionTool(props: Props) {
     if (selection) {
       // Previous selection was undefined and current selection is now defined => selection has started
       if (!prevSelection) {
-        onSelectionStartRef.current?.(selection);
+        onSelectionStartRef.current?.();
       }
 
       // Either way, current selection is defined, so invoke change callback

--- a/packages/lib/src/interactions/hooks.ts
+++ b/packages/lib/src/interactions/hooks.ts
@@ -13,6 +13,7 @@ import type {
   CanvasEventCallbacks,
   InteractionEntry,
   ModifierKey,
+  Selection,
 } from './models';
 
 const ZOOM_FACTOR = 0.95;
@@ -43,15 +44,16 @@ export function useMoveCameraTo() {
   );
 }
 
-export function useZoomOnBox() {
+export function useZoomOnSelection() {
   const { canvasSize } = useVisCanvasContext();
 
   const camera = useThree((state) => state.camera);
   const moveCameraTo = useMoveCameraTo();
 
   return useCallback(
-    (zoomBox: Box) => {
+    ({ world: worldSelection }: Selection) => {
       const { width, height } = canvasSize;
+      const zoomBox = Box.fromPoints(...worldSelection);
 
       // Update camera scale first (since `moveCameraTo` relies on camera scale)
       const { width: zoomWidth, height: zoomHeight } = zoomBox.size;


### PR DESCRIPTION
I realised that the transformed selection as well as the future `isValid` boolean can be derived from the raw selection state; they don't need to be part of the local state. As a result, the justification for having an `isCancelled` flag in the state made in #1338 no longer holds.

So in this PR, I'm going back a little by first reverting #1338 (sorry for the back and forth...) Then, I compute the transformed selection (which I refer to as the "effective" selection in comments) as a derived state in a `useMemo`, and I pass this effective `selection` object to the render prop and to the callbacks.

Finally, now that the render prop of `SelectionTool` has access to both the raw and effective selections, I can refactor `SelectToZoom` in order to compute the effective zoom selection in a `transformSelection` callback instead of twice, in both the render prop and the `onSelectionEnd` callback.