### PR TITLE
Support Blosc2 and Bitshuffle plugins

### DIFF
--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -17,7 +17,7 @@
     "@h5web/h5wasm": "workspace:*",
     "axios": "1.6.2",
     "axios-hooks": "5.0.2",
-    "h5wasm-plugins": "0.0.1",
+    "h5wasm-plugins": "0.0.3",
     "normalize.css": "8.0.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/apps/demo/src/h5wasm/plugin-utils.ts
+++ b/apps/demo/src/h5wasm/plugin-utils.ts
@@ -1,6 +1,9 @@
 // Import compression plugins as static assets (i.e. as URLs)
 // cf. `vite.config.ts` and `src/vite-env.d.ts
+import { Plugin } from '@h5web/h5wasm';
 import blosc from 'h5wasm-plugins/plugins/libH5Zblosc.so';
+import blosc2 from 'h5wasm-plugins/plugins/libH5Zblosc2.so';
+import bshuf from 'h5wasm-plugins/plugins/libH5Zbshuf.so';
 import bz2 from 'h5wasm-plugins/plugins/libH5Zbz2.so';
 import lz4 from 'h5wasm-plugins/plugins/libH5Zlz4.so';
 import lzf from 'h5wasm-plugins/plugins/libH5Zlzf.so';
@@ -8,18 +11,20 @@ import szf from 'h5wasm-plugins/plugins/libH5Zszf.so';
 import zfp from 'h5wasm-plugins/plugins/libH5Zzfp.so';
 import zstd from 'h5wasm-plugins/plugins/libH5Zzstd.so';
 
