### PR TITLE
Allow zooming on very thin selection boxes

### DIFF
--- a/packages/lib/src/interactions/SelectToZoom.tsx
+++ b/packages/lib/src/interactions/SelectToZoom.tsx
@@ -58,7 +58,7 @@ function SelectToZoom(props: Props) {
     <SelectionTool
       id="SelectToZoom"
       transform={computeZoomSelection}
-      validate={({ html }) => Box.fromPoints(...html).hasMinSize(minZoom)}
+      validate={({ html }) => html[0].manhattanDistanceTo(html[1]) >= minZoom}
       onValidSelection={zoomOnSelection}
       {...commonProps}
     >

--- a/packages/lib/src/interactions/hooks.ts
+++ b/packages/lib/src/interactions/hooks.ts
@@ -52,7 +52,11 @@ export function useZoomOnSelection() {
 
       // Update camera scale first (since `moveCameraTo` relies on camera scale)
       const { width: zoomWidth, height: zoomHeight } = zoomBox.size;
-      camera.scale.set(zoomWidth / width, zoomHeight / height, 1);
+      camera.scale.set(
+        Math.max(zoomWidth, 1) / width,
+        Math.max(zoomHeight, 1) / height,
+        1,
+      );
 
       // Then move camera position
       moveCameraTo(zoomBox.center);

--- a/packages/lib/src/interactions/svg/SvgRect.tsx
+++ b/packages/lib/src/interactions/svg/SvgRect.tsx
@@ -1,8 +1,9 @@
 import type { SVGProps } from 'react';
 
+import Box from '../box';
 import type { Rect } from '../models';
 
-interface Props extends SVGProps<SVGRectElement> {
+interface Props extends SVGProps<SVGPathElement> {
   coords: Rect;
   strokePosition?: 'inside' | 'outside'; // no effect without `stroke` prop; assumes `strokeWidth` of 1 unless specified explicitely as prop (CSS ignored)
   strokeWidth?: number; // forbid string
@@ -11,22 +12,20 @@ interface Props extends SVGProps<SVGRectElement> {
 function SvgRect(props: Props) {
   const { coords, strokePosition, ...svgProps } = props;
 
-  const [start, end] = coords;
   const { stroke, strokeWidth = 1 } = svgProps;
 
   // Shrink/grow rectangle to simulate positioning stroke inside/outside
   // https://stackoverflow.com/questions/7241393/can-you-control-how-an-svgs-stroke-width-is-drawn
   const offset =
     stroke && strokePosition
-      ? (strokeWidth / 2) * (strokePosition === 'inside' ? 1 : -1)
+      ? strokeWidth * (strokePosition === 'outside' ? 1 : -1)
       : 0;
 
+  const { min, max } = Box.fromPoints(...coords).expandBySize(offset, offset);
+
   return (
-    <rect
-      x={Math.min(start.x, end.x) + offset}
-      y={Math.min(start.y, end.y) + offset}
-      width={Math.abs(end.x - start.x) - offset * 2}
-      height={Math.abs(end.y - start.y) - offset * 2}
+    <path
+      d={`M ${min.x},${min.y} H ${max.x} V ${max.y} H ${min.x} z`}
       {...svgProps}
     />
   );


### PR DESCRIPTION
Fix #1407 

I've changed the selection validation logic in `SelectToZoom` to compute the manahattan distance. I'm no longer converting the selection to a `Box` and calling `#hasMinSize`, since `Vector3` already provides a method for computing the manhattan distance.

Of course there are always edge cases to deal with and unforeseen consequences...

---

The edge case is zooming on a 0-width or 0-height box. To deal with this, I had a few options:

1. Keep a `hasMinSize(1)` check in the `validate` prop.
    - This kinda goes against the premise of #1407 that if the user releases the pointer, something should happen.
    - It also meant that we could see a dashed line when crossing the 0 width/height threshold (because that's the style of an invalid selection box). This style made more sense when the invalidity threshold was wider.
2. Ensure the zoom box can never be empty via the `transform` prop.
    - This would have made the code of `computeZoomSelection` a bit messy.
3. Ensure we never zoom on an empty box by enforcing a minimum zoom width/height of 1.
    - Seemed like the best compromise, so I went with this solution.

---

The unforeseen consequence had to do with `SvgRect`:

We work around the fact that SVG doesn't support drawing `inside` strokes by drawing a slightly smaller and slightly offset rectangle. The problem is that empty rectangles are simply hidden by browsers, so any `SvgRect` with a width or height lower than or equal to their stroke width would simply vanish.

This behaviour wasn't too problematic when we couldn't zoom on a very thin box, since at the point the selection box disappeared, the zoom box was invalid — so releasing the mouse did nothing. So I had to find a fix.

I decided to replace `rect` with `path`, which seems to work great, fortunately.