### PR TITLE
Rename prop `maskValues` to `mask`

### DIFF
--- a/apps/storybook/src/DataCurve.stories.tsx
+++ b/apps/storybook/src/DataCurve.stories.tsx
@@ -62,6 +62,11 @@ GlyphSize.args = {
   glyphSize: 10,
 };
 
+export const IgnoreValue = Template.bind({});
+IgnoreValue.args = {
+  ignoreValue: (val) => val % 5 === 0,
+};
+
 export const Interactive: Story<DataCurveProps> = (args) => {
   const [index, setIndex] = useState<number>();
   const [hoveredIndex, setHoveredIndex] = useState<number>();

--- a/apps/storybook/src/HeatmapMesh.stories.tsx
+++ b/apps/storybook/src/HeatmapMesh.stories.tsx
@@ -7,6 +7,7 @@ import {
 import type { HeatmapMeshProps, Domain } from '@h5web/lib';
 import { getDims, ScaleType, toTypedNdArray } from '@h5web/shared';
 import type { Meta, Story } from '@storybook/react/types-6-0';
+import { range } from 'lodash';
 import ndarray from 'ndarray';
 import {
   ByteType,
@@ -29,6 +30,14 @@ const domain = getDomain(dataArray.data);
 const uint16Values = [0x4900, 0x4d00, 0x4f80, 0x5100]; // 10, 20, 30, 40
 const uint16DataArray = ndarray(Uint16Array.from(uint16Values), [2, 2]);
 const uint16Domain: Domain = [10, 40];
+const mask = ndarray(
+  Uint8Array.from(
+    range(0, 20 * 41).map((val) =>
+      ((val % 41) * Math.floor(val / 41)) % 5 === 0 ? 255 : 0
+    )
+  ),
+  [20, 41]
+);
 
 const Template: Story<HeatmapMeshProps> = (args) => {
   const { rows, cols } = getDims(args.values);
@@ -71,6 +80,12 @@ BadColor.args = {
   domain: [0.1, 400],
   scaleType: ScaleType.Log,
   badColor: 'steelblue',
+};
+
+export const Mask = Template.bind({});
+Mask.args = {
+  ...Default.args,
+  mask,
 };
 
 export default {

--- a/apps/storybook/src/HeatmapVis.stories.tsx
+++ b/apps/storybook/src/HeatmapVis.stories.tsx
@@ -94,6 +94,12 @@ Alpha.args = {
   alpha: { array: alphaArray, domain: alphaDomain },
 };
 
+export const IgnoreValue = Template.bind({});
+IgnoreValue.args = {
+  ...Default.args,
+  ignoreValue: (val) => val >= 0 && val <= 100,
+};
+
 export const TypedArray = Template.bind({});
 TypedArray.args = {
   dataArray: toTypedNdArray(dataArray, Float32Array),

--- a/apps/storybook/src/LineVis.stories.tsx
+++ b/apps/storybook/src/LineVis.stories.tsx
@@ -115,6 +115,12 @@ AuxiliaryErrors.args = {
   showErrors: true,
 };
 
+export const IgnoreValue = Template.bind({});
+IgnoreValue.args = {
+  ...Default.args,
+  ignoreValue: (val) => val % 5 === 0,
+};
+
 export const TypedArrays = Template.bind({});
 TypedArrays.args = {
   dataArray: toTypedNdArray(primaryArray, Float32Array),

--- a/packages/lib/src/vis/heatmap/HeatmapMaterial.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapMaterial.tsx
@@ -26,7 +26,7 @@ interface Props extends VisMeshProps {
   alphaValues?: NdArray<TextureSafeTypedArray | Uint16Array>; // uint16 values are treated as half floats
   alphaDomain?: Domain;
   badColor?: RGBColor | string;
-  maskValues?: NdArray<Uint8Array>;
+  mask?: NdArray<Uint8Array>;
 }
 
 const DEFAULT_BAD_COLOR = rgb(255, 255, 255, 0);
@@ -55,12 +55,12 @@ function HeatmapMaterial(props: Props) {
     alphaValues,
     alphaDomain = DEFAULT_DOMAIN,
     badColor = DEFAULT_BAD_COLOR,
-    maskValues,
+    mask,
   } = props;
 
   const dataTexture = useDataTexture(values, magFilter);
   const alphaTexture = useDataTexture(alphaValues);
-  const maskTexture = useDataTexture(maskValues);
+  const maskTexture = useDataTexture(mask);
 
   const colorMapTexture = useMemo(() => {
     const interpolator = getInterpolator(colorMap, invertColorMap);

--- a/packages/lib/src/vis/heatmap/HeatmapMesh.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapMesh.tsx
@@ -19,7 +19,7 @@ interface Props extends VisMeshProps {
   alphaValues?: NdArray<TextureSafeTypedArray | Uint16Array>; // uint16 values are treated as half floats
   alphaDomain?: Domain;
   badColor?: RGBColor | string;
-  maskValues?: NdArray<Uint8Array>;
+  mask?: NdArray<Uint8Array>;
 }
 
 function HeatmapMesh(props: Props) {
@@ -33,7 +33,7 @@ function HeatmapMesh(props: Props) {
     alphaValues,
     alphaDomain,
     badColor,
-    maskValues,
+    mask,
     ...visMeshProps
   } = props;
 
@@ -49,7 +49,7 @@ function HeatmapMesh(props: Props) {
         alphaValues={alphaValues}
         alphaDomain={alphaDomain}
         badColor={badColor}
-        maskValues={maskValues}
+        mask={mask}
       />
     </VisMesh>
   );

--- a/packages/lib/src/vis/heatmap/HeatmapVis.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapVis.tsx
@@ -6,9 +6,7 @@ import {
   ScaleType,
 } from '@h5web/shared';
 import type { NdArray } from 'ndarray';
-import ndarray from 'ndarray';
 import type { ReactElement, ReactNode } from 'react';
-import { useMemo } from 'react';
 
 import type { DefaultInteractionsConfig } from '../../interactions/DefaultInteractions';
 import DefaultInteractions from '../../interactions/DefaultInteractions';
@@ -21,7 +19,7 @@ import { DEFAULT_DOMAIN, formatNumType } from '../utils';
 import ColorBar from './ColorBar';
 import HeatmapMesh from './HeatmapMesh';
 import styles from './HeatmapVis.module.css';
-import { usePixelEdgeValues, useTextureSafeNdArray } from './hooks';
+import { useMask, usePixelEdgeValues, useTextureSafeNdArray } from './hooks';
 import type { ColorMap, TooltipData } from './models';
 
 interface Props {
@@ -81,18 +79,7 @@ function HeatmapVis(props: Props) {
 
   const safeDataArray = useTextureSafeNdArray(dataArray);
   const safeAlphaArray = useTextureSafeNdArray(alpha?.array);
-  const maskArray = useMemo(
-    () =>
-      ignoreValue
-        ? ndarray(
-            Uint8Array.from(
-              dataArray.data.map((v) => (ignoreValue(v) ? 255 : 0))
-            ),
-            dataArray.shape
-          )
-        : undefined,
-    [dataArray, ignoreValue]
-  );
+  const maskArray = useMask(dataArray, ignoreValue);
 
   return (
     <figure className={styles.root} aria-label={title} data-keep-canvas-colors>
@@ -151,7 +138,7 @@ function HeatmapVis(props: Props) {
           alphaValues={safeAlphaArray}
           alphaDomain={alpha?.domain}
           scale={[1, flipYAxis ? -1 : 1, 1]}
-          maskValues={maskArray}
+          mask={maskArray}
         />
 
         {children}

--- a/packages/lib/src/vis/heatmap/hooks.ts
+++ b/packages/lib/src/vis/heatmap/hooks.ts
@@ -6,6 +6,7 @@ import {
   getPixelEdgeValues,
   toTextureSafeNdArray,
   getDataTexture,
+  getMask,
 } from './utils';
 
 export const useVisDomain = createMemo(getVisDomain);
@@ -13,3 +14,4 @@ export const useSafeDomain = createMemo(getSafeDomain);
 export const usePixelEdgeValues = createMemo(getPixelEdgeValues);
 export const useTextureSafeNdArray = createMemo(toTextureSafeNdArray);
 export const useDataTexture = createMemo(getDataTexture);
+export const useMask = createMemo(getMask);

--- a/packages/lib/src/vis/heatmap/utils.ts
+++ b/packages/lib/src/vis/heatmap/utils.ts
@@ -2,6 +2,7 @@ import type { Domain, NumArray } from '@h5web/shared';
 import { getDims, ScaleType, toTypedNdArray } from '@h5web/shared';
 import { range } from 'lodash';
 import type { NdArray } from 'ndarray';
+import ndarray from 'ndarray';
 import type { TextureFilter } from 'three';
 import {
   ClampToEdgeWrapping,
@@ -197,4 +198,18 @@ export function getDataTexture(
   texture.needsUpdate = true;
 
   return texture;
+}
+
+export function getMask(
+  dataArray: NdArray<NumArray>,
+  ignoreValue: ((v: number) => boolean) | undefined
+): NdArray<Uint8Array> | undefined {
+  if (!ignoreValue) {
+    return undefined;
+  }
+
+  return ndarray(
+    Uint8Array.from(dataArray.data.map((v) => (ignoreValue(v) ? 255 : 0))),
+    dataArray.shape
+  );
 }


### PR DESCRIPTION
This PR suggests renaming the `maskValues` prop in `HeatmapMesh` and `HeatmapMaterial` to just `mask`.

I know `maskValues` takes inspiration from prop `alphaValues`, but I feel like this is a bit different, since a "mask" in this context implies that it's an array, so the `Values` suffix feels redundant. More importantly, `maskValues` can be interpreted as a callback, like `ignoreValue`, since `mask` can be a verb. 

In addition to this, I document the `ignoreValue` and the now-called `mask` props in Storybook:

![image](https://user-images.githubusercontent.com/2936402/231477294-c4bfd95b-4988-4554-a438-df51d7dad040.png)

![image](https://user-images.githubusercontent.com/2936402/231477799-4490524b-8f03-41c1-868b-4eb9363f18c8.png)

![image](https://user-images.githubusercontent.com/2936402/231477356-bbaafc01-c6f9-4dca-93a3-8b0c93e8e304.png)

![image](https://user-images.githubusercontent.com/2936402/231477430-0f6bb59f-9681-4ced-a514-11302552fe24.png)