### PR TITLE
`[H5WasmProvider + MatrixVis]` Support (u)int64 data inside compound datasets

### DIFF
--- a/packages/h5wasm/src/guards.ts
+++ b/packages/h5wasm/src/guards.ts
@@ -1,5 +1,5 @@
-import type { Dataset } from '@h5web/shared';
-import { DTypeClass } from '@h5web/shared';
+import type { Dataset, DType } from '@h5web/shared';
+import { DTypeClass, isCompoundType } from '@h5web/shared';
 import type { Metadata } from 'h5wasm';
 import {
   BrokenSoftLink as H5WasmSoftLink,
@@ -107,10 +107,17 @@ export function assertNumericMetadata(
   }
 }
 
-export function hasInt64Type(dataset: Dataset) {
+function isInt64Type(type: DType): boolean {
   return (
-    (dataset.type.class === DTypeClass.Integer ||
-      dataset.type.class === DTypeClass.Unsigned) &&
-    dataset.type.size === 64
+    (type.class === DTypeClass.Integer || type.class === DTypeClass.Unsigned) &&
+    type.size === 64
+  );
+}
+
+export function hasInt64Type(dataset: Dataset) {
+  const { type } = dataset;
+  return (
+    isInt64Type(type) ||
+    (isCompoundType(type) && Object.values(type.fields).some(isInt64Type))
   );
 }

--- a/packages/shared/src/guards.ts
+++ b/packages/shared/src/guards.ts
@@ -333,10 +333,14 @@ export function assertPrintableType<S extends Shape>(
   }
 }
 
+export function isCompoundType(type: DType): type is CompoundType {
+  return type.class === DTypeClass.Compound;
+}
+
 export function hasCompoundType<S extends Shape>(
   dataset: Dataset<S>,
 ): dataset is Dataset<S, CompoundType> {
-  return dataset.type.class === DTypeClass.Compound;
+  return isCompoundType(dataset.type);
 }
 
 export function assertCompoundType<S extends Shape>(


### PR DESCRIPTION
- Fix https://github.com/silx-kit/vscode-h5web/issues/15
- Fix https://github.com/silx-kit/vscode-h5web/issues/30