### PR TITLE
Upgrade h5wasm and switch to TS' `"moduleResolution": "bundler"`

### DIFF
--- a/apps/demo/tsconfig.json
+++ b/apps/demo/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.bundler.json",
   "include": ["src"]
 }

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.bundler.json",
   "include": ["src"]
 }

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.bundler.json",
   "include": ["src"]
 }

--- a/packages/h5wasm/package.json
+++ b/packages/h5wasm/package.json
@@ -38,7 +38,7 @@
     "react": ">=16"
   },
   "dependencies": {
-    "h5wasm": "0.4.11",
+    "h5wasm": "0.5.2",
     "nanoid": "4.0.2"
   },
   "devDependencies": {

--- a/packages/h5wasm/src/models.ts
+++ b/packages/h5wasm/src/models.ts
@@ -1,8 +1,9 @@
-import type { Group as H5WasmGroup, Metadata } from 'h5wasm';
 import type {
   CompoundTypeMetadata,
   EnumTypeMetadata,
-} from 'h5wasm/src/hdf5_util_helpers';
+  Group as H5WasmGroup,
+  Metadata,
+} from 'h5wasm';
 
 export type H5WasmEntity = ReturnType<H5WasmGroup['get']>;
 

--- a/packages/h5wasm/tsconfig.json
+++ b/packages/h5wasm/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.bundler.json",
   "include": ["src"]
 }

