### PR TITLE
Deprecate prop `explorerOpen` in favour of `sidebarOpen`

### DIFF
--- a/apps/demo/src/H5GroveApp.tsx
+++ b/apps/demo/src/H5GroveApp.tsx
@@ -19,7 +19,7 @@ function H5GroveApp() {
       filepath={filepath}
       axiosConfig={{ params: { file: filepath } }}
     >
-      <App explorerOpen={!query.has('wide')} getFeedbackURL={getFeedbackURL} />
+      <App sidebarOpen={!query.has('wide')} getFeedbackURL={getFeedbackURL} />
     </H5GroveProvider>
   );
 }

--- a/apps/demo/src/HsdsApp.tsx
+++ b/apps/demo/src/HsdsApp.tsx
@@ -26,7 +26,7 @@ function HsdsApp() {
       password={PASSWORD}
       filepath={filepath}
     >
-      <App explorerOpen={!query.has('wide')} getFeedbackURL={getFeedbackURL} />
+      <App sidebarOpen={!query.has('wide')} getFeedbackURL={getFeedbackURL} />
     </HsdsProvider>
   );
 }

--- a/apps/demo/src/MockApp.tsx
+++ b/apps/demo/src/MockApp.tsx
@@ -8,7 +8,7 @@ function MockApp() {
 
   return (
     <MockProvider>
-      <App explorerOpen={!query.has('wide')} getFeedbackURL={getFeedbackURL} />
+      <App sidebarOpen={!query.has('wide')} getFeedbackURL={getFeedbackURL} />
     </MockProvider>
   );
 }

--- a/apps/demo/src/h5wasm/H5WasmApp.tsx
+++ b/apps/demo/src/h5wasm/H5WasmApp.tsx
@@ -17,7 +17,7 @@ function H5WasmApp() {
 
   return (
     <H5WasmProvider {...h5File}>
-      <App explorerOpen={!query.has('wide')} getFeedbackURL={getFeedbackURL} />
+      <App sidebarOpen={!query.has('wide')} getFeedbackURL={getFeedbackURL} />
     </H5WasmProvider>
   );
 }

--- a/cypress/e2e/app.cy.ts
+++ b/cypress/e2e/app.cy.ts
@@ -386,7 +386,7 @@ describe('/mock?wide', () => {
     cy.waitForStableDOM();
   });
 
