### PR TITLE
Keep the color of curve color legend handles in dark mode

### DIFF
--- a/packages/lib/src/vis/line/LineVis.tsx
+++ b/packages/lib/src/vis/line/LineVis.tsx
@@ -149,6 +149,7 @@ function LineVis(props: Props) {
                   {auxiliaries.length > 0 && (
                     <span
                       className={styles.mark}
+                      data-keep-colors
                       style={{ color: curveColor }}
                     />
                   )}
@@ -163,6 +164,7 @@ function LineVis(props: Props) {
                   <div className={styles.tooltipAux} key={label || index}>
                     <span
                       className={styles.mark}
+                      data-keep-colors
                       style={{ color: auxColors[index % auxColors.length] }}
                     />
                     {label ? `${label} = ` : ''}


### PR DESCRIPTION
For https://github.com/silx-kit/jupyterlab-h5web/issues/118

Oversight from our part in `h5web`: we took care of removing the `invert` on curve colors but not on the legend handles displayed when there are several signals.

The issue is visible at https://h5web.panosc.eu/mock on the path `/nexus_entry/spectrum_with_aux` in dark mode.