### PR TITLE
Fix TS errors in toolbar configs reported only in VS Code

### DIFF
--- a/packages/app/src/vis-packs/core/complex/config.tsx
+++ b/packages/app/src/vis-packs/core/complex/config.tsx
@@ -14,7 +14,7 @@ export interface ComplexConfig {
 function createComplexConfigStore() {
   return createStore<ComplexConfig>()(
     persist(
-      (set) => ({
+      (set): ComplexConfig => ({
         visType: ComplexVisType.Amplitude,
         setVisType: (visType: ComplexVisType) => set(() => ({ visType })),
       }),

--- a/packages/app/src/vis-packs/core/complex/lineConfig.tsx
+++ b/packages/app/src/vis-packs/core/complex/lineConfig.tsx
@@ -15,7 +15,7 @@ export interface ComplexLineConfig {
 function createComplexLineConfigStore() {
   return createStore<ComplexLineConfig>()(
     persist(
-      (set) => ({
+      (set): ComplexLineConfig => ({
         visType: ComplexVisType.Amplitude,
         setVisType: (visType: ComplexLineVisType) => set(() => ({ visType })),
       }),

--- a/packages/app/src/vis-packs/core/heatmap/config.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/config.tsx
@@ -36,7 +36,7 @@ export interface HeatmapConfig {
 function createHeatmapConfigStore() {
   return createStore<HeatmapConfig>()(
     persist(
-      (set) => ({
+      (set): HeatmapConfig => ({
         customDomain: [null, null],
         setCustomDomain: (customDomain: CustomDomain) => set({ customDomain }),
 

--- a/packages/app/src/vis-packs/core/line/config.tsx
+++ b/packages/app/src/vis-packs/core/line/config.tsx
@@ -32,7 +32,7 @@ export interface LineConfig {
 function createLineConfigStore() {
   return createStore<LineConfig>()(
     persist(
-      (set) => ({
+      (set): LineConfig => ({
         curveType: CurveType.LineOnly,
         setCurveType: (type: CurveType) => set({ curveType: type }),
 

--- a/packages/app/src/vis-packs/core/matrix/config.tsx
+++ b/packages/app/src/vis-packs/core/matrix/config.tsx
@@ -20,7 +20,7 @@ export interface MatrixVisConfig {
 function createMatrixConfigStore() {
   return createStore<MatrixVisConfig>()(
     persist(
-      (set) => ({
+      (set): MatrixVisConfig => ({
         sticky: false,
         toggleSticky: () => set((state) => ({ sticky: !state.sticky })),
 

--- a/packages/app/src/vis-packs/core/rgb/config.tsx
+++ b/packages/app/src/vis-packs/core/rgb/config.tsx
@@ -20,7 +20,7 @@ export interface RgbVisConfig {
 function createRgbConfigStore() {
   return createStore<RgbVisConfig>()(
     persist(
-      (set) => ({
+      (set): RgbVisConfig => ({
         showGrid: false,
         toggleGrid: () => set((state) => ({ showGrid: !state.showGrid })),
 

--- a/packages/app/src/vis-packs/core/scatter/config.tsx
+++ b/packages/app/src/vis-packs/core/scatter/config.tsx
@@ -35,7 +35,7 @@ export interface ScatterConfig {
 function createScatterConfigStore() {
   return createStore<ScatterConfig>()(
     persist(
-      (set) => ({
+      (set): ScatterConfig => ({
         customDomain: [null, null],
         setCustomDomain: (customDomain: CustomDomain) => set({ customDomain }),
 

--- a/packages/app/src/vis-packs/core/surface/config.tsx
+++ b/packages/app/src/vis-packs/core/surface/config.tsx
@@ -26,8 +26,8 @@ export interface SurfaceConfig {
 
 function createSurfaceConfigStore() {
   return createStore<SurfaceConfig>()(
-    persist<SurfaceConfig>(
-      (set) => ({
+    persist(
+      (set): SurfaceConfig => ({
         customDomain: [null, null],
         setCustomDomain: (customDomain: CustomDomain) => set({ customDomain }),
 


### PR DESCRIPTION
No error during the build, but the TS language server in VS Code was not happy. A fix was already in place in the config of the `SurfaceVis` toolbar, but it wasn't working in the `LineVis` toolbar config because of the `partialize` option passed to the `persist` middleware. I found another way to fix the error.

![image](https://github.com/silx-kit/h5web/assets/2936402/789042a1-8492-4f19-bffc-a29cdbfc1a34)