-  it('start with the explorer closed', () => {
+  it('start with sidebar closed', () => {
     cy.findByRole('tree').should('not.exist');
 
     if (Cypress.env('TAKE_SNAPSHOTS')) {

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -92,16 +92,19 @@ For `App` to work, it must be wrapped in a data provider:
 </MockProvider>
 ```
 
-#### `explorerOpen?: boolean` (optional)
+#### `sidebarOpen?: boolean` (optional)
 
-Whether the viewer should start with the explorer panel open. Defaults to
-`true`. Pass `false` to hide the explorer on initial render, thus giving more
-space to the visualization. This may be useful when H5Web is embeded inside
-another app.
+Whether the viewer should start with the sidebar open. The sidebar contains the
+explorer and search panels. Defaults to `true`. Pass `false` to hide the sidebar
+on initial render, thus giving more space to the visualization. This is useful
+when H5Web is embeded inside another app.
 
 ```tsx
-<App explorerOpen={false} />
+<App sidebarOpen={false} />
 ```
+
+> This replaces prop `explorerOpen`, which is now deprecated and will be removed
+> in v8.0.0.
 
 #### `initialPath?: string` (optional)
 

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -17,7 +17,9 @@ import { useDataContext } from './providers/DataProvider';
 import Visualizer from './visualizer/Visualizer';
 
 interface Props {
+  /** @deprecated */
   explorerOpen?: boolean;
+  sidebarOpen?: boolean;
   initialPath?: string;
   getFeedbackURL?: (context: FeedbackContext) => string;
   disableDarkMode?: boolean;
@@ -26,7 +28,8 @@ interface Props {
 
 function App(props: Props) {
   const {
-    explorerOpen: initialExplorerOpen = true,
+    explorerOpen = true,
+    sidebarOpen: initialSidebarOpen = explorerOpen,
     initialPath = '/',
     getFeedbackURL,
     disableDarkMode,
@@ -34,7 +37,7 @@ function App(props: Props) {
   } = props;
 
   const [selectedPath, setSelectedPath] = useState<string>(initialPath);
-  const [isExplorerOpen, toggleExplorerOpen] = useToggle(initialExplorerOpen);
+  const [isSidebarOpen, toggleSidebarOpen] = useToggle(initialSidebarOpen);
   const [isInspecting, setInspecting] = useState(false);
 
   const { valuesStore } = useDataContext();
@@ -61,7 +64,7 @@ function App(props: Props) {
       >
         <ReflexElement
           className={styles.sidebarArea}
-          style={{ display: isExplorerOpen ? undefined : 'none' }}
+          style={{ display: isSidebarOpen ? undefined : 'none' }}
           flex={25}
           minSize={150}
         >
@@ -70,15 +73,15 @@ function App(props: Props) {
 
         <ReflexSplitter
           className={styles.splitter}
-          style={{ display: isExplorerOpen ? undefined : 'none' }}
+          style={{ display: isSidebarOpen ? undefined : 'none' }}
         />
 
         <ReflexElement className={styles.mainArea} flex={75} minSize={500}>
           <BreadcrumbsBar
             path={selectedPath}
-            isExplorerOpen={isExplorerOpen}
+            isSidebarOpen={isSidebarOpen}
             isInspecting={isInspecting}
-            onToggleExplorer={toggleExplorerOpen}
+            onToggleSidebar={toggleSidebarOpen}
             onChangeInspecting={setInspecting}
             onSelectPath={onSelectPath}
             getFeedbackURL={getFeedbackURL}

--- a/packages/app/src/__tests__/Explorer.test.tsx
+++ b/packages/app/src/__tests__/Explorer.test.tsx
@@ -14,14 +14,14 @@ test('select root group by default', async () => {
   expect(fileBtn).toHaveAttribute('aria-selected', 'true');
 });
 
-test('toggle explorer sidebar', async () => {
+test('toggle sidebar', async () => {
   const { user } = await renderApp();
 
   const fileBtn = await screen.findByRole('treeitem', {
     name: mockFilepath,
   });
   const sidebarBtn = screen.getByRole('button', {
-    name: 'Toggle explorer sidebar',
+    name: 'Toggle sidebar',
   });
 
   expect(fileBtn).toBeVisible();

--- a/packages/app/src/breadcrumbs/BreadcrumbsBar.tsx
+++ b/packages/app/src/breadcrumbs/BreadcrumbsBar.tsx
@@ -14,9 +14,9 @@ import type { FeedbackContext } from './models';
 
 interface Props {
   path: string;
-  isExplorerOpen: boolean;
+  isSidebarOpen: boolean;
   isInspecting: boolean;
-  onToggleExplorer: () => void;
+  onToggleSidebar: () => void;
   onChangeInspecting: (b: boolean) => void;
   onSelectPath: (path: string) => void;
   getFeedbackURL?: (context: FeedbackContext) => string;
@@ -25,9 +25,9 @@ interface Props {
 function BreadcrumbsBar(props: Props) {
   const {
     path,
-    isExplorerOpen,
+    isSidebarOpen,
     isInspecting,
-    onToggleExplorer,
+    onToggleSidebar,
     onChangeInspecting,
     onSelectPath,
     getFeedbackURL,
@@ -42,11 +42,11 @@ function BreadcrumbsBar(props: Props) {
   return (
     <div className={styles.bar}>
       <ToggleBtn
-        label="Toggle explorer sidebar"
+        label="Toggle sidebar"
         icon={FiSidebar}
         iconOnly
-        value={isExplorerOpen}
-        onToggle={onToggleExplorer}
+        value={isSidebarOpen}
+        onToggle={onToggleSidebar}
       />
 
       <Separator style={{ marginLeft: '0.375rem', marginRight: '0.875rem' }} />
@@ -54,7 +54,7 @@ function BreadcrumbsBar(props: Props) {
       <Breadcrumbs
         path={path}
         onSelect={onSelectPath}
-        showFilename={!isExplorerOpen}
+        showFilename={!isSidebarOpen}
       />
 
       <ToggleGroup


### PR DESCRIPTION
As discussed, I'm deprecating `explorerOpen` instead of removing it to avoid a breaking change in the short term. We'll remove it in v8.