### PR TITLE
Enforce slightly stricter TS config

### DIFF
--- a/packages/app/src/providers/h5grove/h5grove-api.ts
+++ b/packages/app/src/providers/h5grove/h5grove-api.ts
@@ -112,7 +112,7 @@ export class H5GroveApi extends DataProviderApi {
     const { data } = await handleAxiosError(
       () =>
         this.client.get<H5GroveEntityResponse>(`/meta/`, { params: { path } }),
-      (status, errorData) => {
+      (_, errorData) => {
         if (!hasErrorMessage(errorData)) {
           return undefined;
         }
@@ -199,7 +199,7 @@ export class H5GroveApi extends DataProviderApi {
 
     if (isGroupResponse(response)) {
       const { children = [], attributes: attrsMetadata } = response;
-      const attributes = await this.processAttrsMetadata(path, attrsMetadata);
+      const attributes = await this.processAttrsMetadata(attrsMetadata);
       const baseGroup: Group = {
         ...baseEntity,
         kind: EntityKind.Group,
@@ -230,7 +230,7 @@ export class H5GroveApi extends DataProviderApi {
         chunks,
         filters,
       } = response;
-      const attributes = await this.processAttrsMetadata(path, attrsMetadata);
+      const attributes = await this.processAttrsMetadata(attrsMetadata);
       return {
         ...baseEntity,
         attributes,
@@ -276,7 +276,6 @@ export class H5GroveApi extends DataProviderApi {
   }
 
   private async processAttrsMetadata(
-    path: string,
     attrsMetadata: H5GroveAttribute[]
   ): Promise<Attribute[]> {
     return attrsMetadata.map<Attribute>(({ name, dtype, shape }) => ({

--- a/packages/app/src/providers/h5grove/h5grove-api.ts
+++ b/packages/app/src/providers/h5grove/h5grove-api.ts
@@ -72,7 +72,7 @@ export class H5GroveApi extends DataProviderApi {
     return attributes.length > 0 ? this.fetchAttrValues(path) : {};
   }
 
-  public getExportURL<D extends Dataset<ArrayShape>>(
+  public override getExportURL<D extends Dataset<ArrayShape>>(
     format: ExportFormat,
     dataset: D,
     selection: string | undefined,
@@ -100,7 +100,7 @@ export class H5GroveApi extends DataProviderApi {
     return new URL(`${baseURL as string}/data/?${searchParams.toString()}`);
   }
 
-  public async getSearchablePaths(path: string): Promise<string[]> {
+  public override async getSearchablePaths(path: string): Promise<string[]> {
     const { data } = await this.client.get<H5GrovePathsResponse>(`/paths/`, {
       params: { path },
     });

--- a/packages/app/src/providers/hsds/hsds-api.ts
+++ b/packages/app/src/providers/hsds/hsds-api.ts
@@ -151,7 +151,7 @@ export class HsdsApi extends DataProviderApi {
     );
   }
 
-  public getExportURL<D extends Dataset<ArrayShape>>(
+  public override getExportURL<D extends Dataset<ArrayShape>>(
     format: ExportFormat,
     dataset: D,
     selection: string | undefined,

--- a/packages/app/src/providers/mock/mock-api.ts
+++ b/packages/app/src/providers/mock/mock-api.ts
@@ -82,7 +82,7 @@ export class MockApi extends DataProviderApi {
     return sliceValue(value, dataset, selection);
   }
 
-  public getExportURL<D extends Dataset<ArrayShape>>(
+  public override getExportURL<D extends Dataset<ArrayShape>>(
     format: ExportFormat,
     dataset: D,
     selection: string | undefined,
@@ -116,7 +116,7 @@ export class MockApi extends DataProviderApi {
     return undefined;
   }
 
-  public async getSearchablePaths(path: string): Promise<string[]> {
+  public override async getSearchablePaths(path: string): Promise<string[]> {
     return this.getEntityPaths(path);
   }
 

--- a/packages/h5wasm/src/h5wasm-api.ts
+++ b/packages/h5wasm/src/h5wasm-api.ts
@@ -97,7 +97,7 @@ export class H5WasmApi extends ProviderApi {
     );
   }
 
-  public getExportURL<D extends Dataset<ArrayShape>>(
+  public override getExportURL<D extends Dataset<ArrayShape>>(
     format: ExportFormat,
     dataset: D,
     selection: string | undefined,
@@ -111,7 +111,7 @@ export class H5WasmApi extends ProviderApi {
     file.close();
   }
 
-  public async getSearchablePaths(root: string): Promise<string[]> {
+  public override async getSearchablePaths(root: string): Promise<string[]> {
     const file = await this.file;
 
     const h5wEntity = file.get(root);

--- a/packages/lib/src/interactions/box.ts
+++ b/packages/lib/src/interactions/box.ts
@@ -27,7 +27,7 @@ class Box extends Box3 {
     return Box.empty().expandBySize(width, height);
   }
 
-  public clampPoint(pt: Vector3): Vector3 {
+  public override clampPoint(pt: Vector3): Vector3 {
     return super.clampPoint(pt, new Vector3());
   }
 

--- a/packages/shared/src/mock/metadata.ts
+++ b/packages/shared/src/mock/metadata.ts
@@ -299,7 +299,7 @@ export const mockMetadata = makeNxGroup(mockFilepath, 'NXroot', {
         },
         axesAttr: ['.', 'slow_X'],
         auxiliary: {
-          secondary: makeDataset('slow_secondary', intType, [20, 41], {
+          slow_secondary: makeDataset('slow_secondary', intType, [20, 41], {
             valueId: 'secondary',
           }),
         },

--- a/packages/shared/src/mock/values.ts
+++ b/packages/shared/src/mock/values.ts
@@ -167,7 +167,7 @@ export const mockValues = {
   tertiary: twoD.map((inner) => inner.map((v) => v / 2)),
   position: [-1, 1, 3], // pixel boundaries (N + 1)
   scatter_data: arr1.map((val) => Math.cos((val * 3.14) / 40)),
-  Y_scatter: arr1.map((v, i) => ((i % 10) + (i % 5)) / 123_456),
+  Y_scatter: arr1.map((_, i) => ((i % 10) + (i % 5)) / 123_456),
   oneD_compound,
   twoD_compound,
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "declarationMap": true,
     "removeComments": true,
     "strict": true,
+    "noImplicitOverride": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Inspired by https://www.npmjs.com/package/@tsconfig/strictest. I tried enabling a few more options but in the end, I've made only one change to `tsconfig.json`. The other options specified in `@tsconfig/strictest` that we don't already specify are either:

- too crazy and not worth the pain (`exactOptionalPropertyTypes`, `noUncheckedIndexedAccess` and `noPropertyAccessFromIndexSignature`); or
- overly restrictive in development and already reported by ESLint anyway (`allowUnreachableCode`, `noUnusedLocals`, `noUnusedParameters`).

They did allow me to detect and fix a few minor issues, though, which is nice.