--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.bundler.json",
   "include": ["src"]
 }

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.bundler.json",
   "include": ["src"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -359,8 +359,8 @@ importers:
   packages/h5wasm:
     dependencies:
       h5wasm:
-        specifier: 0.4.11
-        version: 0.4.11
+        specifier: 0.5.2
+        version: 0.5.2
       nanoid:
         specifier: 4.0.2
         version: 4.0.2
@@ -388,7 +388,7 @@ importers:
         version: 8.28.0
       eslint-config-galex:
         specifier: 4.5.2
-        version: 4.5.2(eslint@8.28.0)(jest@29.5.0)(tailwindcss@3.3.2)
+        version: 4.5.2(eslint@8.28.0)(tailwindcss@3.3.2)
       react:
         specifier: 17.0.2
         version: 17.0.2
@@ -678,7 +678,7 @@ packages:
       '@babel/traverse': 7.21.5
       '@babel/types': 7.21.5
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.0
@@ -701,7 +701,7 @@ packages:
       '@babel/traverse': 7.21.5
       '@babel/types': 7.21.5
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.0
@@ -2078,7 +2078,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/parser': 7.21.9
       '@babel/types': 7.21.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -2395,7 +2395,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       espree: 9.4.1
       globals: 13.19.0
       ignore: 5.2.4
@@ -2416,7 +2416,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -4294,7 +4294,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.56.0
       '@typescript-eslint/type-utils': 5.56.0(eslint@8.28.0)(typescript@5.0.3)
       '@typescript-eslint/utils': 5.56.0(eslint@8.28.0)(typescript@5.0.3)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       eslint: 8.28.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
@@ -4332,7 +4332,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.56.0
       '@typescript-eslint/types': 5.56.0
       '@typescript-eslint/typescript-estree': 5.56.0(typescript@5.0.4)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       eslint: 8.28.0
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -4367,7 +4367,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.56.0(typescript@5.0.3)
       '@typescript-eslint/utils': 5.56.0(eslint@8.28.0)(typescript@5.0.3)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       eslint: 8.28.0
       tsutils: 3.21.0(typescript@5.0.3)
       typescript: 5.0.3
@@ -4396,7 +4396,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.56.0
       '@typescript-eslint/visitor-keys': 5.56.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.1
@@ -4417,7 +4417,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.56.0
       '@typescript-eslint/visitor-keys': 5.56.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.1
@@ -4438,7 +4438,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.58.0
       '@typescript-eslint/visitor-keys': 5.58.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.1
@@ -6037,6 +6037,17 @@ packages:
       ms: 2.0.0
     dev: true
 
+  /debug@3.2.7:
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+    dev: true
+
   /debug@3.2.7(supports-color@8.1.1):
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -6047,6 +6058,18 @@ packages:
     dependencies:
       ms: 2.1.3
       supports-color: 8.1.1
+    dev: true
+
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
     dev: true
 
   /debug@4.3.4(supports-color@8.1.1):
@@ -6573,6 +6596,49 @@ packages:
       - tailwindcss
     dev: true
 
+  /eslint-config-galex@4.5.2(eslint@8.28.0)(tailwindcss@3.3.2):
+    resolution: {integrity: sha512-KPCROZZehjPDd/g23I0ejVpi/Ik0ADzuBU0gSTIh5XEBinY7avkEJU4y4suzCA60MEGmd+JZWHurWlWrROYZrw==}
+    engines: {node: '>=14.17'}
+    peerDependencies:
+      eslint: '>=8.27.0'
+    dependencies:
+      '@babel/core': 7.21.4
+      '@babel/eslint-parser': 7.21.3(@babel/core@7.21.4)(eslint@8.28.0)
+      '@babel/preset-react': 7.18.6(@babel/core@7.21.4)
+      '@next/eslint-plugin-next': 13.2.4
+      '@typescript-eslint/eslint-plugin': 5.56.0(@typescript-eslint/parser@5.56.0)(eslint@8.28.0)(typescript@5.0.3)
+      '@typescript-eslint/parser': 5.56.0(eslint@8.28.0)(typescript@5.0.4)
+      confusing-browser-globals: 1.0.11
+      eslint: 8.28.0
+      eslint-config-prettier: 8.8.0(eslint@8.28.0)
+      eslint-import-resolver-jsconfig: 1.1.0
+      eslint-import-resolver-node: 0.3.7
+      eslint-import-resolver-typescript: 3.5.4(eslint-plugin-import@2.27.5)(eslint@8.28.0)
+      eslint-plugin-etc: 2.0.2(eslint@8.28.0)(typescript@5.0.3)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.56.0)(eslint-import-resolver-typescript@3.5.4)(eslint@8.28.0)
+      eslint-plugin-jest: 27.2.1(@typescript-eslint/eslint-plugin@5.56.0)(eslint@8.28.0)(typescript@5.0.3)
+      eslint-plugin-jest-dom: 4.0.3(eslint@8.28.0)
+      eslint-plugin-jest-formatting: 3.1.0(eslint@8.28.0)
+      eslint-plugin-jsx-a11y: 6.7.1(eslint@8.28.0)
+      eslint-plugin-promise: 6.1.1(eslint@8.28.0)
+      eslint-plugin-react: 7.32.2(eslint@8.28.0)
+      eslint-plugin-react-hooks: 4.6.0(eslint@8.28.0)
+      eslint-plugin-simple-import-sort: 10.0.0(eslint@8.28.0)
+      eslint-plugin-sonarjs: 0.19.0(eslint@8.28.0)
+      eslint-plugin-storybook: 0.6.11(eslint@8.28.0)(typescript@5.0.3)
+      eslint-plugin-tailwindcss: 3.10.3(tailwindcss@3.3.2)
+      eslint-plugin-testing-library: 5.10.2(eslint@8.28.0)(typescript@5.0.3)
+      eslint-plugin-unicorn: 46.0.0(eslint@8.28.0)
+      lodash.merge: 4.6.2
+      read-pkg-up: 7.0.1
+      typescript: 5.0.3
+    transitivePeerDependencies:
+      - eslint-import-resolver-webpack
+      - jest
+      - supports-color
+      - tailwindcss
+    dev: true
+
   /eslint-config-prettier@8.8.0(eslint@8.28.0):
     resolution: {integrity: sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==}
     hasBin: true
@@ -6608,7 +6674,7 @@ packages:
   /eslint-import-resolver-node@0.3.7:
     resolution: {integrity: sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==}
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       is-core-module: 2.12.0
       resolve: 1.22.2
     transitivePeerDependencies:
@@ -6622,7 +6688,7 @@ packages:
       eslint: '*'
       eslint-plugin-import: '*'
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       enhanced-resolve: 5.12.0
       eslint: 8.28.0
       eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.56.0)(eslint-import-resolver-typescript@3.5.4)(eslint@8.28.0)
@@ -6657,7 +6723,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/parser': 5.56.0(eslint@8.28.0)(typescript@5.0.4)
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       eslint: 8.28.0
       eslint-import-resolver-node: 0.3.7
       eslint-import-resolver-typescript: 3.5.4(eslint-plugin-import@2.27.5)(eslint@8.28.0)
