### PR TITLE
Fix CSS of Raw vis

### DIFF
--- a/packages/lib/src/vis/raw/RawVis.module.css
+++ b/packages/lib/src/vis/raw/RawVis.module.css
@@ -1,5 +1,6 @@
 .root {
   overflow: auto;
+  flex: 1 1 0%;
 }
 
 .raw {


### PR DESCRIPTION
The root, scrollable container was not taking up the whole width:

![image](https://github.com/silx-kit/h5web/assets/2936402/678cd702-8c66-42c2-9cb2-203400e7dd8a)
