### PR TITLE
Allow passing longer abscissa array that data array to `LineVis`

### DIFF
--- a/packages/lib/src/vis/line/LineVis.tsx
+++ b/packages/lib/src/vis/line/LineVis.tsx
@@ -73,18 +73,15 @@ function LineVis(props: Props) {
     scaleType: abscissaScaleType,
   } = abscissaParams;
 
-  assertLength(abscissaValue, dataArray.size, 'abscissa');
   assertLength(errorsArray, dataArray.size, 'error');
   auxiliaries.forEach(({ label, array }, index) =>
     assertLength(array, dataArray.size, `'${label || index}' auxiliary`)
   );
 
   const abscissas = useAxisValues(abscissaValue, dataArray.size);
-
   const abscissaToIndex = useValueToIndexScale(abscissas, true);
 
   const abscissaDomain = useAxisDomain(abscissas, abscissaScaleType, 0.01);
-
   assertDefined(abscissaDomain, 'Abscissas have undefined domain');
 
   const dataDomain = useMemo(() => {

--- a/packages/lib/src/vis/utils.ts
+++ b/packages/lib/src/vis/utils.ts
@@ -389,11 +389,9 @@ export function getAxisValues(
     return range(axisLength);
   }
 
-  if (rawValues.length === axisLength) {
-    return toArray(rawValues);
+  if (rawValues.length < axisLength) {
+    throw new Error(`Expected array to have length ${axisLength} at least`);
   }
 
-  throw new Error(
-    `Expected array to have length ${axisLength}, not ${rawValues.length}`
-  );
+  return toArray(rawValues).slice(0, axisLength);
 }

--- a/packages/shared/src/mock/metadata.ts
+++ b/packages/shared/src/mock/metadata.ts
@@ -151,7 +151,7 @@ export const mockMetadata = makeNxGroup(mockFilepath, 'NXroot', {
           signal: makeDataset('twoD_complex', complexType, [2, 2], {
             valueId: 'twoD_cplx',
           }),
-          axes: { position: makeDataset('position', intType, [2]) },
+          axes: { position: makeDataset('position', intType, [3]) },
           axesAttr: ['.', 'position'],
         }),
         makeNxDataGroup('complex_spectrum', {

--- a/packages/shared/src/mock/values.ts
+++ b/packages/shared/src/mock/values.ts
@@ -165,7 +165,7 @@ export const mockValues = {
   title_twoD: 'NeXus 2D',
   secondary: twoD.map((inner) => inner.map((v) => v * 2)),
   tertiary: twoD.map((inner) => inner.map((v) => v / 2)),
-  position: [-1, 1],
+  position: [-1, 1, 3], // pixel boundaries (N + 1)
   scatter_data: arr1.map((val) => Math.cos((val * 3.14) / 40)),
   Y_scatter: arr1.map((v, i) => ((i % 10) + (i % 5)) / 123_456),
   oneD_compound,


### PR DESCRIPTION
Fix #1350 

I'm loosening the assertion on the length of the `abscissa` array by allowing it to be longer than the data array. If it is, it just gets sliced to the data array's length. I don't think we need to be stricter than that.

Another option was to remove the extra value from the abscissa array inside the NX containers, but it would not have solved the issue for consumers of `@h5web/lib`.