### PR TITLE
Fix overly permissive regex

### DIFF
--- a/packages/app/src/providers/h5grove/utils.ts
+++ b/packages/app/src/providers/h5grove/utils.ts
@@ -54,11 +54,11 @@ export function convertH5GroveDtype(dtype: H5GroveDtype): DType {
 }
 
 function convertDtypeString(dtype: string): DType {
-  const regexp = /([<>=|])?([A-z])(\d*)/u;
+  const regexp = /([<>=|])?([A-Za-z])(\d*)/u;
   const matches = regexp.exec(dtype);
 
   if (matches === null) {
-    throw new Error(`Unknown dtype ${dtype}`);
+    throw new Error(`Invalid dtype string: ${dtype}`);
   }
 
   const [, endianMatch, dataType, lengthMatch] = matches;


### PR DESCRIPTION
I've activated CodeQL analysis on the repo to try it out: https://github.com/silx-kit/h5web/settings/security_analysis

It detected an issue in a regex: https://github.com/silx-kit/h5web/security/code-scanning/1