### PR TITLE
Switch to `wouter` for routing

### DIFF
--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -23,13 +23,12 @@
     "react-dom": "18.2.0",
     "react-dropzone": "14.2.3",
     "react-icons": "4.12.0",
-    "react-router-dom": "6.3.0"
+    "wouter": "3.0.0-rc.2"
   },
   "devDependencies": {
     "@types/node": "^18.19.3",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.17",
-    "@types/react-router-dom": "~5.3.3",
     "@vitejs/plugin-react": "4.2.1",
     "eslint": "8.28.0",
     "eslint-config-galex": "4.5.2",

--- a/apps/demo/src/DemoApp.tsx
+++ b/apps/demo/src/DemoApp.tsx
@@ -1,9 +1,4 @@
-import {
-  BrowserRouter as Router,
-  Navigate,
-  Route,
-  Routes,
-} from 'react-router-dom';
+import { Redirect, Route, Switch } from 'wouter';
 
 import H5GroveApp from './H5GroveApp';
 import H5WasmApp from './h5wasm/H5WasmApp';
@@ -17,16 +12,16 @@ window.H5WEB_EXPERIMENTAL = query.has('experimental');
 
 function DemoApp() {
   return (
-    <Router>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="h5grove" element={<H5GroveApp />} />
-        <Route path="mock" element={<MockApp />} />
-        <Route path="hsds" element={<HsdsApp />} />
-        <Route path="h5wasm" element={<H5WasmApp />} />
-        <Route path="*" element={<Navigate to="/" replace />} />
-      </Routes>
-    </Router>
+    <Switch>
+      <Route path="/" component={Home} />
+      <Route path="/h5grove" component={H5GroveApp} />
+      <Route path="/mock" component={MockApp} />
+      <Route path="/hsds" component={HsdsApp} />
+      <Route path="/h5wasm" component={H5WasmApp} />
+      <Route>
+        <Redirect to="/" replace />
+      </Route>
+    </Switch>
   );
 }
 

--- a/apps/demo/src/H5GroveApp.tsx
+++ b/apps/demo/src/H5GroveApp.tsx
@@ -1,5 +1,5 @@
 import { App, assertEnvVar, H5GroveProvider } from '@h5web/app';
-import { useLocation } from 'react-router-dom';
+import { useSearch } from 'wouter';
 
 import { getFeedbackURL } from './utils';
 
@@ -10,7 +10,7 @@ function H5GroveApp() {
   assertEnvVar(URL, 'VITE_H5GROVE_URL');
   assertEnvVar(FILEPATH, 'VITE_H5GROVE_FALLBACK_FILEPATH');
 
-  const query = new URLSearchParams(useLocation().search);
+  const query = new URLSearchParams(useSearch());
   const filepath = query.get('file') || FILEPATH;
 
   return (

--- a/apps/demo/src/Home.tsx
+++ b/apps/demo/src/Home.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from 'react';
 import { FiChevronsRight } from 'react-icons/fi';
-import { Link } from 'react-router-dom';
+import { Link } from 'wouter';
 
 import styles from './Home.module.css';
 
@@ -40,7 +40,7 @@ function Home() {
         <main className={styles.demos}>
           <section>
             <h2>
-              <Link to="h5grove" className={styles.demoLink}>
+              <Link to="/h5grove" className={styles.demoLink}>
                 H5Grove <FiChevronsRight />
               </Link>
             </h2>
@@ -61,19 +61,19 @@ function Home() {
             </p>
             <ul className={styles.demoFiles}>
               <li>
-                <Link to="h5grove">
+                <Link to="/h5grove">
                   <strong>water_224.h5</strong>
                 </Link>{' '}
                 (default) - a typical NeXus file with various real-world
                 datasets to demonstrate H5Web's core visualizations.
               </li>
               <li>
-                <Link to="h5grove?file=compressed.h5">compressed.h5</Link> - a
+                <Link to="/h5grove?file=compressed.h5">compressed.h5</Link> - a
                 file with datasets compressed with various filters to test
                 decompression.
               </li>
               <li>
-                <Link to="h5grove?file=epics.h5">epics.h5</Link> - a test file
+                <Link to="/h5grove?file=epics.h5">epics.h5</Link> - a test file
                 from the{' '}
                 <a
                   href="https://epics.anl.gov/"
@@ -87,25 +87,25 @@ function Home() {
                 group (Argonne National Laboratory).
               </li>
               <li>
-                <Link to="h5grove?file=grove.h5">grove.h5</Link> - a file used
+                <Link to="/h5grove?file=grove.h5">grove.h5</Link> - a file used
                 to test the <code>H5GroveProvider</code> provider; it contains
                 datasets with <code>NaN</code>, <code>Infinity</code>, boolean
                 and complex values, as well as RGB images and 4D stacks.
               </li>
               <li>
-                <Link to="h5grove?file=links.h5">links.h5</Link> - a file with
+                <Link to="/h5grove?file=links.h5">links.h5</Link> - a file with
                 external links, soft links and a virtual dataset to test link
                 resolution.
               </li>
               <li>
-                <Link to="h5grove?file=tall.h5">tall.h5</Link> - the demo file
+                <Link to="/h5grove?file=tall.h5">tall.h5</Link> - the demo file
                 of HSDS.
               </li>
             </ul>
           </section>
           <section>
             <h2>
-              <Link to="h5wasm" className={styles.demoLink}>
+              <Link to="/h5wasm" className={styles.demoLink}>
                 H5Wasm <FiChevronsRight />
               </Link>
             </h2>
@@ -149,7 +149,7 @@ function Home() {
                   <Fragment key={filename}>
                     {index > 0 && ', '}
                     <Link
-                      to={`h5wasm?url=${encodeURIComponent(
+                      to={`/h5wasm?url=${encodeURIComponent(
                         `https://www.silx.org/pub/h5web/${filename}`,
                       )}`}
                     >
@@ -162,7 +162,7 @@ function Home() {
           </section>
           <section>
             <h2>
-              <Link to="hsds" className={styles.demoLink}>
+              <Link to="/hsds" className={styles.demoLink}>
                 HSDS <FiChevronsRight />
               </Link>
             </h2>
@@ -180,18 +180,18 @@ function Home() {
             <p>
               This demo communicates with an HSDS test server, which serves the
               same files as the H5Grove demo above:{' '}
-              <Link to="hsds">water_224.h5</Link> (<strong>default</strong>),{' '}
-              <Link to="hsds?file=compressed.h5">compressed.h5</Link> (note that
-              bitshuffle is not yet supported by HSDS),{' '}
-              <Link to="hsds?file=epics.h5">epics.h5</Link>,{' '}
-              <Link to="hsds?file=grove.h5">grove.h5</Link>,{' '}
-              <Link to="hsds?file=links.h5">links.h5</Link>,{' '}
-              <Link to="hsds?file=tall.h5">tall.h5</Link>.
+              <Link to="/hsds">water_224.h5</Link> (<strong>default</strong>),{' '}
+              <Link to="/hsds?file=compressed.h5">compressed.h5</Link> (note
+              that bitshuffle is not yet supported by HSDS),{' '}
+              <Link to="/hsds?file=epics.h5">epics.h5</Link>,{' '}
+              <Link to="/hsds?file=grove.h5">grove.h5</Link>,{' '}
+              <Link to="/hsds?file=links.h5">links.h5</Link>,{' '}
+              <Link to="/hsds?file=tall.h5">tall.h5</Link>.
             </p>
           </section>
           <section>
             <h2>
-              <Link to="mock" className={styles.demoLink}>
+              <Link to="/mock" className={styles.demoLink}>
                 Mock data <FiChevronsRight />
               </Link>
             </h2>

--- a/apps/demo/src/HsdsApp.tsx
+++ b/apps/demo/src/HsdsApp.tsx
@@ -1,5 +1,5 @@
 import { App, assertEnvVar, HsdsProvider } from '@h5web/app';
-import { useLocation } from 'react-router-dom';
+import { useSearch } from 'wouter';
 
 import { getFeedbackURL } from './utils';
 
@@ -16,7 +16,7 @@ function HsdsApp() {
   assertEnvVar(SUBDOMAIN, 'VITE_HSDS_SUBDOMAIN');
   assertEnvVar(FILEPATH, 'VITE_HSDS_FALLBACK_FILEPATH');
 
-  const query = new URLSearchParams(useLocation().search);
+  const query = new URLSearchParams(useSearch());
   const filepath = `${SUBDOMAIN}${query.get('file') || FILEPATH}`;
 
   return (

--- a/apps/demo/src/MockApp.tsx
+++ b/apps/demo/src/MockApp.tsx
@@ -1,10 +1,10 @@
 import { App, MockProvider } from '@h5web/app';
-import { useLocation } from 'react-router-dom';
+import { useSearch } from 'wouter';
 
 import { getFeedbackURL } from './utils';
 
 function MockApp() {
-  const query = new URLSearchParams(useLocation().search);
+  const query = new URLSearchParams(useSearch());
 
   return (
     <MockProvider>

--- a/apps/demo/src/h5wasm/H5WasmApp.tsx
+++ b/apps/demo/src/h5wasm/H5WasmApp.tsx
@@ -1,7 +1,7 @@
 import { App } from '@h5web/app';
 import { H5WasmProvider } from '@h5web/h5wasm';
 import { useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useSearch } from 'wouter';
 
 import { getFeedbackURL } from '../utils';
 import DropZone from './DropZone';
@@ -9,7 +9,7 @@ import type { H5File } from './models';
 import { getPlugin } from './plugin-utils';
 
 function H5WasmApp() {
-  const query = new URLSearchParams(useLocation().search);
+  const query = new URLSearchParams(useSearch());
   const [h5File, setH5File] = useState<H5File>();
 
   if (!h5File) {

--- a/apps/demo/src/h5wasm/UrlForm.tsx
+++ b/apps/demo/src/h5wasm/UrlForm.tsx
@@ -2,7 +2,7 @@ import useAxios from 'axios-hooks';
 import type { FormEvent } from 'react';
 import { useCallback, useEffect } from 'react';
 import { FiLoader } from 'react-icons/fi';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useSearch } from 'wouter';
 
 import styles from './H5WasmApp.module.css';
 import type { H5File } from './models';
@@ -14,8 +14,8 @@ interface Props {
 function UrlForm(props: Props) {
   const { onH5File } = props;
 
-  const navigate = useNavigate();
-  const query = new URLSearchParams(useLocation().search);
+  const [, navigate] = useLocation();
+  const query = new URLSearchParams(useSearch());
   const url = query.get('url') || '';
 
   const [{ loading, error }, execute] = useAxios<ArrayBuffer>(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,9 +86,9 @@ importers:
       react-icons:
         specifier: 4.12.0
         version: 4.12.0(react@18.2.0)
-      react-router-dom:
-        specifier: 6.3.0
-        version: 6.3.0(react-dom@18.2.0)(react@18.2.0)
+      wouter:
+        specifier: 3.0.0-rc.2
+        version: 3.0.0-rc.2(react@18.2.0)
     devDependencies:
       '@types/node':
         specifier: ^18.19.3
@@ -99,9 +99,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.17
         version: 18.2.17
-      '@types/react-router-dom':
-        specifier: ~5.3.3
-        version: 5.3.3
       '@vitejs/plugin-react':
         specifier: 4.2.1
         version: 4.2.1(vite@5.0.9)
@@ -5247,10 +5244,6 @@ packages:
       '@types/node': 18.19.3
     dev: true
 
-  /@types/history@4.7.11:
-    resolution: {integrity: sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==}
-    dev: true
-
   /@types/http-errors@2.0.4:
     resolution: {integrity: sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==}
     dev: true
@@ -5413,21 +5406,6 @@ packages:
     resolution: {integrity: sha512-SN9c4kxXZonFhbX4hJrZy37yw9e7EIxcpHCxQv5JUS18wDE5ovkQKlqQEkufdJCCMfuI9BnjUJvhYeJ9x5Ra7g==}
     dependencies:
       '@types/react': 18.2.45
-
-  /@types/react-router-dom@5.3.3:
-    resolution: {integrity: sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==}
-    dependencies:
-      '@types/history': 4.7.11
-      '@types/react': 18.2.45
-      '@types/react-router': 5.1.20
-    dev: true
-
-  /@types/react-router@5.1.20:
-    resolution: {integrity: sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==}
-    dependencies:
-      '@types/history': 4.7.11
-      '@types/react': 18.2.45
-    dev: true
 
   /@types/react-slider@1.3.6:
     resolution: {integrity: sha512-RS8XN5O159YQ6tu3tGZIQz1/9StMLTg/FCIPxwqh2gwVixJnlfIodtVx+fpXVMZHe7A58lAX1Q4XTgAGOQaCQg==}
@@ -5938,7 +5916,7 @@ packages:
     resolution: {integrity: sha512-AfgcRL8ZBhAlc3BFdigClmTUMISmmzHn7sB2h9U1odvc5U/MjWXsAaz18b/WoppUTDBzxOJwo2VdClfUcItu9g==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^4.1.0-beta.0
+      vite: ^4.1.0-beta.0 || 5.x
     dependencies:
       '@babel/core': 7.23.6
       '@babel/plugin-transform-react-jsx-self': 7.23.3(@babel/core@7.23.6)
@@ -5954,7 +5932,7 @@ packages:
     resolution: {integrity: sha512-oojO9IDc4nCUUi8qIR11KoQm0XFFLIwsRBwHRR4d/88IWghn1y6ckz/bJ8GHDCsYEJee8mDzqtJxh15/cisJNQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^4.2.0 || ^5.0.0
+      vite: ^4.2.0 || ^5.0.0 || 5.x
     dependencies:
       '@babel/core': 7.23.6
       '@babel/plugin-transform-react-jsx-self': 7.23.3(@babel/core@7.23.6)
@@ -9249,12 +9227,6 @@ packages:
       function-bind: 1.1.2
     dev: true
 
-  /history@5.3.0:
-    resolution: {integrity: sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==}
-    dependencies:
-      '@babel/runtime': 7.23.6
-    dev: false
-
   /hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
     dev: true
@@ -11432,6 +11404,10 @@ packages:
       yallist: 4.0.0
     dev: true
 
+  /mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+    dev: false
+
   /mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
     dev: true
@@ -12512,27 +12488,6 @@ packages:
       use-sidecar: 1.1.2(@types/react@18.2.45)(react@18.2.0)
     dev: true
 
-  /react-router-dom@6.3.0(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==}
-    peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
-    dependencies:
-      history: 5.3.0
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-router: 6.3.0(react@18.2.0)
-    dev: false
-
-  /react-router@6.3.0(react@18.2.0):
-    resolution: {integrity: sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==}
-    peerDependencies:
-      react: '>=16.8'
-    dependencies:
-      history: 5.3.0
-      react: 18.2.0
-    dev: false
-
   /react-slider@2.0.4(react@18.2.0):
     resolution: {integrity: sha512-sWwQD01n6v+MbeLCYthJGZPc0kzOyhQHyd0bSo0edg+IAxTVQmj3Oy4SBK65eX6gNwS9meUn6Z5sIBUVmwAd9g==}
     peerDependencies:
@@ -12724,6 +12679,11 @@ packages:
       define-properties: 1.2.1
       set-function-name: 2.0.1
     dev: true
+
+  /regexparam@3.0.0:
+    resolution: {integrity: sha512-RSYAtP31mvYLkAHrOlh25pCNQ5hWnT106VukGaaFfuJrZFkGRX5GhUAdPqpSDXxOhA2c4akmRuplv1mRqnBn6Q==}
+    engines: {node: '>=8'}
+    dev: false
 
   /regexpp@3.2.0:
     resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==}
@@ -14610,6 +14570,17 @@ packages:
   /wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
     dev: true
+
+  /wouter@3.0.0-rc.2(react@18.2.0):
+    resolution: {integrity: sha512-OU24Ga0g2JVsGZxpNnlCobnJDy3OteIZTQnTfyVG/A7QU4FHxfe90k1g46AvMavX1YhdRIM32LCosmu27PdMPw==}
+    peerDependencies:
+      react: '>=16.8.0'
+    dependencies:
+      mitt: 3.0.1
+      react: 18.2.0
+      regexparam: 3.0.0
+      use-sync-external-store: 1.2.0(react@18.2.0)
+    dev: false
 
   /wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}


### PR DESCRIPTION
[React Router](https://reactrouter.com/) is maintained by the people who make [Remix](https://remix.run/), and they're pushing a lot of features related to data fetching and SSR into `react-router`. It's now similar to the upcoming [Tanstack Router](https://tanstack.com/router/v1) in terms of features. Those solutions are probably great to manage routing and data fetching in complex apps, especially when server-side rendering is involved. However, this is not our use case here, so I've been wanting to go back to something simpler, lighter, and focused on front-end routing.

I've come across two promising libraries: [type-route](https://type-route.zilch.dev/) and [wouter](https://github.com/molefrog/wouter/). The former is really appealing, with a focus on type safety. The latter is pretty much what `react-router` used to be a bunch of versions ago, with the well-established JSX routing syntax, except with some of the kinks resolved (e.g. explicit route nesting, `useSearch` hook, etc).

I've decided to go with `wouter` for the H5Web demo, since the use case is so basic and type safety is not critical, and to ease migration. I'll probably try `type-route` at some point in another project.

The maintainers of `wouter` have been working on a [new major version](https://github.com/molefrog/wouter/releases) with much needed improvements to the API. This new major is now at the RC stage, so I've installed the latest RC directly to be able to take advantage of `useSearch`.