### PR TITLE
Shorten `flex` shorthand properties

### DIFF
--- a/apps/demo/src/h5wasm/H5WasmApp.module.css
+++ b/apps/demo/src/h5wasm/H5WasmApp.module.css
@@ -18,7 +18,7 @@
 }
 
 .inner {
-  flex: 1 1 0%;
+  flex: 1;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -69,7 +69,7 @@
 }
 
 .urlForm > fieldset {
-  flex: 1 1 0%;
+  flex: 1;
   display: flex;
   justify-content: center;
   border: none;
@@ -78,7 +78,7 @@
 }
 
 .urlInput {
-  flex: 1 1 0%;
+  flex: 1;
   max-width: 20rem;
 }
 

--- a/packages/app/src/breadcrumbs/BreadcrumbsBar.module.css
+++ b/packages/app/src/breadcrumbs/BreadcrumbsBar.module.css
@@ -9,7 +9,7 @@
 }
 
 .breadCrumbs {
-  flex: 1 1 0%;
+  flex: 1;
   display: flex;
   align-items: center;
   overflow: hidden;

--- a/packages/app/src/dimension-mapper/DimensionMapper.module.css
+++ b/packages/app/src/dimension-mapper/DimensionMapper.module.css
@@ -42,13 +42,13 @@
 }
 
 .dimSize {
-  flex: 1 0 0%;
+  flex: 1 0;
   padding: 0 0.1875rem;
   text-align: center;
 }
 
 .sliders {
-  flex: 1 1 0%;
+  flex: 1;
   display: flex;
   justify-content: center;
   padding: 0.5rem 0;

--- a/packages/app/src/dimension-mapper/SlicingSlider.module.css
+++ b/packages/app/src/dimension-mapper/SlicingSlider.module.css
@@ -28,7 +28,7 @@
 }
 
 .track {
-  flex: 1 0 auto;
+  flex: 1;
   margin: calc(var(--thumb-height) / 2) 0;
   width: 2px;
   background-color: var(--secondary-dark);

--- a/packages/app/src/explorer/Explorer.module.css
+++ b/packages/app/src/explorer/Explorer.module.css
@@ -1,6 +1,6 @@
 .explorer {
   position: relative;
-  flex: 1 1 0%;
+  flex: 1;
   min-width: 0;
 }
 

--- a/packages/app/src/search/Search.module.css
+++ b/packages/app/src/search/Search.module.css
@@ -11,7 +11,7 @@
 }
 
 .input {
-  flex: 1 1 0%;
+  flex: 1;
   height: var(--toolbarBtn-height);
   padding: 0 0.5rem;
   border: none;

--- a/packages/app/src/vis-packs/ValueLoader.module.css
+++ b/packages/app/src/vis-packs/ValueLoader.module.css
@@ -1,5 +1,5 @@
 .loader {
-  flex: 1 1 0%;
+  flex: 1;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/app/src/visualizer/Visualizer.module.css
+++ b/packages/app/src/visualizer/Visualizer.module.css
@@ -1,5 +1,5 @@
 .visManager {
-  flex: 1 1 0%;
+  flex: 1;
   min-height: 0;
   display: flex;
   flex-direction: column;
@@ -15,7 +15,7 @@
 }
 
 .visArea {
-  flex: 1 1 0%;
+  flex: 1;
   min-height: 0;
   display: flex;
 }

--- a/packages/lib/src/toolbar/Toolbar.module.css
+++ b/packages/lib/src/toolbar/Toolbar.module.css
@@ -1,5 +1,5 @@
 .toolbar {
-  flex: 1 1 0%;
+  flex: 1;
   position: relative; /* for `z-index` below, in case parent doesn't have `display: flex` */
   z-index: 1; /* for toolbar menus to appear above visualizations (overflow, selectors) */
   display: flex;
@@ -11,7 +11,7 @@
 }
 
 .controls {
-  flex: 1 1 0%;
+  flex: 1;
   display: flex;
   justify-content: flex-end;
   min-width: 0;

--- a/packages/lib/src/toolbar/controls/DomainWidget/BoundEditor.module.css
+++ b/packages/lib/src/toolbar/controls/DomainWidget/BoundEditor.module.css
@@ -14,7 +14,7 @@
 }
 
 .value {
-  flex: 1 0 auto;
+  flex: 1;
   width: 8.5em; /* -9.99999e+999 without overflowing */
   margin-right: 0.375rem;
   padding: 0.25rem 0.375rem;

--- a/packages/lib/src/toolbar/controls/DomainWidget/DomainControls.module.css
+++ b/packages/lib/src/toolbar/controls/DomainWidget/DomainControls.module.css
@@ -57,7 +57,7 @@
 }
 
 .errorMessage {
-  flex: 1 1 0%;
+  flex: 1;
   font-size: 0.9375em;
   font-weight: 600;
 }

--- a/packages/lib/src/toolbar/controls/DomainWidget/DomainWidget.module.css
+++ b/packages/lib/src/toolbar/controls/DomainWidget/DomainWidget.module.css
@@ -11,7 +11,7 @@
 
 .sliderContainer {
   display: flex;
-  flex: 1 1 0%;
+  flex: 1;
   padding: 0 0.375rem;
   margin-right: -0.375rem;
 }

--- a/packages/lib/src/toolbar/controls/Selector/Selector.module.css
+++ b/packages/lib/src/toolbar/controls/Selector/Selector.module.css
@@ -91,11 +91,11 @@
 }
 
 .selectedOption {
-  flex: 1 1 0%;
+  flex: 1;
 }
 
 .option {
-  flex: 1 1 0%;
+  flex: 1;
   padding: 0.5rem 0.75rem;
   cursor: pointer;
   white-space: nowrap;

--- a/packages/lib/src/vis/heatmap/ColorBar.module.css
+++ b/packages/lib/src/vis/heatmap/ColorBar.module.css
@@ -31,7 +31,7 @@
 }
 
 .gradient {
-  flex: 1 1 0%;
+  flex: 1;
   background-repeat: no-repeat; /* fix subtle bug where gradient is repeated over 1px */
 }
 

--- a/packages/lib/src/vis/heatmap/HeatmapVis.module.css
+++ b/packages/lib/src/vis/heatmap/HeatmapVis.module.css
@@ -1,5 +1,5 @@
 .root {
-  flex: 1 1 0%;
+  flex: 1;
   display: flex;
   min-width: 0;
   min-height: 0;

--- a/packages/lib/src/vis/line/LineVis.module.css
+++ b/packages/lib/src/vis/line/LineVis.module.css
@@ -1,5 +1,5 @@
 .root {
-  flex: 1 1 0%;
+  flex: 1;
   display: flex;
   min-width: 0;
   min-height: 0;

--- a/packages/lib/src/vis/matrix/MatrixVis.module.css
+++ b/packages/lib/src/vis/matrix/MatrixVis.module.css
@@ -1,6 +1,6 @@
 .wrapper {
   position: relative;
-  flex: 1 1 0%;
+  flex: 1;
 }
 
 .grid {

--- a/packages/lib/src/vis/raw/RawVis.module.css
+++ b/packages/lib/src/vis/raw/RawVis.module.css
@@ -1,6 +1,6 @@
 .root {
   overflow: auto;
-  flex: 1 1 0%;
+  flex: 1;
 }
 
 .raw {

--- a/packages/lib/src/vis/scatter/ScatterVis.module.css
+++ b/packages/lib/src/vis/scatter/ScatterVis.module.css
@@ -1,5 +1,5 @@
 .root {
-  flex: 1 1 0%;
+  flex: 1;
   display: flex;
   min-width: 0;
   min-height: 0;

--- a/packages/lib/src/vis/shared/VisCanvas.module.css
+++ b/packages/lib/src/vis/shared/VisCanvas.module.css
@@ -1,5 +1,5 @@
 .visCanvas {
-  flex: 1 1 0%;
+  flex: 1;
   overflow: hidden; /* prevent overflow, notably when resizing */
   z-index: 0; /* stacking context for anything rendered above the canvas (axis grid, SVG scene, floating toolbar, tooltip, etc.) */
 

--- a/packages/lib/src/vis/surface/SurfaceVis.module.css
+++ b/packages/lib/src/vis/surface/SurfaceVis.module.css
@@ -1,5 +1,5 @@
 .root {
-  flex: 1 1 0%;
+  flex: 1;
   display: flex;
   min-width: 0;
   min-height: 0;


### PR DESCRIPTION
If unspecified, the defaults for a flex item are:

- `flex-grow: 0`
- `flex-shrink: 1`
- `flex-basis: auto`

Very often, what we want is `flex: 1 1 0` - i.e. for the item to grow/shrink to fill the available space regardless of its intrinsic size (so that all flex items inside a container get sized equally).

The [`flex`](https://devdocs.io/css/flex) shorthand knows this is the most common case and that people don't generally want `flex-basis: auto`, so when one or two unit-less values are specified (for `flex-grow` and `flex-shrink`) it sets `flex-basis` to `0` instead of keeping the default value of `auto`:

- `flex: 1` <=> `flex: 1 1 0`
- `flex: 1 0` <=> `flex:  1 0 0`

I used to think that this behaviour was kind of obscure and always preferred to write `flex: 1 1 0%`. After seeing that modern CSS tooling like [Lightning CSS](https://lightningcss.dev/) minifies `flex: 1 1 0%` to `flex: 1`, I thought I'd reconsider my stance. After all, the `flex` shorthand is trying to help, so perhaps I was silly to not take advantage of it.

When it comes to `0%` vs `0` for `flex-basis`, this used to be a [workaround for ... IE11](https://github.com/philipwalton/flexbugs#flexbug-4)!! I think it's time for me to move on... 😅 