### PR TITLE
Type `abscissaScale` and `ordinateScale` more strictly

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,12 +4,13 @@ const { createConfig } = require('./eslint.shared');
 
 module.exports = createConfig(__dirname, getDependencies(), [
   {
-    files: ['**/*.cy.ts'],
+    files: ['cypress/**/*.ts'],
     rules: {
       'testing-library/await-async-query': 'off', // Cypress has its own way of dealing with asynchronicity
       'testing-library/await-async-utils': 'off', // Cypress has its own way of dealing with asynchronicity
       'testing-library/prefer-screen-queries': 'off', // Cypress provides `cy` object instead of `screen`
       'sonarjs/no-duplicate-string': 'off', // incompatible with Cypress testing syntax
+      'unicorn/numeric-separators-style': 'off', // not supported
     },
   },
 ]);

--- a/cypress/support.ts
+++ b/cypress/support.ts
@@ -7,7 +7,7 @@ addMatchImageSnapshotCommand();
 
 addWaitForStableDomCommand({
   pollInterval: 400, // more than debounce on slicing slider
-  timeout: 5000,
+  timeout: 10000,
 });
 
 Cypress.Commands.add('findExplorerNode', (name: string) => {

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -151,6 +151,11 @@ export type {
   AxisConfig,
   AxisParams,
   VisScaleType,
+  ExtractScaleType,
+  ScaleConfig,
+  ScaleGammaConfig,
+  Scale,
+  AxisScale,
   HistogramParams,
 } from './vis/models';
 

--- a/packages/lib/src/vis/line/utils.ts
+++ b/packages/lib/src/vis/line/utils.ts
@@ -1,6 +1,6 @@
 import type { NumArray } from '@h5web/shared';
 
-import type { Scale } from '../models';
+import type { AxisScale } from '../models';
 
 const NO_ERROR_POSITIONS = {
   topCap: undefined,
@@ -10,8 +10,8 @@ const NO_ERROR_POSITIONS = {
 
 export function getValueToPosition(
   abscissas: NumArray,
-  abscissaScale: Scale,
-  ordinateScale: Scale,
+  abscissaScale: AxisScale,
+  ordinateScale: AxisScale,
   ignoreValue?: (val: number) => boolean
 ): (value: number, index: number) => [number, number] | undefined {
   return (value: number, index: number) => {
@@ -28,7 +28,7 @@ export function getValueToPosition(
 // eslint-disable-next-line sonarjs/cognitive-complexity
 export function getValueToErrorPositions(
   errors: NumArray | undefined,
-  ordinateScale: Scale
+  ordinateScale: AxisScale
 ): (
   value: number,
   index: number,

--- a/packages/lib/src/vis/models.ts
+++ b/packages/lib/src/vis/models.ts
@@ -48,6 +48,9 @@ export interface AxisConfig {
 }
 
 export type VisScaleType = ColorScaleType | [ScaleType.Gamma, number];
+export type ExtractScaleType<V extends VisScaleType> = V extends ColorScaleType
+  ? V
+  : ScaleType.Gamma;
 
 export interface ScaleGammaConfig {
   domain?: Domain;
@@ -56,11 +59,15 @@ export interface ScaleGammaConfig {
   clamp?: boolean;
 }
 
-export type ScaleConfig =
-  | PickScaleConfigWithoutType<ColorScaleType, number>
-  | ScaleGammaConfig;
+export type ScaleConfig<S = ScaleType> = S extends ColorScaleType
+  ? PickScaleConfigWithoutType<S, number>
+  : ScaleGammaConfig;
 
-export type Scale = PickD3Scale<ColorScaleType, number> | ScaleGamma;
+export type Scale<S = ScaleType> = S extends ColorScaleType
+  ? PickD3Scale<S, number>
+  : ScaleGamma;
+
+export type AxisScale = Scale<AxisScaleType>;
 
 export interface AxisOffsets {
   left: number;

--- a/packages/lib/src/vis/scatter/utils.ts
+++ b/packages/lib/src/vis/scatter/utils.ts
@@ -4,16 +4,16 @@ import { rgb } from 'd3-color';
 
 import type { ColorMap } from '../heatmap/models';
 import { getInterpolator } from '../heatmap/utils';
-import type { Scale } from '../models';
+import type { AxisScale } from '../models';
 import { createScale } from '../utils';
 
 const CAMERA_FAR = 1000; // R3F's default
 
 export function getIndexToPosition(
   abscissas: NumArray,
-  abscissaScale: Scale,
+  abscissaScale: AxisScale,
   ordinates: NumArray,
-  ordinateScale: Scale
+  ordinateScale: AxisScale
 ): (index: number) => { x: number; y: number; z: number } {
   return (index: number) => {
     const x = abscissaScale(abscissas[index]);

--- a/packages/lib/src/vis/shared/Axis.tsx
+++ b/packages/lib/src/vis/shared/Axis.tsx
@@ -5,7 +5,7 @@ import { AxisBottom, AxisLeft } from '@visx/axis';
 import { GridColumns, GridRows } from '@visx/grid';
 import type { ElementType } from 'react';
 
-import type { AxisConfig, Scale, Size } from '../models';
+import type { AxisConfig, AxisScale, Size } from '../models';
 import {
   adaptedNumTicks,
   createScale,
@@ -15,7 +15,7 @@ import {
 import styles from './AxisSystem.module.css';
 import Tick from './Tick';
 
-const AXIS_PROPS: Partial<SharedAxisProps<Scale>> = {
+const AXIS_PROPS: Partial<SharedAxisProps<AxisScale>> = {
   labelClassName: styles.label,
   labelProps: {}, // remove any styling props from parent `svg` element
   tickClassName: styles.tick,

--- a/packages/lib/src/vis/shared/VisCanvasProvider.tsx
+++ b/packages/lib/src/vis/shared/VisCanvasProvider.tsx
@@ -6,8 +6,8 @@ import type { Camera } from 'three';
 import { Matrix4, Vector3 } from 'three';
 
 import Box from '../../interactions/box';
-import type { AxisConfig, Scale, Size } from '../models';
-import { getCanvasScale, getSizeToFit } from '../utils';
+import type { AxisConfig, AxisScale, Size } from '../models';
+import { getCanvasAxisScale, getSizeToFit } from '../utils';
 
 export interface VisCanvasContextValue {
   canvasSize: Size;
@@ -17,8 +17,8 @@ export interface VisCanvasContextValue {
   visSize: Size;
   abscissaConfig: AxisConfig;
   ordinateConfig: AxisConfig;
-  abscissaScale: Scale;
-  ordinateScale: Scale;
+  abscissaScale: AxisScale;
+  ordinateScale: AxisScale;
   dataToWorld: (dataPt: Vector3) => Vector3;
   dataToHtml: (camera: Camera, dataPt: Vector3) => Vector3;
   worldToHtml: (camera: Camera, worldPt: Vector3) => Vector3;
@@ -68,8 +68,8 @@ function VisCanvasProvider(props: PropsWithChildren<Props>) {
     [width, height]
   );
 
-  const abscissaScale = getCanvasScale(abscissaConfig, visSize.width);
-  const ordinateScale = getCanvasScale(ordinateConfig, visSize.height);
+  const abscissaScale = getCanvasAxisScale(abscissaConfig, visSize.width);
+  const ordinateScale = getCanvasAxisScale(ordinateConfig, visSize.height);
 
   const dataToWorld = useCallback(
     (dataPt: Vector3) => {

--- a/packages/lib/src/vis/utils.ts
+++ b/packages/lib/src/vis/utils.ts
@@ -32,6 +32,8 @@ import type {
   Aspect,
   AxisConfig,
   AxisOffsets,
+  AxisScale,
+  ExtractScaleType,
   Scale,
   ScaleConfig,
   ScaleGammaConfig,
@@ -65,6 +67,11 @@ const adaptedLogTicksThreshold = scaleLinear({
   domain: [300, 500],
   range: [0.8, 1.4],
 });
+
+export function createScale<
+  V extends VisScaleType,
+  S extends ExtractScaleType<V>
+>(scaleType: V, config: ScaleConfig<S>): Scale<S>;
 
 export function createScale(
   scaleType: VisScaleType,
@@ -207,7 +214,10 @@ export function getValueToIndexScale(
   return scaleThreshold<number, number>({ domain: thresholds, range: indices });
 }
 
-export function getCanvasScale(config: AxisConfig, canvasSize: number): Scale {
+export function getCanvasAxisScale(
+  config: AxisConfig,
+  canvasSize: number
+): AxisScale {
   const { scaleType, visDomain, flip, nice = false } = config;
 
   return createScale(scaleType ?? ScaleType.Linear, {


### PR DESCRIPTION
Follow-up to #1431 to enforce stricter types for the internal `createScale` and `getCanvasScale` utility functions, and therefore for `abscissaScale` and `ordinateScale` (exposed through `VisCanvasContext`).

To do so, I've added a generic to `Scale`, in order for `abscissaScale` and `ordinateScale` to be typed as `Scale<AxisScaleType>`, and I've reintroduced `AxisScale` (removed in #1431, as before it incorrectly meant "any of the supported scales") as an alias to this type.

The [Storybook](https://h5web-docs.panosc.eu/?path=/docs/context--docs) was still saying that the type of `abscissaScale` and `ordinateScale` was `AxisScale` even though it had basically been renamed to `Scale` in #1431. But with the stronger typing and the reintroduction of `AxisScale`, it is now correct.