### PR TITLE
Sync package versions when bumping monorepo version to simplify CI release workflow

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -48,38 +48,8 @@ jobs:
       - name: Build packages 📦
         run: pnpm packages
 
-      - name: Set @h5web/lib version 📌
-        uses: reedyuk/npm-version@1.1.1
-        with:
-          version: ${{ steps.packageVersion.outputs.PACKAGE_VERSION }}
-          package: 'packages/lib'
-
-      - name: Set @h5web/app version 📌
-        uses: reedyuk/npm-version@1.1.1
-        with:
-          version: ${{ steps.packageVersion.outputs.PACKAGE_VERSION }}
-          package: 'packages/app'
-
-      - name: Set @h5web/h5wasm version 📌
-        uses: reedyuk/npm-version@1.1.1
-        with:
-          version: ${{ steps.packageVersion.outputs.PACKAGE_VERSION }}
-          package: 'packages/h5wasm'
-
-      - name: Publish @h5web/lib 🥳
-        run: cd packages/lib && pnpm publish --access public --provenance --no-git-checks --tag $NPM_TAG
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TAG: "${{ contains(steps.packageVersion.outputs.PACKAGE_VERSION, 'beta') && 'next' || 'latest' }}"
-
-      - name: Publish @h5web/app 🥳
-        run: cd packages/app && pnpm publish --access public --provenance --no-git-checks --tag $NPM_TAG
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TAG: "${{ contains(steps.packageVersion.outputs.PACKAGE_VERSION, 'beta') && 'next' || 'latest' }}"
-
-      - name: Publish @h5web/h5wasm 🥳
-        run: cd packages/h5wasm && pnpm publish --access public --provenance --no-git-checks --tag $NPM_TAG
+      - name: Publish packages 🥳
+        run: pnpm -r publish --access public --provenance --no-git-checks --tag $NPM_TAG
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TAG: "${{ contains(steps.packageVersion.outputs.PACKAGE_VERSION, 'beta') && 'next' || 'latest' }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -337,17 +337,21 @@ To release a new version and publish the packages to NPM:
    latest commit on `main` has passed the CI.
 1. Run `pnpm version [ patch | minor | major | <new-version> ]`
 
-This command bumps the version number in the workspace's `package.json`, commits
-the change and then tags the commit with the same version number. The
-`postversion` script then runs automatically and pushes the new commit and the
-new tag to the remote repository. This, in turn, triggers the _Release_ workflow
-on the CI, which builds and publishes the packages to NPM (with `pnpm publish`)
-and deploys the Storybook site.
-
-> A few things happen when `pnpm publish` is run inside each package's
-> directory:
+> The `pnpm version` command:
 >
