### PR TITLE
Split Storybook deployment workflow from package publishing

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,0 +1,64 @@
+name: Deploy Storybook
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - v*
+      - '!v*-beta.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🏷️
+        uses: actions/checkout@v3
+
+      - name: Set up Node 🕹️
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: 'package.json'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install pnpm ⚙️
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8.x
+
+      - name: Restore cache 📌
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/setup-pnpm/node_modules/.bin/store
+            ~/.cache/Cypress
+          key: cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-
+
+      - name: Install dependencies ⚙️
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Storybook 🛠️
+        run: pnpm build:storybook
+
+      - name: Upload artifacts
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'apps/storybook/build'
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      pages: write
+      id-token: write
+
+    steps:
+      - name: Deploy Storybook 🚀
+        id: deployment
+        uses: actions/deploy-pages@v2
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,6 +1,7 @@
 name: Lint & Test
 
 on:
+  workflow_dispatch:
   pull_request: # for PRs from forks
   push:
     branches-ignore:

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Publish packages
 
 on:
   push:
@@ -80,12 +80,3 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TAG: "${{ contains(steps.packageVersion.outputs.PACKAGE_VERSION, 'beta') && 'next' || 'latest' }}"
-
-      - name: Build Storybook 🛠️
-        # https://github.com/storybookjs/storybook/issues/20564
-        run: pnpm build:storybook && touch apps/storybook/build/.nojekyll
-
-      - name: Deploy Storybook 🚀
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: apps/storybook/build


### PR DESCRIPTION
... and try [new GitHub Pages deployment](https://github.blog/changelog/2022-07-27-github-pages-custom-github-actions-workflows-beta/) ([more info](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow)). Instead of deploying via a `github-pages` branch, we can now deploy to a special [`github-pages` "environment"](https://github.com/silx-kit/h5web/settings/environments/1423492/edit).

This allows us to remove the `.nojekyll` workaround, since Jekyll is not involved in the new deployment process. Obviously, I'll have to merge this PR to try the new workflow, but I've added a manual trigger, so I won't have to publish a tag.