### PR TITLE
Remove background mesh from `TiledheatmapMesh`

### DIFF
--- a/packages/lib/src/vis/tiles/TiledHeatmapMesh.tsx
+++ b/packages/lib/src/vis/tiles/TiledHeatmapMesh.tsx
@@ -2,7 +2,6 @@ import { clamp, range } from 'lodash';
 import { useRef } from 'react';
 import type { Group } from 'three';
 
-import { getInterpolator } from '../heatmap/utils';
 import { useCameraState } from '../hooks';
 import type { Size } from '../models';
 import { useVisCanvasContext } from '../shared/VisCanvasProvider';
@@ -70,18 +69,10 @@ function TiledHeatmapMesh(props: Props) {
       : [currentLayerIndex];
   }
 
-  const { colorMap, invertColorMap = false } = colorMapProps;
-
   const onPointerMove = useTooltipOnMoveHandler();
 
   return (
     <group ref={groupRef}>
-      <mesh position={[0, 0, -0.1]}>
-        <planeGeometry args={[meshSize.width, meshSize.height]} />
-        <meshBasicMaterial
-          color={getInterpolator(colorMap, invertColorMap)(0)}
-        />
-      </mesh>
       {layers.map((layer, i) => (
         <TiledLayer
           key={layer}


### PR DESCRIPTION
I need to avoid displaying the "background" color while the `TiledHeatmapMesh` is loading, i.e., not displaying this `mesh`:

https://github.com/silx-kit/h5web/blob/83c5c513ee0e6d3c6e05b29ede5353ae77f254e6/packages/lib/src/vis/tiles/TiledHeatmapMesh.tsx#L79-L84

~~This PR proposes to add a `background` prop that allows to configure this.~~
~~I hesitated to completely remove this `mesh` and leave it to the users to implement it, but since it's there...~~

~~By default it uses the color of the smallest value of the colormap, it accepts a color as well as 'none' to disable it.~~

This PR removes the background mesh. If needed, it can be added below the `TiledHeatmapMesh`.