### PR TITLE
Link to artifact URL from PR when visual diffing fails

### DIFF
--- a/.github/workflows/approve-snapshots.yml
+++ b/.github/workflows/approve-snapshots.yml
@@ -60,7 +60,7 @@ jobs:
           CYPRESS_TAKE_SNAPSHOTS: true
 
       - name: Upload debug screenshots and diffs on failure 🖼️
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cypress

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -157,10 +157,32 @@ jobs:
           CYPRESS_TAKE_SNAPSHOTS: true
 
       - name: Upload debug screenshots and diffs on failure 🖼️
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
+        id: uploadSnapshots
         with:
           name: cypress
           path: |
             cypress/debug/
             cypress/snapshots/**/__diff_output__/
+
+    outputs:
+      snapshotsUrl: ${{ steps.uploadSnapshots.outputs.artifact-url }}
+
+  report:
+    runs-on: ubuntu-latest
+    needs: e2e
+    if: github.event_name == 'pull_request' && needs.e2e.outputs.snapshotsUrl
+    steps:
+      - name: Provide download link in PR
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: github.event.pull_request.number
+          body: |
+            #### :flags: Visual changes detected!
+
+            Please [download and review the snapshot diffs](${{ needs.e2e.outputs.snapshotsUrl }}). If the changes are expected:
+
+            1. Comment with `/approve`.
+            1. Wait for the CI workflow _Approve snapshots_ to open a PR called _Update Cypress reference snapshots_.
+            1. Review and merge the updated snapshots into this PR, ideally with a rebase.

--- a/packages/app/src/providers/mock/mock-file.ts
+++ b/packages/app/src/providers/mock/mock-file.ts
@@ -134,7 +134,7 @@ export function makeMockFile(): GroupWithChildren {
               nxData('nx_data', {
                 signal: array('twoD'),
                 silxStyle: { signalScaleType: ScaleType.SymLog },
-                title: scalar('title', 'NeXus 2D'),
+                title: scalar('title', 'NEXUS 2D'),
               }),
               nxGroup('absolute_default_path', 'NXentry', {
                 defaultPath: '/nexus_entry/nx_process/nx_data',


### PR DESCRIPTION
The [upload-artifact](https://github.com/actions/upload-artifact) action finally exposes an `artifact-url` output! This was probably [their most requested features](https://github.com/actions/upload-artifact/issues/50).

This means we can provide a link to download the artifacts from the PR when visual diffing fails. I do this using the [create-or-update-comment](https://github.com/peter-evans/create-or-update-comment) action.