### PR TITLE
Add support for unsigned 64-bit integers in h5wasm

### DIFF
--- a/packages/h5wasm/src/guards.ts
+++ b/packages/h5wasm/src/guards.ts
@@ -104,5 +104,9 @@ export function assertNumericMetadata(
 }
 
 export function hasInt64Type(dataset: Dataset) {
-  return dataset.type.class === DTypeClass.Integer && dataset.type.size === 64;
+  return (
+    (dataset.type.class === DTypeClass.Integer ||
+      dataset.type.class === DTypeClass.Unsigned) &&
+    dataset.type.size === 64
+  );
 }

--- a/packages/h5wasm/src/h5wasm-api.ts
+++ b/packages/h5wasm/src/h5wasm-api.ts
@@ -67,7 +67,7 @@ export class H5WasmApi extends ProviderApi {
       throw new Error('Compression filter not supported');
     }
 
-    // h5wasm returns integers for bool and BigInt for int64
+    // h5wasm returns integers for bool and BigInt for (u)int64
     // So we use to_array instead to have bool and numbers resp.
     if (hasBoolType(dataset) || hasInt64Type(dataset)) {
       const rawValue = h5wDataset.to_array();


### PR DESCRIPTION
Fix #1371 

Oversight in the `BigInt` conversion: we only checked for regular integers and not unsigned.