-> 1. First, a `prepack` script is triggered that removes the `type` field from
+> 1. bumps the version in the workspace's `package.json`;
+> 1. copies the new version into each package's `package.json` (via the
+>    `version` script);
+> 1. commits and tags the changes, and then pushes the new commit and the new
+>    tag to the remote repository (via the `postversion` script).
+>
+> This, in turn, triggers the _Publish packages_ and _Deploy Storybook_
+> workflows on the CI, which builds and publishes the packages to NPM (with
+> `pnpm -r publish`) and deploys the Storybook site.
+>
+> A few things happen when `pnpm publish` runs for each package:
+>
+> 1. First, it triggers a `prepack` script that removes the `type` field from
 >    the package's `package.json`. The reason for this workaround is explained
 >    in [#1219](https://github.com/silx-kit/h5web/issues/1219).
 > 2. Then, pnpm modifies `package.json` further by merging in the content of the
@@ -357,7 +361,7 @@ and deploys the Storybook site.
 >    [Verdaccio](https://verdaccio.org/)) by overriding NPM's default
 >    [`registry` configuration](https://docs.npmjs.com/cli/v9/using-npm/registry).
 
-Once the _Release_ workflow has completed:
+Once the CI workflows have run successfully:
 
 - Make sure the new package versions are available on NPM and that the live
   Storybook site still works as expected.
@@ -376,9 +380,9 @@ before the official release.
    number as needed).
 
 The CI will then build and deploy the packages with `pnpm publish --tag next`.
-Once the _Release_ workflow has completed, check that the beta packages have
-been published with the correct tag by running `npm dist-tag ls @h5web/lib`.
-This command should print something like:
+Once the _Publish packages_ workflow has run successfully, check that the beta
+packages are published with the correct tag by running
+`npm dist-tag ls @h5web/lib`. This command should print something like:
 
 ```
 latest: <a.b.c>
@@ -390,6 +394,6 @@ like and make sure that they work as expected. Once you're done testing, follow
 the normal release process, making sure to run `pnpm version <x.y.z>` at step 3
 (without the `beta` suffix).
 
-Once the release process has completed, you can remove the `next` tag from the
-obsolete beta packages by running
-`npm dist-tag rm @h5web/lib@<x.y.z>-beta.0 next`
+Once you've completed the release process, you may remove the `next` tag from
+the obsolete beta packages by running
+`npm dist-tag rm @h5web/lib@<x.y.z-beta.0> next`

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test": "jest",
     "cypress": "cypress open --e2e --browser firefox",
     "cypress:run": "cypress run --e2e",
+    "version": "pnpm -r sync-version && git add .",
     "postversion": "git push && git push --tags"
   },
   "devDependencies": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h5web/app",
-  "version": "0.0.1",
+  "version": "10.1.0",
   "description": "H5Web app and providers",
   "author": "European Synchrotron Radiation Facility",
   "license": "MIT",
@@ -36,7 +36,8 @@
     "lint:tsc": "tsc",
     "test": "jest",
     "analyze": "pnpm dlx source-map-explorer dist/index.js --no-border-checks",
-    "prepack": "pnpm dlx dot-json@latest package.json -d type"
+    "prepack": "dot-json package.json -d type",
+    "sync-version": "dot-json ../../package.json version | xargs dot-json package.json version"
   },
   "peerDependencies": {
     "react": ">=18",
@@ -81,6 +82,7 @@
     "@types/react-slider": "~1.3.6",
     "@vitejs/plugin-react": "4.2.1",
     "concat": "1.0.3",
+    "dot-json": "1.3.0",
     "eslint": "8.56.0",
     "eslint-config-galex": "4.5.2",
     "jest": "29.7.0",

--- a/packages/h5wasm/package.json
+++ b/packages/h5wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h5web/h5wasm",
-  "version": "0.0.1",
+  "version": "10.1.0",
   "description": "H5Web providers based on H5Wasm",
   "author": "European Synchrotron Radiation Facility",
   "license": "MIT",
@@ -32,7 +32,8 @@
     "lint:eslint": "eslint \"**/*.{js,cjs,ts,tsx}\" --max-warnings=0",
     "lint:tsc": "tsc",
     "analyze": "pnpm dlx source-map-explorer dist/index.js --no-border-checks",
-    "prepack": "pnpm dlx dot-json@latest package.json -d type"
+    "prepack": "dot-json package.json -d type",
+    "sync-version": "dot-json ../../package.json version | xargs dot-json package.json version"
   },
   "peerDependencies": {
     "@h5web/app": "workspace:*",
@@ -55,6 +56,7 @@
     "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@vitejs/plugin-react": "4.2.1",
+    "dot-json": "1.3.0",
     "eslint": "8.56.0",
     "eslint-config-galex": "4.5.2",
     "react": "18.2.0",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h5web/lib",
-  "version": "0.0.1",
+  "version": "10.1.0",
   "description": "Data visualization toolkit",
   "author": "European Synchrotron Radiation Facility",
   "license": "MIT",
@@ -36,7 +36,8 @@
     "lint:tsc": "tsc",
     "test": "jest",
     "analyze": "pnpm dlx source-map-explorer dist/index.js --no-border-checks",
-    "prepack": "pnpm dlx dot-json@latest package.json -d type"
+    "prepack": "dot-json package.json -d type",
+    "sync-version": "dot-json ../../package.json version | xargs dot-json package.json version"
   },
   "peerDependencies": {
     "@react-three/fiber": ">=8",
@@ -97,6 +98,7 @@
     "@types/three": "0.159.0",
     "@vitejs/plugin-react": "4.2.1",
     "concat": "1.0.3",
+    "dot-json": "1.3.0",
     "eslint": "8.56.0",
     "eslint-config-galex": "4.5.2",
     "jest": "29.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,6 +320,9 @@ importers:
       concat:
         specifier: 1.0.3
         version: 1.0.3
+      dot-json:
+        specifier: 1.3.0
+        version: 1.3.0
       eslint:
         specifier: 8.56.0
         version: 8.56.0
@@ -384,6 +387,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: 4.2.1
         version: 4.2.1(vite@5.0.9)
+      dot-json:
+        specifier: 1.3.0
+        version: 1.3.0
       eslint:
         specifier: 8.56.0
         version: 8.56.0
@@ -541,6 +547,9 @@ importers:
       concat:
         specifier: 1.0.3
         version: 1.0.3
+      dot-json:
+        specifier: 1.3.0
+        version: 1.3.0
       eslint:
         specifier: 8.56.0
         version: 8.56.0
@@ -7502,6 +7511,11 @@ packages:
       webgl-constants: 1.1.1
     dev: false
 
+  /detect-indent@6.0.0:
+    resolution: {integrity: sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==}
+    engines: {node: '>=8'}
+    dev: true
+
   /detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
@@ -7564,6 +7578,11 @@ packages:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
     dev: true
 
+  /docopt@0.6.2:
+    resolution: {integrity: sha512-NqTbaYeE4gA/wU1hdKFdU+AFahpDOpgGLzHP42k6H6DKExJd0A55KEVWYhL9FEmHmgeLvEU2vuKXDuU+4yToOw==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
@@ -7587,6 +7606,15 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       webidl-conversions: 7.0.0
+    dev: true
+
+  /dot-json@1.3.0:
+    resolution: {integrity: sha512-Pu11Prog/Yjf2lBICow82/DSV46n3a2XT1Rqt/CeuhkO1fuacF7xydYhI0SwQx2Ue0jCyLtQzgKPFEO6ewv+bQ==}
+    hasBin: true
+    dependencies:
+      detect-indent: 6.0.0
+      docopt: 0.6.2
+      underscore-keypath: 0.0.22
     dev: true
 
   /dotenv-expand@10.0.0:
@@ -13994,6 +14022,16 @@ packages:
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
+    dev: true
+
+  /underscore-keypath@0.0.22:
+    resolution: {integrity: sha512-fU7aYj1J2LQd+jqdQ67AlCOZKK3Pl+VErS8fGYcgZG75XB9/bY+RLM+F2xEcKHhHNtLvqqFyXAoZQlLYfec3Xg==}
+    dependencies:
+      underscore: 1.13.6
+    dev: true
+
+  /underscore@1.13.6:
+    resolution: {integrity: sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==}
     dev: true
 
   /undici-types@5.26.5:


### PR DESCRIPTION
The main purpose of this PR (which stems from #1543, which I'll rebase on this one) is to be able to pack a package into a tarball without having to worry about its version (i.e. without ending up with a packed package that has version `0.0.1`).

To do so, I add a `version` script (which runs as part of `pnpm version`) that copies the bumped version number of the monorepo into each package's `package.json`. This allows those `package.json` files to be committed with their real version numbers instead of the placeholder `0.0.1`.

As a side benefit, the _Publish packages_ CI workflow is now a lot shorter and less magical: it just builds the packages and publishes them!