### PR TITLE
Ignore FillValue in HeatmapVis

### DIFF
--- a/packages/app/src/vis-packs/core/heatmap/HeatmapVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/HeatmapVisContainer.tsx
@@ -10,6 +10,7 @@ import { useDimMappingState } from '../../../dimension-mapper/hooks';
 import VisBoundary from '../../VisBoundary';
 import type { VisContainerProps } from '../../models';
 import ValueFetcher from '../ValueFetcher';
+import { useFillValue } from '../hooks';
 import { getSliceSelection } from '../utils';
 import MappedHeatmapVis from './MappedHeatmapVis';
 import { useHeatmapConfig } from './config';
@@ -25,6 +26,8 @@ function HeatmapVisContainer(props: VisContainerProps) {
   const [dimMapping, setDimMapping] = useDimMappingState(dims, 2);
 
   const config = useHeatmapConfig();
+
+  const fillValue = useFillValue(entity);
 
   return (
     <>
@@ -45,6 +48,7 @@ function HeatmapVisContainer(props: VisContainerProps) {
               title={entity.name}
               toolbarContainer={toolbarContainer}
               config={config}
+              fillValue={fillValue}
             />
           )}
         />

--- a/packages/app/src/vis-packs/core/heatmap/MappedHeatmapVis.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/MappedHeatmapVis.tsx
@@ -5,7 +5,11 @@ import { createPortal } from 'react-dom';
 
 import type { DimensionMapping } from '../../../dimension-mapper/models';
 import { useDataContext } from '../../../providers/DataProvider';
-import { useMappedArray, useSlicedDimsAndMapping } from '../hooks';
+import {
+  useIgnoreFillValue,
+  useMappedArray,
+  useSlicedDimsAndMapping,
+} from '../hooks';
 import { DEFAULT_DOMAIN, getSliceSelection } from '../utils';
 import HeatmapToolbar from './HeatmapToolbar';
 import type { HeatmapConfig } from './config';
@@ -19,6 +23,7 @@ interface Props {
   title: string;
   toolbarContainer: HTMLDivElement | undefined;
   config: HeatmapConfig;
+  fillValue?: number;
 }
 
 function MappedHeatmapVis(props: Props) {
@@ -31,6 +36,7 @@ function MappedHeatmapVis(props: Props) {
     title,
     toolbarContainer,
     config,
+    fillValue,
   } = props;
 
   const {
@@ -47,7 +53,9 @@ function MappedHeatmapVis(props: Props) {
   const [slicedDims, slicedMapping] = useSlicedDimsAndMapping(dims, dimMapping);
   const [dataArray] = useMappedArray(value, slicedDims, slicedMapping);
 
-  const dataDomain = useDomain(dataArray, scaleType) || DEFAULT_DOMAIN;
+  const ignoreValue = useIgnoreFillValue(fillValue);
+  const dataDomain =
+    useDomain(dataArray, scaleType, undefined, ignoreValue) || DEFAULT_DOMAIN;
   const visDomain = useVisDomain(customDomain, dataDomain);
   const [safeDomain] = useSafeDomain(visDomain, dataDomain, scaleType);
 
@@ -92,6 +100,7 @@ function MappedHeatmapVis(props: Props) {
           value: axisValues?.[yDimIndex],
         }}
         flipYAxis={flipYAxis}
+        fillValue={fillValue}
       />
     </>
   );

--- a/packages/app/src/vis-packs/core/hooks.ts
+++ b/packages/app/src/vis-packs/core/hooks.ts
@@ -163,9 +163,7 @@ export function useSlicedDimsAndMapping(
   );
 }
 
-export function useIgnoreFillValue(
-  dataset: Dataset
-): ((val: number) => boolean) | undefined {
+export function useFillValue(dataset: Dataset): number | undefined {
   const { attrValuesStore } = useDataContext();
 
   const rawFillValue = attrValuesStore.getSingle(dataset, '_FillValue');
@@ -174,11 +172,14 @@ export function useIgnoreFillValue(
   const DTypedArray = typedArrayFromDType(dataset.type);
 
   // Cast fillValue in the type of the dataset values to be able to use `===` for the comparison
-  const fillValue =
-    DTypedArray && typeof wrappedFillValue[0] === 'number'
-      ? new DTypedArray(wrappedFillValue as number[])[0]
-      : undefined;
+  return DTypedArray && typeof wrappedFillValue[0] === 'number'
+    ? new DTypedArray(wrappedFillValue as number[])[0]
+    : undefined;
+}
 
+export function useIgnoreFillValue(
+  fillValue: number | undefined
+): ((val: number) => boolean) | undefined {
   return useMemo(() => {
     return fillValue !== undefined
       ? (val: number) => val === fillValue

--- a/packages/app/src/vis-packs/core/line/LineVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/line/LineVisContainer.tsx
@@ -9,7 +9,7 @@ import { useDimMappingState } from '../../../dimension-mapper/hooks';
 import VisBoundary from '../../VisBoundary';
 import type { VisContainerProps } from '../../models';
 import ValueFetcher from '../ValueFetcher';
-import { useIgnoreFillValue } from '../hooks';
+import { useFillValue, useIgnoreFillValue } from '../hooks';
 import { getSliceSelection } from '../utils';
 import MappedLineVis from './MappedLineVis';
 import { useLineConfig } from './config';
@@ -28,7 +28,8 @@ function LineVisContainer(props: VisContainerProps) {
   const { autoScale } = config;
   const selection = autoScale ? getSliceSelection(dimMapping) : undefined;
 
-  const ignoreValue = useIgnoreFillValue(entity);
+  const fillValue = useFillValue(entity);
+  const ignoreValue = useIgnoreFillValue(fillValue);
 
   return (
     <>

--- a/packages/lib/src/vis/heatmap/HeatmapMaterial.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapMaterial.tsx
@@ -26,6 +26,7 @@ interface Props extends VisMeshProps {
   alphaValues?: NdArray<TextureSafeTypedArray | Uint16Array>; // uint16 values are treated as half floats
   alphaDomain?: Domain;
   badColor?: RGBColor | string;
+  fillValue?: number;
 }
 
 const DEFAULT_BAD_COLOR = rgb(255, 255, 255, 0);
@@ -54,6 +55,7 @@ function HeatmapMaterial(props: Props) {
     alphaValues,
     alphaDomain = DEFAULT_DOMAIN,
     badColor = DEFAULT_BAD_COLOR,
+    fillValue,
   } = props;
 
   const dataTexture = useDataTexture(values, magFilter);
@@ -105,6 +107,7 @@ function HeatmapMaterial(props: Props) {
         badColorAsRgb.b / 255,
         badColorAsRgb.opacity
       ),
+      fillValue: fillValue || Number.NaN,
     }),
     vertexShader: VERTEX_SHADER,
     fragmentShader: `
@@ -121,6 +124,7 @@ function HeatmapMaterial(props: Props) {
       uniform float oneOverAlphaRange;
       uniform int withAlpha;
       uniform vec4 badColor;
+      uniform float fillValue;
 
       const float oneOverLog10 = 0.43429448190325176;
 
@@ -137,7 +141,7 @@ function HeatmapMaterial(props: Props) {
       void main() {
         float value = texture2D(data, coords).r * normRevertFactor;
 
-        if (isnan(value) || !isSupported(value)) {
+        if (isnan(value) || !isSupported(value) || value == fillValue) {
             gl_FragColor = badColor;
         } else {
           float scaledValue = scale(value);

--- a/packages/lib/src/vis/heatmap/HeatmapMesh.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapMesh.tsx
@@ -19,6 +19,7 @@ interface Props extends VisMeshProps {
   alphaValues?: NdArray<TextureSafeTypedArray | Uint16Array>; // uint16 values are treated as half floats
   alphaDomain?: Domain;
   badColor?: RGBColor | string;
+  fillValue?: number;
 }
 
 function HeatmapMesh(props: Props) {
@@ -32,6 +33,7 @@ function HeatmapMesh(props: Props) {
     alphaValues,
     alphaDomain,
     badColor,
+    fillValue,
     ...visMeshProps
   } = props;
 
@@ -47,6 +49,7 @@ function HeatmapMesh(props: Props) {
         alphaValues={alphaValues}
         alphaDomain={alphaDomain}
         badColor={badColor}
+        fillValue={fillValue}
       />
     </VisMesh>
   );

--- a/packages/lib/src/vis/heatmap/HeatmapVis.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapVis.tsx
@@ -39,6 +39,7 @@ interface Props {
   renderTooltip?: (data: TooltipData) => ReactElement;
   children?: ReactNode;
   interactions?: DefaultInteractionsConfig;
+  fillValue?: number;
 }
 
 function HeatmapVis(props: Props) {
@@ -59,6 +60,7 @@ function HeatmapVis(props: Props) {
     renderTooltip,
     children,
     interactions,
+    fillValue,
   } = props;
   const { label: abscissaLabel, value: abscissaValue } = abscissaParams;
   const { label: ordinateLabel, value: ordinateValue } = ordinateParams;
@@ -135,6 +137,7 @@ function HeatmapVis(props: Props) {
           alphaValues={safeAlphaArray}
           alphaDomain={alpha?.domain}
           scale={[1, flipYAxis ? -1 : 1, 1]}
+          fillValue={fillValue}
         />
 
         {children}


### PR DESCRIPTION
Fix #1181 

I had to refactor a bit to revert part of #1381 where we replace the `fillValue` prop by the `ignoreValue` function.

In `HeatmapMaterial`. the check has to be done in shader so having the `ignoreValue` function is not useful.  Instead, I passed the  `fillValue` to be able to pass it as uniform to do the check in the shader.

For this, I broke down (again!) the parsing of `fillValue` and the creation of the `ignoreValue` callback in two hooks to use them in the different contexts:
- In `LineVisContainer` and its children, we only need the `ignoreValue` so I call the two hooks to generate `ignoreValue` and leave the rest of #1381 unchanged.
- In `HeatmapVisContainer`, I only get `fillValue` and pass it to the children (`MappedHeatmapVis`)
- In `MappedHeatmapVis`, we need `ignoreValue` so I use the hook to derive it from the `fillValue` prop but I still pass `fillValue` to the children
- In `HeatmapMaterial`, as explained, I need `fillValue` to implement the check in the shader so I get it from the props.