### PR TITLE
Add dashed and thick line support to DataCurve

### DIFF
--- a/apps/storybook/src/DataCurve.stories.tsx
+++ b/apps/storybook/src/DataCurve.stories.tsx
@@ -45,6 +45,11 @@ DashedLine.args = {
   gapSize: 5,
 };
 
+export const LineWidth = Template.bind({});
+LineWidth.args = {
+  lineWidth: 2,
+};
+
 export const Glyphs = Template.bind({});
 Glyphs.args = {
   curveType: CurveType.GlyphsOnly,
@@ -138,6 +143,7 @@ export default {
   args: {
     abscissas: range(0, mockValues.oneD.length),
     ordinates: mockValues.oneD,
+    errors: mockValues.oneD_errors,
     curveType: CurveType.LineOnly,
     color: 'blue',
     visible: true,

--- a/apps/storybook/src/DataCurve.stories.tsx
+++ b/apps/storybook/src/DataCurve.stories.tsx
@@ -39,6 +39,12 @@ Color.args = {
   color: 'black',
 };
 
+export const DashedLine = Template.bind({});
+DashedLine.args = {
+  dashSize: 5,
+  gapSize: 5,
+};
+
 export const Glyphs = Template.bind({});
 Glyphs.args = {
   curveType: CurveType.GlyphsOnly,

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -65,6 +65,7 @@
     "react-measure": "2.5.2",
     "react-slider": "2.0.4",
     "react-window": "1.8.8",
+    "three-stdlib": "2.21.5",
     "zustand": "4.1.4"
   },
   "devDependencies": {

--- a/packages/lib/src/vis/line/DataCurve.tsx
+++ b/packages/lib/src/vis/line/DataCurve.tsx
@@ -2,7 +2,7 @@ import type { NumArray } from '@h5web/shared';
 import { extend, useThree } from '@react-three/fiber';
 import type { Object3DNode, ThreeEvent } from '@react-three/fiber';
 import { useCallback, useLayoutEffect, useState } from 'react';
-import { BufferGeometry, Float32BufferAttribute, Line } from 'three';
+import { BufferGeometry, Line, } from 'three';
 
 import ErrorBars from './ErrorBars';
 import GlyphMaterial from './GlyphMaterial';
@@ -58,10 +58,9 @@ function DataCurve(props: Props) {
     onDataPointLeave,
   } = props;
 
-  const [dataGeometry] = useState(() => new BufferGeometry());
-  const vertices = (abscissas.flatMap((abscissa, i) => [abscissa, ordinates[i], 0])).flat();
-  dataGeometry.setAttribute("position", new Float32BufferAttribute(vertices, 3));
   const points = useCanvasPoints(abscissas, ordinates, errors);
+  const [dataGeometry] = useState(() => new BufferGeometry());
+  dataGeometry.setFromPoints(points.data);
   const invalidate = useThree((state) => state.invalidate);
 
   useLayoutEffect(() => {
@@ -108,8 +107,17 @@ function DataCurve(props: Props) {
 
   return (
     <>
-      <line_ onUpdate={(line_) => line_.computeLineDistances()} visible={showLine} geometry={dataGeometry}>
-        <lineDashedMaterial color={color} linewidth={linewidth} dashSize={dashSize} gapSize={gapSize}/>
+      <line_
+        visible={showLine}
+        onUpdate={(line_) => line_.computeLineDistances()}
+        geometry={dataGeometry}
+      >
+        <lineDashedMaterial
+          color={color}
+          linewidth={linewidth}
+          dashSize={dashSize}
+          gapSize={gapSize}
+        />
       </line_>
       <points
         visible={showGlyphs}

--- a/packages/lib/src/vis/line/DataCurve.tsx
+++ b/packages/lib/src/vis/line/DataCurve.tsx
@@ -101,7 +101,9 @@ function DataCurve(props: Props) {
     invalidate();
   }, [bufferGeometry, invalidate, points.data]);
   useLayoutEffect(() => {
-    lineGeometry.setPositions(flatData);
+    if (flatData.length >= 3) {
+      lineGeometry.setPositions(flatData);
+    }
     invalidate();
   }, [lineGeometry, invalidate, flatData]);
 

--- a/packages/lib/src/vis/line/DataCurve.tsx
+++ b/packages/lib/src/vis/line/DataCurve.tsx
@@ -2,7 +2,7 @@ import type { NumArray } from '@h5web/shared';
 import { extend, useThree } from '@react-three/fiber';
 import type { Object3DNode, ThreeEvent } from '@react-three/fiber';
 import { useCallback, useLayoutEffect, useState } from 'react';
-import { BufferGeometry, Line } from 'three';
+import { BufferGeometry, Float32BufferAttribute, Line } from 'three';
 
 import ErrorBars from './ErrorBars';
 import GlyphMaterial from './GlyphMaterial';
@@ -27,6 +27,9 @@ interface Props {
   errors?: NumArray;
   showErrors?: boolean;
   color: string;
+  linewidth?: number;
+  dashSize?: number;
+  gapSize?: number;
   curveType?: CurveType;
   glyphType?: GlyphType;
   glyphSize?: number;
@@ -43,6 +46,9 @@ function DataCurve(props: Props) {
     errors,
     showErrors,
     color,
+    linewidth = 1,
+    dashSize = 3,
+    gapSize = 0,
     curveType = CurveType.LineOnly,
     glyphType = GlyphType.Cross,
     glyphSize = 6,
@@ -53,6 +59,8 @@ function DataCurve(props: Props) {
   } = props;
 
   const [dataGeometry] = useState(() => new BufferGeometry());
+  const vertices = (abscissas.flatMap((abscissa, i) => [abscissa, ordinates[i], 0])).flat();
+  dataGeometry.setAttribute("position", new Float32BufferAttribute(vertices, 3));
   const points = useCanvasPoints(abscissas, ordinates, errors);
   const invalidate = useThree((state) => state.invalidate);
 
@@ -100,8 +108,8 @@ function DataCurve(props: Props) {
 
   return (
     <>
-      <line_ visible={showLine} geometry={dataGeometry}>
-        <lineBasicMaterial color={color} />
+      <line_ onUpdate={(line_) => line_.computeLineDistances()} visible={showLine} geometry={dataGeometry}>
+        <lineDashedMaterial color={color} linewidth={linewidth} dashSize={dashSize} gapSize={gapSize}/>
       </line_>
       <points
         visible={showGlyphs}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,6 +342,7 @@ importers:
       rollup: 3.5.1
       rollup-plugin-dts: 5.0.0
       three: 0.141.0
+      three-stdlib: 2.21.5
       typescript: 4.9.3
       vite: 3.2.4
       zustand: 4.1.4
@@ -368,6 +369,7 @@ importers:
       react-measure: 2.5.2_sfoxds7t5ydpegc3knd667wn6m
       react-slider: 2.0.4_react@17.0.2
       react-window: 1.8.8_sfoxds7t5ydpegc3knd667wn6m
+      three-stdlib: 2.21.5_three@0.141.0
       zustand: 4.1.4_react@17.0.2
     devDependencies:
       '@h5web/shared': link:../shared
@@ -15095,6 +15097,25 @@ packages:
 
   /three-stdlib/2.20.0_three@0.141.0:
     resolution: {integrity: sha512-GGQzAD2alkarMhDY/iExbCrY5DQ4uBQxN8vcnKFPlUyf+3YkQMHm6ZAXri1Dgxm73utym8U/OEtUEkZpq6ykpQ==}
+    peerDependencies:
+      three: '>=0.122.0'
+    dependencies:
+      '@babel/runtime': 7.20.6
+      '@types/offscreencanvas': 2019.7.0
+      '@webgpu/glslang': 0.0.15
+      chevrotain: 10.4.2
+      draco3d: 1.5.5
+      fflate: 0.6.10
+      ktx-parse: 0.4.5
+      mmd-parser: 1.0.4
+      opentype.js: 1.3.4
+      potpack: 1.0.2
+      three: 0.141.0
+      zstddec: 0.0.2
+    dev: false
+
+  /three-stdlib/2.21.5_three@0.141.0:
+    resolution: {integrity: sha512-PzlbMFVApPjdFwNoTCnrH6r8J1rQw5Dn40qkHc8P+vVDj1czHOmCduYAA27bYwNNTcd+q3AWE+qutDrvvc5B2g==}
     peerDependencies:
       three: '>=0.122.0'
     dependencies:


### PR DESCRIPTION
This PR enhances `DataCurve` by adding new attributes to its props which:
1. Allow dashed lines by using `LineDashedMaterial`.
2. Support line widths other than 1. WebGL  does not support setting its line primitive to other widths so enable them by using an different Line implementation from `three-stdlib`.
