### PR TITLE
Pass `dtype` as string to visualization components

### DIFF
--- a/packages/app/src/vis-packs/core/heatmap/MappedHeatmapVis.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/MappedHeatmapVis.tsx
@@ -16,7 +16,7 @@ import {
   useSlicedDimsAndMapping,
   useToNumArray,
 } from '../hooks';
-import { DEFAULT_DOMAIN, getSliceSelection } from '../utils';
+import { DEFAULT_DOMAIN, formatNumLikeType, getSliceSelection } from '../utils';
 import type { HeatmapConfig } from './config';
 import HeatmapToolbar from './HeatmapToolbar';
 
@@ -90,7 +90,7 @@ function MappedHeatmapVis(props: Props) {
       <HeatmapVis
         dataArray={dataArray}
         title={title}
-        dtype={dataset.type}
+        dtype={dataset && formatNumLikeType(dataset.type)}
         domain={safeDomain}
         colorMap={colorMap}
         scaleType={scaleType}

--- a/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
+++ b/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
@@ -17,6 +17,7 @@ import {
   useSlicedDimsAndMapping,
   useToNumArray,
 } from '../hooks';
+import { formatNumLikeType } from '../utils';
 import type { LineConfig } from './config';
 import LineToolbar from './LineToolbar';
 
@@ -123,7 +124,7 @@ function MappedLineVis(props: Props) {
         }}
         ordinateLabel={valueLabel}
         title={title}
