### PR TITLE
Revert workaround of bundling in `react-keyed-flatten-children`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,7 +156,7 @@ import.
 
 The build process of`@h5web/h5wasm` is also the same as the lib's, but since the
 package does not include any styles, `vite build` does not generate a
-`style.css` file and there's not `build:css` script.
+`style.css` file and there's no `build:css` script.
 
 Finally, since `@h5web/shared` is not a published package, it does not need to
 be built with Vite. However, its types do need to be built with `tsc` so that

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -62,7 +62,7 @@
     "ndarray-ops": "1.2.2",
     "react-aria-menubutton": "7.0.3",
     "react-icons": "4.8.0",
-    "react-keyed-flatten-children": "1.3.0",
+    "react-keyed-flatten-children": "2.2.1",
     "react-measure": "2.5.2",
     "react-slider": "2.0.4",
     "react-window": "1.8.8",

--- a/packages/lib/vite.config.js
+++ b/packages/lib/vite.config.js
@@ -12,9 +12,7 @@ const [pkg, sharedPkg] = ['.', '../shared'].map((prefix) =>
 
 export const externals = new Set([
   ...Object.keys(sharedPkg.peerDependencies),
-  ...Object.keys(pkg.dependencies).filter(
-    (dep) => dep !== 'react-keyed-flatten-children', // Fix https://github.com/silx-kit/h5web/issues/914
-  ),
+  ...Object.keys(pkg.dependencies),
   ...Object.keys(pkg.peerDependencies),
 ]);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -466,8 +466,8 @@ importers:
         specifier: 4.8.0
         version: 4.8.0(react@18.2.0)
       react-keyed-flatten-children:
-        specifier: 1.3.0
-        version: 1.3.0(react@18.2.0)
+        specifier: 2.2.1
+        version: 2.2.1(react@18.2.0)
       react-measure:
         specifier: 2.5.2
         version: 2.5.2(react-dom@18.2.0)(react@18.2.0)
@@ -11651,15 +11651,14 @@ packages:
 
   /react-is@18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
-    dev: true
 
-  /react-keyed-flatten-children@1.3.0(react@18.2.0):
-    resolution: {integrity: sha512-qB7A6n+NHU0x88qTZGAJw6dsqwI941jcRPBB640c/CyWqjPQQ+YUmXOuzPziuHb7iqplM3xksWAbGYwkQT0tXA==}
+  /react-keyed-flatten-children@2.2.1(react@18.2.0):
+    resolution: {integrity: sha512-6yBLVO6suN8c/OcJk1mzIrUHdeEzf5rtRVBhxEXAHO49D7SlJ70cG4xrSJrBIAG7MMeQ+H/T151mM2dRDNnFaA==}
     peerDependencies:
       react: '>=15.0.0'
     dependencies:
       react: 18.2.0
-      react-is: 16.13.1
+      react-is: 18.2.0
     dev: false
 
   /react-measure@2.5.2(react-dom@18.2.0)(react@18.2.0):


### PR DESCRIPTION
`react-keyed-flatten-children` [now has an ESM bundle](https://github.com/grrowl/react-keyed-flatten-children/blob/master/CHANGELOG.md), which means we should be able to revert the workaround that consisted in inlining it in the lib's output bundle (cf. #914). It is now marked as an `external` in the Vite config, just like every other prod dependency.