### PR TITLE
Implement `useDrag` hook

### DIFF
--- a/apps/storybook/src/SvgElement.stories.tsx
+++ b/apps/storybook/src/SvgElement.stories.tsx
@@ -1,13 +1,12 @@
 import {
   DataToHtml,
-  Pan,
+  DefaultInteractions,
   ResetZoomButton,
   SvgCircle,
   SvgElement,
   SvgLine,
   SvgRect,
   VisCanvas,
-  Zoom,
 } from '@h5web/lib';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Vector3 } from 'three';
@@ -31,10 +30,8 @@ export const Default = {
       abscissaConfig={{ visDomain: [0, 10], showGrid: true }}
       ordinateConfig={{ visDomain: [0, 10], showGrid: true }}
     >
-      <Pan />
-      <Zoom />
+      <DefaultInteractions />
       <ResetZoomButton />
-
       <DataToHtml
         points={[
           new Vector3(2, 8),

--- a/apps/storybook/src/Utilities.mdx
+++ b/apps/storybook/src/Utilities.mdx
@@ -291,6 +291,28 @@ const onPointerMove = useCallback((evt: CanvasEvent<PointerEvent>) => {
 }, [isModifierKeyPressed]);
 ```
 
+#### useDrag
+
+Manages a low-level drag interaction. The returned object contains:
+
+- the `delta` vector of the current drag interaction (with a fallback of `(0, 0, 0)`);
+- an `isDragging` boolean, indicating whether a drag is in progress; and
+- a `startDrag` function that must be called when the user starts interacting with the draggable element (i.e. on `pointerdown`).
+
+```ts
+useDrag(opts: UseDragOpts): UseDragState
+```
+
+The hook is typically coupled with a state, as demonstrated below. For a concrete implementation example,
+see the [_SvgElement/Draggable_](https://h5web-docs.panosc.eu/?path=/story/building-blocks-svgelement--draggable) story.
+
+```ts
+const [position, setPosition] = useState(() => new Vector3(0, 0));
+const { delta, isDragging, startDrag } = useDrag({
+  onDragEnd: (d) => setPosition((c) => c.clone().add(d)),
+});
+```
+
 ### Mock data
 
 The library exposes a utility function to retrieve a mock entity's metadata and a mock dataset's value as ndarray for testing purposes.

--- a/apps/storybook/src/useDrag.stories.module.css
+++ b/apps/storybook/src/useDrag.stories.module.css
@@ -1,0 +1,18 @@
+.dragCircle {
+  fill: teal;
+  fill-opacity: 0.5;
+  stroke: transparent;
+  stroke-width: 2;
+  pointer-events: auto;
+  cursor: grab;
+}
+
+.dragCircle:hover,
+.dragCircle[data-dragging] {
+  fill: blueviolet;
+}
+
+.dragCircle[data-dragging] {
+  stroke: darkmagenta;
+  cursor: grabbing;
+}

--- a/apps/storybook/src/useDrag.stories.tsx
+++ b/apps/storybook/src/useDrag.stories.tsx
@@ -1,0 +1,65 @@
+import {
+  DataToHtml,
+  DefaultInteractions,
+  ResetZoomButton,
+  SvgElement,
+  useDrag,
+  VisCanvas,
+} from '@h5web/lib';
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { Vector3 } from 'three';
+
+import FillHeight from './decorators/FillHeight';
+import styles from './useDrag.stories.module.css';
+
+const meta = {
+  title: 'Experimental/useDrag',
+  decorators: [
+    (Story) => (
+      <VisCanvas
+        abscissaConfig={{ visDomain: [0, 10], showGrid: true }}
+        ordinateConfig={{ visDomain: [0, 10], showGrid: true }}
+      >
+        <DefaultInteractions />
+        <ResetZoomButton />
+        <Story />
+      </VisCanvas>
+    ),
+    FillHeight,
+  ],
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default = {
+  render: () => {
+    const [center, setCenter] = useState(() => new Vector3(2, 6));
+
+    const { delta, isDragging, startDrag } = useDrag({
+      onDragEnd: (d) => setCenter((c) => c.clone().add(d)),
+    });
+
+    return (
+      <DataToHtml points={[center.clone().add(delta)]}>
+        {(htmlCenter) => (
+          <SvgElement>
+            <circle
+              className={styles.dragCircle}
+              cx={htmlCenter.x}
+              cy={htmlCenter.y}
+              r={40}
+              data-dragging={isDragging || undefined}
+              onPointerDown={(evt) => {
+                evt.stopPropagation();
+                startDrag(evt.nativeEvent);
+              }}
+            />
+          </SvgElement>
+        )}
+      </DataToHtml>
+    );
+  },
+} satisfies Story;

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -123,6 +123,7 @@ export {
   useCanvasEvents,
   useInteraction,
   useModifierKeyPressed,
+  useDrag,
 } from './interactions/hooks';
 export { default as Box } from './interactions/box';
 

--- a/packages/lib/src/interactions/models.ts
+++ b/packages/lib/src/interactions/models.ts
@@ -42,3 +42,13 @@ export interface CommonInteractionProps {
   modifierKey?: ModifierKey | ModifierKey[];
   disabled?: boolean;
 }
+
+export interface UseDragOpts {
+  onDragEnd: (delta: Vector3) => void;
+}
+
+export interface UseDragState {
+  delta: Vector3;
+  isDragging: boolean;
+  startDrag: (evt: PointerEvent) => void;
+}


### PR DESCRIPTION
This should hopefully make implementing draggable interactions easier (e.g. moving/resizing ROIs), though I'm hoping it will also abstract out a lot of the code from `SelectionTool` and `Pan`.

The approach taken by `@visx/drag` is not great for us because of our multiple coordinate spaces and because it requires capturing events on a transparent rectangle on top of the element that is being dragged.

Instead, the approach I'm proposing makes use of the new event bubbling mechanism introduced in #1473: `useDrag` automatically registers the `pointermove` and `pointerup` event handlers on `canvasWrapper` with `useCanvasEvents`, thus making sure that no events are missed. The consumer only needs to register a `pointerdown` handler on the draggable element.

I've created a story to demonstrate the use of `useDrag` and how pretty straightforward it is:

![Peek 2023-08-18 16-29](https://github.com/silx-kit/h5web/assets/2936402/1d830a12-9236-4093-a7d4-b35a725d1d39)