### PR TITLE
Remove barrel file from @h5web/shared

### DIFF
--- a/apps/storybook/.storybook/preview.ts
+++ b/apps/storybook/.storybook/preview.ts
@@ -1,5 +1,5 @@
 import 'normalize.css';
-import '@h5web/shared/src/styles.css'; // importing via `@h5web/lib/src/styles.css` fails due ot lack of `~` prefix (as it is not supported by Vite)
+import '@h5web/shared/styles.css'; // importing via `@h5web/lib/src/styles.css` fails due ot lack of `~` prefix (as it is not supported by Vite)
 import '../src/styles.css';
 
 export const parameters = {

--- a/apps/storybook/src/ColorBar.stories.tsx
+++ b/apps/storybook/src/ColorBar.stories.tsx
@@ -1,6 +1,6 @@
 import type { ColorBarProps } from '@h5web/lib';
 import { ColorBar, ScaleType } from '@h5web/lib';
-import { COLOR_SCALE_TYPES } from '@h5web/shared';
+import { COLOR_SCALE_TYPES } from '@h5web/shared/utils';
 import type { Meta, StoryFn, StoryObj } from '@storybook/react';
 
 import FillHeight from './decorators/FillHeight';

--- a/apps/storybook/src/DataCurve.stories.tsx
+++ b/apps/storybook/src/DataCurve.stories.tsx
@@ -7,7 +7,8 @@ import {
   useDomain,
   VisCanvas,
 } from '@h5web/lib';
-import { assertDefined, mockValues } from '@h5web/shared';
+import { assertDefined } from '@h5web/shared/guards';
+import { mockValues } from '@h5web/shared/mock/values';
 import type { Meta, StoryObj } from '@storybook/react';
 import { range } from 'lodash';
 import { useState } from 'react';

--- a/apps/storybook/src/DomainControls.stories.tsx
+++ b/apps/storybook/src/DomainControls.stories.tsx
@@ -1,5 +1,5 @@
 import { DomainControls } from '@h5web/lib';
-import type { Domain } from '@h5web/shared';
+import type { Domain } from '@h5web/shared/models-vis';
 import { useToggle } from '@react-hookz/web';
 import type { Meta, StoryObj } from '@storybook/react';
 import { useEffect, useState } from 'react';

--- a/apps/storybook/src/DomainSlider.stories.tsx
+++ b/apps/storybook/src/DomainSlider.stories.tsx
@@ -5,8 +5,8 @@ import {
   useSafeDomain,
   useVisDomain,
 } from '@h5web/lib';
-import type { Domain } from '@h5web/shared';
-import { COLOR_SCALE_TYPES } from '@h5web/shared';
+import type { Domain } from '@h5web/shared/models-vis';
+import { COLOR_SCALE_TYPES } from '@h5web/shared/utils';
 import type { Meta, StoryObj } from '@storybook/react';
 import { useEffect, useState } from 'react';
 

--- a/apps/storybook/src/DomainWidget.stories.tsx
+++ b/apps/storybook/src/DomainWidget.stories.tsx
@@ -1,6 +1,6 @@
 import type { CustomDomain } from '@h5web/lib';
 import { DomainWidget, ScaleType } from '@h5web/lib';
-import { COLOR_SCALE_TYPES } from '@h5web/shared';
+import { COLOR_SCALE_TYPES } from '@h5web/shared/utils';
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 

--- a/apps/storybook/src/ErrorBars.stories.tsx
+++ b/apps/storybook/src/ErrorBars.stories.tsx
@@ -4,7 +4,9 @@ import {
   useDomain,
   VisCanvas,
 } from '@h5web/lib';
-import { assertDefined, mockValues, ScaleType } from '@h5web/shared';
+import { assertDefined } from '@h5web/shared/guards';
+import { mockValues } from '@h5web/shared/mock/values';
+import { ScaleType } from '@h5web/shared/models-vis';
 import type { Meta, StoryObj } from '@storybook/react';
 import { range } from 'lodash';
 

--- a/apps/storybook/src/GettingStarted.mdx
+++ b/apps/storybook/src/GettingStarted.mdx
@@ -100,7 +100,7 @@ import { Meta } from '@storybook/addon-docs';
 1. Import the library's styles before any other import:
 
    ```ts
-   import '@h5web/lib/dist/styles.css';
+   import '@h5web/lib/styles.css'; // or '@h5web/lib/dist/styles.css' with older bundlers
 
    import { HeatmapVis, getDomain } from '@h5web/lib';
 

--- a/apps/storybook/src/Glyphs.stories.tsx
+++ b/apps/storybook/src/Glyphs.stories.tsx
@@ -5,7 +5,9 @@ import {
   useDomain,
   VisCanvas,
 } from '@h5web/lib';
-import { assertDefined, mockValues, ScaleType } from '@h5web/shared';
+import { assertDefined } from '@h5web/shared/guards';
+import { mockValues } from '@h5web/shared/mock/values';
+import { ScaleType } from '@h5web/shared/models-vis';
 import type { Meta, StoryObj } from '@storybook/react';
 import { range } from 'lodash';
 

--- a/apps/storybook/src/HeatmapMesh.stories.tsx
+++ b/apps/storybook/src/HeatmapMesh.stories.tsx
@@ -6,13 +6,13 @@ import {
   HeatmapMesh,
   VisCanvas,
 } from '@h5web/lib';
+import { assertDefined } from '@h5web/shared/guards';
+import { ScaleType } from '@h5web/shared/models-vis';
 import {
-  assertDefined,
   COLOR_SCALE_TYPES,
   getDims,
-  ScaleType,
   toTypedNdArray,
-} from '@h5web/shared';
+} from '@h5web/shared/utils';
 import type { Meta, StoryObj } from '@storybook/react';
 import { range } from 'lodash';
 import ndarray from 'ndarray';

--- a/apps/storybook/src/HeatmapVis.stories.tsx
+++ b/apps/storybook/src/HeatmapVis.stories.tsx
@@ -5,11 +5,8 @@ import {
   INTERPOLATORS,
   ScaleType,
 } from '@h5web/lib';
-import {
-  assertDefined,
-  COLOR_SCALE_TYPES,
-  toTypedNdArray,
-} from '@h5web/shared';
+import { assertDefined } from '@h5web/shared/guards';
+import { COLOR_SCALE_TYPES, toTypedNdArray } from '@h5web/shared/utils';
 import type { Meta, StoryObj } from '@storybook/react';
 import ndarray from 'ndarray';
 

--- a/apps/storybook/src/HeatmapVisDisplay.stories.tsx
+++ b/apps/storybook/src/HeatmapVisDisplay.stories.tsx
@@ -4,7 +4,7 @@ import {
   getMockDataArray,
   HeatmapVis,
 } from '@h5web/lib';
-import { formatTooltipVal } from '@h5web/shared';
+import { formatTooltipVal } from '@h5web/shared/utils';
 import type { Meta, StoryFn, StoryObj } from '@storybook/react';
 
 import HeatmapVisStoriesMeta from './HeatmapVis.stories';

--- a/apps/storybook/src/Histogram.stories.tsx
+++ b/apps/storybook/src/Histogram.stories.tsx
@@ -1,5 +1,5 @@
 import { Histogram, ScaleType } from '@h5web/lib';
-import { COLOR_SCALE_TYPES } from '@h5web/shared';
+import { COLOR_SCALE_TYPES } from '@h5web/shared/utils';
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 

--- a/apps/storybook/src/Line.stories.tsx
+++ b/apps/storybook/src/Line.stories.tsx
@@ -1,5 +1,7 @@
 import { DefaultInteractions, Line, useDomain, VisCanvas } from '@h5web/lib';
-import { assertDefined, mockValues, ScaleType } from '@h5web/shared';
+import { assertDefined } from '@h5web/shared/guards';
+import { mockValues } from '@h5web/shared/mock/values';
+import { ScaleType } from '@h5web/shared/models-vis';
 import type { Meta, StoryObj } from '@storybook/react';
 import { range } from 'lodash';
 

--- a/apps/storybook/src/LineVis.stories.tsx
+++ b/apps/storybook/src/LineVis.stories.tsx
@@ -8,7 +8,7 @@ import {
   mockValues,
   ScaleType,
 } from '@h5web/lib';
-import { AXIS_SCALE_TYPES, toTypedNdArray } from '@h5web/shared';
+import { AXIS_SCALE_TYPES, toTypedNdArray } from '@h5web/shared/utils';
 import type { Meta, StoryObj } from '@storybook/react';
 import ndarray from 'ndarray';
 

--- a/apps/storybook/src/LineVisDisplay.stories.tsx
+++ b/apps/storybook/src/LineVisDisplay.stories.tsx
@@ -5,7 +5,7 @@ import {
   getMockDataArray,
   LineVis,
 } from '@h5web/lib';
-import { formatTooltipVal } from '@h5web/shared';
+import { formatTooltipVal } from '@h5web/shared/utils';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import LineVisStoriesMeta, { Default } from './LineVis.stories';

--- a/apps/storybook/src/MatrixVis.stories.tsx
+++ b/apps/storybook/src/MatrixVis.stories.tsx
@@ -1,6 +1,6 @@
 import { getMockDataArray, MatrixVis } from '@h5web/lib';
-import type { H5WebComplex } from '@h5web/shared';
-import { createComplexFormatter, toTypedNdArray } from '@h5web/shared';
+import type { H5WebComplex } from '@h5web/shared/models-hdf5';
+import { createComplexFormatter, toTypedNdArray } from '@h5web/shared/utils';
 import type { Meta, StoryObj } from '@storybook/react';
 import { format } from 'd3-format';
 

--- a/apps/storybook/src/ScatterVis.stories.tsx
+++ b/apps/storybook/src/ScatterVis.stories.tsx
@@ -1,5 +1,7 @@
 import { getDomain, INTERPOLATORS, ScatterVis } from '@h5web/lib';
-import { assertDefined, COLOR_SCALE_TYPES, ScaleType } from '@h5web/shared';
+import { assertDefined } from '@h5web/shared/guards';
+import { ScaleType } from '@h5web/shared/models-vis';
+import { COLOR_SCALE_TYPES } from '@h5web/shared/utils';
 import type { Meta, StoryObj } from '@storybook/react';
 import ndarray from 'ndarray';
 import { useState } from 'react';

--- a/apps/storybook/src/SelectToZoom.stories.tsx
+++ b/apps/storybook/src/SelectToZoom.stories.tsx
@@ -6,7 +6,8 @@ import {
   VisCanvas,
   Zoom,
 } from '@h5web/lib';
-import { mockValues, ScaleType } from '@h5web/shared';
+import { mockValues } from '@h5web/shared/mock/values';
+import { ScaleType } from '@h5web/shared/models-vis';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import FillHeight from './decorators/FillHeight';

--- a/apps/storybook/src/SurfaceVis.stories.tsx
+++ b/apps/storybook/src/SurfaceVis.stories.tsx
@@ -1,9 +1,6 @@
-import { getDomain, SurfaceVis } from '@h5web/lib';
-import {
-  assertDefined,
-  createArrayFromView,
-  getMockDataArray,
-} from '@h5web/shared';
+import { getDomain, getMockDataArray, SurfaceVis } from '@h5web/lib';
+import { assertDefined } from '@h5web/shared/guards';
+import { createArrayFromView } from '@h5web/shared/utils';
 import { OrbitControls } from '@react-three/drei';
 import type { Meta, StoryObj } from '@storybook/react';
 

--- a/apps/storybook/src/TiledHeatmapMesh/TiledHeatmapMesh.stories.tsx
+++ b/apps/storybook/src/TiledHeatmapMesh/TiledHeatmapMesh.stories.tsx
@@ -5,7 +5,8 @@ import {
   TiledTooltipMesh,
   VisCanvas,
 } from '@h5web/lib';
-import { COLOR_SCALE_TYPES, ScaleType } from '@h5web/shared';
+import { ScaleType } from '@h5web/shared/models-vis';
+import { COLOR_SCALE_TYPES } from '@h5web/shared/utils';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import FillHeight from '../decorators/FillHeight';

--- a/apps/storybook/src/TiledHeatmapMesh/mandlebrot-api.ts
+++ b/apps/storybook/src/TiledHeatmapMesh/mandlebrot-api.ts
@@ -1,6 +1,6 @@
 import type { Size } from '@h5web/lib';
 import { getLayerSizes, TilesApi } from '@h5web/lib';
-import type { Domain } from '@h5web/shared';
+import type { Domain } from '@h5web/shared/models-vis';
 import greenlet from 'greenlet';
 import { clamp } from 'lodash';
 import type { NdArray } from 'ndarray';

--- a/apps/storybook/src/TiledHeatmapMesh/utils.tsx
+++ b/apps/storybook/src/TiledHeatmapMesh/utils.tsx
@@ -1,4 +1,4 @@
-import { formatTooltipVal } from '@h5web/shared';
+import { formatTooltipVal } from '@h5web/shared/utils';
 
 import type { TileParams } from './models';
 

--- a/apps/storybook/src/Toolbar.stories.tsx
+++ b/apps/storybook/src/Toolbar.stories.tsx
@@ -11,8 +11,8 @@ import {
   ToggleGroup,
   Toolbar,
 } from '@h5web/lib';
-import type { AxisScaleType } from '@h5web/shared';
-import { AXIS_SCALE_TYPES } from '@h5web/shared';
+import type { AxisScaleType } from '@h5web/shared/models-vis';
+import { AXIS_SCALE_TYPES } from '@h5web/shared/utils';
 import { useToggle } from '@react-hookz/web';
 import type { Meta, StoryFn, StoryObj } from '@storybook/react';
 import { useState } from 'react';

--- a/apps/storybook/src/TooltipMesh.stories.tsx
+++ b/apps/storybook/src/TooltipMesh.stories.tsx
@@ -1,5 +1,5 @@
 import { DefaultInteractions, TooltipMesh, VisCanvas } from '@h5web/lib';
-import { formatTooltipVal } from '@h5web/shared';
+import { formatTooltipVal } from '@h5web/shared/utils';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import FillHeight from './decorators/FillHeight';

--- a/apps/storybook/src/hooks.ts
+++ b/apps/storybook/src/hooks.ts
@@ -1,5 +1,6 @@
 import { useDomain } from '@h5web/lib';
-import type { ArrayShape, Domain } from '@h5web/shared';
+import type { ArrayShape } from '@h5web/shared/models-hdf5';
+import type { Domain } from '@h5web/shared/models-vis';
 import type { NdArray } from 'ndarray';
 import ndarray from 'ndarray';
 import { useMemo } from 'react';

--- a/packages/app/rollup.config.js
+++ b/packages/app/rollup.config.js
@@ -2,6 +2,7 @@ import alias from '@rollup/plugin-alias';
 import { defineConfig } from 'rollup';
 import dts from 'rollup-plugin-dts';
 
+import { aliasEntries } from '../shared/rollup.utils.js';
 import { externals } from './vite.config.js';
 
 export default defineConfig({
@@ -9,15 +10,7 @@ export default defineConfig({
   output: [{ file: 'dist/index.d.ts', format: 'es' }],
   external: [...externals, /\.css$/u],
   plugins: [
-    alias({
-      entries: [
-        {
-          // Make sure rollup-plugin-dts can find shared types
-          find: '@h5web/shared',
-          replacement: '../shared/dist-ts/index.d.ts',
-        },
-      ],
-    }),
+    alias({ entries: aliasEntries }), // make sure rollup-plugin-dts can find type declatations in @h5web/shared
     dts(),
   ],
 });

--- a/packages/app/src/VisConfigProvider.tsx
+++ b/packages/app/src/VisConfigProvider.tsx
@@ -1,4 +1,4 @@
-import { isDefined } from '@h5web/shared';
+import { isDefined } from '@h5web/shared/guards';
 import type { ReactNode } from 'react';
 
 import { CORE_VIS } from './vis-packs/core/visualizations';

--- a/packages/app/src/__tests__/Explorer.test.tsx
+++ b/packages/app/src/__tests__/Explorer.test.tsx
@@ -1,4 +1,4 @@
-import { mockFilepath } from '@h5web/shared';
+import { mockFilepath } from '@h5web/shared/mock/metadata';
 import { screen } from '@testing-library/react';
 
 import { SLOW_TIMEOUT } from '../providers/mock/mock-api';

--- a/packages/app/src/breadcrumbs/Breadcrumbs.tsx
+++ b/packages/app/src/breadcrumbs/Breadcrumbs.tsx
@@ -1,4 +1,4 @@
-import { assertAbsolutePath } from '@h5web/shared';
+import { assertAbsolutePath } from '@h5web/shared/guards';
 
 import { useDataContext } from '../providers/DataProvider';
 import styles from './BreadcrumbsBar.module.css';

--- a/packages/app/src/dimension-mapper/AxisMapper.tsx
+++ b/packages/app/src/dimension-mapper/AxisMapper.tsx
@@ -1,5 +1,6 @@
 import { ToggleGroup } from '@h5web/lib';
-import type { Axis, AxisMapping } from '@h5web/shared';
+import type { AxisMapping } from '@h5web/shared/models-nexus';
+import type { Axis } from '@h5web/shared/models-vis';
 import { isNumber } from 'lodash';
 
 import styles from './DimensionMapper.module.css';

--- a/packages/app/src/dimension-mapper/DimensionMapper.tsx
+++ b/packages/app/src/dimension-mapper/DimensionMapper.tsx
@@ -1,4 +1,4 @@
-import type { AxisMapping } from '@h5web/shared';
+import type { AxisMapping } from '@h5web/shared/models-nexus';
 import { isNumber } from 'lodash';
 
 import AxisMapper from './AxisMapper';

--- a/packages/app/src/dimension-mapper/models.ts
+++ b/packages/app/src/dimension-mapper/models.ts
@@ -1,3 +1,3 @@
-import type { Axis } from '@h5web/shared';
+import type { Axis } from '@h5web/shared/models-vis';
 
 export type DimensionMapping = (number | Axis)[];

--- a/packages/app/src/dimension-mapper/utils.ts
+++ b/packages/app/src/dimension-mapper/utils.ts
@@ -1,4 +1,4 @@
-import type { Axis } from '@h5web/shared';
+import type { Axis } from '@h5web/shared/models-vis';
 import { isNumber } from 'lodash';
 
 export function isAxis(elem: number | Axis): elem is Axis {

--- a/packages/app/src/explorer/EntityItem.tsx
+++ b/packages/app/src/explorer/EntityItem.tsx
@@ -1,5 +1,5 @@
-import type { ChildEntity } from '@h5web/shared';
-import { isGroup } from '@h5web/shared';
+import { isGroup } from '@h5web/shared/guards';
+import type { ChildEntity } from '@h5web/shared/models-hdf5';
 import { useToggle } from '@react-hookz/web';
 import type { CSSProperties, KeyboardEvent } from 'react';
 import { Suspense, useCallback, useEffect, useRef } from 'react';

--- a/packages/app/src/explorer/EntityList.tsx
+++ b/packages/app/src/explorer/EntityList.tsx
@@ -1,4 +1,5 @@
-import { assertGroup, buildEntityPath } from '@h5web/shared';
+import { assertGroup } from '@h5web/shared/guards';
+import { buildEntityPath } from '@h5web/shared/utils';
 
 import { useDataContext } from '../providers/DataProvider';
 import EntityItem from './EntityItem';

--- a/packages/app/src/explorer/Icon.tsx
+++ b/packages/app/src/explorer/Icon.tsx
@@ -1,5 +1,6 @@
-import type { ChildEntity } from '@h5web/shared';
-import { EntityKind, isGroup } from '@h5web/shared';
+import { isGroup } from '@h5web/shared/guards';
+import type { ChildEntity } from '@h5web/shared/models-hdf5';
+import { EntityKind } from '@h5web/shared/models-hdf5';
 import {
   FiChevronDown,
   FiChevronRight,

--- a/packages/app/src/explorer/NxBadge.tsx
+++ b/packages/app/src/explorer/NxBadge.tsx
@@ -1,4 +1,4 @@
-import type { ChildEntity } from '@h5web/shared';
+import type { ChildEntity } from '@h5web/shared/models-hdf5';
 
 import { useDataContext } from '../providers/DataProvider';
 import styles from './Explorer.module.css';

--- a/packages/app/src/explorer/utils.ts
+++ b/packages/app/src/explorer/utils.ts
@@ -1,5 +1,5 @@
-import type { ChildEntity } from '@h5web/shared';
-import { assertStr, isGroup } from '@h5web/shared';
+import { assertStr, isGroup } from '@h5web/shared/guards';
+import type { ChildEntity } from '@h5web/shared/models-hdf5';
 import type { KeyboardEvent } from 'react';
 
 import type { AttrValuesStore } from '../providers/models';

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -16,11 +16,11 @@ export { useDataContext } from './providers/DataProvider';
 export type { DataContextValue } from './providers/DataProvider';
 
 // Undocumented
-export { assertEnvVar } from '@h5web/shared';
+export { assertEnvVar } from '@h5web/shared/guards';
 
 // Undocumented (for @h5web/h5wasm)
 export { default as DataProvider } from './providers/DataProvider';
 export { DataProviderApi } from './providers/api';
 export type { ValuesStoreParams } from './providers/models';
 export { flattenValue, getNameFromPath, sliceValue } from './providers/utils';
-export { assertNonNull } from '@h5web/shared';
+export { assertNonNull } from '@h5web/shared/guards';

--- a/packages/app/src/metadata-viewer/AttributesInfo.tsx
+++ b/packages/app/src/metadata-viewer/AttributesInfo.tsx
@@ -1,5 +1,5 @@
-import type { ProvidedEntity } from '@h5web/shared';
-import { isComplexValue } from '@h5web/shared';
+import { isComplexValue } from '@h5web/shared/guards';
+import type { ProvidedEntity } from '@h5web/shared/models-hdf5';
 
 import { useDataContext } from '../providers/DataProvider';
 import AttributeLink from './AttributeLink';

--- a/packages/app/src/metadata-viewer/EntityInfo.tsx
+++ b/packages/app/src/metadata-viewer/EntityInfo.tsx
@@ -1,5 +1,5 @@
-import type { ProvidedEntity } from '@h5web/shared';
-import { isDataset, isDatatype } from '@h5web/shared';
+import { isDataset, isDatatype } from '@h5web/shared/guards';
+import type { ProvidedEntity } from '@h5web/shared/models-hdf5';
 
 import { useDataContext } from '../providers/DataProvider';
 import styles from './MetadataViewer.module.css';

--- a/packages/app/src/metadata-viewer/FiltersInfo.tsx
+++ b/packages/app/src/metadata-viewer/FiltersInfo.tsx
@@ -1,4 +1,4 @@
-import type { Filter } from '@h5web/shared';
+import type { Filter } from '@h5web/shared/models-hdf5';
 
 interface Props {
   filters: Filter[];

--- a/packages/app/src/metadata-viewer/MetadataViewer.tsx
+++ b/packages/app/src/metadata-viewer/MetadataViewer.tsx
@@ -1,9 +1,6 @@
-import {
-  buildEntityPath,
-  EntityKind,
-  isAbsolutePath,
-  isDataset,
-} from '@h5web/shared';
+import { isAbsolutePath, isDataset } from '@h5web/shared/guards';
+import { EntityKind } from '@h5web/shared/models-hdf5';
+import { buildEntityPath } from '@h5web/shared/utils';
 import { capitalize } from 'lodash';
 import { memo, Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';

--- a/packages/app/src/metadata-viewer/RawInspector.tsx
+++ b/packages/app/src/metadata-viewer/RawInspector.tsx
@@ -1,4 +1,4 @@
-import type { ProvidedEntity } from '@h5web/shared';
+import type { ProvidedEntity } from '@h5web/shared/models-hdf5';
 
 import styles from './RawInspector.module.css';
 

--- a/packages/app/src/metadata-viewer/utils.ts
+++ b/packages/app/src/metadata-viewer/utils.ts
@@ -1,11 +1,16 @@
-import type { ComplexArray, DType, H5WebComplex, Shape } from '@h5web/shared';
 import {
-  DTypeClass,
-  formatScalarComplex,
   isH5WebComplex,
   isNumericType,
   isScalarShape,
-} from '@h5web/shared';
+} from '@h5web/shared/guards';
+import type {
+  ComplexArray,
+  DType,
+  H5WebComplex,
+  Shape,
+} from '@h5web/shared/models-hdf5';
+import { DTypeClass } from '@h5web/shared/models-hdf5';
+import { formatScalarComplex } from '@h5web/shared/utils';
 
 export function renderShape(shape: Shape): string {
   if (shape === null) {

--- a/packages/app/src/providers/DataProvider.tsx
+++ b/packages/app/src/providers/DataProvider.tsx
@@ -1,5 +1,5 @@
-import type { ChildEntity, Entity, Group } from '@h5web/shared';
-import { isGroup } from '@h5web/shared';
+import { isGroup } from '@h5web/shared/guards';
+import type { ChildEntity, Entity, Group } from '@h5web/shared/models-hdf5';
 import type { PropsWithChildren } from 'react';
 import { createContext, useContext, useMemo } from 'react';
 import { createFetchStore } from 'react-suspense-fetch';

--- a/packages/app/src/providers/api.ts
+++ b/packages/app/src/providers/api.ts
@@ -6,7 +6,7 @@ import type {
   Entity,
   ProvidedEntity,
   Value,
-} from '@h5web/shared';
+} from '@h5web/shared/models-hdf5';
 import type {
   AxiosInstance,
   AxiosProgressEvent,

--- a/packages/app/src/providers/h5grove/h5grove-api.ts
+++ b/packages/app/src/providers/h5grove/h5grove-api.ts
@@ -1,3 +1,4 @@
+import { hasNumericType, hasScalarShape } from '@h5web/shared/guards';
 import type {
   ArrayShape,
   Attribute,
@@ -8,13 +9,9 @@ import type {
   Group,
   ProvidedEntity,
   Value,
-} from '@h5web/shared';
-import {
-  buildEntityPath,
-  EntityKind,
-  hasNumericType,
-  hasScalarShape,
-} from '@h5web/shared';
+} from '@h5web/shared/models-hdf5';
+import { EntityKind } from '@h5web/shared/models-hdf5';
+import { buildEntityPath } from '@h5web/shared/utils';
 import type { AxiosRequestConfig } from 'axios';
 
 import { DataProviderApi } from '../api';

--- a/packages/app/src/providers/h5grove/models.ts
+++ b/packages/app/src/providers/h5grove/models.ts
@@ -1,4 +1,8 @@
-import type { AttributeValues, EntityKind, Filter } from '@h5web/shared';
+import type {
+  AttributeValues,
+  EntityKind,
+  Filter,
+} from '@h5web/shared/models-hdf5';
 
 export interface H5GroveEntityResponse {
   name: string;

--- a/packages/app/src/providers/h5grove/utils.test.ts
+++ b/packages/app/src/providers/h5grove/utils.test.ts
@@ -1,4 +1,4 @@
-import { DTypeClass, Endianness } from '@h5web/shared';
+import { DTypeClass, Endianness } from '@h5web/shared/models-hdf5';
 
 import { convertH5GroveDtype } from './utils';
 

--- a/packages/app/src/providers/h5grove/utils.ts
+++ b/packages/app/src/providers/h5grove/utils.ts
@@ -1,5 +1,5 @@
-import type { DType } from '@h5web/shared';
-import { DTypeClass, Endianness, EntityKind } from '@h5web/shared';
+import type { DType } from '@h5web/shared/models-hdf5';
+import { DTypeClass, Endianness, EntityKind } from '@h5web/shared/models-hdf5';
 
 import type {
   H5GroveDatasetResponse,

--- a/packages/app/src/providers/hsds/hsds-api.ts
+++ b/packages/app/src/providers/hsds/hsds-api.ts
@@ -1,3 +1,8 @@
+import {
+  assertDefined,
+  assertGroup,
+  hasArrayShape,
+} from '@h5web/shared/guards';
 import type {
   ArrayShape,
   AttributeValues,
@@ -9,15 +14,9 @@ import type {
   GroupWithChildren,
   ProvidedEntity,
   Value,
-} from '@h5web/shared';
-import {
-  assertDefined,
-  assertGroup,
-  buildEntityPath,
-  EntityKind,
-  getChildEntity,
-  hasArrayShape,
-} from '@h5web/shared';
+} from '@h5web/shared/models-hdf5';
+import { EntityKind } from '@h5web/shared/models-hdf5';
+import { buildEntityPath, getChildEntity } from '@h5web/shared/utils';
 
 import { DataProviderApi } from '../api';
 import type { ExportFormat, ExportURL, ValuesStoreParams } from '../models';

--- a/packages/app/src/providers/hsds/models.ts
+++ b/packages/app/src/providers/hsds/models.ts
@@ -1,4 +1,4 @@
-import type { Entity } from '@h5web/shared';
+import type { Entity } from '@h5web/shared/models-hdf5';
 
 /* --------------------- */
 /* ----- RESPONSES ----- */

--- a/packages/app/src/providers/hsds/utils.test.ts
+++ b/packages/app/src/providers/hsds/utils.test.ts
@@ -1,5 +1,5 @@
-import type { DType } from '@h5web/shared';
-import { DTypeClass, Endianness } from '@h5web/shared';
+import type { DType } from '@h5web/shared/models-hdf5';
+import { DTypeClass, Endianness } from '@h5web/shared/models-hdf5';
 
 import type {
   HsdsArrayType,

--- a/packages/app/src/providers/hsds/utils.ts
+++ b/packages/app/src/providers/hsds/utils.ts
@@ -1,3 +1,4 @@
+import { isGroup } from '@h5web/shared/guards';
 import type {
   ArrayShape,
   Attribute,
@@ -10,8 +11,8 @@ import type {
   NumericType,
   ScalarShape,
   Shape,
-} from '@h5web/shared';
-import { DTypeClass, Endianness, isGroup } from '@h5web/shared';
+} from '@h5web/shared/models-hdf5';
+import { DTypeClass, Endianness } from '@h5web/shared/models-hdf5';
 
 import type {
   HsdsAttribute,

--- a/packages/app/src/providers/mock/mock-api.ts
+++ b/packages/app/src/providers/mock/mock-api.ts
@@ -1,3 +1,19 @@
+import { findMockEntity } from '@h5web/lib';
+import {
+  assertArrayOrTypedArray,
+  assertArrayShape,
+  assertDefined,
+  hasArrayShape,
+  hasNumericType,
+  isGroup,
+  isTypedArray,
+} from '@h5web/shared/guards';
+import { mockFilepath } from '@h5web/shared/mock/metadata';
+import type { MockDataset } from '@h5web/shared/mock/models';
+import {
+  assertMockAttribute,
+  assertMockDataset,
+} from '@h5web/shared/mock/utils';
 import type {
   ArrayShape,
   AttributeValues,
@@ -7,21 +23,7 @@ import type {
   ProvidedEntity,
   ScalarShape,
   Value,
-} from '@h5web/shared';
-import {
-  assertArrayOrTypedArray,
-  assertArrayShape,
-  assertDefined,
-  assertMockAttribute,
-  assertMockDataset,
-  findMockEntity,
-  hasArrayShape,
-  hasNumericType,
-  isGroup,
-  isTypedArray,
-  mockFilepath,
-} from '@h5web/shared';
-import type { MockDataset } from '@h5web/shared/src/mock/models';
+} from '@h5web/shared/models-hdf5';
 import axios from 'axios';
 
 import { DataProviderApi } from '../api';

--- a/packages/app/src/providers/models.ts
+++ b/packages/app/src/providers/models.ts
@@ -5,7 +5,7 @@ import type {
   Entity,
   ProvidedEntity,
   ScalarShape,
-} from '@h5web/shared';
+} from '@h5web/shared/models-hdf5';
 import type { FetchStore } from 'react-suspense-fetch';
 
 import type { ImageAttribute } from '../vis-packs/core/models';

--- a/packages/app/src/providers/utils.ts
+++ b/packages/app/src/providers/utils.ts
@@ -1,11 +1,12 @@
+import { assertArray, isNumericType } from '@h5web/shared/guards';
 import type {
   ArrayShape,
   Dataset,
   DType,
   Primitive,
   ScalarShape,
-} from '@h5web/shared';
-import { assertArray, DTypeClass, isNumericType } from '@h5web/shared';
+} from '@h5web/shared/models-hdf5';
+import { DTypeClass } from '@h5web/shared/models-hdf5';
 import { AxiosError } from 'axios';
 import ndarray from 'ndarray';
 

--- a/packages/app/src/test-utils.tsx
+++ b/packages/app/src/test-utils.tsx
@@ -1,4 +1,4 @@
-import { assertDefined, assertNonNull } from '@h5web/shared';
+import { assertDefined, assertNonNull } from '@h5web/shared/guards';
 import type { RenderResult } from '@testing-library/react';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/packages/app/src/utils.ts
+++ b/packages/app/src/utils.ts
@@ -1,4 +1,4 @@
-import type { Entity } from '@h5web/shared';
+import type { Entity } from '@h5web/shared/models-hdf5';
 
 import type { AttrName } from './providers/models';
 

--- a/packages/app/src/vis-packs/core/ValueFetcher.tsx
+++ b/packages/app/src/vis-packs/core/ValueFetcher.tsx
@@ -1,4 +1,9 @@
-import type { ArrayShape, Dataset, ScalarShape, Value } from '@h5web/shared';
+import type {
+  ArrayShape,
+  Dataset,
+  ScalarShape,
+  Value,
+} from '@h5web/shared/models-hdf5';
 import type { ReactNode } from 'react';
 
 import { useDatasetValue } from './hooks';

--- a/packages/app/src/vis-packs/core/complex/ComplexLineToolbar.tsx
+++ b/packages/app/src/vis-packs/core/complex/ComplexLineToolbar.tsx
@@ -7,7 +7,7 @@ import {
   ToggleGroup,
   Toolbar,
 } from '@h5web/lib';
-import { AXIS_SCALE_TYPES } from '@h5web/shared';
+import { AXIS_SCALE_TYPES } from '@h5web/shared/utils';
 import { MdDomain, MdGridOn } from 'react-icons/md';
 
 import type { LineConfig } from '../line/config';

--- a/packages/app/src/vis-packs/core/complex/ComplexLineVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/complex/ComplexLineVisContainer.tsx
@@ -2,7 +2,7 @@ import {
   assertArrayShape,
   assertComplexType,
   assertDataset,
-} from '@h5web/shared';
+} from '@h5web/shared/guards';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useDimMappingState } from '../../../dimension-mapper/hooks';

--- a/packages/app/src/vis-packs/core/complex/ComplexToolbar.tsx
+++ b/packages/app/src/vis-packs/core/complex/ComplexToolbar.tsx
@@ -9,7 +9,7 @@ import {
   ToggleBtn,
   Toolbar,
 } from '@h5web/lib';
-import { COLOR_SCALE_TYPES } from '@h5web/shared';
+import { COLOR_SCALE_TYPES } from '@h5web/shared/utils';
 import { MdAspectRatio, MdGridOn } from 'react-icons/md';
 
 import type { HeatmapConfig } from '../heatmap/config';

--- a/packages/app/src/vis-packs/core/complex/ComplexVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/complex/ComplexVisContainer.tsx
@@ -3,7 +3,7 @@ import {
   assertComplexType,
   assertDataset,
   assertMinDims,
-} from '@h5web/shared';
+} from '@h5web/shared/guards';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useDimMappingState } from '../../../dimension-mapper/hooks';

--- a/packages/app/src/vis-packs/core/complex/MappedComplexLineVis.tsx
+++ b/packages/app/src/vis-packs/core/complex/MappedComplexLineVis.tsx
@@ -1,4 +1,6 @@
-import type { AxisMapping, H5WebComplex, NumArray } from '@h5web/shared';
+import type { H5WebComplex } from '@h5web/shared/models-hdf5';
+import type { AxisMapping } from '@h5web/shared/models-nexus';
+import type { NumArray } from '@h5web/shared/models-vis';
 import { useMemo } from 'react';
 import { createPortal } from 'react-dom';
 

--- a/packages/app/src/vis-packs/core/complex/MappedComplexVis.tsx
+++ b/packages/app/src/vis-packs/core/complex/MappedComplexVis.tsx
@@ -4,7 +4,9 @@ import {
   useValidDomainForScale,
   useVisDomain,
 } from '@h5web/lib';
-import type { AxisMapping, H5WebComplex, NumArray } from '@h5web/shared';
+import type { H5WebComplex } from '@h5web/shared/models-hdf5';
+import type { AxisMapping } from '@h5web/shared/models-nexus';
+import type { NumArray } from '@h5web/shared/models-vis';
 import { useMemo } from 'react';
 import { createPortal } from 'react-dom';
 

--- a/packages/app/src/vis-packs/core/complex/utils.ts
+++ b/packages/app/src/vis-packs/core/complex/utils.ts
@@ -1,5 +1,6 @@
-import type { Bounds, H5WebComplex } from '@h5web/shared';
-import { getNewBounds } from '@h5web/shared';
+import type { H5WebComplex } from '@h5web/shared/models-hdf5';
+import type { Bounds } from '@h5web/shared/models-vis';
+import { getNewBounds } from '@h5web/shared/utils';
 
 const INITIAL_BOUNDS: Bounds = {
   min: Infinity,

--- a/packages/app/src/vis-packs/core/compound/CompoundMatrixVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/compound/CompoundMatrixVisContainer.tsx
@@ -3,7 +3,7 @@ import {
   assertCompoundType,
   assertDataset,
   assertPrintableCompoundType,
-} from '@h5web/shared';
+} from '@h5web/shared/guards';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useDimMappingState } from '../../../dimension-mapper/hooks';

--- a/packages/app/src/vis-packs/core/compound/MappedCompoundMatrixVis.tsx
+++ b/packages/app/src/vis-packs/core/compound/MappedCompoundMatrixVis.tsx
@@ -5,7 +5,7 @@ import type {
   Primitive,
   PrintableCompoundType,
   PrintableType,
-} from '@h5web/shared';
+} from '@h5web/shared/models-hdf5';
 import { createPortal } from 'react-dom';
 
 import type { DimensionMapping } from '../../../dimension-mapper/models';

--- a/packages/app/src/vis-packs/core/heatmap/HeatmapToolbar.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/HeatmapToolbar.tsx
@@ -11,7 +11,7 @@ import {
   ToggleBtn,
   Toolbar,
 } from '@h5web/lib';
-import { COLOR_SCALE_TYPES } from '@h5web/shared';
+import { COLOR_SCALE_TYPES } from '@h5web/shared/utils';
 import { MdAspectRatio } from 'react-icons/md';
 
 import type { ExportFormat, ExportURL } from '../../../providers/models';

--- a/packages/app/src/vis-packs/core/heatmap/HeatmapVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/HeatmapVisContainer.tsx
@@ -3,7 +3,7 @@ import {
   assertDataset,
   assertMinDims,
   assertNumericLikeType,
-} from '@h5web/shared';
+} from '@h5web/shared/guards';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useDimMappingState } from '../../../dimension-mapper/hooks';

--- a/packages/app/src/vis-packs/core/heatmap/MappedHeatmapVis.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/MappedHeatmapVis.tsx
@@ -2,11 +2,11 @@ import { HeatmapVis, useDomain, useSafeDomain, useVisDomain } from '@h5web/lib';
 import type {
   ArrayShape,
   ArrayValue,
-  AxisMapping,
   Dataset,
-  NumArray,
   NumericLikeType,
-} from '@h5web/shared';
+} from '@h5web/shared/models-hdf5';
+import type { AxisMapping } from '@h5web/shared/models-nexus';
+import type { NumArray } from '@h5web/shared/models-vis';
 import { createPortal } from 'react-dom';
 
 import type { DimensionMapping } from '../../../dimension-mapper/models';

--- a/packages/app/src/vis-packs/core/heatmap/config.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/config.tsx
@@ -1,6 +1,7 @@
 import type { CustomDomain } from '@h5web/lib';
-import type { ColorScaleType } from '@h5web/shared';
-import { isDefined, ScaleType } from '@h5web/shared';
+import { isDefined } from '@h5web/shared/guards';
+import type { ColorScaleType } from '@h5web/shared/models-vis';
+import { ScaleType } from '@h5web/shared/models-vis';
 import { useMap } from '@react-hookz/web';
 import { createContext, useContext, useState } from 'react';
 import type { StoreApi } from 'zustand';

--- a/packages/app/src/vis-packs/core/hooks.ts
+++ b/packages/app/src/vis-packs/core/hooks.ts
@@ -1,11 +1,12 @@
+import { createMemo } from '@h5web/shared/createMemo';
+import { assertDatasetValue, isDefined } from '@h5web/shared/guards';
 import type {
   ArrayShape,
   Dataset,
-  NumArray,
   ScalarShape,
   Value,
-} from '@h5web/shared';
-import { assertDatasetValue, createMemo, isDefined } from '@h5web/shared';
+} from '@h5web/shared/models-hdf5';
+import type { NumArray } from '@h5web/shared/models-vis';
 import { castArray } from 'lodash';
 import type { NdArray, TypedArray } from 'ndarray';
 import { useMemo } from 'react';

--- a/packages/app/src/vis-packs/core/line/LineToolbar.tsx
+++ b/packages/app/src/vis-packs/core/line/LineToolbar.tsx
@@ -7,7 +7,7 @@ import {
   ToggleGroup,
   Toolbar,
 } from '@h5web/lib';
-import { AXIS_SCALE_TYPES } from '@h5web/shared';
+import { AXIS_SCALE_TYPES } from '@h5web/shared/utils';
 import { FiItalic } from 'react-icons/fi';
 import { MdDomain, MdGridOn } from 'react-icons/md';
 

--- a/packages/app/src/vis-packs/core/line/LineVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/line/LineVisContainer.tsx
@@ -2,7 +2,7 @@ import {
   assertArrayShape,
   assertDataset,
   assertNumericLikeType,
-} from '@h5web/shared';
+} from '@h5web/shared/guards';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useDimMappingState } from '../../../dimension-mapper/hooks';

--- a/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
+++ b/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
@@ -2,11 +2,11 @@ import { LineVis, useCombinedDomain, useDomain, useDomains } from '@h5web/lib';
 import type {
   ArrayShape,
   ArrayValue,
-  AxisMapping,
   Dataset,
-  NumArray,
   NumericLikeType,
-} from '@h5web/shared';
+} from '@h5web/shared/models-hdf5';
+import type { AxisMapping } from '@h5web/shared/models-nexus';
+import type { NumArray } from '@h5web/shared/models-vis';
 import { createPortal } from 'react-dom';
 
 import type { DimensionMapping } from '../../../dimension-mapper/models';

--- a/packages/app/src/vis-packs/core/line/config.tsx
+++ b/packages/app/src/vis-packs/core/line/config.tsx
@@ -1,6 +1,7 @@
 import { CurveType } from '@h5web/lib';
-import type { AxisScaleType } from '@h5web/shared';
-import { isDefined, ScaleType } from '@h5web/shared';
+import { isDefined } from '@h5web/shared/guards';
+import type { AxisScaleType } from '@h5web/shared/models-vis';
+import { ScaleType } from '@h5web/shared/models-vis';
 import { useMap } from '@react-hookz/web';
 import { omit } from 'lodash';
 import { createContext, useContext, useState } from 'react';

--- a/packages/app/src/vis-packs/core/matrix/MappedMatrixVis.tsx
+++ b/packages/app/src/vis-packs/core/matrix/MappedMatrixVis.tsx
@@ -4,7 +4,7 @@ import type {
   ArrayValue,
   Dataset,
   PrintableType,
-} from '@h5web/shared';
+} from '@h5web/shared/models-hdf5';
 import { createPortal } from 'react-dom';
 
 import type { DimensionMapping } from '../../../dimension-mapper/models';

--- a/packages/app/src/vis-packs/core/matrix/MatrixVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/matrix/MatrixVisContainer.tsx
@@ -2,7 +2,7 @@ import {
   assertArrayShape,
   assertDataset,
   assertPrintableType,
-} from '@h5web/shared';
+} from '@h5web/shared/guards';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useDimMappingState } from '../../../dimension-mapper/hooks';

--- a/packages/app/src/vis-packs/core/matrix/utils.ts
+++ b/packages/app/src/vis-packs/core/matrix/utils.ts
@@ -1,16 +1,13 @@
 import { Notation } from '@h5web/lib';
+import { isComplexType, isNumericType } from '@h5web/shared/guards';
 import type {
   ComplexType,
   NumericType,
   PrintableCompoundType,
   PrintableType,
-} from '@h5web/shared';
-import {
-  createComplexFormatter,
-  DTypeClass,
-  isComplexType,
-  isNumericType,
-} from '@h5web/shared';
+} from '@h5web/shared/models-hdf5';
+import { DTypeClass } from '@h5web/shared/models-hdf5';
+import { createComplexFormatter } from '@h5web/shared/utils';
 import { format } from 'd3-format';
 
 import type { ValueFormatter } from '../models';

--- a/packages/app/src/vis-packs/core/models.ts
+++ b/packages/app/src/vis-packs/core/models.ts
@@ -1,4 +1,4 @@
-import type { DType, Primitive } from '@h5web/shared';
+import type { DType, Primitive } from '@h5web/shared/models-hdf5';
 
 export type ImageAttribute = 'CLASS' | 'IMAGE_SUBCLASS';
 

--- a/packages/app/src/vis-packs/core/raw/RawVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/raw/RawVisContainer.tsx
@@ -1,5 +1,5 @@
 import { RawVis } from '@h5web/lib';
-import { assertDataset, assertNonNullShape } from '@h5web/shared';
+import { assertDataset, assertNonNullShape } from '@h5web/shared/guards';
 import { createPortal } from 'react-dom';
 
 import { useDataContext } from '../../../providers/DataProvider';

--- a/packages/app/src/vis-packs/core/rgb/MappedRgbVis.tsx
+++ b/packages/app/src/vis-packs/core/rgb/MappedRgbVis.tsx
@@ -1,5 +1,7 @@
 import { RgbVis } from '@h5web/lib';
-import type { AxisMapping, NumArray, NumArrayDataset } from '@h5web/shared';
+import type { NumArrayDataset } from '@h5web/shared/models-hdf5';
+import type { AxisMapping } from '@h5web/shared/models-nexus';
+import type { NumArray } from '@h5web/shared/models-vis';
 import type { TypedArray } from 'ndarray';
 import { createPortal } from 'react-dom';
 

--- a/packages/app/src/vis-packs/core/rgb/RgbVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/rgb/RgbVisContainer.tsx
@@ -3,7 +3,7 @@ import {
   assertDataset,
   assertMinDims,
   assertNumericType,
-} from '@h5web/shared';
+} from '@h5web/shared/guards';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useDimMappingState } from '../../../dimension-mapper/hooks';

--- a/packages/app/src/vis-packs/core/scalar/ScalarVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/scalar/ScalarVisContainer.tsx
@@ -3,7 +3,7 @@ import {
   assertDataset,
   assertPrintableType,
   assertScalarShape,
-} from '@h5web/shared';
+} from '@h5web/shared/guards';
 
 import type { VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';

--- a/packages/app/src/vis-packs/core/scalar/utils.ts
+++ b/packages/app/src/vis-packs/core/scalar/utils.ts
@@ -1,10 +1,11 @@
+import { hasComplexType } from '@h5web/shared/guards';
 import type {
   ArrayShape,
   Dataset,
   H5WebComplex,
   PrintableType,
-} from '@h5web/shared';
-import { formatScalarComplex, hasComplexType } from '@h5web/shared';
+} from '@h5web/shared/models-hdf5';
+import { formatScalarComplex } from '@h5web/shared/utils';
 
 import type { ValueFormatter } from '../models';
 

--- a/packages/app/src/vis-packs/core/scatter/MappedScatterVis.tsx
+++ b/packages/app/src/vis-packs/core/scatter/MappedScatterVis.tsx
@@ -1,6 +1,7 @@
 import { ScatterVis, useDomain, useSafeDomain, useVisDomain } from '@h5web/lib';
-import type { AxisMapping, NumArray } from '@h5web/shared';
-import { assertDefined } from '@h5web/shared';
+import { assertDefined } from '@h5web/shared/guards';
+import type { AxisMapping } from '@h5web/shared/models-nexus';
+import type { NumArray } from '@h5web/shared/models-vis';
 import { createPortal } from 'react-dom';
 
 import { useBaseArray } from '../hooks';

--- a/packages/app/src/vis-packs/core/scatter/ScatterToolbar.tsx
+++ b/packages/app/src/vis-packs/core/scatter/ScatterToolbar.tsx
@@ -7,7 +7,7 @@ import {
   Separator,
   Toolbar,
 } from '@h5web/lib';
-import { AXIS_SCALE_TYPES, COLOR_SCALE_TYPES } from '@h5web/shared';
+import { AXIS_SCALE_TYPES, COLOR_SCALE_TYPES } from '@h5web/shared/utils';
 
 import { BASE_INTERACTIONS } from '../utils';
 import type { ScatterConfig } from './config';

--- a/packages/app/src/vis-packs/core/scatter/config.tsx
+++ b/packages/app/src/vis-packs/core/scatter/config.tsx
@@ -1,6 +1,7 @@
 import type { CustomDomain } from '@h5web/lib';
-import type { AxisScaleType, ColorScaleType } from '@h5web/shared';
-import { isDefined, ScaleType } from '@h5web/shared';
+import { isDefined } from '@h5web/shared/guards';
+import type { AxisScaleType, ColorScaleType } from '@h5web/shared/models-vis';
+import { ScaleType } from '@h5web/shared/models-vis';
 import { useMap } from '@react-hookz/web';
 import { createContext, useContext, useState } from 'react';
 import type { StoreApi } from 'zustand';

--- a/packages/app/src/vis-packs/core/surface/MappedSurfaceVis.tsx
+++ b/packages/app/src/vis-packs/core/surface/MappedSurfaceVis.tsx
@@ -1,5 +1,5 @@
 import { SurfaceVis, useDomain, useSafeDomain, useVisDomain } from '@h5web/lib';
-import type { NumArrayDataset } from '@h5web/shared';
+import type { NumArrayDataset } from '@h5web/shared/models-hdf5';
 import type { TypedArray } from 'ndarray';
 import { createPortal } from 'react-dom';
 

--- a/packages/app/src/vis-packs/core/surface/SurfaceToolbar.tsx
+++ b/packages/app/src/vis-packs/core/surface/SurfaceToolbar.tsx
@@ -7,7 +7,7 @@ import {
   SnapshotBtn,
   Toolbar,
 } from '@h5web/lib';
-import { COLOR_SCALE_TYPES } from '@h5web/shared';
+import { COLOR_SCALE_TYPES } from '@h5web/shared/utils';
 
 import type { SurfaceConfig } from './config';
 

--- a/packages/app/src/vis-packs/core/surface/SurfaceVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/surface/SurfaceVisContainer.tsx
@@ -3,7 +3,7 @@ import {
   assertDataset,
   assertMinDims,
   assertNumericType,
-} from '@h5web/shared';
+} from '@h5web/shared/guards';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useDimMappingState } from '../../../dimension-mapper/hooks';

--- a/packages/app/src/vis-packs/core/surface/config.tsx
+++ b/packages/app/src/vis-packs/core/surface/config.tsx
@@ -1,6 +1,7 @@
 import type { CustomDomain } from '@h5web/lib';
-import type { ColorScaleType } from '@h5web/shared';
-import { isDefined, ScaleType } from '@h5web/shared';
+import { isDefined } from '@h5web/shared/guards';
+import type { ColorScaleType } from '@h5web/shared/models-vis';
+import { ScaleType } from '@h5web/shared/models-vis';
 import { useMap } from '@react-hookz/web';
 import { createContext, useContext, useState } from 'react';
 import type { StoreApi } from 'zustand';

--- a/packages/app/src/vis-packs/core/utils.ts
+++ b/packages/app/src/vis-packs/core/utils.ts
@@ -1,11 +1,8 @@
-import type {
-  ArrayValue,
-  Axis,
-  Domain,
-  NumArray,
-  NumericLikeType,
-} from '@h5web/shared';
-import { createArrayFromView, DTypeClass, isNumericType } from '@h5web/shared';
+import { isNumericType } from '@h5web/shared/guards';
+import type { ArrayValue, NumericLikeType } from '@h5web/shared/models-hdf5';
+import { DTypeClass } from '@h5web/shared/models-hdf5';
+import type { Axis, Domain, NumArray } from '@h5web/shared/models-vis';
+import { createArrayFromView } from '@h5web/shared/utils';
 import { isNumber } from 'lodash';
 import type { NdArray, TypedArray } from 'ndarray';
 import ndarray from 'ndarray';

--- a/packages/app/src/vis-packs/core/visualizations.test.ts
+++ b/packages/app/src/vis-packs/core/visualizations.test.ts
@@ -1,5 +1,3 @@
-import type { Entity } from '@h5web/shared';
-import { assertMockAttribute } from '@h5web/shared';
 import {
   booleanType,
   complexType,
@@ -11,7 +9,9 @@ import {
   stringType,
   unsignedType,
   withImageAttributes,
-} from '@h5web/shared/src/mock/metadata-utils';
+} from '@h5web/shared/mock/metadata-utils';
+import { assertMockAttribute } from '@h5web/shared/mock/utils';
+import type { Entity } from '@h5web/shared/models-hdf5';
 
 import type { AttrValuesStore } from '../../providers/models';
 import { CORE_VIS } from './visualizations';

--- a/packages/app/src/vis-packs/core/visualizations.ts
+++ b/packages/app/src/vis-packs/core/visualizations.ts
@@ -1,4 +1,3 @@
-import type { Dataset } from '@h5web/shared';
 import {
   hasArrayShape,
   hasComplexType,
@@ -10,7 +9,8 @@ import {
   hasPrintableCompoundType,
   hasPrintableType,
   hasScalarShape,
-} from '@h5web/shared';
+} from '@h5web/shared/guards';
+import type { Dataset } from '@h5web/shared/models-hdf5';
 import {
   FiActivity,
   FiCode,

--- a/packages/app/src/vis-packs/models.ts
+++ b/packages/app/src/vis-packs/models.ts
@@ -1,4 +1,4 @@
-import type { ProvidedEntity } from '@h5web/shared';
+import type { ProvidedEntity } from '@h5web/shared/models-hdf5';
 import type { ElementType, ReactNode } from 'react';
 import type { IconType } from 'react-icons';
 

--- a/packages/app/src/vis-packs/nexus/NxValuesFetcher.tsx
+++ b/packages/app/src/vis-packs/nexus/NxValuesFetcher.tsx
@@ -1,4 +1,4 @@
-import type { ComplexType, NumericType } from '@h5web/shared';
+import type { ComplexType, NumericType } from '@h5web/shared/models-hdf5';
 import type { ReactNode } from 'react';
 
 import {

--- a/packages/app/src/vis-packs/nexus/containers/NxComplexImageContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxComplexImageContainer.tsx
@@ -1,4 +1,4 @@
-import { assertGroup, assertMinDims } from '@h5web/shared';
+import { assertGroup, assertMinDims } from '@h5web/shared/guards';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useDimMappingState } from '../../../dimension-mapper/hooks';

--- a/packages/app/src/vis-packs/nexus/containers/NxComplexSpectrumContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxComplexSpectrumContainer.tsx
@@ -1,4 +1,5 @@
-import { assertGroup, isAxisScaleType, ScaleType } from '@h5web/shared';
+import { ScaleType } from '@h5web/lib';
+import { assertGroup, isAxisScaleType } from '@h5web/shared/guards';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useDimMappingState } from '../../../dimension-mapper/hooks';

--- a/packages/app/src/vis-packs/nexus/containers/NxImageContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxImageContainer.tsx
@@ -1,4 +1,4 @@
-import { assertGroup, assertMinDims } from '@h5web/shared';
+import { assertGroup, assertMinDims } from '@h5web/shared/guards';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useDimMappingState } from '../../../dimension-mapper/hooks';

--- a/packages/app/src/vis-packs/nexus/containers/NxRgbContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxRgbContainer.tsx
@@ -1,4 +1,4 @@
-import { assertGroup, assertMinDims } from '@h5web/shared';
+import { assertGroup, assertMinDims } from '@h5web/shared/guards';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useDimMappingState } from '../../../dimension-mapper/hooks';

--- a/packages/app/src/vis-packs/nexus/containers/NxScatterContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxScatterContainer.tsx
@@ -1,4 +1,8 @@
-import { assertDefined, assertGroup, assertNumDims } from '@h5web/shared';
+import {
+  assertDefined,
+  assertGroup,
+  assertNumDims,
+} from '@h5web/shared/guards';
 import { isEqual } from 'lodash';
 
 import { useScatterConfig } from '../../core/scatter/config';

--- a/packages/app/src/vis-packs/nexus/containers/NxSpectrumContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxSpectrumContainer.tsx
@@ -1,4 +1,5 @@
-import { assertGroup, isAxisScaleType, ScaleType } from '@h5web/shared';
+import { ScaleType } from '@h5web/lib';
+import { assertGroup, isAxisScaleType } from '@h5web/shared/guards';
 import { isEqual } from 'lodash';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';

--- a/packages/app/src/vis-packs/nexus/guards.ts
+++ b/packages/app/src/vis-packs/nexus/guards.ts
@@ -1,5 +1,5 @@
-import type { ComplexType, NumericType } from '@h5web/shared';
-import { assertComplexType, assertNumericType } from '@h5web/shared';
+import { assertComplexType, assertNumericType } from '@h5web/shared/guards';
+import type { ComplexType, NumericType } from '@h5web/shared/models-hdf5';
 
 import type { NxData } from './models';
 

--- a/packages/app/src/vis-packs/nexus/hooks.ts
+++ b/packages/app/src/vis-packs/nexus/hooks.ts
@@ -1,5 +1,5 @@
-import type { GroupWithChildren } from '@h5web/shared';
-import { isDefined } from '@h5web/shared';
+import { isDefined } from '@h5web/shared/guards';
+import type { GroupWithChildren } from '@h5web/shared/models-hdf5';
 
 import { useDataContext } from '../../providers/DataProvider';
 import type { NxData } from './models';

--- a/packages/app/src/vis-packs/nexus/models.ts
+++ b/packages/app/src/vis-packs/nexus/models.ts
@@ -1,17 +1,16 @@
+import type { AxisScaleType, ColorScaleType } from '@h5web/lib';
 import type {
   ArrayShape,
   ArrayValue,
-  AxisMapping,
-  AxisScaleType,
-  ColorScaleType,
   ComplexType,
   Dataset,
-  NumArray,
   NumArrayDataset,
   NumericType,
   ScalarShape,
   StringType,
-} from '@h5web/shared';
+} from '@h5web/shared/models-hdf5';
+import type { AxisMapping } from '@h5web/shared/models-nexus';
+import type { NumArray } from '@h5web/shared/models-vis';
 
 export type NxAttribute =
   | 'NX_class'

--- a/packages/app/src/vis-packs/nexus/utils.test.ts
+++ b/packages/app/src/vis-packs/nexus/utils.test.ts
@@ -1,4 +1,4 @@
-import { intType, makeDataset } from '@h5web/shared/src/mock/metadata-utils';
+import { intType, makeDataset } from '@h5web/shared/mock/metadata-utils';
 
 import { guessKeepRatio } from './utils';
 

--- a/packages/app/src/vis-packs/nexus/utils.ts
+++ b/packages/app/src/vis-packs/nexus/utils.ts
@@ -1,14 +1,3 @@
-import type {
-  ArrayShape,
-  ComplexType,
-  Dataset,
-  Group,
-  GroupWithChildren,
-  NumArrayDataset,
-  NumericType,
-  ScalarShape,
-  StringType,
-} from '@h5web/shared';
 import {
   assertArray,
   assertArrayShape,
@@ -20,10 +9,21 @@ import {
   assertScalarShape,
   assertStr,
   assertStringType,
-  getChildEntity,
   isAxisScaleType,
   isColorScaleType,
-} from '@h5web/shared';
+} from '@h5web/shared/guards';
+import type {
+  ArrayShape,
+  ComplexType,
+  Dataset,
+  Group,
+  GroupWithChildren,
+  NumArrayDataset,
+  NumericType,
+  ScalarShape,
+  StringType,
+} from '@h5web/shared/models-hdf5';
+import { getChildEntity } from '@h5web/shared/utils';
 
 import type { AttrValuesStore } from '../../providers/models';
 import { hasAttribute } from '../../utils';

--- a/packages/app/src/visualizer/VisManager.tsx
+++ b/packages/app/src/visualizer/VisManager.tsx
@@ -1,5 +1,5 @@
-import type { ProvidedEntity } from '@h5web/shared';
-import { assertDefined } from '@h5web/shared';
+import { assertDefined } from '@h5web/shared/guards';
+import type { ProvidedEntity } from '@h5web/shared/models-hdf5';
 import { useState } from 'react';
 
 import { useDataContext } from '../providers/DataProvider';

--- a/packages/app/src/visualizer/utils.ts
+++ b/packages/app/src/visualizer/utils.ts
@@ -1,14 +1,14 @@
-import type { ChildEntity, ProvidedEntity } from '@h5web/shared';
 import {
   assertStr,
-  buildEntityPath,
   hasComplexType,
   hasMinDims,
   hasNumDims,
   isDataset,
   isGroup,
-  NxInterpretation,
-} from '@h5web/shared';
+} from '@h5web/shared/guards';
+import type { ChildEntity, ProvidedEntity } from '@h5web/shared/models-hdf5';
+import { NxInterpretation } from '@h5web/shared/models-nexus';
+import { buildEntityPath } from '@h5web/shared/utils';
 
 import type { AttrValuesStore, EntitiesStore } from '../providers/models';
 import { hasAttribute } from '../utils';

--- a/packages/h5wasm/rollup.config.js
+++ b/packages/h5wasm/rollup.config.js
@@ -2,6 +2,7 @@ import alias from '@rollup/plugin-alias';
 import { defineConfig } from 'rollup';
 import dts from 'rollup-plugin-dts';
 
+import { aliasEntries } from '../shared/rollup.utils.js';
 import { externals } from './vite.config.js';
 
 export default defineConfig({
@@ -9,15 +10,7 @@ export default defineConfig({
   output: [{ file: 'dist/index.d.ts', format: 'es' }],
   external: [...externals, /\.css$/u],
   plugins: [
-    alias({
-      entries: [
-        {
-          // Make sure rollup-plugin-dts can find shared types
-          find: '@h5web/shared',
-          replacement: '../shared/dist-ts/index.d.ts',
-        },
-      ],
-    }),
+    alias({ entries: aliasEntries }), // make sure rollup-plugin-dts can find type declatations in @h5web/shared
     dts(),
   ],
 });

--- a/packages/h5wasm/src/guards.ts
+++ b/packages/h5wasm/src/guards.ts
@@ -1,5 +1,6 @@
-import type { Dataset, DType } from '@h5web/shared';
-import { DTypeClass, isCompoundType } from '@h5web/shared';
+import { isCompoundType } from '@h5web/shared/guards';
+import type { Dataset, DType } from '@h5web/shared/models-hdf5';
+import { DTypeClass } from '@h5web/shared/models-hdf5';
 import type { Metadata } from 'h5wasm';
 import {
   BrokenSoftLink as H5WasmSoftLink,

--- a/packages/h5wasm/src/h5wasm-api.ts
+++ b/packages/h5wasm/src/h5wasm-api.ts
@@ -5,6 +5,7 @@ import {
   getNameFromPath,
   sliceValue,
 } from '@h5web/app';
+import { assertNonNull, hasArrayShape } from '@h5web/shared/guards';
 import type {
   ArrayShape,
   Attribute,
@@ -15,13 +16,9 @@ import type {
   ProvidedEntity,
   Shape,
   Value,
-} from '@h5web/shared';
-import {
-  assertNonNull,
-  buildEntityPath,
-  EntityKind,
-  hasArrayShape,
-} from '@h5web/shared';
+} from '@h5web/shared/models-hdf5';
+import { EntityKind } from '@h5web/shared/models-hdf5';
+import { buildEntityPath } from '@h5web/shared/utils';
 import type { Attribute as H5WasmAttribute, Filter, Module } from 'h5wasm';
 import { File as H5WasmFile, ready as h5wasmReady } from 'h5wasm';
 import { nanoid } from 'nanoid';

--- a/packages/h5wasm/src/utils.ts
+++ b/packages/h5wasm/src/utils.ts
@@ -1,5 +1,6 @@
-import type { DType, NumericType } from '@h5web/shared';
-import { assertDefined, DTypeClass, Endianness } from '@h5web/shared';
+import { assertDefined } from '@h5web/shared/guards';
+import type { DType, NumericType } from '@h5web/shared/models-hdf5';
+import { DTypeClass, Endianness } from '@h5web/shared/models-hdf5';
 import type { Dataset as H5WasmDataset, Metadata } from 'h5wasm';
 
 import {

--- a/packages/lib/rollup.config.js
+++ b/packages/lib/rollup.config.js
@@ -2,6 +2,7 @@ import alias from '@rollup/plugin-alias';
 import { defineConfig } from 'rollup';
 import dts from 'rollup-plugin-dts';
 
+import { aliasEntries } from '../shared/rollup.utils.js';
 import { externals } from './vite.config.js';
 
 export default defineConfig({
@@ -9,15 +10,7 @@ export default defineConfig({
   output: [{ file: 'dist/index.d.ts', format: 'es' }],
   external: [...externals, /\.css$/u],
   plugins: [
-    alias({
-      entries: [
-        {
-          // Make sure rollup-plugin-dts can find shared types
-          find: '@h5web/shared',
-          replacement: '../shared/dist-ts/index.d.ts',
-        },
-      ],
-    }),
+    alias({ entries: aliasEntries }), // make sure rollup-plugin-dts can find type declatations in @h5web/shared
     dts(),
   ],
 });

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -147,12 +147,12 @@ export { default as ScatterPointsGeometry } from './vis/scatter/scatterPointsGeo
 export { default as SurfaceMeshGeometry } from './vis/surface/surfaceMeshGeometry';
 
 // Constants
-export { COLOR_SCALE_TYPES, AXIS_SCALE_TYPES } from '@h5web/shared';
+export { COLOR_SCALE_TYPES, AXIS_SCALE_TYPES } from '@h5web/shared/utils';
 export { CAMERA_FAR } from './vis/utils';
 export { INTERPOLATORS } from './vis/heatmap/interpolators';
 
 // Enums
-export { ScaleType } from '@h5web/shared';
+export { ScaleType } from '@h5web/shared/models-vis';
 export { CurveType, GlyphType } from './vis/line/models';
 export { ImageType } from './vis/rgb/models';
 export { Notation } from './vis/matrix/models';
@@ -166,7 +166,7 @@ export type {
   Axis,
   ColorScaleType,
   AxisScaleType,
-} from '@h5web/shared';
+} from '@h5web/shared/models-vis';
 
 export type {
   Aspect,
@@ -198,12 +198,9 @@ export type {
 } from './interactions/models';
 
 // Mock data and utilities
-export {
-  mockMetadata,
-  mockValues,
-  findMockEntity,
-  getMockDataArray,
-} from '@h5web/shared';
+export { mockValues } from '@h5web/shared/mock/values';
+export { mockMetadata } from '@h5web/shared/mock/metadata';
+export { findMockEntity, getMockDataArray } from '@h5web/shared/mock/utils';
 
 // Undocumented and/or experimental
 export { default as SnapshotBtn } from './toolbar/controls/SnapshotBtn';
@@ -218,7 +215,11 @@ export { default as TiledHeatmapMesh } from './vis/tiles/TiledHeatmapMesh';
 export { default as TiledTooltipMesh } from './vis/tiles/TiledTooltipMesh';
 export { getLayerSizes, TilesApi } from './vis/tiles/api';
 export { useValidDomainForScale } from './vis/hooks';
-export { assertLength, assertDefined, assertNonNull } from '@h5web/shared';
+export {
+  assertLength,
+  assertDefined,
+  assertNonNull,
+} from '@h5web/shared/guards';
 export type { TiledHeatmapMeshProps } from './vis/tiles/TiledHeatmapMesh';
 export { default as SurfaceVis } from './vis/surface/SurfaceVis';
 export type { SurfaceVisProps } from './vis/surface/SurfaceVis';

--- a/packages/lib/src/interactions/AxialSelectToZoom.tsx
+++ b/packages/lib/src/interactions/AxialSelectToZoom.tsx
@@ -1,4 +1,4 @@
-import type { Axis } from '@h5web/shared';
+import type { Axis } from '@h5web/shared/models-vis';
 
 import { useVisCanvasContext } from '../vis/shared/VisCanvasProvider';
 import AxialSelectionTool from './AxialSelectionTool';

--- a/packages/lib/src/interactions/AxialSelectionTool.tsx
+++ b/packages/lib/src/interactions/AxialSelectionTool.tsx
@@ -1,4 +1,4 @@
-import type { Axis } from '@h5web/shared';
+import type { Axis } from '@h5web/shared/models-vis';
 import type { Camera } from 'three';
 import { Vector3 } from 'three';
 

--- a/packages/lib/src/interactions/SelectionTool.tsx
+++ b/packages/lib/src/interactions/SelectionTool.tsx
@@ -1,4 +1,4 @@
-import { assertDefined } from '@h5web/shared';
+import { assertDefined } from '@h5web/shared/guards';
 import {
   useEventListener,
   useKeyboardEvent,

--- a/packages/lib/src/styles.css
+++ b/packages/lib/src/styles.css
@@ -1,2 +1,2 @@
-/* Global lib styles for demo/Storybook */
-@import '@h5web/shared/src/styles.css'; /* global shared styles */
+/* Global lib styles for demo/Storybook (imported via `packages/app/src/styles.css`) */
+@import '@h5web/shared/styles.css'; /* global shared styles */

--- a/packages/lib/src/styles.ts
+++ b/packages/lib/src/styles.ts
@@ -1,4 +1,4 @@
 /* Entry point of `vite.styles.config.js` when building lib styles for distribution.
    Includes global lib styles only; output is later concatenated with local lib styles. */
 
-import '@h5web/shared/src/styles.css'; // global shared styles
+import '@h5web/shared/styles.css'; // global shared styles

--- a/packages/lib/src/toolbar/controls/DomainWidget/BoundEditor.tsx
+++ b/packages/lib/src/toolbar/controls/DomainWidget/BoundEditor.tsx
@@ -1,4 +1,4 @@
-import { formatBoundInput } from '@h5web/shared';
+import { formatBoundInput } from '@h5web/shared/utils';
 import {
   forwardRef,
   useEffect,

--- a/packages/lib/src/toolbar/controls/DomainWidget/DomainControls.tsx
+++ b/packages/lib/src/toolbar/controls/DomainWidget/DomainControls.tsx
@@ -1,5 +1,5 @@
-import type { Domain } from '@h5web/shared';
-import { formatBound } from '@h5web/shared';
+import type { Domain } from '@h5web/shared/models-vis';
+import { formatBound } from '@h5web/shared/utils';
 import { forwardRef, useImperativeHandle, useRef } from 'react';
 
 import type { DomainErrors } from '../../../vis/models';

--- a/packages/lib/src/toolbar/controls/DomainWidget/DomainSlider.tsx
+++ b/packages/lib/src/toolbar/controls/DomainWidget/DomainSlider.tsx
@@ -1,4 +1,4 @@
-import type { ColorScaleType, Domain } from '@h5web/shared';
+import type { ColorScaleType, Domain } from '@h5web/shared/models-vis';
 import { useState } from 'react';
 import { FiSkipBack, FiSkipForward } from 'react-icons/fi';
 import ReactSlider from 'react-slider';

--- a/packages/lib/src/toolbar/controls/DomainWidget/DomainWidget.tsx
+++ b/packages/lib/src/toolbar/controls/DomainWidget/DomainWidget.tsx
@@ -1,4 +1,4 @@
-import type { ColorScaleType, Domain } from '@h5web/shared';
+import type { ColorScaleType, Domain } from '@h5web/shared/models-vis';
 import { useClickOutside, useKeyboardEvent, useToggle } from '@react-hookz/web';
 import { useEffect, useRef, useState } from 'react';
 import { FiEdit3 } from 'react-icons/fi';

--- a/packages/lib/src/toolbar/controls/DomainWidget/Track.tsx
+++ b/packages/lib/src/toolbar/controls/DomainWidget/Track.tsx
@@ -1,4 +1,4 @@
-import type { Domain } from '@h5web/shared';
+import type { Domain } from '@h5web/shared/models-vis';
 
 import type { Scale } from '../../../vis/models';
 import styles from './Track.module.css';

--- a/packages/lib/src/toolbar/controls/Histogram/Histogram.tsx
+++ b/packages/lib/src/toolbar/controls/Histogram/Histogram.tsx
@@ -1,4 +1,4 @@
-import type { ColorScaleType, Domain } from '@h5web/shared';
+import type { ColorScaleType, Domain } from '@h5web/shared/models-vis';
 import { useMeasure } from '@react-hookz/web';
 import { AxisBottom, AxisLeft } from '@visx/axis';
 import { scaleLinear } from '@visx/scale';

--- a/packages/lib/src/toolbar/controls/Histogram/Markers.tsx
+++ b/packages/lib/src/toolbar/controls/Histogram/Markers.tsx
@@ -1,4 +1,4 @@
-import type { Domain } from '@h5web/shared';
+import type { Domain } from '@h5web/shared/models-vis';
 import { Drag } from '@visx/drag';
 import { useState } from 'react';
 

--- a/packages/lib/src/toolbar/controls/ScaleSelector/ScaleOption.tsx
+++ b/packages/lib/src/toolbar/controls/ScaleSelector/ScaleOption.tsx
@@ -1,4 +1,4 @@
-import { ScaleType } from '@h5web/shared';
+import { ScaleType } from '@h5web/shared/models-vis';
 import type { IconType } from 'react-icons/lib';
 import { MdFilterList, MdFlare, MdSort } from 'react-icons/md';
 

--- a/packages/lib/src/toolbar/controls/ScaleSelector/ScaleSelector.tsx
+++ b/packages/lib/src/toolbar/controls/ScaleSelector/ScaleSelector.tsx
@@ -1,4 +1,4 @@
-import type { ScaleType } from '@h5web/shared';
+import type { ScaleType } from '@h5web/shared/models-vis';
 
 import Selector from '../Selector/Selector';
 import ScaleOption from './ScaleOption';

--- a/packages/lib/src/vis/heatmap/ColorBar.tsx
+++ b/packages/lib/src/vis/heatmap/ColorBar.tsx
@@ -1,5 +1,6 @@
-import type { Domain } from '@h5web/shared';
-import { formatBound, formatTick, ScaleType } from '@h5web/shared';
+import type { Domain } from '@h5web/shared/models-vis';
+import { ScaleType } from '@h5web/shared/models-vis';
+import { formatBound, formatTick } from '@h5web/shared/utils';
 import { useMeasure } from '@react-hookz/web';
 import { AxisBottom, AxisRight } from '@visx/axis';
 

--- a/packages/lib/src/vis/heatmap/HeatmapMaterial.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapMaterial.tsx
@@ -1,5 +1,5 @@
-import type { Domain } from '@h5web/shared';
-import { ScaleType } from '@h5web/shared';
+import type { Domain } from '@h5web/shared/models-vis';
+import { ScaleType } from '@h5web/shared/models-vis';
 import type { RGBColor } from 'd3-color';
 import { rgb } from 'd3-color';
 import type { NdArray } from 'ndarray';

--- a/packages/lib/src/vis/heatmap/HeatmapMesh.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapMesh.tsx
@@ -1,4 +1,4 @@
-import type { Domain } from '@h5web/shared';
+import type { Domain } from '@h5web/shared/models-vis';
 import type { RGBColor } from 'd3-color';
 import type { NdArray } from 'ndarray';
 import type { MagnificationTextureFilter } from 'three';

--- a/packages/lib/src/vis/heatmap/HeatmapVis.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapVis.tsx
@@ -1,10 +1,7 @@
-import type { Domain, NumArray } from '@h5web/shared';
-import {
-  assertDefined,
-  formatTooltipVal,
-  getDims,
-  ScaleType,
-} from '@h5web/shared';
+import { assertDefined } from '@h5web/shared/guards';
+import type { Domain, NumArray } from '@h5web/shared/models-vis';
+import { ScaleType } from '@h5web/shared/models-vis';
+import { formatTooltipVal, getDims } from '@h5web/shared/utils';
 import type { NdArray } from 'ndarray';
 import type { ReactElement, ReactNode } from 'react';
 

--- a/packages/lib/src/vis/heatmap/hooks.ts
+++ b/packages/lib/src/vis/heatmap/hooks.ts
@@ -1,4 +1,4 @@
-import { createMemo } from '@h5web/shared';
+import { createMemo } from '@h5web/shared/createMemo';
 
 import {
   getDataTexture,

--- a/packages/lib/src/vis/heatmap/utils.test.ts
+++ b/packages/lib/src/vis/heatmap/utils.test.ts
@@ -1,4 +1,4 @@
-import { ScaleType } from '@h5web/shared';
+import { ScaleType } from '@h5web/shared/models-vis';
 import { interpolateGreys } from 'd3-scale-chromatic';
 
 import { DomainError } from '../models';

--- a/packages/lib/src/vis/heatmap/utils.ts
+++ b/packages/lib/src/vis/heatmap/utils.ts
@@ -1,5 +1,6 @@
-import type { Domain, NumArray } from '@h5web/shared';
-import { getDims, ScaleType, toTypedNdArray } from '@h5web/shared';
+import type { Domain, NumArray } from '@h5web/shared/models-vis';
+import { ScaleType } from '@h5web/shared/models-vis';
+import { getDims, toTypedNdArray } from '@h5web/shared/utils';
 import { range } from 'lodash';
 import type { NdArray } from 'ndarray';
 import ndarray from 'ndarray';

--- a/packages/lib/src/vis/hooks.ts
+++ b/packages/lib/src/vis/hooks.ts
@@ -1,10 +1,7 @@
-import type { AnyNumArray, Domain } from '@h5web/shared';
-import {
-  createMemo,
-  getBounds,
-  getValidDomainForScale,
-  ScaleType,
-} from '@h5web/shared';
+import { createMemo } from '@h5web/shared/createMemo';
+import type { AnyNumArray, Domain } from '@h5web/shared/models-vis';
+import { ScaleType } from '@h5web/shared/models-vis';
+import { getBounds, getValidDomainForScale } from '@h5web/shared/utils';
 import { useRerender, useSyncedRef } from '@react-hookz/web';
 import type { Camera } from '@react-three/fiber';
 import { useFrame, useThree } from '@react-three/fiber';

--- a/packages/lib/src/vis/line/DataCurve.tsx
+++ b/packages/lib/src/vis/line/DataCurve.tsx
@@ -1,4 +1,4 @@
-import type { NumArray } from '@h5web/shared';
+import type { NumArray } from '@h5web/shared/models-vis';
 import type { ThreeEvent } from '@react-three/fiber';
 import { useCallback } from 'react';
 

--- a/packages/lib/src/vis/line/ErrorBars.tsx
+++ b/packages/lib/src/vis/line/ErrorBars.tsx
@@ -1,4 +1,4 @@
-import type { NumArray } from '@h5web/shared';
+import type { NumArray } from '@h5web/shared/models-vis';
 
 import { useVisCanvasContext } from '../..';
 import { useGeometry } from '../hooks';

--- a/packages/lib/src/vis/line/Glyphs.tsx
+++ b/packages/lib/src/vis/line/Glyphs.tsx
@@ -1,4 +1,4 @@
-import type { NumArray } from '@h5web/shared';
+import type { NumArray } from '@h5web/shared/models-vis';
 import type { PointsProps } from '@react-three/fiber';
 
 import { useGeometry } from '../hooks';

--- a/packages/lib/src/vis/line/Line.tsx
+++ b/packages/lib/src/vis/line/Line.tsx
@@ -1,4 +1,4 @@
-import type { NumArray } from '@h5web/shared';
+import type { NumArray } from '@h5web/shared/models-vis';
 import type { Object3DNode } from '@react-three/fiber';
 import { extend } from '@react-three/fiber';
 import { Line as R3FLine } from 'three';

--- a/packages/lib/src/vis/line/LineVis.tsx
+++ b/packages/lib/src/vis/line/LineVis.tsx
@@ -1,11 +1,7 @@
-import type { AxisScaleType, Domain, NumArray } from '@h5web/shared';
-import {
-  assertDefined,
-  assertLength,
-  formatTooltipErr,
-  formatTooltipVal,
-  ScaleType,
-} from '@h5web/shared';
+import { assertDefined, assertLength } from '@h5web/shared/guards';
+import type { AxisScaleType, Domain, NumArray } from '@h5web/shared/models-vis';
+import { ScaleType } from '@h5web/shared/models-vis';
+import { formatTooltipErr, formatTooltipVal } from '@h5web/shared/utils';
 import type { NdArray } from 'ndarray';
 import type { ReactElement, ReactNode } from 'react';
 import { useMemo } from 'react';

--- a/packages/lib/src/vis/line/errorBarsGeometry.ts
+++ b/packages/lib/src/vis/line/errorBarsGeometry.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import type { NumArray } from '@h5web/shared';
+import type { NumArray } from '@h5web/shared/models-vis';
 
 import type { AxisScale } from '../models';
 import H5WebGeometry from '../shared/h5webGeometry';

--- a/packages/lib/src/vis/line/errorCapsGeometry.ts
+++ b/packages/lib/src/vis/line/errorCapsGeometry.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import type { NumArray } from '@h5web/shared';
+import type { NumArray } from '@h5web/shared/models-vis';
 
 import type { AxisScale } from '../models';
 import H5WebGeometry from '../shared/h5webGeometry';

--- a/packages/lib/src/vis/line/glyphsGeometry.ts
+++ b/packages/lib/src/vis/line/glyphsGeometry.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import type { NumArray } from '@h5web/shared';
+import type { NumArray } from '@h5web/shared/models-vis';
 
 import type { AxisScale } from '../models';
 import H5WebGeometry from '../shared/h5webGeometry';

--- a/packages/lib/src/vis/line/hooks.ts
+++ b/packages/lib/src/vis/line/hooks.ts
@@ -1,4 +1,4 @@
-import { createMemo } from '@h5web/shared';
+import { createMemo } from '@h5web/shared/createMemo';
 
 import { getAxisValues } from './utils';
 

--- a/packages/lib/src/vis/line/lineGeometry.ts
+++ b/packages/lib/src/vis/line/lineGeometry.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import type { NumArray } from '@h5web/shared';
+import type { NumArray } from '@h5web/shared/models-vis';
 
 import type { AxisScale } from '../models';
 import H5WebGeometry from '../shared/h5webGeometry';

--- a/packages/lib/src/vis/line/models.ts
+++ b/packages/lib/src/vis/line/models.ts
@@ -1,4 +1,4 @@
-import type { NumArray } from '@h5web/shared';
+import type { NumArray } from '@h5web/shared/models-vis';
 import type { NdArray } from 'ndarray';
 
 export enum CurveType {

--- a/packages/lib/src/vis/line/utils.ts
+++ b/packages/lib/src/vis/line/utils.ts
@@ -1,4 +1,4 @@
-import type { NumArray } from '@h5web/shared';
+import type { NumArray } from '@h5web/shared/models-vis';
 import { range } from 'd3-array';
 
 export function getAxisValues(

--- a/packages/lib/src/vis/matrix/MatrixVis.tsx
+++ b/packages/lib/src/vis/matrix/MatrixVis.tsx
@@ -1,4 +1,4 @@
-import type { ArrayValue, Primitive } from '@h5web/shared';
+import type { ArrayValue, Primitive } from '@h5web/shared/models-hdf5';
 import type { NdArray } from 'ndarray';
 
 import type { PrintableType } from '../models';

--- a/packages/lib/src/vis/models.ts
+++ b/packages/lib/src/vis/models.ts
@@ -1,14 +1,16 @@
 import type {
-  AxisScaleType,
   BooleanType,
-  ColorScaleType,
   ComplexType,
+  NumericType,
+  StringType,
+} from '@h5web/shared/models-hdf5';
+import type {
+  AxisScaleType,
+  ColorScaleType,
   Domain,
   NumArray,
-  NumericType,
   ScaleType,
-  StringType,
-} from '@h5web/shared';
+} from '@h5web/shared/models-vis';
 import type { PickD3Scale, PickScaleConfigWithoutType } from '@visx/scale';
 
 import type { ColorMap } from './heatmap/models';

--- a/packages/lib/src/vis/rgb/RgbVis.tsx
+++ b/packages/lib/src/vis/rgb/RgbVis.tsx
@@ -1,5 +1,6 @@
-import type { NumArray } from '@h5web/shared';
-import { assertDefined, getDims } from '@h5web/shared';
+import { assertDefined } from '@h5web/shared/guards';
+import type { NumArray } from '@h5web/shared/models-vis';
+import { getDims } from '@h5web/shared/utils';
 import type { NdArray } from 'ndarray';
 import type { ReactNode } from 'react';
 import { useMemo } from 'react';

--- a/packages/lib/src/vis/rgb/utils.ts
+++ b/packages/lib/src/vis/rgb/utils.ts
@@ -1,5 +1,5 @@
-import type { NumArray } from '@h5web/shared';
-import { getDims, toTypedNdArray } from '@h5web/shared';
+import type { NumArray } from '@h5web/shared/models-vis';
+import { getDims, toTypedNdArray } from '@h5web/shared/utils';
 import type { NdArray } from 'ndarray';
 import ndarray from 'ndarray';
 import { Data3DTexture, FloatType, RedFormat, UnsignedByteType } from 'three';

--- a/packages/lib/src/vis/scalar/ScalarVis.tsx
+++ b/packages/lib/src/vis/scalar/ScalarVis.tsx
@@ -1,4 +1,4 @@
-import type { Primitive, PrintableType } from '@h5web/shared';
+import type { Primitive, PrintableType } from '@h5web/shared/models-hdf5';
 
 import styles from './ScalarVis.module.css';
 

--- a/packages/lib/src/vis/scaleGamma.ts
+++ b/packages/lib/src/vis/scaleGamma.ts
@@ -1,4 +1,4 @@
-import type { Domain } from '@h5web/shared';
+import type { Domain } from '@h5web/shared/models-vis';
 import { scalePower } from '@visx/scale';
 import { interpolateNumber, interpolateRound } from 'd3-interpolate';
 import type {

--- a/packages/lib/src/vis/scatter/ScatterPoints.tsx
+++ b/packages/lib/src/vis/scatter/ScatterPoints.tsx
@@ -1,4 +1,8 @@
-import type { ColorScaleType, Domain, NumArray } from '@h5web/shared';
+import type {
+  ColorScaleType,
+  Domain,
+  NumArray,
+} from '@h5web/shared/models-vis';
 import type { ThreeEvent } from '@react-three/fiber';
 import { useCallback, useMemo } from 'react';
 

--- a/packages/lib/src/vis/scatter/ScatterVis.tsx
+++ b/packages/lib/src/vis/scatter/ScatterVis.tsx
@@ -1,15 +1,16 @@
-import type { ColorScaleType, Domain, NumArray } from '@h5web/shared';
-import {
-  assertDefined,
-  assertLength,
-  formatTooltipVal,
-  ScaleType,
-} from '@h5web/shared';
+import type {
+  ColorScaleType,
+  Domain,
+  NumArray,
+} from '@h5web/shared/models-vis';
+import { ScaleType } from '@h5web/shared/models-vis';
+import { formatTooltipVal } from '@h5web/shared/utils';
 import type { ThreeEvent } from '@react-three/fiber';
 import { useTooltip } from '@visx/tooltip';
 import type { NdArray } from 'ndarray';
 import type { ReactNode } from 'react';
 
+import { assertDefined, assertLength } from '../..';
 import type { DefaultInteractionsConfig } from '../../interactions/DefaultInteractions';
 import DefaultInteractions from '../../interactions/DefaultInteractions';
 import ResetZoomButton from '../../toolbar/floating/ResetZoomButton';

--- a/packages/lib/src/vis/scatter/models.ts
+++ b/packages/lib/src/vis/scatter/models.ts
@@ -1,4 +1,4 @@
-import type { AxisScaleType, NumArray } from '@h5web/shared';
+import type { AxisScaleType, NumArray } from '@h5web/shared/models-vis';
 
 export interface ScatterAxisParams {
   label?: string;

--- a/packages/lib/src/vis/scatter/scatterPointsGeometry.ts
+++ b/packages/lib/src/vis/scatter/scatterPointsGeometry.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import type { ColorScaleType, NumArray } from '@h5web/shared';
+import type { ColorScaleType, NumArray } from '@h5web/shared/models-vis';
 import { rgb } from 'd3-color';
 
 import type { D3Interpolator } from '../heatmap/models';

--- a/packages/lib/src/vis/shared/Axis.tsx
+++ b/packages/lib/src/vis/shared/Axis.tsx
@@ -1,5 +1,5 @@
-import type { Domain } from '@h5web/shared';
-import { ScaleType } from '@h5web/shared';
+import type { Domain } from '@h5web/shared/models-vis';
+import { ScaleType } from '@h5web/shared/models-vis';
 import type { SharedAxisProps } from '@visx/axis';
 import { AxisBottom, AxisLeft } from '@visx/axis';
 import { GridColumns, GridRows } from '@visx/grid';

--- a/packages/lib/src/vis/shared/DataToHtml.tsx
+++ b/packages/lib/src/vis/shared/DataToHtml.tsx
@@ -1,4 +1,4 @@
-import type { MappedTuple } from '@h5web/shared';
+import type { MappedTuple } from '@h5web/shared/models-vis';
 import type { ReactNode } from 'react';
 import type { Vector3 } from 'three';
 

--- a/packages/lib/src/vis/shared/VisCanvasProvider.tsx
+++ b/packages/lib/src/vis/shared/VisCanvasProvider.tsx
@@ -1,5 +1,5 @@
-import type { VisibleDomains } from '@h5web/shared';
-import { assertDefined, assertNonNull } from '@h5web/shared';
+import { assertDefined, assertNonNull } from '@h5web/shared/guards';
+import type { VisibleDomains } from '@h5web/shared/models-vis';
 import { useThree } from '@react-three/fiber';
 import type { PropsWithChildren } from 'react';
 import { createContext, useCallback, useContext, useMemo } from 'react';

--- a/packages/lib/src/vis/surface/SurfaceMesh.tsx
+++ b/packages/lib/src/vis/surface/SurfaceMesh.tsx
@@ -1,4 +1,4 @@
-import { getDims } from '@h5web/shared';
+import { getDims } from '@h5web/shared/utils';
 import { LinearFilter } from 'three';
 
 import HeatmapMaterial from '../heatmap/HeatmapMaterial';

--- a/packages/lib/src/vis/surface/SurfaceVis.tsx
+++ b/packages/lib/src/vis/surface/SurfaceVis.tsx
@@ -1,5 +1,9 @@
-import type { ColorScaleType, Domain, NumArray } from '@h5web/shared';
-import { ScaleType } from '@h5web/shared';
+import type {
+  ColorScaleType,
+  Domain,
+  NumArray,
+} from '@h5web/shared/models-vis';
+import { ScaleType } from '@h5web/shared/models-vis';
 import type { NdArray } from 'ndarray';
 import type { PropsWithChildren } from 'react';
 

--- a/packages/lib/src/vis/surface/surfaceMeshGeometry.ts
+++ b/packages/lib/src/vis/surface/surfaceMeshGeometry.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import type { NumArray } from '@h5web/shared';
+import type { NumArray } from '@h5web/shared/models-vis';
 
 import H5WebGeometry from '../shared/h5webGeometry';
 import { createBufferAttr, createIndex } from '../utils';

--- a/packages/lib/src/vis/tiles/models.ts
+++ b/packages/lib/src/vis/tiles/models.ts
@@ -1,4 +1,4 @@
-import type { Domain } from '@h5web/shared';
+import type { Domain } from '@h5web/shared/models-vis';
 import type { NdArray } from 'ndarray';
 
 import type { ColorMap, TextureSafeTypedArray } from '../heatmap/models';

--- a/packages/lib/src/vis/tiles/utils.ts
+++ b/packages/lib/src/vis/tiles/utils.ts
@@ -1,4 +1,4 @@
-import { ScaleType } from '@h5web/shared';
+import { ScaleType } from '@h5web/shared/models-vis';
 import type { Camera } from '@react-three/fiber';
 import type { RefObject } from 'react';
 import type { Matrix4, Object3D } from 'three';

--- a/packages/lib/src/vis/utils.test.ts
+++ b/packages/lib/src/vis/utils.test.ts
@@ -1,5 +1,5 @@
-import type { Domain } from '@h5web/shared';
-import { ScaleType } from '@h5web/shared';
+import type { Domain } from '@h5web/shared/models-vis';
+import { ScaleType } from '@h5web/shared/models-vis';
 import { tickStep } from 'd3-array';
 
 import {

--- a/packages/lib/src/vis/utils.ts
+++ b/packages/lib/src/vis/utils.ts
@@ -1,3 +1,4 @@
+import { isDefined, isTypedArray } from '@h5web/shared/guards';
 import type {
   AnyNumArray,
   AxisScaleType,
@@ -5,15 +6,13 @@ import type {
   Domain,
   NumArray,
   TypedArrayConstructor,
-} from '@h5web/shared';
+} from '@h5web/shared/models-vis';
+import { ScaleType } from '@h5web/shared/models-vis';
 import {
   formatTick,
   getBounds,
   getValidDomainForScale,
-  isDefined,
-  isTypedArray,
-  ScaleType,
-} from '@h5web/shared';
+} from '@h5web/shared/utils';
 import {
   scaleLinear,
   scaleLog,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -6,6 +6,21 @@
   "type": "module",
   "sideEffects": false,
   "main": "src/index.ts",
+  "exports": {
+    "./createMemo": "./src/createMemo.ts",
+    "./guards": "./src/guards.ts",
+    "./models-hdf5": "./src/models-hdf5.ts",
+    "./models-nexus": "./src/models-nexus.ts",
+    "./models-vis": "./src/models-vis.ts",
+    "./utils": "./src/utils.ts",
+    "./mock/metadata-utils": "./src/mock/metadata-utils.ts",
+    "./mock/metadata": "./src/mock/metadata.ts",
+    "./mock/models": "./src/mock/models.ts",
+    "./mock/utils": "./src/mock/utils.ts",
+    "./mock/values": "./src/mock/values.ts",
+    "./styles.css": "./src/styles.css",
+    ".": "./src/index.ts"
+  },
   "scripts": {
     "build": "run-p build:*",
     "build:dts": "tsc --build tsconfig.build.json",

--- a/packages/shared/rollup.utils.js
+++ b/packages/shared/rollup.utils.js
@@ -1,0 +1,24 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const dirname = fileURLToPath(new URL('.', import.meta.url));
+const pkg = JSON.parse(fs.readFileSync(path.resolve(dirname, 'package.json')));
+
+/*
+ * Since `@h5web/shared` is not published, its type declarations must be
+ * inlined into the compiled declaration file of each published package.
+ *
+ * The object below tells `rollup-plugin-dts` how to map `@h5web/shared/*`
+ * imports to their corresponding declaration files.
+ *
+ * e.g. @h5web/shared/utils => ../shared/dist-ts/utils.d.ts
+ */
+export const aliasEntries = Object.fromEntries(
+  Object.entries(pkg.exports)
+    .filter(([, value]) => value.endsWith('.ts'))
+    .map(([key, value]) => [
+      key.replace(/^\./u, '@h5web/shared'),
+      value.replace(/^\.\/src\/(.+)\.ts$/u, '../shared/dist-ts/$1.d.ts'),
+    ]),
+);

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,9 +1,2 @@
-export * from './guards';
-export * from './models-hdf5';
-export * from './models-nexus';
-export * from './models-vis';
-export * from './utils';
-export * from './createMemo';
-export * from './mock/metadata';
-export * from './mock/values';
-export * from './mock/utils';
+// Placeholder file because `exports['.']` is mandatory in package.json
+export {};


### PR DESCRIPTION
Before v5, TypeScript could not understand the `exports` property in `package.json` that allows defining multiple entry points in a package. As a result we had to re-export everything from a single file, `src/index.ts`, and import everything from `@h5web/shared`. Unfortunately, this type of "barrel" file is really bad for performance in development, since any change to any module in the shared package would trigger an HMR update of every module that depend on the shared package. This used to really ruin the development experience...

Now that we've fully switched to `moduleResolution: 'bundler'`, which does understand `exports`, I was able to add export entries for each file in `@h5web/shared`.

The only challenge was to make sure Rollup knew where to find the shared compiled declaration files in `packages/shared/dist-ts` when generating `packages/<app,lib,h5wasm>/dist/index.d.ts`.

HMR performance is now much, much better. It's still not perfect, and we could probably also provide multiple entry points in the lib package, but it's a start!