### PR TITLE
Preserve GL buffer to fix "save image as"

### DIFF
--- a/packages/lib/src/vis/shared/R3FCanvas.tsx
+++ b/packages/lib/src/vis/shared/R3FCanvas.tsx
@@ -17,6 +17,7 @@ function R3FCanvas(props: PropsWithChildren<Props>) {
       frameloop="demand" // disable game loop
       dpr={[1, 3]} // https://discoverthreejs.com/tips-and-tricks/#performance
       resize={{ debounce: { scroll: 20, resize: 200 }, scroll: false }} // https://github.com/pmndrs/react-three-fiber/discussions/1906
+      gl={{ preserveDrawingBuffer: true }} // for "Save Image As..." and snapshot feature to work
     >
       <ambientLight />
       {children}


### PR DESCRIPTION
Fix #1453. I was able to trace this regression back to the extraction of the `R3FCanvas` component in #1303. The `gl` prop got dropped and we didn't notice it. Thanks for the report @LogWell!