### PR TITLE
Add API for searchable paths

### DIFF
--- a/packages/app/src/providers/DataProvider.tsx
+++ b/packages/app/src/providers/DataProvider.tsx
@@ -27,6 +27,7 @@ export interface DataContextValue {
   getExportURL?: DataProviderApi['getExportURL'];
   addProgressListener: (cb: ProgressCallback) => void;
   removeProgressListener: (cb: ProgressCallback) => void;
+  getSearchablePaths?: DataProviderApi['getSearchablePaths'];
 }
 
 const DataContext = createContext({} as DataContextValue);
@@ -113,6 +114,7 @@ function DataProvider(props: PropsWithChildren<Props>) {
         getExportURL: api.getExportURL?.bind(api),
         addProgressListener: api.addProgressListener.bind(api),
         removeProgressListener: api.removeProgressListener.bind(api),
+        getSearchablePaths: api.getSearchablePaths?.bind(api),
       }}
     >
       {children}

--- a/packages/app/src/providers/api.ts
+++ b/packages/app/src/providers/api.ts
@@ -61,6 +61,8 @@ export abstract class DataProviderApi {
     value: Value<D>
   ): ExportURL;
 
+  public getSearchablePaths?(path: string): Promise<string[]>;
+
   public addProgressListener(cb: ProgressCallback): void {
     this.progressListeners.add(cb);
     cb([...this.progress.values()]); // notify once

--- a/packages/app/src/providers/h5grove/h5grove-api.ts
+++ b/packages/app/src/providers/h5grove/h5grove-api.ts
@@ -25,6 +25,7 @@ import type {
   H5GroveAttrValuesResponse,
   H5GroveDataResponse,
   H5GroveEntityResponse,
+  H5GrovePathsResponse,
 } from './models';
 import {
   convertH5GroveDtype,
@@ -98,6 +99,14 @@ export class H5GroveApi extends DataProviderApi {
     }
 
     return new URL(`${baseURL as string}/data/?${searchParams.toString()}`);
+  }
+
+  public async getSearchablePaths(path: string): Promise<string[]> {
+    const { data } = await this.client.get<H5GrovePathsResponse>(`/paths/`, {
+      params: { path },
+    });
+
+    return data;
   }
 
   private async fetchEntity(path: string): Promise<H5GroveEntityResponse> {

--- a/packages/app/src/providers/h5grove/models.ts
+++ b/packages/app/src/providers/h5grove/models.ts
@@ -50,3 +50,5 @@ export interface H5GroveAttribute {
 
 export type H5GroveAttrValuesResponse = AttributeValues;
 export type H5GroveDataResponse = unknown;
+
+export type H5GrovePathsResponse = string[];

--- a/packages/h5wasm/package.json
+++ b/packages/h5wasm/package.json
@@ -38,7 +38,7 @@
     "react": ">=16"
   },
   "dependencies": {
-    "h5wasm": "0.4.7",
+    "h5wasm": "0.4.10",
     "nanoid": "4.0.0"
   },
   "devDependencies": {

--- a/packages/h5wasm/src/h5wasm-api.ts
+++ b/packages/h5wasm/src/h5wasm-api.ts
@@ -111,6 +111,19 @@ export class H5WasmApi extends ProviderApi {
     file.close();
   }
 
+  public async getSearchablePaths(root: string): Promise<string[]> {
+    const file = await this.file;
+
+    const h5wEntity = file.get(root);
+
+    if (isH5WasmGroup(h5wEntity)) {
+      // Build absolute paths since .paths() are relative
+      return h5wEntity.paths().map((path) => `${root}${path}`);
+    }
+
+    return [];
+  }
+
   private async initFile(buffer: ArrayBuffer): Promise<H5WasmFile> {
     const { FS } = await h5wasmReady;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,7 +267,7 @@ importers:
       '@vitejs/plugin-react': 2.2.0
       eslint: '>=8'
       eslint-config-galex: 4.4.2
-      h5wasm: 0.4.7
+      h5wasm: 0.4.10
       nanoid: 4.0.0
       react: 17.0.2
       rollup: 3.10.0
@@ -275,7 +275,7 @@ importers:
       typescript: 4.9.4
       vite: 3.2.5
     dependencies:
-      h5wasm: 0.4.7
+      h5wasm: 0.4.10
       nanoid: 4.0.0
     devDependencies:
       '@h5web/app': link:../app
@@ -9783,8 +9783,8 @@ packages:
     resolution: {integrity: sha512-W/kKzq7ZSF/LFItIjaSaccw8L6js+9SMSS5buXZs/Td7qZAT91Kd0LTxuUjSWDwuyv4MPo/fhZdkRLV1zsuClg==}
     dev: false
 
-  /h5wasm/0.4.7:
-    resolution: {integrity: sha512-bBwBkK57iMXdnVDIdqJU4BR3iEtbo9vsXh1r8tAyO079U5DakO08cHJqZ8o0/xcsNEdEoXaKuCcBpUpP1dsKKQ==}
+  /h5wasm/0.4.10:
+    resolution: {integrity: sha512-JQpErzcw4vLqMbtM9VAXoRnmmvp4uQUlCdXzuQ6MDaafRusFL4FMmpDfsSk2QiiBLb7Sndx9CAvydgk/iKSD9g==}
     dev: false
 
   /handlebars/4.7.7:


### PR DESCRIPTION
Pre-requisite for #1348 

Adds a `getSearchablePaths` mathods to API to return a list of paths in the group. This method can be implemented by the APIs that support it (for now, `h5grove` and `h5wasm` that was updated to 0.4.10)