### PR TITLE
Prevent stroke of zoom rectangles from being cropped by canvas

### DIFF
--- a/apps/storybook/src/AxialSelectionTool.stories.tsx
+++ b/apps/storybook/src/AxialSelectionTool.stories.tsx
@@ -1,6 +1,7 @@
 import type { AxialSelectionToolProps, Selection } from '@h5web/lib';
 import { Box } from '@h5web/lib';
-import { getSvgRectCoords, SvgElement } from '@h5web/lib';
+import { SvgRect } from '@h5web/lib';
+import { SvgElement } from '@h5web/lib';
 import {
   AxialSelectionTool,
   Pan,
@@ -38,8 +39,8 @@ const Template: Story<AxialSelectionToolProps> = (args) => {
       >
         {({ html: htmlSelection }, _, isValid) => (
           <SvgElement>
-            <rect
-              {...getSvgRectCoords(htmlSelection)}
+            <SvgRect
+              coords={htmlSelection}
               fill={isValid ? 'teal' : 'orangered'}
               fillOpacity={0.5}
             />

--- a/apps/storybook/src/SelectionTool.stories.tsx
+++ b/apps/storybook/src/SelectionTool.stories.tsx
@@ -5,8 +5,8 @@ import type {
   SelectionToolProps,
 } from '@h5web/lib';
 import { Box } from '@h5web/lib';
-import { getSvgLineCoords } from '@h5web/lib';
-import { getSvgRectCoords } from '@h5web/lib';
+import { SvgLine } from '@h5web/lib';
+import { SvgRect } from '@h5web/lib';
 import { SvgElement } from '@h5web/lib';
 import { DataToHtml } from '@h5web/lib';
 import {
@@ -62,12 +62,13 @@ const Template: Story<TemplateProps> = (args) => {
       >
         {({ html: htmlSelection }, _, isValid) => (
           <SvgElement>
-            <rect
-              {...getSvgRectCoords(htmlSelection)}
-              stroke={isValid ? 'teal' : 'orangered'}
-              strokeWidth={2}
+            <SvgRect
+              coords={htmlSelection}
               fill={isValid ? 'teal' : 'orangered'}
               fillOpacity={0.5}
+              stroke={isValid ? 'teal' : 'orangered'}
+              strokeWidth={2}
+              strokePosition="inside"
             />
           </SvgElement>
         )}
@@ -109,8 +110,8 @@ export const PersistedDataSelection: Story = () => {
       >
         {({ html: htmlSelection }, _, isValid) => (
           <SvgElement>
-            <rect
-              {...getSvgRectCoords(htmlSelection)}
+            <SvgRect
+              coords={htmlSelection}
               fill={isValid ? 'teal' : 'orangered'}
               fillOpacity="0.3"
             />
@@ -122,11 +123,7 @@ export const PersistedDataSelection: Story = () => {
         <DataToHtml points={persistedDataSelection}>
           {(...htmlSelection) => (
             <SvgElement>
-              <rect
-                {...getSvgRectCoords(htmlSelection)}
-                fill="teal"
-                fillOpacity="0.6"
-              />
+              <SvgRect coords={htmlSelection} fill="teal" fillOpacity="0.6" />
             </SvgElement>
           )}
         </DataToHtml>
@@ -168,8 +165,8 @@ export const LineWithLengthValidation: Story<TemplateProps> = () => {
       >
         {({ html: htmlSelection }, _, isValid) => (
           <SvgElement>
-            <line
-              {...getSvgLineCoords(htmlSelection)}
+            <SvgLine
+              coords={htmlSelection}
               stroke={isValid ? 'teal' : 'orangered'}
               strokeWidth={3}
               strokeLinecap="round"

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -57,7 +57,6 @@ export { default as SelectToZoom } from './interactions/SelectToZoom';
 export { default as AxialSelectToZoom } from './interactions/AxialSelectToZoom';
 export { default as SelectionTool } from './interactions/SelectionTool';
 export { default as AxialSelectionTool } from './interactions/AxialSelectionTool';
-export { default as SvgElement } from './interactions/SvgElement';
 export type { PanProps } from './interactions/Pan';
 export type { ZoomProps } from './interactions/Zoom';
 export type { XAxisZoomProps } from './interactions/XAxisZoom';
@@ -67,7 +66,14 @@ export type { SelectToZoomProps } from './interactions/SelectToZoom';
 export type { AxialSelectionToolProps } from './interactions/AxialSelectionTool';
 export type { AxialSelectToZoomProps } from './interactions/AxialSelectToZoom';
 export type { DefaultInteractionsConfig } from './interactions/DefaultInteractions';
-export type { SvgElementProps } from './interactions/SvgElement';
+
+// SVG
+export { default as SvgElement } from './interactions/svg/SvgElement';
+export { default as SvgLine } from './interactions/svg/SvgLine';
+export { default as SvgRect } from './interactions/svg/SvgRect';
+export type { SvgElementProps } from './interactions/svg/SvgElement';
+export type { SvgLineProps } from './interactions/svg/SvgLine';
+export type { SvgRectProps } from './interactions/svg/SvgRect';
 
 // Context
 export { useVisCanvasContext } from './vis/shared/VisCanvasProvider';
@@ -106,7 +112,6 @@ export {
 export { useVisDomain, useSafeDomain } from './vis/heatmap/hooks';
 
 export { scaleGamma } from './vis/scaleGamma';
-export { getSvgRectCoords, getSvgLineCoords } from './interactions/utils';
 export { useCanvasEvents } from './interactions/hooks';
 export { default as Box } from './interactions/box';
 

--- a/packages/lib/src/interactions/AxialSelectToZoom.tsx
+++ b/packages/lib/src/interactions/AxialSelectToZoom.tsx
@@ -2,11 +2,12 @@ import type { Axis } from '@h5web/shared';
 
 import { useVisCanvasContext } from '../vis/shared/VisCanvasProvider';
 import AxialSelectionTool from './AxialSelectionTool';
-import SvgElement from './SvgElement';
+import styles from './SelectToZoom.module.css';
 import Box from './box';
 import { useZoomOnSelection } from './hooks';
 import type { CommonInteractionProps } from './models';
-import { getSvgRectCoords } from './utils';
+import SvgElement from './svg/SvgElement';
+import SvgRect from './svg/SvgRect';
 
 const MIN_SIZE = 20;
 
@@ -31,13 +32,11 @@ function AxialSelectToZoom(props: Props) {
     >
       {({ html: htmlSelection }, _, isValid) => (
         <SvgElement>
-          <rect
-            {...getSvgRectCoords(htmlSelection)}
-            fill="white"
-            fillOpacity={isValid ? 0.25 : 0}
-            stroke="black"
-            strokeDasharray={isValid ? undefined : 4}
-            style={{ transition: 'fill-opacity 0.2s' }}
+          <SvgRect
+            className={styles.rawSelection}
+            coords={htmlSelection}
+            strokePosition="inside"
+            data-valid={isValid || undefined}
           />
         </SvgElement>
       )}

--- a/packages/lib/src/interactions/SelectToZoom.module.css
+++ b/packages/lib/src/interactions/SelectToZoom.module.css
@@ -1,0 +1,18 @@
+.selection {
+  fill: white;
+  fill-opacity: 0;
+  stroke: black;
+  transition: 'fill-opacity 0.2s';
+}
+
+.selection[data-valid] {
+  fill-opacity: 0.25;
+}
+
+.rawSelection {
+  composes: selection;
+}
+
+.rawSelection:not([data-valid]) {
+  stroke-dasharray: 4;
+}

--- a/packages/lib/src/interactions/SelectToZoom.tsx
+++ b/packages/lib/src/interactions/SelectToZoom.tsx
@@ -2,12 +2,13 @@ import { useThree } from '@react-three/fiber';
 import { Vector3 } from 'three';
 
 import { useVisCanvasContext } from '../vis/shared/VisCanvasProvider';
+import styles from './SelectToZoom.module.css';
 import SelectionTool from './SelectionTool';
-import SvgElement from './SvgElement';
 import Box from './box';
 import { useZoomOnSelection } from './hooks';
 import type { CommonInteractionProps, Rect, Selection } from './models';
-import { getSvgRectCoords } from './utils';
+import SvgElement from './svg/SvgElement';
+import SvgRect from './svg/SvgRect';
 
 const MIN_SIZE = 20;
 
@@ -60,21 +61,18 @@ function SelectToZoom(props: Props) {
     >
       {({ html: htmlSelection }, { html: rawHtmlSelection }, isValid) => (
         <SvgElement>
-          <rect
-            {...getSvgRectCoords(rawHtmlSelection)}
-            fill="white"
-            fillOpacity={keepRatio || !isValid ? 0 : 0.25}
-            stroke="black"
-            strokeDasharray={keepRatio || !isValid ? 4 : undefined}
-            style={{ transition: 'fill-opacity 0.2s' }}
+          <SvgRect
+            className={styles.rawSelection}
+            coords={rawHtmlSelection}
+            strokePosition="inside"
+            data-valid={(!keepRatio && isValid) || undefined}
           />
           {keepRatio && (
-            <rect
-              {...getSvgRectCoords(htmlSelection)}
-              fill="white"
-              fillOpacity={isValid ? 0.25 : 0}
-              stroke="black"
-              style={{ transition: 'fill-opacity 0.2s' }}
+            <SvgRect
+              className={styles.selection}
+              coords={htmlSelection}
+              strokePosition="inside"
+              data-valid={isValid || undefined}
             />
           )}
         </SvgElement>

--- a/packages/lib/src/interactions/svg/SvgElement.tsx
+++ b/packages/lib/src/interactions/svg/SvgElement.tsx
@@ -1,8 +1,8 @@
 import type { ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 
-import Html from '../vis/shared/Html';
-import { useVisCanvasContext } from '../vis/shared/VisCanvasProvider';
+import Html from '../../vis/shared/Html';
+import { useVisCanvasContext } from '../../vis/shared/VisCanvasProvider';
 
 interface Props {
   children?: ReactNode;

--- a/packages/lib/src/interactions/svg/SvgLine.tsx
+++ b/packages/lib/src/interactions/svg/SvgLine.tsx
@@ -1,0 +1,17 @@
+import type { SVGProps } from 'react';
+
+import type { Rect } from '../models';
+
+interface Props extends SVGProps<SVGLineElement> {
+  coords: Rect;
+}
+
+function SvgLine(props: Props) {
+  const { coords, ...svgProps } = props;
+  const [start, end] = coords;
+
+  return <line x1={start.x} y1={start.y} x2={end.x} y2={end.y} {...svgProps} />;
+}
+
+export type { Props as SvgLineProps };
+export default SvgLine;

--- a/packages/lib/src/interactions/svg/SvgRect.tsx
+++ b/packages/lib/src/interactions/svg/SvgRect.tsx
@@ -1,0 +1,36 @@
+import type { SVGProps } from 'react';
+
+import type { Rect } from '../models';
+
+interface Props extends SVGProps<SVGRectElement> {
+  coords: Rect;
+  strokeWidth?: number; // forbid string
+  strokePosition?: 'inside' | 'outside';
+}
+
+function SvgRect(props: Props) {
+  const { coords, strokePosition, ...svgProps } = props;
+
+  const [start, end] = coords;
+  const { stroke, strokeWidth = 1 } = svgProps;
+
+  // Shrink/grow rectangle to simulate positioning stroke inside/outside
+  // https://stackoverflow.com/questions/7241393/can-you-control-how-an-svgs-stroke-width-is-drawn
+  const offset =
+    stroke && strokePosition
+      ? (strokeWidth / 2) * (strokePosition === 'inside' ? 1 : -1)
+      : 0;
+
+  return (
+    <rect
+      x={Math.min(start.x, end.x) + offset}
+      y={Math.min(start.y, end.y) + offset}
+      width={Math.abs(end.x - start.x) - offset * 2}
+      height={Math.abs(end.y - start.y) - offset * 2}
+      {...svgProps}
+    />
+  );
+}
+
+export type { Props as SvgRectProps };
+export default SvgRect;

--- a/packages/lib/src/interactions/utils.ts
+++ b/packages/lib/src/interactions/utils.ts
@@ -1,29 +1,7 @@
-import type { ModifierKey, Rect } from './models';
+import type { ModifierKey } from './models';
 
 export function getModifierKeyArray(
   keys: ModifierKey | ModifierKey[] | undefined = []
 ): ModifierKey[] {
   return Array.isArray(keys) ? keys : [keys];
-}
-
-export function getSvgRectCoords(rect: Rect) {
-  const [start, end] = rect;
-
-  return {
-    x: Math.min(start.x, end.x),
-    y: Math.min(start.y, end.y),
-    width: Math.abs(end.x - start.x),
-    height: Math.abs(end.y - start.y),
-  };
-}
-
-export function getSvgLineCoords(rect: Rect) {
-  const [start, end] = rect;
-
-  return {
-    x1: start.x,
-    y1: start.y,
-    x2: end.x,
-    y2: end.y,
-  };
 }

--- a/packages/lib/src/vis/shared/DataToHtml.tsx
+++ b/packages/lib/src/vis/shared/DataToHtml.tsx
@@ -1,9 +1,8 @@
 import type { MappedTuple } from '@h5web/shared';
-import { useThree } from '@react-three/fiber';
 import type { ReactNode } from 'react';
 import type { Vector3 } from 'three';
 
-import { useVisCanvasContext } from './VisCanvasProvider';
+import { useCameraState } from '../hooks';
 
 interface Props<T extends Vector3[]> {
   points: T;
@@ -13,12 +12,11 @@ interface Props<T extends Vector3[]> {
 function DataToHtml<T extends Vector3[]>(props: Props<T>) {
   const { points, children } = props;
 
-  const { dataToHtml } = useVisCanvasContext();
-  const camera = useThree((state) => state.camera);
-
-  const htmlPoints = points.map((pt) => {
-    return dataToHtml(camera, pt);
-  }) as MappedTuple<T, Vector3>;
+  const htmlPoints = useCameraState(
+    (camera, { dataToHtml }) =>
+      points.map((pt) => dataToHtml(camera, pt)) as MappedTuple<T, Vector3>,
+    [points]
+  );
 
   return <>{children(...htmlPoints)}</>;
 }


### PR DESCRIPTION
And.... `SvgRect` and `SvgLine` are back!! 😂 

This is something I had been meaning to fix for a while. Notice how the stroke of the zoom rectangle gets cropped by the the canvas:

![stroke-cropped](https://user-images.githubusercontent.com/2936402/211840975-85b75184-f6f2-4239-b25c-da04480f9b3a.gif)

What it looks like now:

![stroke-not-cropped](https://user-images.githubusercontent.com/2936402/211841002-8e0b6b38-1ae2-4e8d-bdf8-ed88980ccca5.gif)

This is a good use case for re-introducing `SvgRect` and `SvgLine`, as "shifting" the stroke inside of the rectangle requires knowing the `strokeWidth` (and whether `stroke` is declared at all). Utilities aren't great to handle this.

Note, however, that I'm now choosing to keep `SvgElement` out of `SvgRect/Line`.