### PR TITLE
Parse and display chunks when present in h5wasm metadata

### DIFF
--- a/packages/h5wasm/src/h5wasm-api.ts
+++ b/packages/h5wasm/src/h5wasm-api.ts
@@ -201,6 +201,7 @@ export class H5WasmApi extends ProviderApi {
       const { shape, metadata, dtype, filters } = h5wEntity;
       return {
         ...baseEntity,
+        chunks: metadata.chunks ?? undefined,
         kind: EntityKind.Dataset,
         attributes: this.processH5WasmAttrs(h5wEntity.attrs),
         shape,


### PR DESCRIPTION
https://github.com/silx-kit/h5web/pull/1424#issuecomment-1515863874

Unfortunately, this does not work for some reason. See the path `/gzip` in https://h5web.panosc.eu/h5grove?file=compressed.h5 that has `Chunk size` for h5grove and not for h5wasm.

Perhaps an issue to forward to Brian.