### PR TITLE
Test `H5GroveApi`

### DIFF
--- a/apps/demo/src/Home.tsx
+++ b/apps/demo/src/Home.tsx
@@ -87,15 +87,21 @@ function Home() {
                 group (Argonne National Laboratory).
               </li>
               <li>
-                <Link to="/h5grove?file=grove.h5">grove.h5</Link> - a file used
-                to test the <code>H5GroveProvider</code> provider; it contains
-                datasets with <code>NaN</code>, <code>Infinity</code>, boolean
-                and complex values, as well as RGB images and 4D stacks.
+                <Link to="/h5grove?file=grove.h5">grove.h5</Link> - a file
+                designed to demonstrate the capabilities of{' '}
+                <code>H5GroveProvider</code>; it contains datasets with{' '}
+                <code>NaN</code>, <code>Infinity</code>, boolean and complex
+                values, as well as RGB images and 4D stacks.
               </li>
               <li>
                 <Link to="/h5grove?file=links.h5">links.h5</Link> - a file with
                 external links, soft links and a virtual dataset to test link
                 resolution.
+              </li>
+              <li>
+                <Link to="/h5grove?file=sample.h5">sample.h5</Link> - the file
+                used to test <code>H5GroveApi</code> and <code>H5WasmApi</code>{' '}
+                internally.
               </li>
               <li>
                 <Link to="/h5grove?file=tall.h5">tall.h5</Link> - the demo file
@@ -144,20 +150,24 @@ function Home() {
                 silx.org
               </a>
               :{' '}
-              {['water_224.h5', 'epics.h5', 'grove.h5', 'tall.h5 '].map(
-                (filename, index) => (
-                  <Fragment key={filename}>
-                    {index > 0 && ', '}
-                    <Link
-                      to={`/h5wasm?url=${encodeURIComponent(
-                        `https://www.silx.org/pub/h5web/${filename}`,
-                      )}`}
-                    >
-                      {filename}
-                    </Link>
-                  </Fragment>
-                ),
-              )}
+              {[
+                'water_224.h5',
+                'epics.h5',
+                'grove.h5',
+                'sample.h5',
+                'tall.h5 ',
+              ].map((filename, index) => (
+                <Fragment key={filename}>
+                  {index > 0 && ', '}
+                  <Link
+                    to={`/h5wasm?url=${encodeURIComponent(
+                      `https://www.silx.org/pub/h5web/${filename}`,
+                    )}`}
+                  >
+                    {filename}
+                  </Link>
+                </Fragment>
+              ))}
             </p>
           </section>
           <section>

--- a/create_h5_sample.py
+++ b/create_h5_sample.py
@@ -7,7 +7,7 @@ if sys.version_info.major < 3:
     raise RuntimeError("Python 2 is not supported")
 
 BASE_PATH = os.path.dirname(os.path.realpath(sys.argv[0]))
-DIST_PATH = os.path.join(BASE_PATH, "dist-h5")
+DIST_PATH = os.path.join(BASE_PATH, "dist")
 os.makedirs(DIST_PATH, exist_ok=True)
 
 h5py.get_config().track_order = True

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -22,5 +22,10 @@ export { assertEnvVar } from '@h5web/shared/guards';
 export { default as DataProvider } from './providers/DataProvider';
 export { DataProviderApi } from './providers/api';
 export type { ValuesStoreParams } from './providers/models';
-export { flattenValue, getNameFromPath, sliceValue } from './providers/utils';
+export {
+  flattenValue,
+  getNameFromPath,
+  sliceValue,
+  getValueOrError,
+} from './providers/utils';
 export { assertNonNull } from '@h5web/shared/guards';

--- a/packages/app/src/providers/h5grove/__snapshots__/h5grove-api.test.ts.snap
+++ b/packages/app/src/providers/h5grove/__snapshots__/h5grove-api.test.ts.snap
@@ -1,0 +1,1088 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`test file matches snapshot 1`] = `
+[
+  {
+    "name": "int8_scalar",
+    "rawType": "|i1",
+    "shape": [],
+    "type": {
+      "class": "Integer",
+      "endianness": "little-endian",
+      "size": 8,
+    },
+    "value": -128,
+  },
+  {
+    "name": "int8_2D",
+    "rawType": "|i1",
+    "shape": [
+      2,
+      3,
+    ],
+    "type": {
+      "class": "Integer",
+      "endianness": "little-endian",
+      "size": 8,
+    },
+    "value": Int8Array [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+    ],
+  },
+  {
+    "name": "int16_scalar",
+    "rawType": "<i2",
+    "shape": [],
+    "type": {
+      "class": "Integer",
+      "endianness": "little-endian",
+      "size": 16,
+    },
+    "value": -32768,
+  },
+  {
+    "name": "int16_2D",
+    "rawType": "<i2",
+    "shape": [
+      2,
+      3,
+    ],
+    "type": {
+      "class": "Integer",
+      "endianness": "little-endian",
+      "size": 16,
+    },
+    "value": Int16Array [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+    ],
+  },
+  {
+    "name": "int32_scalar",
+    "rawType": "<i4",
+    "shape": [],
+    "type": {
+      "class": "Integer",
+      "endianness": "little-endian",
+      "size": 32,
+    },
+    "value": -2147483648,
+  },
+  {
+    "name": "int32_BE_scalar",
+    "rawType": ">i4",
+    "shape": [],
+    "type": {
+      "class": "Integer",
+      "endianness": "big-endian",
+      "size": 32,
+    },
+    "value": 0,
+  },
+  {
+    "name": "int32_2D",
+    "rawType": "<i4",
+    "shape": [
+      2,
+      3,
+    ],
+    "type": {
+      "class": "Integer",
+      "endianness": "little-endian",
+      "size": 32,
+    },
+    "value": Int32Array [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+    ],
+  },
+  {
+    "name": "int64_scalar",
+    "rawType": "<i8",
+    "shape": [],
+    "type": {
+      "class": "Integer",
+      "endianness": "little-endian",
+      "size": 64,
+    },
+    "value": -9223372036854776000,
+  },
+  {
+    "name": "int64_2D",
+    "rawType": "<i8",
+    "shape": [
+      2,
+      3,
+    ],
+    "type": {
+      "class": "Integer",
+      "endianness": "little-endian",
+      "size": 64,
+    },
+    "value": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+    ],
+  },
+  {
+    "name": "uint8_scalar",
+    "rawType": "|u1",
+    "shape": [],
+    "type": {
+      "class": "Integer (unsigned)",
+      "endianness": "little-endian",
+      "size": 8,
+    },
+    "value": 255,
+  },
+  {
+    "name": "uint8_2D",
+    "rawType": "|u1",
+    "shape": [
+      2,
+      3,
+    ],
+    "type": {
+      "class": "Integer (unsigned)",
+      "endianness": "little-endian",
+      "size": 8,
+    },
+    "value": Uint8Array [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+    ],
+  },
+  {
+    "name": "uint16_scalar",
+    "rawType": "<u2",
+    "shape": [],
+    "type": {
+      "class": "Integer (unsigned)",
+      "endianness": "little-endian",
+      "size": 16,
+    },
+    "value": 65535,
+  },
+  {
+    "name": "uint16_2D",
+    "rawType": "<u2",
+    "shape": [
+      2,
+      3,
+    ],
+    "type": {
+      "class": "Integer (unsigned)",
+      "endianness": "little-endian",
+      "size": 16,
+    },
+    "value": Uint16Array [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+    ],
+  },
+  {
+    "name": "uint32_scalar",
+    "rawType": "<u4",
+    "shape": [],
+    "type": {
+      "class": "Integer (unsigned)",
+      "endianness": "little-endian",
+      "size": 32,
+    },
+    "value": 4294967295,
+  },
+  {
+    "name": "uint32_2D",
+    "rawType": "<u4",
+    "shape": [
+      2,
+      3,
+    ],
+    "type": {
+      "class": "Integer (unsigned)",
+      "endianness": "little-endian",
+      "size": 32,
+    },
+    "value": Uint32Array [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+    ],
+  },
+  {
+    "name": "uint64_scalar",
+    "rawType": "<u8",
+    "shape": [],
+    "type": {
+      "class": "Integer (unsigned)",
+      "endianness": "little-endian",
+      "size": 64,
+    },
+    "value": 18446744073709552000,
+  },
+  {
+    "name": "uint64_3D",
+    "rawType": "<u8",
+    "shape": [
+      2,
+      2,
+      2,
+    ],
+    "type": {
+      "class": "Integer (unsigned)",
+      "endianness": "little-endian",
+      "size": 64,
+    },
+    "value": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      18446744073709552000,
+    ],
+  },
+  {
+    "name": "float16_scalar",
+    "rawType": "<f2",
+    "shape": [],
+    "type": {
+      "class": "Float",
+      "endianness": "little-endian",
+      "size": 16,
+    },
+    "value": 0.00006103515625,
+  },
+  {
+    "name": "float16_2D",
+    "rawType": "<f2",
+    "shape": [
+      2,
+      3,
+    ],
+    "type": {
+      "class": "Float",
+      "endianness": "little-endian",
+      "size": 16,
+    },
+    "value": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+    ],
+  },
+  {
+    "name": "float32_empty",
+    "rawType": "<f4",
+    "shape": null,
+    "type": {
+      "class": "Float",
+      "endianness": "little-endian",
+      "size": 32,
+    },
+    "value": null,
+  },
+  {
+    "name": "float32_scalar",
+    "rawType": "<f4",
+    "shape": [],
+    "type": {
+      "class": "Float",
+      "endianness": "little-endian",
+      "size": 32,
+    },
+    "value": 1.1754943508222875e-38,
+  },
+  {
+    "name": "float32_BE_scalar",
+    "rawType": ">f4",
+    "shape": [],
+    "type": {
+      "class": "Float",
+      "endianness": "big-endian",
+      "size": 32,
+    },
+    "value": 0,
+  },
+  {
+    "name": "float32_2D",
+    "rawType": "<f4",
+    "shape": [
+      2,
+      3,
+    ],
+    "type": {
+      "class": "Float",
+      "endianness": "little-endian",
+      "size": 32,
+    },
+    "value": Float32Array [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+    ],
+  },
+  {
+    "name": "float64_scalar",
+    "rawType": "<f8",
+    "shape": [],
+    "type": {
+      "class": "Float",
+      "endianness": "little-endian",
+      "size": 64,
+    },
+    "value": 2.2250738585072014e-308,
+  },
+  {
+    "name": "float64_nan_scalar",
+    "rawType": "<f8",
+    "shape": [],
+    "type": {
+      "class": "Float",
+      "endianness": "little-endian",
+      "size": 64,
+    },
+    "value": NaN,
+  },
+  {
+    "name": "float64_inf_scalar",
+    "rawType": "<f8",
+    "shape": [],
+    "type": {
+      "class": "Float",
+      "endianness": "little-endian",
+      "size": 64,
+    },
+    "value": Infinity,
+  },
+  {
+    "name": "float64_ninf_scalar",
+    "rawType": "<f8",
+    "shape": [],
+    "type": {
+      "class": "Float",
+      "endianness": "little-endian",
+      "size": 64,
+    },
+    "value": -Infinity,
+  },
+  {
+    "name": "float64_zero_scalar",
+    "rawType": "<f8",
+    "shape": [],
+    "type": {
+      "class": "Float",
+      "endianness": "little-endian",
+      "size": 64,
+    },
+    "value": 0,
+  },
+  {
+    "name": "float64_nzero_scalar",
+    "rawType": "<f8",
+    "shape": [],
+    "type": {
+      "class": "Float",
+      "endianness": "little-endian",
+      "size": 64,
+    },
+    "value": -0,
+  },
+  {
+    "name": "float64_pi_scalar",
+    "rawType": "<f8",
+    "shape": [],
+    "type": {
+      "class": "Float",
+      "endianness": "little-endian",
+      "size": 64,
+    },
+    "value": 3.141592653589793,
+  },
+  {
+    "name": "float64_2D",
+    "rawType": "<f8",
+    "shape": [
+      3,
+      5,
+    ],
+    "type": {
+      "class": "Float",
+      "endianness": "little-endian",
+      "size": 64,
+    },
+    "value": Float64Array [
+      0,
+      1,
+      Infinity,
+      3,
+      4,
+      3,
+      4,
+      NaN,
+      6,
+      7,
+      6,
+      7,
+      -Infinity,
+      9,
+      10,
+    ],
+  },
+  {
+    "name": "float128_scalar",
+    "rawType": "<f16",
+    "shape": [],
+    "type": {
+      "class": "Float",
+      "endianness": "little-endian",
+      "size": 128,
+    },
+    "value": 0,
+  },
+  {
+    "name": "float128_2D",
+    "rawType": "<f16",
+    "shape": [
+      2,
+      3,
+    ],
+    "type": {
+      "class": "Float",
+      "endianness": "little-endian",
+      "size": 128,
+    },
+    "value": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+    ],
+  },
+  {
+    "name": "ascii_vlen_empty",
+    "rawType": "|O",
+    "shape": null,
+    "type": {
+      "charSet": "UTF-8",
+      "class": "String",
+    },
+    "value": null,
+  },
+  {
+    "name": "ascii_vlen_scalar",
+    "rawType": "|O",
+    "shape": [],
+    "type": {
+      "charSet": "UTF-8",
+      "class": "String",
+    },
+    "value": "Some text",
+  },
+  {
+    "name": "ascii_fixed_scalar",
+    "rawType": "|S9",
+    "shape": [],
+    "type": {
+      "charSet": "ASCII",
+      "class": "String",
+      "length": 9,
+    },
+    "value": "Some text",
+  },
+  {
+    "name": "utf8_vlen_scalar",
+    "rawType": "|O",
+    "shape": [],
+    "type": {
+      "charSet": "UTF-8",
+      "class": "String",
+    },
+    "value": "Some text",
+  },
+  {
+    "name": "utf8_vlen_1D",
+    "rawType": "|O",
+    "shape": [
+      3,
+    ],
+    "type": {
+      "charSet": "UTF-8",
+      "class": "String",
+    },
+    "value": [
+      "foo",
+      "bar",
+      "baz",
+    ],
+  },
+  {
+    "name": "utf8_fixed_scalar",
+    "rawType": "|S9",
+    "shape": [],
+    "type": {
+      "charSet": "ASCII",
+      "class": "String",
+      "length": 9,
+    },
+    "value": "Some text",
+  },
+  {
+    "name": "byte_string_scalar",
+    "rawType": "|V3",
+    "shape": [],
+    "type": {
+      "class": "Unknown",
+    },
+    "value": " "",
+  },
+  {
+    "name": "datetime64_scalar",
+    "rawType": "|V8",
+    "shape": [],
+    "type": {
+      "class": "Unknown",
+    },
+    "value": [AxiosError: Request failed with status code 500],
+  },
+  {
+    "name": "datetime64_not-a-time_scalar",
+    "rawType": "|V8",
+    "shape": [],
+    "type": {
+      "class": "Unknown",
+    },
+    "value": [AxiosError: Request failed with status code 500],
+  },
+  {
+    "name": "complex64_scalar",
+    "rawType": "<c8",
+    "shape": [],
+    "type": {
+      "class": "Complex",
+      "imagType": {
+        "class": "Float",
+        "endianness": "little-endian",
+        "size": 32,
+      },
+      "realType": {
+        "class": "Float",
+        "endianness": "little-endian",
+        "size": 32,
+      },
+    },
+    "value": [
+      1.1754943508222875e-38,
+      3.4028234663852886e+38,
+    ],
+  },
+  {
+    "name": "complex64_2D",
+    "rawType": "<c8",
+    "shape": [
+      2,
+      2,
+    ],
+    "type": {
+      "class": "Complex",
+      "imagType": {
+        "class": "Float",
+        "endianness": "little-endian",
+        "size": 32,
+      },
+      "realType": {
+        "class": "Float",
+        "endianness": "little-endian",
+        "size": 32,
+      },
+    },
+    "value": [
+      [
+        1,
+        2,
+      ],
+      [
+        3,
+        4,
+      ],
+      [
+        5,
+        6,
+      ],
+      [
+        7,
+        8,
+      ],
+    ],
+  },
+  {
+    "name": "complex128_scalar",
+    "rawType": "<c16",
+    "shape": [],
+    "type": {
+      "class": "Complex",
+      "imagType": {
+        "class": "Float",
+        "endianness": "little-endian",
+        "size": 64,
+      },
+      "realType": {
+        "class": "Float",
+        "endianness": "little-endian",
+        "size": 64,
+      },
+    },
+    "value": [
+      2.2250738585072014e-308,
+      1.7976931348623157e+308,
+    ],
+  },
+  {
+    "name": "complex128_BE_scalar",
+    "rawType": ">c16",
+    "shape": [],
+    "type": {
+      "class": "Complex",
+      "imagType": {
+        "class": "Float",
+        "endianness": "big-endian",
+        "size": 64,
+      },
+      "realType": {
+        "class": "Float",
+        "endianness": "big-endian",
+        "size": 64,
+      },
+    },
+    "value": [
+      1,
+      2,
+    ],
+  },
+  {
+    "name": "complex128_2D",
+    "rawType": "<c16",
+    "shape": [
+      2,
+      2,
+    ],
+    "type": {
+      "class": "Complex",
+      "imagType": {
+        "class": "Float",
+        "endianness": "little-endian",
+        "size": 64,
+      },
+      "realType": {
+        "class": "Float",
+        "endianness": "little-endian",
+        "size": 64,
+      },
+    },
+    "value": [
+      [
+        1,
+        2,
+      ],
+      [
+        3,
+        4,
+      ],
+      [
+        5,
+        6,
+      ],
+      [
+        7,
+        8,
+      ],
+    ],
+  },
+  {
+    "name": "complex256_scalar",
+    "rawType": "<c32",
+    "shape": [],
+    "type": {
+      "class": "Complex",
+      "imagType": {
+        "class": "Float",
+        "endianness": "little-endian",
+        "size": 128,
+      },
+      "realType": {
+        "class": "Float",
+        "endianness": "little-endian",
+        "size": 128,
+      },
+    },
+    "value": [AxiosError: Request failed with status code 500],
+  },
+  {
+    "name": "complex256_2D",
+    "rawType": "<c32",
+    "shape": [
+      2,
+      2,
+    ],
+    "type": {
+      "class": "Complex",
+      "imagType": {
+        "class": "Float",
+        "endianness": "little-endian",
+        "size": 128,
+      },
+      "realType": {
+        "class": "Float",
+        "endianness": "little-endian",
+        "size": 128,
+      },
+    },
+    "value": [AxiosError: Request failed with status code 500],
+  },
+  {
+    "name": "compound_scalar",
+    "rawType": {
+      "bigint": "<i8",
+      "double": "<f8",
+      "utf-8": "|O",
+    },
+    "shape": [],
+    "type": {
+      "class": "Compound",
+      "fields": {
+        "bigint": {
+          "class": "Integer",
+          "endianness": "little-endian",
+          "size": 64,
+        },
+        "double": {
+          "class": "Float",
+          "endianness": "little-endian",
+          "size": 64,
+        },
+        "utf-8": {
+          "charSet": "UTF-8",
+          "class": "String",
+        },
+      },
+    },
+    "value": [
+      1,
+      2,
+      "foo",
+    ],
+  },
+  {
+    "name": "compound_1D",
+    "rawType": {
+      "bigint": "<i8",
+      "double": "<f8",
+      "utf-8": "|O",
+    },
+    "shape": [
+      3,
+    ],
+    "type": {
+      "class": "Compound",
+      "fields": {
+        "bigint": {
+          "class": "Integer",
+          "endianness": "little-endian",
+          "size": 64,
+        },
+        "double": {
+          "class": "Float",
+          "endianness": "little-endian",
+          "size": 64,
+        },
+        "utf-8": {
+          "charSet": "UTF-8",
+          "class": "String",
+        },
+      },
+    },
+    "value": [
+      [
+        1,
+        null,
+        "foo",
+      ],
+      [
+        2,
+        null,
+        "bar",
+      ],
+      [
+        3,
+        -0,
+        "baz",
+      ],
+    ],
+  },
+  {
+    "name": "compound_nested_scalar",
+    "rawType": {
+      "nested": {
+        "bool": "|b1",
+        "cplx": "<c8",
+      },
+    },
+    "shape": [],
+    "type": {
+      "class": "Compound",
+      "fields": {
+        "nested": {
+          "class": "Compound",
+          "fields": {
+            "bool": {
+              "class": "Boolean",
+            },
+            "cplx": {
+              "class": "Complex",
+              "imagType": {
+                "class": "Float",
+                "endianness": "little-endian",
+                "size": 32,
+              },
+              "realType": {
+                "class": "Float",
+                "endianness": "little-endian",
+                "size": 32,
+              },
+            },
+          },
+        },
+      },
+    },
+    "value": [
+      [
+        true,
+        [
+          1,
+          2,
+        ],
+      ],
+    ],
+  },
+  {
+    "name": "compound_array_vlen_1D",
+    "rawType": {
+      "arr": "|V8",
+      "vlen": "|O",
+    },
+    "shape": [
+      3,
+    ],
+    "type": {
+      "class": "Compound",
+      "fields": {
+        "arr": {
+          "class": "Unknown",
+        },
+        "vlen": {
+          "charSet": "UTF-8",
+          "class": "String",
+        },
+      },
+    },
+    "value": [
+      [
+        [
+          0,
+          1,
+        ],
+        [
+          0,
+        ],
+      ],
+      [
+        [
+          2,
+          3,
+        ],
+        [
+          0,
+          1,
+        ],
+      ],
+      [
+        [
+          4,
+          5,
+        ],
+        [
+          0,
+          1,
+          2,
+        ],
+      ],
+    ],
+  },
+  {
+    "name": "reference_scalar",
+    "rawType": "|O",
+    "shape": [],
+    "type": {
+      "charSet": "UTF-8",
+      "class": "String",
+    },
+    "value": "<HDF5 object reference>",
+  },
+  {
+    "name": "reference_region_scalar",
+    "rawType": "|O",
+    "shape": [],
+    "type": {
+      "charSet": "UTF-8",
+      "class": "String",
+    },
+    "value": "<HDF5 object reference>",
+  },
+  {
+    "name": "bool_empty",
+    "rawType": "|b1",
+    "shape": null,
+    "type": {
+      "class": "Boolean",
+    },
+    "value": null,
+  },
+  {
+    "name": "bool_false_scalar",
+    "rawType": "|b1",
+    "shape": [],
+    "type": {
+      "class": "Boolean",
+    },
+    "value": false,
+  },
+  {
+    "name": "bool_true_scalar",
+    "rawType": "|b1",
+    "shape": [],
+    "type": {
+      "class": "Boolean",
+    },
+    "value": true,
+  },
+  {
+    "name": "bool_2D",
+    "rawType": "|b1",
+    "shape": [
+      2,
+      4,
+    ],
+    "type": {
+      "class": "Boolean",
+    },
+    "value": [
+      true,
+      false,
+      true,
+      true,
+      false,
+      false,
+      true,
+      false,
+    ],
+  },
+  {
+    "name": "enum_uint8_scalar",
+    "rawType": "|u1",
+    "shape": [],
+    "type": {
+      "class": "Integer (unsigned)",
+      "endianness": "little-endian",
+      "size": 8,
+    },
+    "value": 1,
+  },
+  {
+    "name": "enum_int32_scalar",
+    "rawType": "<i4",
+    "shape": [],
+    "type": {
+      "class": "Integer",
+      "endianness": "little-endian",
+      "size": 32,
+    },
+    "value": 256,
+  },
+  {
+    "name": "vlen_int8_scalar",
+    "rawType": "|O",
+    "shape": [],
+    "type": {
+      "charSet": "UTF-8",
+      "class": "String",
+    },
+    "value": [
+      0,
+      1,
+    ],
+  },
+  {
+    "name": "vlen_int64_1D",
+    "rawType": "|O",
+    "shape": [
+      3,
+    ],
+    "type": {
+      "charSet": "UTF-8",
+      "class": "String",
+    },
+    "value": [
+      [
+        0,
+      ],
+      [
+        0,
+        1,
+      ],
+      [
+        0,
+        1,
+        2,
+      ],
+    ],
+  },
+]
+`;

--- a/packages/app/src/providers/h5grove/h5grove-api.test.ts
+++ b/packages/app/src/providers/h5grove/h5grove-api.test.ts
@@ -1,0 +1,38 @@
+import {
+  assertDataset,
+  assertGroup,
+  assertGroupWithChildren,
+  hasNonNullShape,
+} from '@h5web/shared/guards';
+import { expect, test } from 'vitest';
+
+import { getValueOrError } from '../utils';
+import { H5GroveApi } from './h5grove-api';
+
+const H5GROVE_URL = 'https://bosquet.silx.org/h5grove';
+const TEST_FILE = 'sample.h5'; // `https` would complicate things...
+
+test('test file matches snapshot', async () => {
+  const api = new H5GroveApi(H5GROVE_URL, TEST_FILE, {
+    params: { file: TEST_FILE },
+  });
+
+  const root = await api.getEntity('/');
+  assertGroup(root);
+  assertGroupWithChildren(root);
+
+  const children = await Promise.all(
+    root.children.map(async (child) => {
+      assertDataset(child);
+      const { name, shape, type, rawType } = child;
+
+      const value = hasNonNullShape(child)
+        ? await getValueOrError(api, child)
+        : null;
+
+      return { name, shape, type, rawType, value };
+    }),
+  );
+
+  expect(children).toMatchSnapshot();
+});

--- a/packages/app/src/providers/utils.ts
+++ b/packages/app/src/providers/utils.ts
@@ -10,6 +10,7 @@ import { DTypeClass } from '@h5web/shared/hdf5-models';
 import { AxiosError } from 'axios';
 import ndarray from 'ndarray';
 
+import type { DataProviderApi } from '..';
 import { applyMapping } from '../vis-packs/core/utils';
 
 export const CANCELLED_ERROR_MSG = 'Request cancelled';
@@ -111,4 +112,15 @@ export function typedArrayFromDType(dtype: DType) {
   }
 
   return undefined;
+}
+
+export async function getValueOrError(
+  api: DataProviderApi,
+  dataset: Dataset<ArrayShape | ScalarShape>,
+): Promise<unknown> {
+  try {
+    return await api.getValue({ dataset });
+  } catch (error) {
+    return error;
+  }
 }

--- a/packages/app/src/providers/utils.ts
+++ b/packages/app/src/providers/utils.ts
@@ -10,8 +10,8 @@ import { DTypeClass } from '@h5web/shared/hdf5-models';
 import { AxiosError } from 'axios';
 import ndarray from 'ndarray';
 
-import type { DataProviderApi } from '..';
 import { applyMapping } from '../vis-packs/core/utils';
+import type { DataProviderApi } from './api';
 
 export const CANCELLED_ERROR_MSG = 'Request cancelled';
 

--- a/packages/h5wasm/src/h5wasm-api.test.ts
+++ b/packages/h5wasm/src/h5wasm-api.test.ts
@@ -1,3 +1,7 @@
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
 import {
   assertDataset,
   assertGroup,
@@ -9,14 +13,11 @@ import type {
   Dataset,
   ScalarShape,
 } from '@h5web/shared/hdf5-models';
-import { existsSync } from 'fs';
-import { readFile } from 'fs/promises';
-import path from 'path';
 import { expect, test } from 'vitest';
 
 import { H5WasmApi } from './h5wasm-api';
 
-const LOCAL_TEST_FILE = path.resolve(__dirname, '../dist-h5/sample.h5');
+const LOCAL_TEST_FILE = path.resolve(process.cwd(), 'dist/sample.h5');
 const REMOTE_TEST_FILE = 'http://www.silx.org/pub/h5web/sample.h5'; // `https` would complicate things...
 
 async function loadTestFile(): Promise<ArrayBuffer> {

--- a/packages/h5wasm/src/h5wasm-api.test.ts
+++ b/packages/h5wasm/src/h5wasm-api.test.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
-import { DataProviderApi, getValueOrError } from '@h5web/app';
+import { getValueOrError } from '@h5web/app';
 import {
   assertDataset,
   assertGroup,

--- a/packages/h5wasm/src/h5wasm-api.test.ts
+++ b/packages/h5wasm/src/h5wasm-api.test.ts
@@ -2,17 +2,13 @@ import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
+import { DataProviderApi, getValueOrError } from '@h5web/app';
 import {
   assertDataset,
   assertGroup,
   assertGroupWithChildren,
   hasNonNullShape,
 } from '@h5web/shared/guards';
-import type {
-  ArrayShape,
-  Dataset,
-  ScalarShape,
-} from '@h5web/shared/hdf5-models';
 import { expect, test } from 'vitest';
 
 import { H5WasmApi } from './h5wasm-api';
@@ -27,17 +23,6 @@ async function loadTestFile(): Promise<ArrayBuffer> {
 
   const resp = await fetch(REMOTE_TEST_FILE);
   return resp.arrayBuffer();
-}
-
-async function getValueOrError(
-  api: H5WasmApi,
-  dataset: Dataset<ArrayShape | ScalarShape>,
-): Promise<unknown> {
-  try {
-    return await api.getValue({ dataset });
-  } catch (error) {
-    return error;
-  }
 }
 
 test('test file matches snapshot', async () => {


### PR DESCRIPTION
Diffing the two files (after removing the `rawType` keys) is quite enlightening: https://www.diffchecker.com/0lEq6wKG/ (`H5GroveApi` on the left, `H5WasmApi` on the right).

I can already see some obvious bugs, some potential quick wins, and some more complicated inconsistencies.