### PR TITLE
Allow canceling select-to-zoom interaction with right click

### DIFF
--- a/packages/lib/src/interactions/SelectionTool.tsx
+++ b/packages/lib/src/interactions/SelectionTool.tsx
@@ -1,5 +1,6 @@
 import { assertDefined } from '@h5web/shared';
 import {
+  useEventListener,
   useKeyboardEvent,
   usePrevious,
   useRafState,
@@ -138,15 +139,16 @@ function SelectionTool(props: Props) {
 
   useCanvasEvents({ onPointerDown, onPointerMove, onPointerUp });
 
-  useKeyboardEvent(
-    'Escape',
-    () => {
-      startEvtRef.current = undefined;
-      setRawSelection(undefined);
-    },
-    [],
-    { event: 'keydown' },
-  );
+  function cancelSelection() {
+    startEvtRef.current = undefined;
+    setRawSelection(undefined);
+  }
+
+  useKeyboardEvent('Escape', cancelSelection, [], { event: 'keydown' });
+  useEventListener(window, 'contextmenu', (evt: MouseEvent) => {
+    evt.preventDefault();
+    cancelSelection();
+  });
 
   // Compute effective selection
   const selection = useMemo(


### PR DESCRIPTION
Fix #1370 -- this is quite a neat interaction, actually.

Couple of notes:

- Pressing the context menu key on the keyboard also cancels the interaction.
- Firefox does not fire the [`contextmenu` event](https://developer.mozilla.org/en-US/docs/Web/API/Element/contextmenu_event) at all when <kbd>Shift</kbd> is pressed. So with the proposed solution, a select-to-zoom interaction configured with the `Shift` modifier key cannot be cancelled with right click.