### PR TITLE
Fix Rollup alias warnings when building packages

### DIFF
--- a/packages/shared/rollup.utils.js
+++ b/packages/shared/rollup.utils.js
@@ -12,13 +12,16 @@ const pkg = JSON.parse(fs.readFileSync(path.resolve(dirname, 'package.json')));
  * The object below tells `rollup-plugin-dts` how to map `@h5web/shared/*`
  * imports to their corresponding declaration files.
  *
- * e.g. @h5web/shared/vis-utils => ../shared/dist-ts/vis-utils.d.ts
+ * e.g. @h5web/shared/vis-utils => /<local-path>/packages/shared/dist-ts/vis-utils.d.ts
  */
 export const aliasEntries = Object.fromEntries(
   Object.entries(pkg.exports)
     .filter(([, value]) => value.endsWith('.ts'))
     .map(([key, value]) => [
       key.replace(/^\./u, '@h5web/shared'),
-      value.replace(/^\.\/src\/(.+)\.ts$/u, '../shared/dist-ts/$1.d.ts'),
+      value.replace(
+        /^\.\/src\/(.+)\.ts$/u,
+        path.join(dirname, 'dist-ts/$1.d.ts'),
+      ),
     ]),
 );


### PR DESCRIPTION
Rollup wants the aliases to be to absolute paths.