### PR TITLE
Add `SvgCircle` component

### DIFF
--- a/apps/storybook/src/SvgElement.stories.tsx
+++ b/apps/storybook/src/SvgElement.stories.tsx
@@ -2,6 +2,7 @@ import {
   DataToHtml,
   Pan,
   ResetZoomButton,
+  SvgCircle,
   SvgElement,
   SvgLine,
   SvgRect,
@@ -51,6 +52,7 @@ export const Default: Story = () => {
               strokeWidth={10}
               strokePosition="outside"
             />
+            <SvgCircle coords={[pt5, pt6]} fill="none" stroke="lightseagreen" />
           </SvgElement>
         )}
       </DataToHtml>

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -71,9 +71,11 @@ export type { DefaultInteractionsConfig } from './interactions/DefaultInteractio
 export { default as SvgElement } from './interactions/svg/SvgElement';
 export { default as SvgLine } from './interactions/svg/SvgLine';
 export { default as SvgRect } from './interactions/svg/SvgRect';
+export { default as SvgCircle } from './interactions/svg/SvgCircle';
 export type { SvgElementProps } from './interactions/svg/SvgElement';
 export type { SvgLineProps } from './interactions/svg/SvgLine';
 export type { SvgRectProps } from './interactions/svg/SvgRect';
+export type { SvgCircleProps } from './interactions/svg/SvgCircle';
 
 // Context
 export { useVisCanvasContext } from './vis/shared/VisCanvasProvider';

--- a/packages/lib/src/interactions/svg/SvgCircle.tsx
+++ b/packages/lib/src/interactions/svg/SvgCircle.tsx
@@ -1,0 +1,19 @@
+import type { SVGProps } from 'react';
+
+import type { Rect } from '../models';
+
+interface Props extends SVGProps<SVGCircleElement> {
+  coords: Rect;
+}
+
+function SvgCircle(props: Props) {
+  const { coords, ...svgProps } = props;
+
+  const [start, end] = coords;
+  const radius = end.distanceTo(start);
+
+  return <circle cx={start.x} cy={start.y} r={radius} {...svgProps} />;
+}
+
+export type { Props as SvgCircleProps };
+export default SvgCircle;


### PR DESCRIPTION
Bringing in this component from Braggy where it is used for [drawing circular profiles](https://gitlab.esrf.fr/ui/h5web-braggy/-/blob/1a61841290e7fed59ee5caa0ddf0ed1f89fc7167/src/imageview/profile/ProfileSelectionTool.tsx).

As shown in the story below, where the circle and the rectangle share the same set of `Rect` coordinates, I went with a simple implementation that matches the SVG attributes: the center of the circle is the `start` point and the radius is the distance between `start` and `end`.

We could imagine providing additional features later, such as drawing inscribed and circumscribed circles, if the need arises.

![image](https://user-images.githubusercontent.com/2936402/225620224-0f6ef7ac-6671-4e0c-9965-9440a91d60a6.png)
