### PR TITLE
Fix stacking order of canvas

### DIFF
--- a/apps/storybook/src/Stacking.stories.mdx
+++ b/apps/storybook/src/Stacking.stories.mdx
@@ -12,37 +12,40 @@ This allows its children (both direct and nested) to be stacked in relation with
 
 ### Stacking order
 
-The stacking order is organised into five layers, from furthest (behind) to closest (in front):
+The stacking order is organised into six layers, from furthest (behind) to closest (in front):
 
-1. **axis system** (including the axis grid);
-2. **SVG elements** rendered via [`SvgElement`](http://localhost:6006/?path=/story/building-blocks-svgelement--default) into the `svg` overlay, in DOM order;
-3. **HTML elements** rendered via [`Html`](http://localhost:6006/?path=/story/building-blocks-html--default), in DOM order (including [`Annotation`](http://localhost:6006/?path=/story/building-blocks-annotation--default) and [`Overlay`](http://localhost:6006/?path=/story/building-blocks-overlay--default));
-4. **tooltip**
-5. **floating toolbar** (typically with reset zoom button)
+1. **WebGL canvas**;
+2. **axis system** (including the axis grid);
+3. **SVG elements** rendered via [`SvgElement`](http://localhost:6006/?path=/story/building-blocks-svgelement--default) into the `svg` overlay, in DOM order;
+4. **HTML elements** rendered via [`Html`](http://localhost:6006/?path=/story/building-blocks-html--default), in DOM order (including [`Annotation`](http://localhost:6006/?path=/story/building-blocks-annotation--default) and [`Overlay`](http://localhost:6006/?path=/story/building-blocks-overlay--default));
+5. **tooltip**
+6. **floating toolbar** (typically with reset zoom button)
 
 ```
 ┌──────────────────────────────────┐
-│ 1. Axis system                   │
+│ 1. Canvas                        │
 │   ┌──────────────────────────────┴───┐
-│   │ 2. SVG elements                  │
+│   │ 2. Axis system                   │
 └── ┤   ┌──────────────────────────────┴───┐
-    │   │ 3. HTML elements                 │
+    │   │ 3. SVG elements                  │
     └── ┤   ┌──────────────────────────────┴───┐
-        │   │ 4. Tooltip                       │
+        │   │ 4. HTML elements                 │
         └── ┤   ┌──────────────────────────────┴───┐
-            │   │ 5. Floating toolbar              │
-            └── ┤                                  │
-                │                                  │
-                └──────────────────────────────────┘
+            │   │ 5. Tooltip                       │
+            └── ┤   ┌──────────────────────────────┴───┐
+                │   │ 6. Floating toolbar              │
+                └── ┤                                  │
+                    │                                  │
+                    └──────────────────────────────────┘
 ```
 
-As a consumer of the library, you have control over the stacking of the SVG and HTML elements that you render (i.e. layers 2 and 3).
+As a consumer of the library, you have control over the stacking of the SVG and HTML elements that you render (i.e. layers 3 and 4).
 Within each of these two layers, all you need to do to move element `A` behind, or in front of, element `B` is to **render `A`
 before or after `B`** in your React tree, respectively.
 
 However, there are some pitfalls:
 
-- Elements from layers 2 and 3 **cannot be interleaved** with one another. Consider the `svg` overlay as its own stacking context:
+- Elements from layers 3 and 4 **cannot be interleaved** with one another. Consider the `svg` overlay as its own stacking context:
   its children are stacked only in relation with one another within their parent SVG document.
 - When `Html` and `SvgElement` unmount and then remount (e.g. based on conditions), their children can end up **moving down the DOM tree** and therefore
   in front of other elements that remained in the DOM. This can be worked around in a few ways, as explained below.

--- a/packages/lib/src/vis/shared/Annotation.tsx
+++ b/packages/lib/src/vis/shared/Annotation.tsx
@@ -52,7 +52,6 @@ function Annotation(props: Props) {
           position: 'absolute',
           top: htmlPt.y,
           left: htmlPt.x,
-          pointerEvents: 'none',
           transformOrigin: scaleOnZoom && !center ? 'top left' : undefined,
           transform: transforms.join(' ').trim(),
           ...style,

--- a/packages/lib/src/vis/shared/Overlay.tsx
+++ b/packages/lib/src/vis/shared/Overlay.tsx
@@ -21,7 +21,6 @@ function Overlay(props: Props) {
           position: 'absolute',
           top: 0,
           left: 0,
-          pointerEvents: 'none',
           ...canvasSize,
           ...style,
         }}

--- a/packages/lib/src/vis/shared/TooltipMesh.module.css
+++ b/packages/lib/src/vis/shared/TooltipMesh.module.css
@@ -1,3 +1,7 @@
+.overlay {
+  z-index: var(--h5w-zi-tooltip);
+}
+
 .tooltip {
   padding: 0.25rem 0.5rem;
   background-color: var(--h5w-tooltip--bgColor, rgba(255, 255, 255, 0.9));
@@ -6,7 +10,7 @@
   color: var(--h5w-tooltip--color, inherit);
   font-family: var(--h5w-tooltip--fontFamily, inherit);
   font-size: var(--h5w-tooltip--fontSize, 0.75em);
-  z-index: var(--h5w-zi-tooltip);
+  user-select: none;
 }
 
 .guides {

--- a/packages/lib/src/vis/shared/TooltipOverlay.tsx
+++ b/packages/lib/src/vis/shared/TooltipOverlay.tsx
@@ -21,7 +21,7 @@ function TooltipOverlay(props: Props) {
   const { width, height } = canvasSize;
 
   return (
-    <Overlay>
+    <Overlay className={styles.overlay}>
       {tooltipOpen && children && (
         <>
           <TooltipWithBounds

--- a/packages/lib/src/vis/shared/VisCanvas.module.css
+++ b/packages/lib/src/vis/shared/VisCanvas.module.css
@@ -6,20 +6,34 @@
 
   /*
    * Stacking order, from furthest to closest:
-   * 1. axis system (i.e. most notably the grid)
-   * 2. SVG overlay
-   * 3. anything rendered via `Html` (`Overlay`, `Annotation`, etc.) -- by default with no z-index, which is equivalent to `z-index: 0`
-   * 4. tooltip
-   * 5. floating toolbar
+   * 1. WebGL canvas
+   * 2. axis system (i.e. most notably the grid)
+   * 3. SVG overlay
+   * 4. anything rendered via `Html` (`Overlay`, `Annotation`, etc.) — by default with no z-index, which is equivalent to `z-index: 0`
+   * 5. tooltip + guides
+   * 6. floating toolbar
    */
-  --h5w-zi-axisSystem: -10000;
+  --h5w-zi-canvas: -3000;
+  --h5w-zi-axisSystem: -2000;
   --h5w-zi-svgOverlay: -1000;
   --h5w-zi-tooltip: 1000;
-  --h5w-zi-floatingToolbar: 10000;
+  --h5w-zi-floatingToolbar: 2000;
 }
 
 .r3fRoot {
+  /* `r3fRoot` is implicitely stacked at `z-index: 0`, so it intercepts events before they reach the canvas.
+   * We can't stack it explicitly without creating a new stacking context, which breaks the stacking order
+   * (the axis system ends up either behind or in front of everything else, neither of which is acceptable).
+   * So we disable pointer events and restore them only on the `canvas` and on specific interactive elements,
+   * like the floating toolbar. */
+  pointer-events: none;
   background-color: var(--h5w-canvas--bgColor, transparent);
+}
+
+.r3fRoot > canvas {
+  position: relative;
+  z-index: var(--h5w-zi-canvas);
+  pointer-events: auto;
 }
 
 .svgOverlay {
@@ -28,7 +42,6 @@
   top: 0;
   width: 100%;
   height: 100%;
-  pointer-events: none;
   z-index: var(--h5w-zi-svgOverlay);
 }
 
@@ -38,4 +51,5 @@
   bottom: 0;
   display: flex;
   z-index: var(--h5w-zi-floatingToolbar);
+  pointer-events: auto;
 }


### PR DESCRIPTION
Regression introduced in #1387 ... so much for bringing stacking under control :sweat: 

The canvas was still stacked implicitly at `z-index: 0`, so in front of the grid and SVG elements... Sorry about that. So now it moves behind everything.

Unfortunately, in doing so, `r3fRoot`—which is still stacked implicitly at `z-index: 0` (and cannot be stacked explicitly without creating a new stacking context and breaking the stacking order, as explained in a comment in the CSS)—captures events before the reach the canvas... I had to work around this by moving `pointer-events: none` to `r3fRoot` instead of setting it on every overlay, and then re-enabling it to `auto` on the canvas and floating toolbar.

This feels better in the end, since it removes a bunch of `pointer-events: none` and saves us and consumers from forgetting to add them.

--- 

Note that this may very well change when dealing with #1388. To be continued...