### PR TITLE
[HeatmapVis] Fix min axis array length off by 1 in error message

### DIFF
--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -100,7 +100,6 @@ export {
   getDomains,
   getCombinedDomain,
   extendDomain,
-  getAxisValues,
   getAxisDomain,
   getValueToIndexScale,
   createBufferAttr,
@@ -111,12 +110,14 @@ export {
   useDomain,
   useDomains,
   useCombinedDomain,
-  useAxisValues,
   useAxisDomain,
   useValueToIndexScale,
   useCameraState,
   useGeometry,
 } from './vis/hooks';
+
+export { getAxisValues } from './vis/line/utils';
+export { useAxisValues } from './vis/line/hooks';
 
 export {
   getLinearGradient,

--- a/packages/lib/src/vis/heatmap/utils.ts
+++ b/packages/lib/src/vis/heatmap/utils.ts
@@ -17,7 +17,7 @@ import {
 
 import type { CustomDomain, DomainErrors } from '../models';
 import { DomainError } from '../models';
-import { getAxisValues, SCALES_VALID_MINS } from '../utils';
+import { SCALES_VALID_MINS } from '../utils';
 import { INTERPOLATORS } from './interpolators';
 import type { ColorMap, D3Interpolator, TextureSafeTypedArray } from './models';
 
@@ -108,14 +108,23 @@ export function getPixelEdgeValues(
   rawValues: NumArray | undefined,
   pixelCount: number,
 ): NumArray {
-  if (rawValues && rawValues.length === pixelCount) {
+  const pixelEdgeCount = pixelCount + 1;
+
+  if (!rawValues) {
+    return range(pixelEdgeCount);
+  }
+
+  if (rawValues.length < pixelCount) {
+    throw new Error(`Expected array to have length ${pixelCount} at least`);
+  }
+
+  if (rawValues.length === pixelCount) {
     // Add value at right-hand side of last pixel, assuming raw values are regularly spaced
     const deltaCoord = rawValues[1] - rawValues[0];
     return [...rawValues, rawValues[rawValues.length - 1] + deltaCoord];
   }
 
-  // nEdges = nPixels + 1
-  return getAxisValues(rawValues, pixelCount + 1);
+  return rawValues.slice(0, pixelEdgeCount);
 }
 
 export function getInterpolator(colorMap: ColorMap, reverse: boolean) {

--- a/packages/lib/src/vis/hooks.ts
+++ b/packages/lib/src/vis/hooks.ts
@@ -15,7 +15,6 @@ import type { BufferAttribute } from 'three';
 import type H5WebGeometry from './shared/h5webGeometry';
 import {
   getAxisDomain,
-  getAxisValues,
   getCombinedDomain,
   getValueToIndexScale,
 } from './utils';
@@ -26,7 +25,6 @@ export const useValidDomainForScale = createMemo(getValidDomainForScale);
 export const useCombinedDomain = createMemo(getCombinedDomain);
 export const useValueToIndexScale = createMemo(getValueToIndexScale);
 export const useAxisDomain = createMemo(getAxisDomain);
-export const useAxisValues = createMemo(getAxisValues);
 
 export function useDomain(
   valuesArray: AnyNumArray,

--- a/packages/lib/src/vis/line/LineVis.tsx
+++ b/packages/lib/src/vis/line/LineVis.tsx
@@ -13,17 +13,13 @@ import { useMemo } from 'react';
 import type { DefaultInteractionsConfig } from '../../interactions/DefaultInteractions';
 import DefaultInteractions from '../../interactions/DefaultInteractions';
 import ResetZoomButton from '../../toolbar/floating/ResetZoomButton';
-import {
-  useAxisDomain,
-  useAxisValues,
-  useCssColors,
-  useValueToIndexScale,
-} from '../hooks';
+import { useAxisDomain, useCssColors, useValueToIndexScale } from '../hooks';
 import type { AxisParams } from '../models';
 import TooltipMesh from '../shared/TooltipMesh';
 import VisCanvas from '../shared/VisCanvas';
 import { DEFAULT_DOMAIN, extendDomain } from '../utils';
 import DataCurve from './DataCurve';
+import { useAxisValues } from './hooks';
 import styles from './LineVis.module.css';
 import type { AuxiliaryParams, TooltipData } from './models';
 import { CurveType } from './models';

--- a/packages/lib/src/vis/line/hooks.ts
+++ b/packages/lib/src/vis/line/hooks.ts
@@ -1,0 +1,5 @@
+import { createMemo } from '@h5web/shared';
+
+import { getAxisValues } from './utils';
+
+export const useAxisValues = createMemo(getAxisValues);

--- a/packages/lib/src/vis/line/utils.ts
+++ b/packages/lib/src/vis/line/utils.ts
@@ -1,0 +1,17 @@
+import type { NumArray } from '@h5web/shared';
+import { range } from 'd3-array';
+
+export function getAxisValues(
+  rawValues: NumArray | undefined,
+  axisLength: number,
+): NumArray {
+  if (!rawValues) {
+    return range(axisLength);
+  }
+
+  if (rawValues.length < axisLength) {
+    throw new Error(`Expected array to have length ${axisLength} at least`);
+  }
+
+  return rawValues.slice(0, axisLength);
+}

--- a/packages/lib/src/vis/utils.ts
+++ b/packages/lib/src/vis/utils.ts
@@ -376,21 +376,6 @@ export function toArray(arr: NumArray): number[] {
   return isTypedArray(arr) ? [...arr] : arr;
 }
 
-export function getAxisValues(
-  rawValues: NumArray | undefined,
-  axisLength: number,
-): NumArray {
-  if (!rawValues) {
-    return range(axisLength);
-  }
-
-  if (rawValues.length < axisLength) {
-    throw new Error(`Expected array to have length ${axisLength} at least`);
-  }
-
-  return rawValues.slice(0, axisLength);
-}
-
 export function createBufferAttr(
   dataLength: number,
   itemSize = 3,


### PR DESCRIPTION
When the size of an axis dataset doesn't match the size of the dimension to which it is mapped (via the NX `axes` attribute), the error message was so far reporting an incorrect value, off by 1:

![image](https://github.com/silx-kit/h5web/assets/2936402/769c61fe-b6ed-461b-9095-5c6db0b33062)

This was due to `HeatmapVis` calling `getPixelEdgeValues`, which in turn was calling `getAxisValues(rawValues, pixelCount + 1);` to account for the fact that the axis values need to include the value of the outside edge of the last pixel.

I didn't try to be smart: I stopped calling `getAxisValues` from `getPixelEdgeValues` and instead duplicated/tweaked the logic appropriately. Since `getAxisValues` is now only used by `LineVis`, I moved it and its hook into dedicated files.

![image](https://github.com/silx-kit/h5web/assets/2936402/aa29b071-f128-4d00-a4c5-9d643f6aed23)
