### PR TITLE
Support validating selections

### DIFF
--- a/apps/storybook/src/AxialSelectionTool.stories.tsx
+++ b/apps/storybook/src/AxialSelectionTool.stories.tsx
@@ -1,4 +1,5 @@
 import type { AxialSelectionToolProps, Selection } from '@h5web/lib';
+import { Box } from '@h5web/lib';
 import { getSvgRectCoords, SvgElement } from '@h5web/lib';
 import {
   AxialSelectionTool,
@@ -31,15 +32,15 @@ const Template: Story<AxialSelectionToolProps> = (args) => {
       <ResetZoomButton />
 
       <AxialSelectionTool
-        {...args}
         onSelectionChange={setActiveSelection}
         onSelectionEnd={() => setActiveSelection(undefined)}
+        {...args}
       >
-        {({ html: htmlSelection }) => (
+        {({ html: htmlSelection }, _, isValid) => (
           <SvgElement>
             <rect
               {...getSvgRectCoords(htmlSelection)}
-              fill="teal"
+              fill={isValid ? 'teal' : 'orangered'}
               fillOpacity={0.5}
             />
           </SvgElement>
@@ -60,6 +61,11 @@ Disabled.args = { disabled: true };
 
 export const WithModifierKey = Template.bind({});
 WithModifierKey.args = { modifierKey: 'Control' };
+
+export const WithValidation = Template.bind({});
+WithValidation.args = {
+  validate: ({ html }) => Box.fromPoints(...html).hasMinSize(200),
+};
 
 export default {
   title: 'Building Blocks/AxialSelectionTool',

--- a/packages/lib/src/interactions/AxialSelectToZoom.tsx
+++ b/packages/lib/src/interactions/AxialSelectToZoom.tsx
@@ -5,8 +5,10 @@ import AxialSelectionTool from './AxialSelectionTool';
 import SvgElement from './SvgElement';
 import Box from './box';
 import { useZoomOnSelection } from './hooks';
-import type { Selection, CommonInteractionProps } from './models';
+import type { CommonInteractionProps } from './models';
 import { getSvgRectCoords } from './utils';
+
+const MIN_SIZE = 20;
 
 interface Props extends CommonInteractionProps {
   axis: Axis;
@@ -18,28 +20,24 @@ function AxialSelectToZoom(props: Props) {
   const { visRatio } = useVisCanvasContext();
   const zoomOnSelection = useZoomOnSelection();
 
-  function onSelectionEnd(selection: Selection) {
-    const { size } = Box.fromPoints(...selection.html);
-    if (size.width > 0 && size.height > 0) {
-      zoomOnSelection(selection);
-    }
-  }
-
   return (
     <AxialSelectionTool
       axis={axis}
       id={`${axis.toUpperCase()}SelectToZoom`}
       modifierKey={modifierKey}
       disabled={visRatio !== undefined || disabled}
-      onSelectionEnd={onSelectionEnd}
+      validate={({ html }) => Box.fromPoints(...html).hasMinSize(MIN_SIZE)}
+      onValidSelection={zoomOnSelection}
     >
-      {({ html: htmlSelection }) => (
+      {({ html: htmlSelection }, _, isValid) => (
         <SvgElement>
           <rect
             {...getSvgRectCoords(htmlSelection)}
             fill="white"
+            fillOpacity={isValid ? 0.25 : 0}
             stroke="black"
-            fillOpacity={0.25}
+            strokeDasharray={isValid ? undefined : 4}
+            style={{ transition: 'fill-opacity 0.2s' }}
           />
         </SvgElement>
       )}

--- a/packages/lib/src/interactions/AxialSelectionTool.tsx
+++ b/packages/lib/src/interactions/AxialSelectionTool.tsx
@@ -41,7 +41,7 @@ function AxialSelectionTool(props: Props) {
 
   return (
     <SelectionTool
-      transformSelection={toAxialSelection}
+      transform={toAxialSelection}
       onSelectionStart={onSelectionStart}
       onSelectionChange={onSelectionChange}
       onSelectionEnd={onSelectionEnd}

--- a/packages/lib/src/interactions/box.ts
+++ b/packages/lib/src/interactions/box.ts
@@ -50,6 +50,11 @@ class Box extends Box3 {
     return this.expandBySize(0, width / ratio - height); // increase height
   }
 
+  public hasMinSize(minWidth: number, minHeight = minWidth): boolean {
+    const { width, height } = this.size;
+    return width >= minWidth && height >= minHeight;
+  }
+
   public keepWithin(area: Box): this {
     const { center, size } = this;
     const { width: areaWidth, height: areaHeight } = area.size;


### PR DESCRIPTION
At last, the `SelectionTool` can now report whether the selection is valid or not!

By default, it checks for a default width and height of 20px, which seems to be a sensible default behaviour for rectangle selections. Since the validity check is performed on the transformed selection, this behaviour works perfectly for both `SelectToZoom` and `AxialSelectToZoom`:

![valid-selection](https://user-images.githubusercontent.com/2936402/211784601-f7805118-067f-4511-8fbb-c3828b3e1dc9.gif)

![valid-selection-rect](https://user-images.githubusercontent.com/2936402/211784717-3d380d6e-c18a-42ca-a868-cf0c44d19330.gif)

However, the default validation behaviour does not work for line selection (e.g. for drawing line profiles), as in this case, what matters is the length of the line, not the size of the box. To cover this use case (and most likely others), `SelecionTool` simply accepts a custom validation function. This function has access to the current selection in all three coordinate spaces, so it's really flexible:

![valid-selection-line](https://user-images.githubusercontent.com/2936402/211784740-d76c57b3-d327-4607-9b00-b650e643eeb2.gif)