-const PLUGINS: Record<string, string> = {
-  blosc,
-  bz2,
-  lz4,
-  lzf,
-  szf,
-  zfp,
-  zstd,
+const PLUGINS: Record<Plugin, string> = {
+  [Plugin.Blosc]: blosc,
+  [Plugin.Blosc2]: blosc2,
+  [Plugin.Bitshuffle]: bshuf,
+  [Plugin.BZIP2]: bz2,
+  [Plugin.LZ4]: lz4,
+  [Plugin.LZF]: lzf,
+  [Plugin.SZ]: szf,
+  [Plugin.ZFP]: zfp,
+  [Plugin.Zstandard]: zstd,
 };
 
 export async function getPlugin(
-  name: string,
+  name: Plugin,
 ): Promise<ArrayBuffer | undefined> {
   if (!PLUGINS[name]) {
     return undefined;

--- a/packages/h5wasm/README.md
+++ b/packages/h5wasm/README.md
@@ -166,7 +166,7 @@ See
 this time, so if you don't provide your own, the export menu will remain
 disabled in the toolbar.
 
-#### `getPlugin?: (name: string) => Promise<ArrayBuffer | undefined>`
+#### `getPlugin?: (name: Plugin) => Promise<ArrayBuffer | undefined>`
 
 If provided, this aysnchronous function is invoked when loading a compressed
 dataset. It receives the name of a compression plugin as parameter and should
@@ -184,6 +184,8 @@ A typical implementation of `getPlugin` in a bundled front-end application might
 look like this:
 
 ```ts
+import type { Plugin } from '@h5web/h5wasm';
+
 /*
  * Import the plugins' source files as static assets (i.e. as URLs).
  * The exact syntax may vary depending on your bundler (Vite, webpack ...)
@@ -193,9 +195,13 @@ import blosc from 'h5wasm-plugins/plugins/libH5Zblosc.so';
 import bz2 from 'h5wasm-plugins/plugins/libH5Zbz2.so';
 // ...
 
-const PLUGINS = { blosc, bz2 /* ... */ };
+const PLUGINS: Record<Plugin, string> = {
+  [Plugin.Blosc]: blosc,
+  [Plugin.BZIP2]: bz2,
+  // ...
+};
 
-async function getPlugin(name: string): Promise<ArrayBuffer | undefined> {
+async function getPlugin(name: Plugin): Promise<ArrayBuffer | undefined> {
   if (!PLUGINS[name]) {
     return undefined;
   }

--- a/packages/h5wasm/src/H5WasmProvider.tsx
+++ b/packages/h5wasm/src/H5WasmProvider.tsx
@@ -4,12 +4,13 @@ import type { PropsWithChildren } from 'react';
 import { useEffect, useState } from 'react';
 
 import { H5WasmApi } from './h5wasm-api';
+import type { Plugin } from './utils';
 
 interface Props {
   filename: string;
   buffer: ArrayBuffer;
   getExportURL?: DataProviderApi['getExportURL'];
-  getPlugin?: (name: string) => Promise<ArrayBuffer | undefined>;
+  getPlugin?: (name: Plugin) => Promise<ArrayBuffer | undefined>;
 }
 
 function H5WasmProvider(props: PropsWithChildren<Props>) {

--- a/packages/h5wasm/src/h5wasm-api.ts
+++ b/packages/h5wasm/src/h5wasm-api.ts
@@ -23,6 +23,7 @@ import { nanoid } from 'nanoid';
 
 import { assertH5WasmDataset, hasInt64Type } from './guards';
 import type { H5WasmEntity } from './models';
+import type { Plugin } from './utils';
 import {
   convertSelectionToRanges,
   parseEntity,
@@ -40,7 +41,7 @@ export class H5WasmApi extends DataProviderApi {
     buffer: ArrayBuffer,
     private readonly _getExportURL?: DataProviderApi['getExportURL'],
     private readonly getPlugin?: (
-      name: string,
+      name: Plugin,
     ) => Promise<ArrayBuffer | undefined>,
   ) {
     super(filename);

--- a/packages/h5wasm/src/index.ts
+++ b/packages/h5wasm/src/index.ts
@@ -1,1 +1,2 @@
 export { default as H5WasmProvider } from './H5WasmProvider';
+export { Plugin } from './utils';

--- a/packages/h5wasm/src/utils.ts
+++ b/packages/h5wasm/src/utils.ts
@@ -35,15 +35,29 @@ import {
 import type { H5WasmAttributes, H5WasmEntity } from './models';
 
 // https://github.com/h5wasm/h5wasm-plugins#included-plugins
+export enum Plugin {
+  Bitshuffle = 'bshuf',
+  Blosc = 'blosc',
+  Blosc2 = 'blosc2',
+  BZIP2 = 'bz2',
+  LZ4 = 'lz4',
+  LZF = 'lzf',
+  SZ = 'szf',
+  ZFP = 'zfp',
+  Zstandard = 'zstd',
+}
+
 // https://support.hdfgroup.org/services/contributions.html
-export const PLUGINS_BY_FILTER_ID: Record<number, string> = {
-  307: 'bz2',
-  32_000: 'lzf',
-  32_001: 'blosc',
-  32_004: 'lz4',
-  32_013: 'zfp',
-  32_015: 'zstd',
-  32_017: 'szf',
+export const PLUGINS_BY_FILTER_ID: Record<number, Plugin> = {
+  307: Plugin.BZIP2,
+  32_000: Plugin.LZF,
+  32_001: Plugin.Blosc,
+  32_004: Plugin.LZ4,
+  32_008: Plugin.Bitshuffle,
+  32_013: Plugin.ZFP,
+  32_015: Plugin.Zstandard,
+  32_017: Plugin.SZ,
+  32_026: Plugin.Blosc2,
 };
 
 export function parseEntity(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,8 +69,8 @@ importers:
         specifier: 5.0.2
         version: 5.0.2(axios@1.6.2)(react@18.2.0)
       h5wasm-plugins:
-        specifier: 0.0.1
-        version: 0.0.1
+        specifier: 0.0.3
+        version: 0.0.3
       normalize.css:
         specifier: 8.0.1
         version: 8.0.1
@@ -9052,14 +9052,14 @@ packages:
       through2: 2.0.5
     dev: true
 
-  /h5wasm-plugins@0.0.1:
-    resolution: {integrity: sha512-aWExcfukKiT3ULIhQBDePc1xY8xhWLEmz7AZtb85xYusCGFiH3/dm7o7RIKbZtPBMfJDS4NqAr0kBNtGqh/5fw==}
+  /h5wasm-plugins@0.0.3:
+    resolution: {integrity: sha512-hOI1ERa6QfjrN/AWJW0mqFaAU4D4NtzYXjb03h7f1MufkIzCkYo/bZoB7NZy+Qy9vHsxL31rz7hNlZCPouf+tQ==}
     dependencies:
-      h5wasm: 0.6.8
+      h5wasm: 0.6.10
     dev: false
 
-  /h5wasm@0.6.8:
-    resolution: {integrity: sha512-BaEWwjxCtG8C/wmGw9SEx9cUAopvVa7E4DHmy3dyPo4i2M1dcCvcvi2kGOeX1tabOVC5O2HuBIMybdHHp40bxQ==}
+  /h5wasm@0.6.10:
+    resolution: {integrity: sha512-GxBWGVxBftyq67kAbS4WPmTH3a8hGKigdMm+IVJ7tLY7BHj+nqDTUKO9RmmPBHy6Pvq5uW1YpIJr/oGanw+RyQ==}
     dev: false
 
   /h5wasm@0.7.0:


### PR DESCRIPTION
With [hwasm@0.6.10](https://github.com/usnistgov/h5wasm/releases), the Blosc2 plugin now works as expected! :tada: 

<details>
<summary>Initial PR description</summary>

Opening as draft because Blosc2 is not working as expected. The `blosc2` dataset of the test file `filters.h5` is not correctly decompressed. You can try it locally: http://localhost:5173/h5wasm?url=https%3A%2F%2Fwww.silx.org%2Fpub%2Fh5web%2Ffilters.h5

![image](https://github.com/silx-kit/h5web/assets/2936402/d70c7d38-d7a5-4336-aeaf-7e23d9dd7c69)

---

What's more, there's definitely something weird going on — it seems that plugins have an impact of the decompression of datasets compressed with other plugins. For instance:

1. Open `filters.h5`
2. Select `lz4` dataset => looks correctly decompressed
3. Select `blosc2` then `lz4` again => still works
4. Reload
5. Select `blosc2` first, then `lz4` => no longer works

![image](https://github.com/silx-kit/h5web/assets/2936402/d4b500bd-d867-4b3e-b9f4-bd1647c6204f)

Other example: if you select `zstd` first and then `blosc2`, it looks different than before:

![image](https://github.com/silx-kit/h5web/assets/2936402/3a6aa634-cf49-4a42-9451-440f0bd575a1)

</details>