### PR TITLE
Add missing "types" entries in package.json exports

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -22,8 +22,9 @@
       "./dist/styles.css": "./dist/styles.css",
       "./styles.css": "./dist/styles.css",
       ".": {
-        "require": "./dist/index.js",
-        "import": "./dist/index.esm.js"
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.esm.js",
+        "default": "./dist/index.js"
       }
     }
   },

--- a/packages/h5wasm/package.json
+++ b/packages/h5wasm/package.json
@@ -20,8 +20,9 @@
     "types": "dist/index.d.ts",
     "exports": {
       ".": {
-        "require": "./dist/index.js",
-        "import": "./dist/index.esm.js"
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.esm.js",
+        "default": "./dist/index.js"
       }
     }
   },

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -22,8 +22,9 @@
       "./dist/styles.css": "./dist/styles.css",
       "./styles.css": "./dist/styles.css",
       ".": {
-        "require": "./dist/index.js",
-        "import": "./dist/index.esm.js"
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.esm.js",
+        "default": "./dist/index.js"
       }
     }
   },


### PR DESCRIPTION
I came across this tool, which reported a couple of errors around missing types: https://arethetypeswrong.github.io/

To fix the issues, I followed the recommendation given in this article: https://blog.isquaredsoftware.com/2023/08/esm-modernization-lessons/#round-2-results