### PR TITLE
Skip linting and type checking when building for production to save time

### DIFF
--- a/apps/demo/vite.config.js
+++ b/apps/demo/vite.config.js
@@ -6,7 +6,11 @@ import eslintPlugin from 'vite-plugin-eslint';
 export default defineConfig({
   server: { open: true },
   preview: { open: true },
-  plugins: [react(), eslintPlugin(), checker({ typescript: true })],
+  plugins: [
+    react(),
+    { ...eslintPlugin(), apply: 'serve' }, // dev only to reduce build time
+    { ...checker({ typescript: true }), apply: 'serve' }, // dev only to reduce build time
+  ],
 
   // `es2020` required by @h5web/h5wasm for BigInt `123n` notation support
   optimizeDeps: { esbuildOptions: { target: 'es2020' } },


### PR DESCRIPTION
Linting and type checking in the demo project can be run separately from the production build (and potentially in parallel) with `pnpm lint:eslint` and `pnpm lint:tsc`. This is already the case in the CI (we build the demo before running the E2E tests), so we were basically doubling up on the work.