-        dtype={dataset?.type}
+        dtype={dataset && formatNumLikeType(dataset.type)}
         errorsArray={errorArray}
         showErrors={showErrors}
         auxiliaries={auxArrays.map((array, i) => ({

--- a/packages/app/src/vis-packs/core/utils.ts
+++ b/packages/app/src/vis-packs/core/utils.ts
@@ -5,7 +5,7 @@ import type {
   NumArray,
   NumericLikeType,
 } from '@h5web/shared';
-import { createArrayFromView } from '@h5web/shared';
+import { createArrayFromView, DTypeClass, isNumericType } from '@h5web/shared';
 import { isNumber } from 'lodash';
 import type { NdArray, TypedArray } from 'ndarray';
 import ndarray from 'ndarray';
@@ -96,4 +96,15 @@ export function toNumArray(arr: ArrayValue<NumericLikeType>): NumArray {
   }
 
   return arr as NumArray;
+}
+
+const TYPE_STRINGS: Record<NumericLikeType['class'], string> = {
+  [DTypeClass.Bool]: 'bool',
+  [DTypeClass.Integer]: 'int',
+  [DTypeClass.Unsigned]: 'uint',
+  [DTypeClass.Float]: 'float',
+};
+
+export function formatNumLikeType(type: NumericLikeType): string {
+  return `${TYPE_STRINGS[type.class]}${isNumericType(type) ? type.size : ''}`;
 }

--- a/packages/lib/src/vis/heatmap/HeatmapVis.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapVis.tsx
@@ -1,4 +1,4 @@
-import type { Domain, NumArray, NumericLikeType } from '@h5web/shared';
+import type { Domain, NumArray } from '@h5web/shared';
 import {
   assertDefined,
   formatTooltipVal,
@@ -15,7 +15,7 @@ import { useAxisDomain, useValueToIndexScale } from '../hooks';
 import type { Aspect, AxisParams, VisScaleType } from '../models';
 import TooltipMesh from '../shared/TooltipMesh';
 import VisCanvas from '../shared/VisCanvas';
-import { DEFAULT_DOMAIN, formatNumLikeType } from '../utils';
+import { DEFAULT_DOMAIN } from '../utils';
 import ColorBar from './ColorBar';
 import HeatmapMesh from './HeatmapMesh';
 import styles from './HeatmapVis.module.css';
@@ -30,7 +30,7 @@ interface Props {
   aspect?: Aspect;
   showGrid?: boolean;
   title?: string;
-  dtype?: NumericLikeType;
+  dtype?: string;
   invertColorMap?: boolean;
   abscissaParams?: AxisParams;
   ordinateParams?: AxisParams;
@@ -121,7 +121,7 @@ function HeatmapVis(props: Props) {
                 {`${ordinateLabel ?? 'y'}=${formatTooltipVal(ordinate)}`}
                 <div className={styles.tooltipValue}>
                   <strong>{formatTooltipVal(dataArray.get(yi, xi))}</strong>
-                  {dtype && <em>{` (${formatNumLikeType(dtype)})`}</em>}
+                  {dtype && <em>{` (${dtype})`}</em>}
                   {alpha && ` (${formatTooltipVal(alpha.array.get(yi, xi))})`}
                 </div>
               </>

--- a/packages/lib/src/vis/line/LineVis.tsx
+++ b/packages/lib/src/vis/line/LineVis.tsx
@@ -1,9 +1,4 @@
-import type {
-  AxisScaleType,
-  Domain,
-  NumArray,
-  NumericLikeType,
-} from '@h5web/shared';
+import type { AxisScaleType, Domain, NumArray } from '@h5web/shared';
 import {
   assertDefined,
   assertLength,
@@ -27,7 +22,7 @@ import {
 import type { AxisParams } from '../models';
 import TooltipMesh from '../shared/TooltipMesh';
 import VisCanvas from '../shared/VisCanvas';
-import { DEFAULT_DOMAIN, extendDomain, formatNumLikeType } from '../utils';
+import { DEFAULT_DOMAIN, extendDomain } from '../utils';
 import DataCurve from './DataCurve';
 import styles from './LineVis.module.css';
 import type { AuxiliaryParams, TooltipData } from './models';
@@ -42,7 +37,7 @@ interface Props {
   abscissaParams?: AxisParams;
   ordinateLabel?: string;
   title?: string;
-  dtype?: NumericLikeType;
+  dtype?: string;
   errorsArray?: NdArray<NumArray>;
   showErrors?: boolean;
   auxiliaries?: AuxiliaryParams[];
@@ -156,7 +151,7 @@ function LineVis(props: Props) {
                   <span>
                     <strong>{formatTooltipVal(value)}</strong>
                     {error !== undefined && ` ±${formatTooltipErr(error)}`}
-                    {dtype && <em>{` (${formatNumLikeType(dtype)})`}</em>}
+                    {dtype && <em>{` (${dtype})`}</em>}
                   </span>
                 </div>
 

--- a/packages/lib/src/vis/utils.ts
+++ b/packages/lib/src/vis/utils.ts
@@ -4,15 +4,12 @@ import type {
   ColorScaleType,
   Domain,
   NumArray,
-  NumericLikeType,
 } from '@h5web/shared';
 import {
-  DTypeClass,
   formatTick,
   getBounds,
   getValidDomainForScale,
   isDefined,
-  isNumericType,
   isTypedArray,
   ScaleType,
 } from '@h5web/shared';
@@ -351,13 +348,6 @@ export function getAxisDomain(
     : extendedDomain;
 }
 
-const TYPE_STRINGS: Record<NumericLikeType['class'], string> = {
-  [DTypeClass.Bool]: 'bool',
-  [DTypeClass.Integer]: 'int',
-  [DTypeClass.Unsigned]: 'uint',
-  [DTypeClass.Float]: 'float',
-};
-
 export const VERTEX_SHADER = `
   varying vec2 coords;
 
@@ -366,10 +356,6 @@ export const VERTEX_SHADER = `
     gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
   }
 `;
-
-export function formatNumLikeType(type: NumericLikeType): string {
-  return `${TYPE_STRINGS[type.class]}${isNumericType(type) ? type.size : ''}`;
-}
 
 export function getUniforms(
   uniforms: Record<string, unknown>,


### PR DESCRIPTION
I wasn't fond of `LineVis` and `HeatmapVis` being aware of some of the `DType` models—those should concern only the H5Web viewer.