### PR TITLE
Switch to Node 18

### DIFF
--- a/.github/workflows/approve-snapshots.yml
+++ b/.github/workflows/approve-snapshots.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           ref: ${{ steps.getBranchName.outputs.branch }}
 
-      - name: Use Node 16 🕹️
+      - name: Set up Node 🕹️
         uses: actions/setup-node@v3
         with:
           node-version-file: 'package.json'

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout 🏷️
         uses: actions/checkout@v3
 
-      - name: Use Node 16 🕹️
+      - name: Set up Node 🕹️
         uses: actions/setup-node@v3
         with:
           node-version-file: 'package.json'
@@ -51,7 +51,7 @@ jobs:
       - name: Checkout 🏷️
         uses: actions/checkout@v3
 
-      - name: Use Node 16 🕹️
+      - name: Set up Node 🕹️
         uses: actions/setup-node@v3
         with:
           node-version-file: 'package.json'
@@ -88,7 +88,7 @@ jobs:
       - name: Checkout 🏷️
         uses: actions/checkout@v3
 
-      - name: Use Node 16 🕹️
+      - name: Set up Node 🕹️
         uses: actions/setup-node@v3
         with:
           node-version-file: 'package.json'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,10 @@ jobs:
         with:
           TAG_PREFIX: v
 