@@ -6697,7 +6763,7 @@ packages:
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       doctrine: 2.1.0
       eslint: 8.28.0
       eslint-import-resolver-node: 0.3.7
@@ -6754,6 +6820,27 @@ packages:
       '@typescript-eslint/utils': 5.58.0(eslint@8.28.0)(typescript@5.0.3)
       eslint: 8.28.0
       jest: 29.5.0(@types/node@18.15.11)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /eslint-plugin-jest@27.2.1(@typescript-eslint/eslint-plugin@5.56.0)(eslint@8.28.0)(typescript@5.0.3):
+    resolution: {integrity: sha512-l067Uxx7ZT8cO9NJuf+eJHvt6bqJyz2Z29wykyEdz/OtmcELQl2MQGQLX8J94O1cSJWAwUSEvCjwjA7KEK3Hmg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^5.0.0
+      eslint: ^7.0.0 || ^8.0.0
+      jest: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
+      jest:
+        optional: true
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 5.56.0(@typescript-eslint/parser@5.56.0)(eslint@8.28.0)(typescript@5.0.3)
+      '@typescript-eslint/utils': 5.58.0(eslint@8.28.0)(typescript@5.0.3)
+      eslint: 8.28.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -6960,7 +7047,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.1.1
@@ -7830,8 +7917,8 @@ packages:
       through2: 2.0.5
     dev: true
 
-  /h5wasm@0.4.11:
-    resolution: {integrity: sha512-yb5/LRvOChAKAF7rqbMlaU3nBjARt11Y9dqwhFUcVqrM4dV7/SoUKkpt99CXeIzIc3fl1mnaA0V6+cYTayZcEA==}
+  /h5wasm@0.5.2:
+    resolution: {integrity: sha512-5hceMJnleFgkLir7WUjRqcKasIaB0kU1ro/wexBOG5HI/Q27Jx3QnKUdyVfatgzTFnU9iicNILI9zxfOAVrRrQ==}
     dev: false
 
   /handlebars@4.7.7:
@@ -10514,7 +10601,7 @@ packages:
     dependencies:
       lilconfig: 2.1.0
       postcss: 8.4.23
-      yaml: 2.2.2
+      yaml: 2.3.0
     dev: true
 
   /postcss-nested@6.0.1(postcss@8.4.23):
@@ -13033,9 +13120,9 @@ packages:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
     dev: true
 
-  /yaml@2.2.2:
-    resolution: {integrity: sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==}
-    engines: {node: '>= 14'}
+  /yaml@2.3.0:
+    resolution: {integrity: sha512-8/1wgzdKc7bc9E6my5wZjmdavHLvO/QOmLG1FBugblEvY4IXrLjlViIOmL24HthU042lWTDRO90Fz1Yp66UnMw==}
+    engines: {node: '>= 14', npm: '>= 7'}
     dev: true
 
   /yargs-parser@20.2.9:

--- a/tsconfig.bundler.json
+++ b/tsconfig.bundler.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": { "moduleResolution": "bundler" }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
     "isolatedModules": true,
     "resolveJsonModule": true,
     "noEmit": true,


### PR DESCRIPTION
[H5wasm v0.5.0](https://github.com/usnistgov/h5wasm/releases/tag/v0.5.0) brings the ability to [dynamically link](https://emscripten.org/docs/compiling/Dynamic-Linking.html) WASM modules at runtime, which will hopefully allow us to support HDF5 compression plugins in the `@h5web/h5wasm` package (notably for [myHDF5](https://myhdf5.hdfgroup.org/) and the [VS Code extension](https://marketplace.visualstudio.com/items?itemName=h5web.vscode-h5web)).

In addition, [h5wasm v0.5.2](https://github.com/usnistgov/h5wasm/releases/tag/v0.5.2) (v0.5.1 was skipped) fixes a package distribution issue that prevented it from working with TS's new [`moduleResolution: "bundler"` setting](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#moduleresolution-bundler). I've now switched to this setting, but note that Cypress doesn't like it in the root `tsconfig.json` file, so I had to create a dedicated `tsconfig.bundler.json` file, which the projects' tsconfigs now extend.

`moduleResolution: "bundler"` means that TS can now read [`exports` declarations](https://nodejs.org/api/packages.html#package-entry-points) in `package.json` files, which should hopefully allow us to split the `@h5web/shared` package's entrypoint so Vite/Rollup can tree shake the output bundles better.