### PR TITLE
Parse nested array types returned by h5wasm

### DIFF
--- a/packages/h5wasm/src/guards.ts
+++ b/packages/h5wasm/src/guards.ts
@@ -61,6 +61,10 @@ export function isStringMetadata(metadata: Metadata) {
   return metadata.type === 3;
 }
 
+export function isArrayMetadata(metadata: Metadata) {
+  return metadata.type === 10;
+}
+
 export function isCompoundMetadata(
   metadata: Metadata,
 ): metadata is CompoundMetadata {

--- a/packages/h5wasm/src/utils.ts
+++ b/packages/h5wasm/src/utils.ts
@@ -1,9 +1,10 @@
 import type { DType, NumericType } from '@h5web/shared';
-import { DTypeClass, Endianness } from '@h5web/shared';
+import { assertDefined, DTypeClass, Endianness } from '@h5web/shared';
 import type { Dataset as H5WasmDataset, Metadata } from 'h5wasm';
 
 import {
   assertNumericMetadata,
+  isArrayMetadata,
   isCompoundMetadata,
   isEnumMetadata,
   isFloatMetadata,
@@ -53,6 +54,17 @@ export function convertMetadataToDType(metadata: Metadata): DType {
       // not the size of actual variable-length string data (https://portal.hdfgroup.org/display/HDF5/H5T_GET_SIZE)
       length: vlen ? undefined : size,
       charSet: cset === 1 ? 'UTF-8' : 'ASCII',
+    };
+  }
+
+  if (isArrayMetadata(metadata)) {
+    const { array_type } = metadata;
+    assertDefined(array_type);
+
+    return {
+      class: DTypeClass.Array,
+      base: convertMetadataToDType(array_type),
+      dims: array_type.shape,
     };
   }
 


### PR DESCRIPTION
I was playing with compound datasets as part of #1485 when I noticed this "Unknown" type. Definitely a bit of a niche fix...

| Before | After |
|--------|--------|
| ![image](https://github.com/silx-kit/h5web/assets/2936402/1d76d27e-15ad-4ba3-8936-320c47dda4ee) | ![image](https://github.com/silx-kit/h5web/assets/2936402/7e2295d3-2981-4621-a682-24eed571bf8a) |