-      - name: Use Node 16 🕹️
+      - name: Set up Node 🕹️
         uses: actions/setup-node@v3
         with:
           node-version-file: 'package.json'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install pnpm ⚙️
         uses: pnpm/action-setup@v2

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/silx-kit/h5web"
   },
   "engines": {
-    "node": "16.x",
+    "node": "18.x",
     "pnpm": "7.x"
   },
   "scripts": {
@@ -33,7 +33,7 @@
     "react-router-dom": "6.3.0"
   },
   "devDependencies": {
-    "@types/node": "^16.18.23",
+    "@types/node": "^18.15.11",
     "@types/react": "^17.0.56",
     "@types/react-dom": "^17.0.19",
     "@types/react-router-dom": "5.3.3",

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/silx-kit/h5web"
   },
   "engines": {
-    "node": "16.x",
+    "node": "18.x",
     "pnpm": "7.x"
   },
   "scripts": {
@@ -48,7 +48,7 @@
     "@types/d3-format": "3.0.1",
     "@types/lodash": "4.14.192",
     "@types/ndarray": "1.0.11",
-    "@types/node": "^16.18.23",
+    "@types/node": "^18.15.11",
     "@types/react": "^17.0.56",
     "@types/react-dom": "^17.0.19",
     "@types/three": "0.141.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/silx-kit/h5web"
   },
   "engines": {
-    "node": "16.x",
+    "node": "18.x",
     "pnpm": "7.x"
   },
   "scripts": {
@@ -36,7 +36,7 @@
     "@testing-library/cypress": "9.0.0",
     "@types/cypress-image-snapshot": "3.1.6",
     "@types/jest": "^29.5.0",
-    "@types/node": "^16.18.23",
+    "@types/node": "^18.15.11",
     "cypress": "12.3.0",
     "cypress-image-snapshot": "4.0.1",
     "cypress-wait-for-stable-dom": "0.1.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -68,7 +68,7 @@
     "@types/d3-format": "3.0.1",
     "@types/lodash": "4.14.192",
     "@types/ndarray": "1.0.11",
-    "@types/node": "^16.18.23",
+    "@types/node": "^18.15.11",
     "@types/react": "^17.0.56",
     "@types/react-dom": "^17.0.19",
     "@types/react-slider": "1.3.1",

--- a/packages/h5wasm/package.json
+++ b/packages/h5wasm/package.json
@@ -45,7 +45,7 @@
     "@h5web/app": "workspace:*",
     "@h5web/shared": "workspace:*",
     "@rollup/plugin-alias": "4.0.3",
-    "@types/node": "^16.18.23",
+    "@types/node": "^18.15.11",
     "@types/react": "^17.0.56",
     "@vitejs/plugin-react": "2.2.0",
     "eslint": "8.28.0",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -80,7 +80,7 @@
     "@types/d3-scale-chromatic": "3.0.0",
     "@types/lodash": "4.14.192",
     "@types/ndarray": "1.0.11",
-    "@types/node": "^16.18.23",
+    "@types/node": "^18.15.11",
     "@types/react": "^17.0.56",
     "@types/react-aria-menubutton": "6.2.9",
     "@types/react-dom": "^17.0.19",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -30,7 +30,7 @@
     "@types/lodash": "4.14.192",
     "@types/ndarray": "1.0.11",
     "@types/ndarray-ops": "1.2.4",
-    "@types/node": "^16.18.23",
+    "@types/node": "^18.15.11",
     "@types/react": "^17.0.56",
     "d3-format": "3.1.0",
     "eslint": "8.28.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
       '@testing-library/cypress': 9.0.0
       '@types/cypress-image-snapshot': 3.1.6
       '@types/jest': ^29.5.0
-      '@types/node': ^16.18.23
+      '@types/node': ^18.15.11
       cypress: 12.3.0
       cypress-image-snapshot: 4.0.1
       cypress-wait-for-stable-dom: 0.1.0
@@ -30,14 +30,14 @@ importers:
       '@testing-library/cypress': 9.0.0_cypress@12.3.0
       '@types/cypress-image-snapshot': 3.1.6
       '@types/jest': 29.5.0
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       cypress: 12.3.0
       cypress-image-snapshot: 4.0.1_cypress@12.3.0+jest@29.3.1
       cypress-wait-for-stable-dom: 0.1.0
       eslint: 8.28.0
       eslint-config-galex: 4.4.2_eslint@8.28.0+jest@29.3.1
       identity-obj-proxy: 3.0.0
-      jest: 29.3.1_@types+node@16.18.23
+      jest: 29.3.1_@types+node@18.15.11
       jest-transform-stub: 2.0.0
       npm-run-all: 4.1.5
       prettier: 2.8.7
@@ -48,7 +48,7 @@ importers:
     specifiers:
       '@h5web/app': workspace:*
       '@h5web/h5wasm': workspace:*
-      '@types/node': ^16.18.23
+      '@types/node': ^18.15.11
       '@types/react': ^17.0.56
       '@types/react-dom': ^17.0.19
       '@types/react-router-dom': 5.3.3
@@ -79,7 +79,7 @@ importers:
       react-icons: 4.8.0_react@17.0.2
       react-router-dom: 6.3.0_sfoxds7t5ydpegc3knd667wn6m
     devDependencies:
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       '@types/react': 17.0.56
       '@types/react-dom': 17.0.19
       '@types/react-router-dom': 5.3.3
@@ -87,7 +87,7 @@ importers:
       eslint: 8.28.0
       eslint-config-galex: 4.4.2_eslint@8.28.0
       typescript: 4.9.4
-      vite: 3.2.5_@types+node@16.18.23
+      vite: 3.2.5_@types+node@18.15.11
       vite-plugin-checker: 0.5.3_atpybpjwglj5rdouice2tzmsgu
       vite-plugin-eslint: 1.8.1_eslint@8.28.0+vite@3.2.5
 
@@ -108,7 +108,7 @@ importers:
       '@types/d3-format': 3.0.1
       '@types/lodash': 4.14.192
       '@types/ndarray': 1.0.11
-      '@types/node': ^16.18.23
+      '@types/node': ^18.15.11
       '@types/react': ^17.0.56
       '@types/react-dom': ^17.0.19
       '@types/three': 0.141.0
@@ -155,7 +155,7 @@ importers:
       '@types/d3-format': 3.0.1
       '@types/lodash': 4.14.192
       '@types/ndarray': 1.0.11
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       '@types/react': 17.0.56
       '@types/react-dom': 17.0.19
       '@types/three': 0.141.0
@@ -180,7 +180,7 @@ importers:
       '@types/d3-format': 3.0.1
       '@types/lodash': 4.14.192
       '@types/ndarray': 1.0.11
-      '@types/node': ^16.18.23
+      '@types/node': ^18.15.11
       '@types/react': ^17.0.56
       '@types/react-dom': ^17.0.19
       '@types/react-slider': 1.3.1
@@ -237,7 +237,7 @@ importers:
       '@types/d3-format': 3.0.1
       '@types/lodash': 4.14.192
       '@types/ndarray': 1.0.11
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       '@types/react': 17.0.56
       '@types/react-dom': 17.0.19
       '@types/react-slider': 1.3.1
@@ -246,7 +246,7 @@ importers:
       concat: 1.0.3
       eslint: 8.28.0
       eslint-config-galex: 4.4.2_eslint@8.28.0+jest@29.3.1
-      jest: 29.3.1_@types+node@16.18.23
+      jest: 29.3.1_@types+node@18.15.11
       jest-environment-jsdom: 29.3.1
       npm-run-all: 4.1.5
       react: 17.0.2
@@ -255,14 +255,14 @@ importers:
       rollup: 3.10.0
       rollup-plugin-dts: 5.1.1_eymahajmafh3u7vrzmo7ylp2pa
       typescript: 4.9.4
-      vite: 3.2.5_@types+node@16.18.23
+      vite: 3.2.5_@types+node@18.15.11
 
   packages/h5wasm:
     specifiers:
       '@h5web/app': workspace:*
       '@h5web/shared': workspace:*
       '@rollup/plugin-alias': 4.0.3
-      '@types/node': ^16.18.23
+      '@types/node': ^18.15.11
       '@types/react': ^17.0.56
       '@vitejs/plugin-react': 2.2.0
       eslint: '>=8'
@@ -281,7 +281,7 @@ importers:
       '@h5web/app': link:../app
       '@h5web/shared': link:../shared
       '@rollup/plugin-alias': 4.0.3_rollup@3.10.0
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       '@types/react': 17.0.56
       '@vitejs/plugin-react': 2.2.0_vite@3.2.5
       eslint: 8.28.0
@@ -290,7 +290,7 @@ importers:
       rollup: 3.10.0
       rollup-plugin-dts: 5.1.1_eymahajmafh3u7vrzmo7ylp2pa
       typescript: 4.9.4
-      vite: 3.2.5_@types+node@16.18.23
+      vite: 3.2.5_@types+node@18.15.11
 
   packages/lib:
     specifiers:
@@ -306,7 +306,7 @@ importers:
       '@types/d3-scale-chromatic': 3.0.0
       '@types/lodash': 4.14.192
       '@types/ndarray': 1.0.11
-      '@types/node': ^16.18.23
+      '@types/node': ^18.15.11
       '@types/react': ^17.0.56
       '@types/react-aria-menubutton': 6.2.9
       '@types/react-dom': ^17.0.19
@@ -386,7 +386,7 @@ importers:
       '@types/d3-scale-chromatic': 3.0.0
       '@types/lodash': 4.14.192
       '@types/ndarray': 1.0.11
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       '@types/react': 17.0.56
       '@types/react-aria-menubutton': 6.2.9
       '@types/react-dom': 17.0.19
@@ -398,7 +398,7 @@ importers:
       concat: 1.0.3
       eslint: 8.28.0
       eslint-config-galex: 4.4.2_eslint@8.28.0+jest@29.3.1
-      jest: 29.3.1_@types+node@16.18.23
+      jest: 29.3.1_@types+node@18.15.11
       npm-run-all: 4.1.5
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -407,7 +407,7 @@ importers:
       rollup-plugin-dts: 5.1.1_eymahajmafh3u7vrzmo7ylp2pa
       three: 0.141.0
       typescript: 4.9.4
-      vite: 3.2.5_@types+node@16.18.23
+      vite: 3.2.5_@types+node@18.15.11
 
   packages/shared:
     specifiers:
@@ -415,7 +415,7 @@ importers:
       '@types/lodash': 4.14.192
       '@types/ndarray': 1.0.11
       '@types/ndarray-ops': 1.2.4
-      '@types/node': ^16.18.23
+      '@types/node': ^18.15.11
       '@types/react': ^17.0.56
       d3-format: 3.1.0
       eslint: '>=8'
@@ -431,12 +431,12 @@ importers:
       '@types/lodash': 4.14.192
       '@types/ndarray': 1.0.11
       '@types/ndarray-ops': 1.2.4
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       '@types/react': 17.0.56
       d3-format: 3.1.0
       eslint: 8.28.0
       eslint-config-galex: 4.4.2_eslint@8.28.0+jest@29.3.1
-      jest: 29.3.1_@types+node@16.18.23
+      jest: 29.3.1_@types+node@18.15.11
       lodash: 4.17.21
       ndarray: 1.0.19
       ndarray-ops: 1.2.2
@@ -2325,7 +2325,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.3.1
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       chalk: 4.1.2
       jest-message-util: 29.3.1
       jest-util: 29.3.1
@@ -2346,14 +2346,14 @@ packages:
       '@jest/test-result': 29.3.1
       '@jest/transform': 29.3.1
       '@jest/types': 29.3.1
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.7.0
       exit: 0.1.2
       graceful-fs: 4.2.10
       jest-changed-files: 29.2.0
-      jest-config: 29.3.1_@types+node@16.18.23
+      jest-config: 29.3.1_@types+node@18.15.11
       jest-haste-map: 29.3.1
       jest-message-util: 29.3.1
       jest-regex-util: 29.2.0
@@ -2380,7 +2380,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.3.1
       '@jest/types': 29.3.1
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       jest-mock: 29.3.1
     dev: true
 
@@ -2407,7 +2407,7 @@ packages:
     dependencies:
       '@jest/types': 29.3.1
       '@sinonjs/fake-timers': 9.1.2
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       jest-message-util: 29.3.1
       jest-mock: 29.3.1
       jest-util: 29.3.1
@@ -2440,7 +2440,7 @@ packages:
       '@jest/transform': 29.3.1
       '@jest/types': 29.3.1
       '@jridgewell/trace-mapping': 0.3.17
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -2475,7 +2475,7 @@ packages:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.17
       callsites: 3.1.0
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
     dev: true
 
   /@jest/test-result/29.3.1:
@@ -2493,7 +2493,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/test-result': 29.3.1
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       jest-haste-map: 29.3.1
       slash: 3.0.0
     dev: true
@@ -2550,7 +2550,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       '@types/yargs': 15.0.15
       chalk: 4.1.2
     dev: true
@@ -2562,7 +2562,7 @@ packages:
       '@jest/schemas': 29.0.0
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       '@types/yargs': 17.0.24
       chalk: 4.1.2
     dev: true
@@ -4484,20 +4484,20 @@ packages:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
     dev: true
 
   /@types/glob/8.1.0:
     resolution: {integrity: sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
     dev: true
 
   /@types/graceful-fs/4.1.6:
     resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
     dependencies:
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
     dev: true
 
   /@types/hast/2.3.4:
@@ -4548,7 +4548,7 @@ packages:
   /@types/jsdom/20.0.1:
     resolution: {integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==}
     dependencies:
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       '@types/tough-cookie': 4.0.2
       parse5: 7.1.2
     dev: true
@@ -4587,7 +4587,7 @@ packages:
   /@types/node-fetch/2.6.3:
     resolution: {integrity: sha512-ETTL1mOEdq/sxUtgtOhKjyB2Irra4cjxksvcMUR5Zr4n+PxVhsCD9WS46oPbHL3et9Zde7CNRr+WUNlcHvsX+w==}
     dependencies:
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       form-data: 3.0.1
     dev: true
 
@@ -4597,6 +4597,10 @@ packages:
 
   /@types/node/16.18.23:
     resolution: {integrity: sha512-XAMpaw1s1+6zM+jn2tmw8MyaRDIJfXxqmIQIS0HfoGYPuf7dUWeiUKopwq13KFX9lEp1+THGtlaaYx39Nxr58g==}
+    dev: true
+
+  /@types/node/18.15.11:
+    resolution: {integrity: sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==}
     dev: true
 
   /@types/normalize-package-data/2.4.1:
@@ -4745,7 +4749,7 @@ packages:
   /@types/webpack-sources/3.2.0:
     resolution: {integrity: sha512-Ft7YH3lEVRQ6ls8k4Ff1oB4jN6oy/XmU6tQISKdhfh+1mR+viZFphS6WL0IrtDOzvefmJg5a0s7ZQoRXwqTEFg==}
     dependencies:
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       '@types/source-list-map': 0.1.2
       source-map: 0.7.4
     dev: true
@@ -4753,7 +4757,7 @@ packages:
   /@types/webpack/4.41.33:
     resolution: {integrity: sha512-PPajH64Ft2vWevkerISMtnZ8rTs4YmRbs+23c402J0INmxDKCrhZNvwZYtzx96gY2wAtXdrK1BS2fiC8MlLr3g==}
     dependencies:
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       '@types/tapable': 1.0.8
       '@types/uglify-js': 3.17.1
       '@types/webpack-sources': 3.2.0
@@ -4785,7 +4789,7 @@ packages:
     resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
     requiresBuild: true
     dependencies:
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
     dev: true
     optional: true
 
@@ -5165,7 +5169,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.19.6_@babel+core@7.20.12
       magic-string: 0.26.7
       react-refresh: 0.14.0
-      vite: 3.2.5_@types+node@16.18.23
+      vite: 3.2.5_@types+node@18.15.11
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5977,7 +5981,7 @@ packages:
       babel-plugin-istanbul: 6.1.1
       babel-preset-jest: 29.2.0_@babel+core@7.20.12
       chalk: 4.1.2
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
@@ -8633,7 +8637,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 5.42.1_53dvuwv4da6ibosl6x26v6csqy
       '@typescript-eslint/utils': 5.48.2_wy4udjehnvkneqnogzx5kughki
       eslint: 8.28.0
-      jest: 29.3.1_@types+node@16.18.23
+      jest: 29.3.1_@types+node@18.15.11
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -10961,7 +10965,7 @@ packages:
       '@jest/expect': 29.3.1
       '@jest/test-result': 29.3.1
       '@jest/types': 29.3.1
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -10980,7 +10984,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli/29.3.1_@types+node@16.18.23:
+  /jest-cli/29.3.1_@types+node@18.15.11:
     resolution: {integrity: sha512-TO/ewvwyvPOiBBuWZ0gm04z3WWP8TIK8acgPzE4IxgsLKQgb377NYGrQLc3Wl/7ndWzIH2CDNNsUjGxwLL43VQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -10997,7 +11001,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.10
       import-local: 3.1.0
-      jest-config: 29.3.1_@types+node@16.18.23
+      jest-config: 29.3.1_@types+node@18.15.11
       jest-util: 29.3.1
       jest-validate: 29.3.1
       prompts: 2.4.2
@@ -11008,7 +11012,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-config/29.3.1_@types+node@16.18.23:
+  /jest-config/29.3.1_@types+node@18.15.11:
     resolution: {integrity: sha512-y0tFHdj2WnTEhxmGUK1T7fgLen7YK4RtfvpLFBXfQkh2eMJAQq24Vx9472lvn5wg0MAO6B+iPfJfzdR9hJYalg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -11023,7 +11027,7 @@ packages:
       '@babel/core': 7.20.12
       '@jest/test-sequencer': 29.3.1
       '@jest/types': 29.3.1
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       babel-jest: 29.3.1_@babel+core@7.20.12
       chalk: 4.1.2
       ci-info: 3.7.0
@@ -11088,7 +11092,7 @@ packages:
       '@jest/fake-timers': 29.3.1
       '@jest/types': 29.3.1
       '@types/jsdom': 20.0.1
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       jest-mock: 29.3.1
       jest-util: 29.3.1
       jsdom: 20.0.3
@@ -11105,7 +11109,7 @@ packages:
       '@jest/environment': 29.3.1
       '@jest/fake-timers': 29.3.1
       '@jest/types': 29.3.1
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       jest-mock: 29.3.1
       jest-util: 29.3.1
     dev: true
@@ -11121,7 +11125,7 @@ packages:
     dependencies:
       '@jest/types': 26.6.2
       '@types/graceful-fs': 4.1.6
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -11144,7 +11148,7 @@ packages:
     dependencies:
       '@jest/types': 29.3.1
       '@types/graceful-fs': 4.1.6
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.10
@@ -11166,7 +11170,7 @@ packages:
       chalk: 1.1.3
       get-stdin: 5.0.1
       glur: 1.1.2
-      jest: 29.3.1_@types+node@16.18.23
+      jest: 29.3.1_@types+node@18.15.11
       lodash: 4.17.21
       mkdirp: 0.5.5
       pixelmatch: 5.2.1
@@ -11213,7 +11217,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.3.1
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       jest-util: 29.3.1
     dev: true
 
@@ -11273,7 +11277,7 @@ packages:
       '@jest/test-result': 29.3.1
       '@jest/transform': 29.3.1
       '@jest/types': 29.3.1
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.10
@@ -11304,7 +11308,7 @@ packages:
       '@jest/test-result': 29.3.1
       '@jest/transform': 29.3.1
       '@jest/types': 29.3.1
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       chalk: 4.1.2
       cjs-module-lexer: 1.2.2
       collect-v8-coverage: 1.0.1
@@ -11327,7 +11331,7 @@ packages:
     resolution: {integrity: sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==}
     engines: {node: '>= 10.14.2'}
     dependencies:
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       graceful-fs: 4.2.11
     dev: true
 
@@ -11372,7 +11376,7 @@ packages:
     engines: {node: '>= 10.14.2'}
     dependencies:
       '@jest/types': 26.6.2
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       chalk: 4.1.2
       graceful-fs: 4.2.11
       is-ci: 2.0.0
@@ -11384,7 +11388,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.3.1
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       chalk: 4.1.2
       ci-info: 3.7.1
       graceful-fs: 4.2.10
@@ -11409,7 +11413,7 @@ packages:
     dependencies:
       '@jest/test-result': 29.3.1
       '@jest/types': 29.3.1
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -11421,7 +11425,7 @@ packages:
     resolution: {integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       merge-stream: 2.0.0
       supports-color: 7.2.0
     dev: true
@@ -11430,7 +11434,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -11439,13 +11443,13 @@ packages:
     resolution: {integrity: sha512-lY4AnnmsEWeiXirAIA0c9SDPbuCBq8IYuDVL8PMm0MZ2PEs2yPvRA/J64QBXuZp7CYKrDM/rmNrc9/i3KJQncw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       jest-util: 29.3.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
 
-  /jest/29.3.1_@types+node@16.18.23:
+  /jest/29.3.1_@types+node@18.15.11:
     resolution: {integrity: sha512-6iWfL5DTT0Np6UYs/y5Niu7WIfNv/wRTtN5RSXt2DIEft3dx3zPuw/3WJQBCJfmEzvDiEKwoqMbGD9n49+qLSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -11458,7 +11462,7 @@ packages:
       '@jest/core': 29.3.1
       '@jest/types': 29.3.1
       import-local: 3.1.0
-      jest-cli: 29.3.1_@types+node@16.18.23
+      jest-cli: 29.3.1_@types+node@18.15.11
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -11600,7 +11604,7 @@ packages:
   /jsonfile/4.0.0:
     resolution: {integrity: sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=}
     optionalDependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
     dev: true
 
   /jsonfile/6.1.0:
@@ -15544,7 +15548,7 @@ packages:
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.3.1_@types+node@16.18.23
+      jest: 29.3.1_@types+node@18.15.11
       jest-util: 29.3.1
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -16114,7 +16118,7 @@ packages:
       strip-ansi: 6.0.1
       tiny-invariant: 1.3.1
       typescript: 4.9.4
-      vite: 3.2.5_@types+node@16.18.23
+      vite: 3.2.5_@types+node@18.15.11
       vscode-languageclient: 7.0.0
       vscode-languageserver: 7.0.0
       vscode-languageserver-textdocument: 1.0.8
@@ -16131,10 +16135,10 @@ packages:
       '@types/eslint': 8.37.0
       eslint: 8.28.0
       rollup: 2.79.0
-      vite: 3.2.5_@types+node@16.18.23
+      vite: 3.2.5_@types+node@18.15.11
     dev: true
 
-  /vite/3.2.5_@types+node@16.18.23:
+  /vite/3.2.5_@types+node@18.15.11:
     resolution: {integrity: sha512-4mVEpXpSOgrssFZAOmGIr85wPHKvaDAcXqxVxVRZhljkJOMZi1ibLibzjLHzJvcok8BMguLc7g1W6W/GqZbLdQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -16159,7 +16163,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 16.18.23
+      '@types/node': 18.15.11
       esbuild: 0.15.18
       postcss: 8.4.21
       resolve: 1.22.1


### PR DESCRIPTION
It's been LTS [for a few months now](https://github.com/nodejs/release#release-schedule), and packages are starting to drop Node 16, like [eslint-config-galex](https://github.com/ljosberinn/eslint-config-galex/releases/tag/v4.5.0). The end-of-life date of Node 16 has been brought forward to September 2023: https://nodejs.org/en/blog/announcements/nodejs16-eol