### PR TITLE
Remove `type` fields in prepublish scripts instead of CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,14 +63,6 @@ jobs:
           version: ${{ steps.packageVersion.outputs.PACKAGE_VERSION }}
           package: 'packages/h5wasm'
 
-      # https://github.com/silx-kit/h5web/issues/1219
-      - name: 'Remove `"type": "module"` from `package.json` files'
-        run: |
-          cd packages
-          cat <<< $(pnpm --package=node-jq dlx jq "del(.type)" app/package.json) > app/package.json
-          cat <<< $(pnpm --package=node-jq dlx jq "del(.type)" h5wasm/package.json) > h5wasm/package.json
-          cat <<< $(pnpm --package=node-jq dlx jq "del(.type)" lib/package.json) > lib/package.json
-
       - name: Publish @h5web/lib 🥳
         run: cd packages/lib && pnpm publish --access public --no-git-checks --tag $NPM_TAG
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -334,6 +334,19 @@ new tag to the remote repository. This, in turn, triggers the _Release_ workflow
 on the CI, which builds and publishes the packages to NPM (with `pnpm publish`)
 and deploys the Storybook site.
 
+> A few things happen when `pnpm publish` is run inside each package's
+> directory:
+>
+> 1. First, a `prepublish` script is triggered that removes the `type` field
+>    from the package's `package.json`. The reason for this workaround is
+>    explained in [#1219](https://github.com/silx-kit/h5web/issues/1219).
+> 2. Then, pnpm modifies `package.json` further by merging in the content of the
+>    [`publishConfig` field](https://pnpm.io/package_json#publishconfig).
+> 3. Finally, the package gets published to NPM. Note that it's possible to
+>    publish to a local registry for testing purposes (e.g.
+>    [Verdaccio](https://verdaccio.org/)) by overriding NPM's default
+>    [`registry` configuration](https://docs.npmjs.com/cli/v9/using-npm/registry).
+
 Once the _Release_ workflow has completed:
 
 - Make sure the new package versions are available on NPM and that the live

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -34,7 +34,8 @@
     "lint:eslint": "eslint \"**/*.{js,cjs,ts,tsx}\" --max-warnings=0",
     "lint:tsc": "tsc",
     "test": "jest",
-    "analyze": "pnpx source-map-explorer dist/index.js --no-border-checks"
+    "analyze": "pnpx source-map-explorer dist/index.js --no-border-checks",
+    "prepublish": "pnpx dot-json package.json -d type"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/h5wasm/package.json
+++ b/packages/h5wasm/package.json
@@ -30,7 +30,8 @@
     "build:dts": "tsc --build tsconfig.build.json && rollup -c",
     "lint:eslint": "eslint \"**/*.{js,cjs,ts,tsx}\" --max-warnings=0",
     "lint:tsc": "tsc",
-    "analyze": "pnpx source-map-explorer dist/index.js --no-border-checks"
+    "analyze": "pnpx source-map-explorer dist/index.js --no-border-checks",
+    "prepublish": "pnpx dot-json package.json -d type"
   },
   "peerDependencies": {
     "@h5web/app": "workspace:*",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -34,7 +34,8 @@
     "lint:eslint": "eslint \"**/*.{js,cjs,ts,tsx}\" --max-warnings=0",
     "lint:tsc": "tsc",
     "test": "jest",
-    "analyze": "pnpx source-map-explorer dist/index.js --no-border-checks"
+    "analyze": "pnpx source-map-explorer dist/index.js --no-border-checks",
+    "prepublish": "pnpx dot-json package.json -d type"
   },
   "peerDependencies": {
     "@react-three/fiber": ">=6.0.14",


### PR DESCRIPTION
This helps with publishing H5Web's packages manually - e.g. to a local registry like Verdaccio: https://github.com/silx-kit/h5web/discussions/1334#discussioncomment-4707965.

I will publish a beta version once merged to confirm that this work as expected.