### PR TITLE
Support any number of points in SelectionTool

### DIFF
--- a/apps/storybook/src/utils.ts
+++ b/apps/storybook/src/utils.ts
@@ -1,15 +1,16 @@
-import type { CustomDomain, Domain, Rect } from '@h5web/lib';
+import type { CustomDomain, Domain, Points } from '@h5web/lib';
 import { format } from 'd3-format';
 
 export const formatCoord = format('.2f');
 export const formatDomainValue = format('.3~f');
 
-export function getTitleForSelection(selection: Rect | undefined) {
+export function getTitleForSelection(selection: Points | undefined) {
   if (!selection) {
     return 'No selection';
   }
 
-  const [start, end] = selection;
+  const start = selection[0];
+  const end = selection[selection.length - 1];
   return `Selection from (${formatCoord(start.x)}, ${formatCoord(
     start.y
   )}) to (${formatCoord(end.x)}, ${formatCoord(end.y)})`;

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -73,10 +73,12 @@ export type { DefaultInteractionsConfig } from './interactions/DefaultInteractio
 // SVG
 export { default as SvgElement } from './interactions/svg/SvgElement';
 export { default as SvgLine } from './interactions/svg/SvgLine';
+export { default as SvgPolyline } from './interactions/svg/SvgPolyline';
 export { default as SvgRect } from './interactions/svg/SvgRect';
 export { default as SvgCircle } from './interactions/svg/SvgCircle';
 export type { SvgElementProps } from './interactions/svg/SvgElement';
 export type { SvgLineProps } from './interactions/svg/SvgLine';
+export type { SvgPolylineProps } from './interactions/svg/SvgPolyline';
 export type { SvgRectProps } from './interactions/svg/SvgRect';
 export type { SvgCircleProps } from './interactions/svg/SvgCircle';
 
@@ -130,6 +132,7 @@ export type {
   InteractionInfo,
   ModifierKey,
   Selection,
+  Points,
   Rect,
   CanvasEvent,
   CanvasEventCallbacks,

--- a/packages/lib/src/interactions/SelectionTool.tsx
+++ b/packages/lib/src/interactions/SelectionTool.tsx
@@ -188,6 +188,7 @@ function SelectionTool(props: Props) {
         useNewPointRef.current = true;
       }
       if (done || (nPts >= minPoints && maxPoints > 0 && nPts === maxPoints)) {
+        setRawSelection(undefined);
         finishSelection(eTarget, pointerId, isDown, doInteract);
       }
     },
@@ -199,6 +200,7 @@ function SelectionTool(props: Props) {
       maxMovement,
       startSelection,
       finishSelection,
+      setRawSelection,
     ]
   );
 

--- a/packages/lib/src/interactions/box.ts
+++ b/packages/lib/src/interactions/box.ts
@@ -1,7 +1,7 @@
 import { Box3, Vector3 } from 'three';
 
 import type { Size } from '../vis/models';
-import type { Rect } from './models';
+import type { Points } from './models';
 
 const ZERO_VECTOR = new Vector3(0, 0, 0);
 
@@ -77,7 +77,7 @@ class Box extends Box3 {
     return this.translate(shift);
   }
 
-  public toRect(): Rect {
+  public toRect(): Points {
     return [this.min, this.max];
   }
 }

--- a/packages/lib/src/interactions/models.ts
+++ b/packages/lib/src/interactions/models.ts
@@ -8,11 +8,12 @@ export enum MouseButton {
 }
 
 export type Rect = [Vector3, Vector3];
+export type Points = Vector3[] | Rect;
 
 export interface Selection {
-  html: Rect;
-  world: Rect;
-  data: Rect;
+  html: Points;
+  world: Points;
+  data: Points;
 }
 
 export interface CanvasEvent<T extends MouseEvent> {

--- a/packages/lib/src/interactions/svg/SvgCircle.tsx
+++ b/packages/lib/src/interactions/svg/SvgCircle.tsx
@@ -1,9 +1,9 @@
 import type { SVGProps } from 'react';
 
-import type { Rect } from '../models';
+import type { Points } from '../models';
 
 interface Props extends SVGProps<SVGCircleElement> {
-  coords: Rect;
+  coords: Points;
 }
 
 function SvgCircle(props: Props) {

--- a/packages/lib/src/interactions/svg/SvgLine.tsx
+++ b/packages/lib/src/interactions/svg/SvgLine.tsx
@@ -1,9 +1,9 @@
 import type { SVGProps } from 'react';
 
-import type { Rect } from '../models';
+import type { Points } from '../models';
 
 interface Props extends SVGProps<SVGLineElement> {
-  coords: Rect;
+  coords: Points;
 }
 
 function SvgLine(props: Props) {

--- a/packages/lib/src/interactions/svg/SvgPolyline.tsx
+++ b/packages/lib/src/interactions/svg/SvgPolyline.tsx
@@ -1,0 +1,16 @@
+import type { SVGProps } from 'react';
+
+import type { Points } from '../models';
+
+export interface SvgPolylineProps extends SVGProps<SVGPolylineElement> {
+  coords: Points;
+}
+
+function SvgPolyline(props: SvgPolylineProps) {
+  const { coords, fill = 'none', ...svgProps } = props;
+  const pts = coords.map((c) => `${c.x},${c.y}`).join(' ');
+
+  return <polyline points={pts} fill={fill} {...svgProps} />;
+}
+
+export default SvgPolyline;

--- a/packages/lib/src/interactions/svg/SvgRect.tsx
+++ b/packages/lib/src/interactions/svg/SvgRect.tsx
@@ -1,9 +1,9 @@
 import type { SVGProps } from 'react';
 
-import type { Rect } from '../models';
+import type { Points } from '../models';
 
 interface Props extends SVGProps<SVGRectElement> {
-  coords: Rect;
+  coords: Points;
   strokePosition?: 'inside' | 'outside'; // no effect without `stroke` prop; assumes `strokeWidth` of 1 unless specified explicitely as prop (CSS ignored)
   strokeWidth?: number; // forbid string
 }


### PR DESCRIPTION
This adds a capability to define selections that need different number of points:
  1. Can specify minimum number of points
  2. Can specify maximum number of points, can be -1 for no limit
  3. When number of points is at least minimum
    - set status boolean
    - end selection on enter/return key press
    - pointer down on same position sets last point (within maxMovement)

Also make SVG selections compatible using new type, add SvgPolyline and use in new story