### PR TITLE
Simplify and document usage of `useInteraction` and `useModifierKeyPressed`

### DIFF
--- a/apps/storybook/src/Utilities.mdx
+++ b/apps/storybook/src/Utilities.mdx
@@ -243,6 +243,54 @@ const pt = useCameraState(
 );
 ```
 
+#### useInteraction
+
+Register an interaction. You must provide a unique ID that is not used by other interactions inside the current `VisCanvas` (pan, zoom, etc.)
+
+The hook returns a function, conventionally named `shouldInteract`, that allows testing if a given mouse event (`PointerEvent` or `WheelEvent`)
+is allowed to start or continue the interaction. It checks whether the event was triggered with the same mouse button and modifier key(s)
+with which the interaction was registered and ensures that there is no interaction that is better suited to handle this event.
+
+```ts
+useInteraction(
+  id: string,
+  config: InteractionConfig,
+): (event: MouseEvent) => boolean
+
+const shouldInteract = useInteraction('MyInteraction', {
+  button: MouseButton.Left,
+  modifierKey: 'Control',
+})
+
+const onPointerDown = useCallback((evt: CanvasEvent<PointerEvent>) => {
+  if (shouldInteract(evt.sourceEvent)) {
+    /* ... */
+  }
+},
+[shouldInteract]);
+
+useCanvasEvents({ onPointerDown }};
+```
+
+#### useModifierKeyPressed
+
+Keeps track of the pressed state of one or more modifier keys.
+
+The hook removes the need for a mouse event to be fired to know the state of the given modifier keys, which allows reacting to the user releasing
+a key at any time, even when the mouse is immobile.
+
+```ts
+useModifierKeyPressed(modifierKey?: ModifierKey | ModifierKey[]): boolean
+
+const isModifierKeyPressed = useModifierKeyPressed('Shift');
+
+const onPointerMove = useCallback((evt: CanvasEvent<PointerEvent>) => {
+  if (isModifierKeyPressed) {
+    return;
+  }
+}, [isModifierKeyPressed]);
+```
+
 ### Mock data
 
 The library exposes a utility function to retrieve a mock entity's metadata and a mock dataset's value as ndarray for testing purposes.

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -124,30 +124,20 @@ export {
   useInteraction,
   useModifierKeyPressed,
 } from './interactions/hooks';
-export { MouseButton } from './interactions/models';
-export { getModifierKeyArray } from './interactions/utils';
 export { default as Box } from './interactions/box';
 
+// Constants
 export { COLOR_SCALE_TYPES, AXIS_SCALE_TYPES } from '@h5web/shared';
-
-// Models
 export { INTERPOLATORS } from './vis/heatmap/interpolators';
+
+// Enums
 export { ScaleType } from '@h5web/shared';
 export { CurveType, GlyphType } from './vis/line/models';
 export { ImageType } from './vis/rgb/models';
 export { Notation } from './vis/matrix/models';
+export { MouseButton } from './interactions/models';
 
-export type {
-  ModifierKey,
-  Rect,
-  Selection,
-  CanvasEvent,
-  CanvasEventCallbacks,
-  InteractionInfo,
-  InteractionEntry,
-  CommonInteractionProps,
-} from './interactions/models';
-
+// Models
 export type {
   Domain,
   VisibleDomains,
@@ -175,6 +165,17 @@ export type {
 
 export type { D3Interpolator, ColorMap } from './vis/heatmap/models';
 export type { ScatterAxisParams } from './vis/scatter/models';
+
+export type {
+  ModifierKey,
+  Rect,
+  Selection,
+  CanvasEvent,
+  CanvasEventCallbacks,
+  InteractionInfo,
+  InteractionConfig,
+  CommonInteractionProps,
+} from './interactions/models';
 
 // Mock data and utilities
 export {

--- a/packages/lib/src/interactions/Pan.tsx
+++ b/packages/lib/src/interactions/Pan.tsx
@@ -10,7 +10,6 @@ import {
 } from './hooks';
 import type { CanvasEvent, CommonInteractionProps } from './models';
 import { MouseButton } from './models';
-import { getModifierKeyArray } from './utils';
 
 interface Props extends CommonInteractionProps {
   id?: string;
@@ -25,18 +24,13 @@ function Pan(props: Props) {
     disabled,
   } = props;
 
-  const modifierKeys = getModifierKeyArray(modifierKey);
-  const shouldInteract = useInteraction(id, {
-    button,
-    modifierKeys,
-    disabled,
-  });
+  const shouldInteract = useInteraction(id, { button, modifierKey, disabled });
 
   const camera = useThree((state) => state.camera);
   const moveCameraTo = useMoveCameraTo();
 
   const startOffsetPosition = useRef<Vector3>(); // `useRef` to avoid re-renders
-  const isModifierKeyPressed = useModifierKeyPressed(modifierKeys);
+  const isModifierKeyPressed = useModifierKeyPressed(modifierKey);
 
   const onPointerDown = useCallback(
     (evt: CanvasEvent<PointerEvent>) => {

--- a/packages/lib/src/interactions/SelectionTool.tsx
+++ b/packages/lib/src/interactions/SelectionTool.tsx
@@ -25,7 +25,6 @@ import type {
   Selection,
 } from './models';
 import { MouseButton } from './models';
-import { getModifierKeyArray } from './utils';
 
 interface Props extends CommonInteractionProps {
   id?: string;
@@ -80,12 +79,11 @@ function SelectionTool(props: Props) {
   const startEvtRef = useRef<CanvasEvent<PointerEvent>>();
   const hasSuccessfullyEndedRef = useRef<boolean>(false);
 
-  const modifierKeys = getModifierKeyArray(modifierKey);
-  const isModifierKeyPressed = useModifierKeyPressed(modifierKeys);
+  const isModifierKeyPressed = useModifierKeyPressed(modifierKey);
 
   const shouldInteract = useInteraction(id, {
     button: MouseButton.Left,
-    modifierKeys,
+    modifierKey,
     disabled,
   });
 

--- a/packages/lib/src/interactions/XAxisZoom.tsx
+++ b/packages/lib/src/interactions/XAxisZoom.tsx
@@ -1,7 +1,6 @@
 import { useVisCanvasContext } from '../vis/shared/VisCanvasProvider';
 import { useCanvasEvents, useInteraction, useZoomOnWheel } from './hooks';
 import type { CommonInteractionProps } from './models';
-import { getModifierKeyArray } from './utils';
 
 type Props = CommonInteractionProps;
 
@@ -10,9 +9,9 @@ function XAxisZoom(props: Props) {
   const { visRatio } = useVisCanvasContext();
 
   const shouldInteract = useInteraction('XAxisZoom', {
-    modifierKeys: getModifierKeyArray(modifierKey),
-    disabled: visRatio !== undefined || disabled,
     button: 'Wheel',
+    modifierKey,
+    disabled: visRatio !== undefined || disabled,
   });
 
   const isZoomAllowed = (sourceEvent: WheelEvent) => ({

--- a/packages/lib/src/interactions/YAxisZoom.tsx
+++ b/packages/lib/src/interactions/YAxisZoom.tsx
@@ -1,7 +1,6 @@
 import { useVisCanvasContext } from '../vis/shared/VisCanvasProvider';
 import { useCanvasEvents, useInteraction, useZoomOnWheel } from './hooks';
 import type { CommonInteractionProps } from './models';
-import { getModifierKeyArray } from './utils';
 
 type Props = CommonInteractionProps;
 
@@ -10,9 +9,9 @@ function YAxisZoom(props: Props) {
   const { visRatio } = useVisCanvasContext();
 
   const shouldInteract = useInteraction('YAxisZoom', {
-    modifierKeys: getModifierKeyArray(modifierKey),
-    disabled: visRatio !== undefined || disabled,
     button: 'Wheel',
+    modifierKey,
+    disabled: visRatio !== undefined || disabled,
   });
 
   const isZoomAllowed = (sourceEvent: WheelEvent) => ({

--- a/packages/lib/src/interactions/Zoom.tsx
+++ b/packages/lib/src/interactions/Zoom.tsx
@@ -1,15 +1,14 @@
 import { useCanvasEvents, useInteraction, useZoomOnWheel } from './hooks';
 import type { CommonInteractionProps } from './models';
-import { getModifierKeyArray } from './utils';
 
 type Props = CommonInteractionProps;
 
 function Zoom(props: Props) {
   const { modifierKey, disabled } = props;
   const shouldInteract = useInteraction('Zoom', {
-    modifierKeys: getModifierKeyArray(modifierKey),
-    disabled,
     button: 'Wheel',
+    modifierKey,
+    disabled,
   });
 
   const isZoomAllowed = (sourceEvent: WheelEvent) => {

--- a/packages/lib/src/interactions/hooks.ts
+++ b/packages/lib/src/interactions/hooks.ts
@@ -1,5 +1,6 @@
 import { useEventListener, useToggle } from '@react-hookz/web';
 import { useThree } from '@react-three/fiber';
+import { castArray } from 'lodash';
 import { useCallback, useEffect, useState } from 'react';
 import { Vector3 } from 'three';
 
@@ -9,7 +10,7 @@ import { useInteractionsContext } from './InteractionsProvider';
 import type {
   CanvasEvent,
   CanvasEventCallbacks,
-  InteractionEntry,
+  InteractionConfig,
   ModifierKey,
   Selection,
 } from './models';
@@ -181,14 +182,17 @@ export function useCanvasEvents(callbacks: CanvasEventCallbacks): void {
   useEventListener(domElement, 'wheel', handleWheel);
 }
 
-export function useInteraction(id: string, value: InteractionEntry) {
+export function useInteraction(
+  id: string,
+  config: InteractionConfig,
+): (event: MouseEvent) => boolean {
   const { shouldInteract, registerInteraction, unregisterInteraction } =
     useInteractionsContext();
 
   useEffect(() => {
-    registerInteraction(id, value);
+    registerInteraction(id, config);
     return () => unregisterInteraction(id);
-  }, [id, registerInteraction, unregisterInteraction, value]);
+  }, [id, registerInteraction, unregisterInteraction, config]);
 
   return useCallback(
     (event: MouseEvent) => shouldInteract(id, event),
@@ -196,7 +200,10 @@ export function useInteraction(id: string, value: InteractionEntry) {
   );
 }
 
-export function useModifierKeyPressed(modifierKeys: ModifierKey[]): boolean {
+export function useModifierKeyPressed(
+  modifierKey: ModifierKey | ModifierKey[] = [],
+): boolean {
+  const modifierKeys = castArray(modifierKey);
   const { domElement } = useThree((state) => state.gl);
 
   const [pressedKeys] = useState(new Map<string, boolean>());

--- a/packages/lib/src/interactions/interaction.ts
+++ b/packages/lib/src/interactions/interaction.ts
@@ -1,0 +1,44 @@
+import { castArray } from 'lodash';
+import type { ModifierKey } from 'react';
+
+import type { InteractionConfig } from './models';
+import { MouseButton } from './models';
+
+export class Interaction {
+  public readonly buttons: MouseButton[];
+  public readonly modifierKeys: ModifierKey[];
+  public readonly isWheel: boolean;
+  public readonly isEnabled: boolean;
+
+  public constructor(
+    public readonly id: string,
+    config: InteractionConfig,
+  ) {
+    const {
+      button = MouseButton.Left,
+      modifierKey = [],
+      disabled = false,
+    } = config;
+
+    if (button === 'Wheel') {
+      this.buttons = [];
+      this.isWheel = true;
+    } else {
+      this.buttons = castArray(button);
+      this.isWheel = false;
+    }
+
+    this.modifierKeys = castArray(modifierKey);
+    this.isEnabled = !disabled;
+  }
+
+  public matches(event: MouseEvent): boolean {
+    return (
+      this.isEnabled &&
+      (event instanceof WheelEvent
+        ? this.isWheel
+        : this.buttons.includes(event.button)) &&
+      this.modifierKeys.every((key) => event.getModifierState(key))
+    );
+  }
+}

--- a/packages/lib/src/interactions/models.ts
+++ b/packages/lib/src/interactions/models.ts
@@ -34,10 +34,8 @@ export interface InteractionInfo {
   description: string;
 }
 
-export interface InteractionEntry {
-  button: MouseButton | MouseButton[] | 'Wheel';
-  modifierKeys: ModifierKey[];
-  disabled?: boolean;
+export interface InteractionConfig extends CommonInteractionProps {
+  button?: MouseButton | MouseButton[] | 'Wheel';
 }
 
 export interface CommonInteractionProps {

--- a/packages/lib/src/interactions/utils.ts
+++ b/packages/lib/src/interactions/utils.ts
@@ -1,9 +1,0 @@
-import { castArray } from 'lodash';
-
-import type { ModifierKey } from './models';
-
-export function getModifierKeyArray(
-  keys: ModifierKey | ModifierKey[] | undefined = [],
-): ModifierKey[] {
-  return castArray(keys);
-}


### PR DESCRIPTION
Following #1475, I'm documenting the newly exported `useInteraction` and `useModifierKeyPressed` hooks.

I'm also taking the opportunity to do a bit of a refactoring now, to avoid a breaking change down the line:

- `InteractionEntry` (the second parameter of `useInteraction`) becomes `InteractionConfig`
- We no longer need to cast the `modifierKey` prop to an array before calling `useInteraction` and `useMdifierKeyPressed` (thus removing the need for `getModifierKeyArray`)
- I'm introducing an `Interaction` class internally to encapsulate the casting of the `modiferKeys` and `buttons` arrays and the logic of whether an interaction "matches" a mouse event.