### PR TITLE
Refactor providers to notably remove unneeded type guards

### DIFF
--- a/packages/app/src/providers/h5grove/h5grove-api.ts
+++ b/packages/app/src/providers/h5grove/h5grove-api.ts
@@ -168,29 +168,29 @@ export class H5GroveApi extends DataProviderApi {
     return data;
   }
 
-  private async parseEntity(
+  private parseEntity(
     path: string,
     h5gEntity: H5GroveEntity,
     isChild: true,
-  ): Promise<ChildEntity>;
+  ): ChildEntity;
 
-  private async parseEntity(
+  private parseEntity(
     path: string,
     h5gEntity: H5GroveEntity,
     isChild?: false,
-  ): Promise<ProvidedEntity>;
+  ): ProvidedEntity;
 
-  private async parseEntity(
+  private parseEntity(
     path: string,
     h5gEntity: H5GroveEntity,
     isChild = false,
-  ): Promise<ProvidedEntity | ChildEntity> {
+  ): ProvidedEntity | ChildEntity {
     const { name } = h5gEntity;
     const baseEntity = { name, path };
 
     if (h5gEntity.type === EntityKind.Group) {
       const { children = [], attributes: attrsMetadata } = h5gEntity;
-      const attributes = await this.parseAttributes(attrsMetadata);
+      const attributes = this.parseAttributes(attrsMetadata);
       const baseGroup: Group = {
         ...baseEntity,
         kind: EntityKind.Group,
@@ -203,13 +203,10 @@ export class H5GroveApi extends DataProviderApi {
 
       return {
         ...baseGroup,
-        // Fetch attribute values of any child groups in parallel
-        children: await Promise.all(
-          children.map((child) => {
-            const childPath = buildEntityPath(path, child.name);
-            return this.parseEntity(childPath, child, true);
-          }),
-        ),
+        children: children.map((child) => {
+          const childPath = buildEntityPath(path, child.name);
+          return this.parseEntity(childPath, child, true);
+        }),
       };
     }
 
@@ -221,7 +218,7 @@ export class H5GroveApi extends DataProviderApi {
         chunks,
         filters,
       } = h5gEntity;
-      const attributes = await this.parseAttributes(attrsMetadata);
+      const attributes = this.parseAttributes(attrsMetadata);
       return {
         ...baseEntity,
         attributes,
@@ -266,9 +263,7 @@ export class H5GroveApi extends DataProviderApi {
     };
   }
 
-  private async parseAttributes(
-    attrsMetadata: H5GroveAttribute[],
-  ): Promise<Attribute[]> {
+  private parseAttributes(attrsMetadata: H5GroveAttribute[]): Attribute[] {
     return attrsMetadata.map<Attribute>(({ name, dtype, shape }) => ({
       name,
       shape,

--- a/packages/app/src/providers/h5grove/h5grove-api.ts
+++ b/packages/app/src/providers/h5grove/h5grove-api.ts
@@ -218,16 +218,15 @@ export class H5GroveApi extends DataProviderApi {
         chunks,
         filters,
       } = h5gEntity;
-      const attributes = this.parseAttributes(attrsMetadata);
       return {
         ...baseEntity,
-        attributes,
         kind: EntityKind.Dataset,
         shape,
         type: parseDType(dtype),
         rawType: dtype,
         ...(chunks && { chunks }),
         ...(filters && { filters }),
+        attributes: this.parseAttributes(attrsMetadata),
       };
     }
 
@@ -235,8 +234,8 @@ export class H5GroveApi extends DataProviderApi {
       const { target_path } = h5gEntity;
       return {
         ...baseEntity,
-        attributes: [],
         kind: EntityKind.Unresolved,
+        attributes: [],
         link: { class: 'Soft', path: target_path },
       };
     }
@@ -258,8 +257,8 @@ export class H5GroveApi extends DataProviderApi {
     // Treat other entities as unresolved
     return {
       ...baseEntity,
-      attributes: [],
       kind: EntityKind.Unresolved,
+      attributes: [],
     };
   }
 

--- a/packages/app/src/providers/h5grove/models.ts
+++ b/packages/app/src/providers/h5grove/models.ts
@@ -4,55 +4,52 @@ import type {
   Filter,
 } from '@h5web/shared/hdf5-models';
 
-export interface H5GroveEntityResponse {
+export type H5GroveEntityResponse = H5GroveEntity;
+export type H5GroveDataResponse = unknown;
+export type H5GroveAttrValuesResponse = AttributeValues;
+export type H5GrovePathsResponse = string[];
+
+export type H5GroveEntity =
+  | H5GroveGroup
+  | H5GroveDataset
+  | H5GroveSoftLink
+  | H5GroveExternalLink;
+
+export interface H5GroveBaseEntity {
   name: string;
-  type:
-    | EntityKind.Dataset
-    | EntityKind.Group
-    | 'external_link'
-    | 'soft_link'
-    | 'other';
+  type: string;
 }
 
-export type H5GroveDtype =
-  | string
-  | {
-      [k: string]: H5GroveDtype;
-    };
-
-export interface H5GroveDatasetResponse extends H5GroveEntityResponse {
-  type: EntityKind.Dataset;
-  dtype: H5GroveDtype;
-  shape: number[];
+export interface H5GroveGroup extends H5GroveBaseEntity {
+  type: EntityKind.Group;
+  children?: H5GroveEntity[];
   attributes: H5GroveAttribute[];
+}
+
+export interface H5GroveDataset extends H5GroveBaseEntity {
+  type: EntityKind.Dataset;
+  shape: number[];
+  dtype: H5GroveDtype;
   chunks: number[] | null;
   filters: Filter[] | null;
-}
-
-export interface H5GroveGroupResponse extends H5GroveEntityResponse {
-  type: EntityKind.Group;
-  children?: H5GroveEntityResponse[];
   attributes: H5GroveAttribute[];
 }
 
-export interface H5GroveSoftLinkResponse extends H5GroveEntityResponse {
+export interface H5GroveSoftLink extends H5GroveBaseEntity {
   type: 'soft_link';
   target_path: string;
 }
 
-export interface H5GroveExternalLinkResponse extends H5GroveEntityResponse {
+export interface H5GroveExternalLink extends H5GroveBaseEntity {
   type: 'external_link';
   target_file: string;
   target_path: string;
 }
 
 export interface H5GroveAttribute {
-  dtype: H5GroveDtype;
   name: string;
   shape: number[];
+  dtype: H5GroveDtype;
 }
 
-export type H5GroveAttrValuesResponse = AttributeValues;
-export type H5GroveDataResponse = unknown;
-
-export type H5GrovePathsResponse = string[];
+export type H5GroveDtype = string | { [k: string]: H5GroveDtype };

--- a/packages/app/src/providers/h5grove/utils.test.ts
+++ b/packages/app/src/providers/h5grove/utils.test.ts
@@ -11,53 +11,43 @@ import {
 } from '@h5web/shared/hdf5-utils';
 import { describe, expect, it } from 'vitest';
 
-import { convertH5GroveDtype } from './utils';
+import { parseDType } from './utils';
 
-describe('convertH5GroveDtype', () => {
+describe('parseDType', () => {
   it('should convert integer dtypes', () => {
-    expect(convertH5GroveDtype('<i4')).toStrictEqual(
-      intType(32, Endianness.LE),
-    );
-    expect(convertH5GroveDtype('>u8')).toStrictEqual(
-      uintType(64, Endianness.BE),
-    );
+    expect(parseDType('<i4')).toStrictEqual(intType(32, Endianness.LE));
+    expect(parseDType('>u8')).toStrictEqual(uintType(64, Endianness.BE));
   });
 
   it('should convert float dtypes', () => {
-    expect(convertH5GroveDtype('<f4')).toStrictEqual(
-      floatType(32, Endianness.LE),
-    );
-    expect(convertH5GroveDtype('>f8')).toStrictEqual(
-      floatType(64, Endianness.BE),
-    );
+    expect(parseDType('<f4')).toStrictEqual(floatType(32, Endianness.LE));
+    expect(parseDType('>f8')).toStrictEqual(floatType(64, Endianness.BE));
   });
 
   it('should convert complex dtypes', () => {
-    expect(convertH5GroveDtype('<c8')).toStrictEqual(
+    expect(parseDType('<c8')).toStrictEqual(
       cplxType(floatType(32, Endianness.LE), floatType(32, Endianness.LE)),
     );
   });
 
   it('should convert bytes string dtypes', () => {
-    expect(convertH5GroveDtype('|S6')).toStrictEqual(strType('ASCII', 6));
+    expect(parseDType('|S6')).toStrictEqual(strType('ASCII', 6));
   });
 
   it('should interpret objects as strings', () => {
-    expect(convertH5GroveDtype('|O')).toStrictEqual(strType('UTF-8'));
+    expect(parseDType('|O')).toStrictEqual(strType('UTF-8'));
   });
 
   it('should interpret |b1 as booleans', () => {
-    expect(convertH5GroveDtype('|b1')).toStrictEqual(boolType());
+    expect(parseDType('|b1')).toStrictEqual(boolType());
   });
 
   it('should handle "not applicable" endianness symbol', () => {
-    expect(convertH5GroveDtype('|f8')).toStrictEqual(floatType(64));
+    expect(parseDType('|f8')).toStrictEqual(floatType(64));
   });
 
   it('should convert compound dtype', () => {
-    expect(
-      convertH5GroveDtype({ country: '|S10', population: '<i4' }),
-    ).toStrictEqual(
+    expect(parseDType({ country: '|S10', population: '<i4' })).toStrictEqual(
       compoundType({
         country: strType('ASCII', 10),
         population: intType(32, Endianness.LE),
@@ -66,6 +56,6 @@ describe('convertH5GroveDtype', () => {
   });
 
   it('should handle unknown type', () => {
-    expect(convertH5GroveDtype('>notAType')).toStrictEqual(unknownType());
+    expect(parseDType('>notAType')).toStrictEqual(unknownType());
   });
 });

--- a/packages/app/src/providers/h5grove/utils.ts
+++ b/packages/app/src/providers/h5grove/utils.ts
@@ -1,5 +1,5 @@
 import type { DType } from '@h5web/shared/hdf5-models';
-import { Endianness, EntityKind } from '@h5web/shared/hdf5-models';
+import { Endianness } from '@h5web/shared/hdf5-models';
 import {
   boolType,
   compoundType,
@@ -11,14 +11,7 @@ import {
   unknownType,
 } from '@h5web/shared/hdf5-utils';
 
-import type {
-  H5GroveDatasetResponse,
-  H5GroveDtype,
-  H5GroveEntityResponse,
-  H5GroveExternalLinkResponse,
-  H5GroveGroupResponse,
-  H5GroveSoftLinkResponse,
-} from './models';
+import type { H5GroveDtype } from './models';
 
 // https://numpy.org/doc/stable/reference/generated/numpy.dtype.byteorder.html#numpy.dtype.byteorder
 const ENDIANNESS_MAPPING: Record<string, Endianness> = {
@@ -26,43 +19,19 @@ const ENDIANNESS_MAPPING: Record<string, Endianness> = {
   '>': Endianness.BE,
 };
 
-export function isGroupResponse(
-  response: H5GroveEntityResponse,
-): response is H5GroveGroupResponse {
-  return response.type === EntityKind.Group;
-}
-
-export function isDatasetResponse(
-  response: H5GroveEntityResponse,
-): response is H5GroveDatasetResponse {
-  return response.type === EntityKind.Dataset;
-}
-
-export function isSoftLinkResponse(
-  response: H5GroveEntityResponse,
-): response is H5GroveSoftLinkResponse {
-  return response.type === 'soft_link';
-}
-
-export function isExternalLinkResponse(
-  response: H5GroveEntityResponse,
-): response is H5GroveExternalLinkResponse {
-  return response.type === 'external_link';
-}
-
-export function convertH5GroveDtype(dtype: H5GroveDtype): DType {
+export function parseDType(dtype: H5GroveDtype): DType {
   if (typeof dtype === 'string') {
-    return convertDtypeString(dtype);
+    return parseDTypeFromString(dtype);
   }
 
   return compoundType(
     Object.fromEntries(
-      Object.entries(dtype).map(([k, v]) => [k, convertH5GroveDtype(v)]),
+      Object.entries(dtype).map(([k, v]) => [k, parseDType(v)]),
     ),
   );
 }
 
-function convertDtypeString(dtype: string): DType {
+function parseDTypeFromString(dtype: string): DType {
   const regexp = /([<>=|])?([A-Za-z])(\d*)/u;
   const matches = regexp.exec(dtype);
 

--- a/packages/app/src/providers/h5grove/utils.ts
+++ b/packages/app/src/providers/h5grove/utils.ts
@@ -1,7 +1,14 @@
-import type { DType } from '@h5web/shared/hdf5-models';
-import { Endianness } from '@h5web/shared/hdf5-models';
+import type {
+  Attribute,
+  ChildEntity,
+  DType,
+  Group,
+  ProvidedEntity,
+} from '@h5web/shared/hdf5-models';
+import { Endianness, EntityKind } from '@h5web/shared/hdf5-models';
 import {
   boolType,
+  buildEntityPath,
   compoundType,
   cplxType,
   floatType,
@@ -11,7 +18,109 @@ import {
   unknownType,
 } from '@h5web/shared/hdf5-utils';
 
-import type { H5GroveDtype } from './models';
+import type { H5GroveAttribute, H5GroveDtype, H5GroveEntity } from './models';
+
+export function parseEntity(
+  path: string,
+  h5gEntity: H5GroveEntity,
+  isChild: true,
+): ChildEntity;
+
+export function parseEntity(
+  path: string,
+  h5gEntity: H5GroveEntity,
+  isChild?: false,
+): ProvidedEntity;
+
+export function parseEntity(
+  path: string,
+  h5gEntity: H5GroveEntity,
+  isChild = false,
+): ProvidedEntity | ChildEntity {
+  const { name } = h5gEntity;
+  const baseEntity = { name, path };
+
+  if (h5gEntity.type === EntityKind.Group) {
+    const { children = [], attributes: attrsMetadata } = h5gEntity;
+    const attributes = parseAttributes(attrsMetadata);
+    const baseGroup: Group = {
+      ...baseEntity,
+      kind: EntityKind.Group,
+      attributes,
+    };
+
+    if (isChild) {
+      return baseGroup;
+    }
+
+    return {
+      ...baseGroup,
+      children: children.map((child) => {
+        const childPath = buildEntityPath(path, child.name);
+        return parseEntity(childPath, child, true);
+      }),
+    };
+  }
+
+  if (h5gEntity.type === EntityKind.Dataset) {
+    const {
+      attributes: attrsMetadata,
+      dtype,
+      shape,
+      chunks,
+      filters,
+    } = h5gEntity;
+    return {
+      ...baseEntity,
+      kind: EntityKind.Dataset,
+      shape,
+      type: parseDType(dtype),
+      rawType: dtype,
+      ...(chunks && { chunks }),
+      ...(filters && { filters }),
+      attributes: parseAttributes(attrsMetadata),
+    };
+  }
+
+  if (h5gEntity.type === 'soft_link') {
+    const { target_path } = h5gEntity;
+    return {
+      ...baseEntity,
+      kind: EntityKind.Unresolved,
+      attributes: [],
+      link: { class: 'Soft', path: target_path },
+    };
+  }
+
+  if (h5gEntity.type === 'external_link') {
+    const { target_file, target_path } = h5gEntity;
+    return {
+      ...baseEntity,
+      kind: EntityKind.Unresolved,
+      attributes: [],
+      link: {
+        class: 'External',
+        file: target_file,
+        path: target_path,
+      },
+    };
+  }
+
+  // Treat other entities as unresolved
+  return {
+    ...baseEntity,
+    kind: EntityKind.Unresolved,
+    attributes: [],
+  };
+}
+
+function parseAttributes(attrsMetadata: H5GroveAttribute[]): Attribute[] {
+  return attrsMetadata.map<Attribute>(({ name, dtype, shape }) => ({
+    name,
+    shape,
+    type: parseDType(dtype),
+  }));
+}
 
 // https://numpy.org/doc/stable/reference/generated/numpy.dtype.byteorder.html#numpy.dtype.byteorder
 const ENDIANNESS_MAPPING: Record<string, Endianness> = {

--- a/packages/h5wasm/src/guards.ts
+++ b/packages/h5wasm/src/guards.ts
@@ -2,13 +2,7 @@ import { isCompoundType } from '@h5web/shared/guards';
 import type { Dataset, DType } from '@h5web/shared/hdf5-models';
 import { DTypeClass } from '@h5web/shared/hdf5-models';
 import type { Metadata } from 'h5wasm';
-import {
-  BrokenSoftLink as H5WasmSoftLink,
-  Dataset as H5WasmDataset,
-  Datatype as H5WasmDatatype,
-  ExternalLink as H5WasmExternalLink,
-  Group as H5WasmGroup,
-} from 'h5wasm';
+import { Dataset as H5WasmDataset } from 'h5wasm';
 
 import type {
   CompoundMetadata,
@@ -17,30 +11,12 @@ import type {
   NumericMetadata,
 } from './models';
 
-export function isH5WasmGroup(entity: H5WasmEntity): entity is H5WasmGroup {
-  return entity instanceof H5WasmGroup;
-}
-
-export function isH5WasmDataset(entity: H5WasmEntity): entity is H5WasmDataset {
-  return entity instanceof H5WasmDataset;
-}
-
-export function isH5WasmDatatype(
+export function assertH5WasmDataset(
   entity: H5WasmEntity,
-): entity is H5WasmDatatype {
-  return entity instanceof H5WasmDatatype;
-}
-
-export function isH5WasmSoftLink(
-  entity: H5WasmEntity,
-): entity is H5WasmSoftLink {
-  return entity instanceof H5WasmSoftLink;
-}
-
-export function isH5WasmExternalLink(
-  entity: H5WasmEntity,
-): entity is H5WasmExternalLink {
-  return entity instanceof H5WasmExternalLink;
+): asserts entity is H5WasmDataset {
+  if (!(entity instanceof H5WasmDataset)) {
+    throw new TypeError('Expected H5Wasm entity to be dataset');
+  }
 }
 
 // See H5T_class_t in https://github.com/usnistgov/h5wasm/blob/main/src/hdf5_util_helpers.d.ts
@@ -74,22 +50,6 @@ export function isCompoundMetadata(
 
 export function isEnumMetadata(metadata: Metadata): metadata is EnumMetadata {
   return metadata.type === 8;
-}
-
-export function assertH5WasmDataset(
-  entity: H5WasmEntity,
-): asserts entity is H5WasmDataset {
-  if (!isH5WasmDataset(entity)) {
-    throw new Error('Expected H5Wasm entity to be dataset');
-  }
-}
-
-export function assertH5WasmEntityWithAttrs(
-  entity: H5WasmEntity,
-): asserts entity is H5WasmGroup | H5WasmDataset {
-  if (!isH5WasmGroup(entity) && !isH5WasmDataset(entity)) {
-    throw new Error('Expected H5Wasm entity with attributes');
-  }
 }
 
 export function assertCompoundMetadata(

--- a/packages/h5wasm/src/h5wasm-api.ts
+++ b/packages/h5wasm/src/h5wasm-api.ts
@@ -8,23 +8,13 @@ import {
 import { assertNonNull, hasArrayShape } from '@h5web/shared/guards';
 import type {
   ArrayShape,
-  Attribute,
-  ChildEntity,
   Dataset,
   Entity,
-  Group,
   ProvidedEntity,
-  Shape,
   Value,
 } from '@h5web/shared/hdf5-models';
-import { EntityKind } from '@h5web/shared/hdf5-models';
-import { buildEntityPath } from '@h5web/shared/hdf5-utils';
-import type { Attribute as H5WasmAttribute, Filter, Module } from 'h5wasm';
+import type { Filter, Module } from 'h5wasm';
 import {
-  BrokenSoftLink as H5WasmSoftLink,
-  Dataset as H5WasmDataset,
-  Datatype as H5WasmDatatype,
-  ExternalLink as H5WasmExternalLink,
   File as H5WasmFile,
   Group as H5WasmGroup,
   ready as h5wasmReady,
@@ -32,10 +22,10 @@ import {
 import { nanoid } from 'nanoid';
 
 import { assertH5WasmDataset, hasInt64Type } from './guards';
-import type { H5WasmAttributes, H5WasmEntity } from './models';
+import type { H5WasmEntity } from './models';
 import {
   convertSelectionToRanges,
-  parseDType,
+  parseEntity,
   PLUGINS_BY_FILTER_ID,
 } from './utils';
 
@@ -61,7 +51,7 @@ export class H5WasmApi extends DataProviderApi {
 
   public async getEntity(path: string): Promise<ProvidedEntity> {
     const h5wEntity = await this.getH5WasmEntity(path);
-    return this.parseEntity(getNameFromPath(path), path, h5wEntity);
+    return parseEntity(getNameFromPath(path), path, h5wEntity);
   }
 
   public async getValue(params: ValuesStoreParams): Promise<unknown> {
@@ -169,6 +159,20 @@ export class H5WasmApi extends DataProviderApi {
     return new H5WasmFile(id, 'r');
   }
 
+  private async getH5WasmEntity(
+    path: string,
+  ): Promise<NonNullable<H5WasmEntity>> {
+    const file = await this.file;
+
+    const h5wEntity = file.get(path);
+    assertNonNull(
+      h5wEntity,
+      path === '/' ? `Expected valid HDF5 file` : `No entity found at ${path}`,
+    );
+
+    return h5wEntity;
+  }
+
   private async processFilters(filters: Filter[]): Promise<void> {
     const h5Module = await this.h5wasm;
 
@@ -197,125 +201,5 @@ export class H5WasmApi extends DataProviderApi {
 
       h5Module.FS.writeFile(pluginPath, new Uint8Array(buffer));
     }
-  }
-
-  private async getH5WasmEntity(
-    path: string,
-  ): Promise<NonNullable<H5WasmEntity>> {
-    const file = await this.file;
-
-    const h5wEntity = file.get(path);
-    assertNonNull(
-      h5wEntity,
-      path === '/' ? `Expected valid HDF5 file` : `No entity found at ${path}`,
-    );
-
-    return h5wEntity;
-  }
-
-  private parseEntity(
-    name: string,
-    path: string,
-    h5wEntity: H5WasmEntity,
-    isChild: true,
-  ): ChildEntity;
-
-  private parseEntity(
-    name: string,
-    path: string,
-    h5wEntity: H5WasmEntity,
-    isChild?: false,
-  ): ProvidedEntity;
-
-  private parseEntity(
-    name: string,
-    path: string,
-    h5wEntity: H5WasmEntity,
-    isChild = false,
-  ): ProvidedEntity | ChildEntity {
-    const baseEntity = { name, path };
-
-    if (h5wEntity instanceof H5WasmGroup) {
-      const baseGroup: Group = {
-        ...baseEntity,
-        kind: EntityKind.Group,
-        attributes: this.parseAttributes(h5wEntity.attrs),
-      };
-
-      if (isChild) {
-        return baseGroup;
-      }
-
-      return {
-        ...baseGroup,
-        children: h5wEntity.keys().map((childName) => {
-          const h5wChild = h5wEntity.get(childName);
-
-          const childPath = buildEntityPath(path, childName);
-          return this.parseEntity(childName, childPath, h5wChild, true);
-        }),
-      };
-    }
-
-    if (h5wEntity instanceof H5WasmDataset) {
-      const { metadata, filters } = h5wEntity;
-      const { chunks, maxshape, shape, ...rawType } = metadata; // keep `rawType` concise
-
-      return {
-        ...baseEntity,
-        kind: EntityKind.Dataset,
-        shape: metadata.shape,
-        type: parseDType(metadata),
-        chunks: metadata.chunks ?? undefined,
-        filters,
-        attributes: this.parseAttributes(h5wEntity.attrs),
-        rawType,
-      };
-    }
-
-    if (h5wEntity instanceof H5WasmSoftLink) {
-      return {
-        ...baseEntity,
-        attributes: [],
-        kind: EntityKind.Unresolved,
-        link: {
-          class: 'Soft',
-          path: h5wEntity.target,
-        },
-      };
-    }
-
-    if (h5wEntity instanceof H5WasmExternalLink) {
-      return {
-        ...baseEntity,
-        attributes: [],
-        kind: EntityKind.Unresolved,
-        link: {
-          class: 'External',
-          path: h5wEntity.obj_path,
-          file: h5wEntity.filename,
-        },
-      };
-    }
-
-    return {
-      ...baseEntity,
-      attributes: [],
-      kind:
-        h5wEntity instanceof H5WasmDatatype
-          ? EntityKind.Datatype
-          : EntityKind.Unresolved,
-    };
-  }
-
-  private parseAttributes(h5wAttrs: H5WasmAttributes): Attribute[] {
-    return Object.entries(h5wAttrs).map(([name, attr]) => {
-      const { shape, metadata } = attr as unknown as H5WasmAttribute;
-      return {
-        name,
-        shape: shape as Shape,
-        type: parseDType(metadata),
-      };
-    });
   }
 }

--- a/packages/h5wasm/src/utils.ts
+++ b/packages/h5wasm/src/utils.ts
@@ -40,7 +40,7 @@ export const PLUGINS_BY_FILTER_ID: Record<number, string> = {
   32_017: 'szf',
 };
 
-export function convertNumericMetadataToDType(
+export function parseDTypeFromNumericMetadata(
   metadata: NumericMetadata,
 ): NumericType {
   const { signed, size: length, littleEndian } = metadata;
@@ -58,9 +58,9 @@ export function convertNumericMetadataToDType(
   throw new Error('Expected numeric metadata');
 }
 
-export function convertMetadataToDType(metadata: Metadata): DType {
+export function parseDType(metadata: Metadata): DType {
   if (isNumericMetadata(metadata)) {
-    return convertNumericMetadataToDType(metadata);
+    return parseDTypeFromNumericMetadata(metadata);
   }
 
   if (isStringMetadata(metadata)) {
@@ -78,7 +78,7 @@ export function convertMetadataToDType(metadata: Metadata): DType {
     const { array_type } = metadata;
     assertDefined(array_type);
 
-    return arrayType(convertMetadataToDType(array_type), array_type.shape);
+    return arrayType(parseDType(array_type), array_type.shape);
   }
 
   if (isCompoundMetadata(metadata)) {
@@ -91,14 +91,14 @@ export function convertMetadataToDType(metadata: Metadata): DType {
       assertNumericMetadata(imagTypeMetadata);
 
       return cplxType(
-        convertNumericMetadataToDType(realTypeMetadata),
-        convertNumericMetadataToDType(imagTypeMetadata),
+        parseDTypeFromNumericMetadata(realTypeMetadata),
+        parseDTypeFromNumericMetadata(imagTypeMetadata),
       );
     }
 
     return compoundType(
       Object.fromEntries(
-        members.map((member) => [member.name, convertMetadataToDType(member)]),
+        members.map((member) => [member.name, parseDType(member)]),
       ),
     );
   }
@@ -110,7 +110,7 @@ export function convertMetadataToDType(metadata: Metadata): DType {
     const baseMetadata = { ...metadata, type: baseType };
     assertNumericMetadata(baseMetadata);
 
-    const type = enumType(convertNumericMetadataToDType(baseMetadata), mapping);
+    const type = enumType(parseDTypeFromNumericMetadata(baseMetadata), mapping);
     return isBoolEnumType(type) ? boolType() : type; // booleans stored as enums by h5py
   }
 

--- a/packages/h5wasm/src/utils.ts
+++ b/packages/h5wasm/src/utils.ts
@@ -1,9 +1,18 @@
 import { assertDefined } from '@h5web/shared/guards';
-import type { DType, NumericType } from '@h5web/shared/hdf5-models';
-import { Endianness } from '@h5web/shared/hdf5-models';
+import type {
+  Attribute,
+  ChildEntity,
+  DType,
+  Group,
+  NumericType,
+  ProvidedEntity,
+  Shape,
+} from '@h5web/shared/hdf5-models';
+import { Endianness, EntityKind } from '@h5web/shared/hdf5-models';
 import {
   arrayType,
   boolType,
+  buildEntityPath,
   compoundType,
   cplxType,
   enumType,
@@ -14,7 +23,14 @@ import {
   uintType,
   unknownType,
 } from '@h5web/shared/hdf5-utils';
-import type { Dataset as H5WasmDataset, Metadata } from 'h5wasm';
+import type { Metadata } from 'h5wasm';
+import {
+  BrokenSoftLink as H5WasmSoftLink,
+  Dataset as H5WasmDataset,
+  Datatype as H5WasmDatatype,
+  ExternalLink as H5WasmExternalLink,
+  Group as H5WasmGroup,
+} from 'h5wasm';
 
 import {
   assertNumericMetadata,
@@ -26,7 +42,7 @@ import {
   isNumericMetadata,
   isStringMetadata,
 } from './guards';
-import type { NumericMetadata } from './models';
+import type { H5WasmAttributes, H5WasmEntity, NumericMetadata } from './models';
 
 // https://github.com/h5wasm/h5wasm-plugins#included-plugins
 // https://support.hdfgroup.org/services/contributions.html
@@ -39,6 +55,112 @@ export const PLUGINS_BY_FILTER_ID: Record<number, string> = {
   32_015: 'zstd',
   32_017: 'szf',
 };
+
+export function parseEntity(
+  name: string,
+  path: string,
+  h5wEntity: H5WasmEntity,
+  isChild: true,
+): ChildEntity;
+
+export function parseEntity(
+  name: string,
+  path: string,
+  h5wEntity: H5WasmEntity,
+  isChild?: false,
+): ProvidedEntity;
+
+export function parseEntity(
+  name: string,
+  path: string,
+  h5wEntity: H5WasmEntity,
+  isChild = false,
+): ProvidedEntity | ChildEntity {
+  const baseEntity = { name, path };
+
+  if (h5wEntity instanceof H5WasmGroup) {
+    const baseGroup: Group = {
+      ...baseEntity,
+      kind: EntityKind.Group,
+      attributes: parseAttributes(h5wEntity.attrs),
+    };
+
+    if (isChild) {
+      return baseGroup;
+    }
+
+    return {
+      ...baseGroup,
+      children: h5wEntity.keys().map((childName) => {
+        const h5wChild = h5wEntity.get(childName);
+
+        const childPath = buildEntityPath(path, childName);
+        return parseEntity(childName, childPath, h5wChild, true);
+      }),
+    };
+  }
+
+  if (h5wEntity instanceof H5WasmDataset) {
+    const { metadata, filters } = h5wEntity;
+    const { chunks, maxshape, shape, ...rawType } = metadata; // keep `rawType` concise
+
+    return {
+      ...baseEntity,
+      kind: EntityKind.Dataset,
+      shape: metadata.shape,
+      type: parseDType(metadata),
+      chunks: metadata.chunks ?? undefined,
+      filters,
+      attributes: parseAttributes(h5wEntity.attrs),
+      rawType,
+    };
+  }
+
+  if (h5wEntity instanceof H5WasmSoftLink) {
+    return {
+      ...baseEntity,
+      attributes: [],
+      kind: EntityKind.Unresolved,
+      link: {
+        class: 'Soft',
+        path: h5wEntity.target,
+      },
+    };
+  }
+
+  if (h5wEntity instanceof H5WasmExternalLink) {
+    return {
+      ...baseEntity,
+      attributes: [],
+      kind: EntityKind.Unresolved,
+      link: {
+        class: 'External',
+        path: h5wEntity.obj_path,
+        file: h5wEntity.filename,
+      },
+    };
+  }
+
+  return {
+    ...baseEntity,
+    attributes: [],
+    kind:
+      h5wEntity instanceof H5WasmDatatype
+        ? EntityKind.Datatype
+        : EntityKind.Unresolved,
+  };
+}
+
+function parseAttributes(h5wAttrs: H5WasmAttributes): Attribute[] {
+  return Object.entries(h5wAttrs).map(([name, attr]) => {
+    const { shape, metadata } = attr;
+    return {
+      name,
+      shape: shape as Shape,
+      type: parseDType(metadata),
+    };
+  });
+}
 
 export function parseDTypeFromNumericMetadata(
   metadata: NumericMetadata,


### PR DESCRIPTION
A bit of clean-up before I start improving the parsing of the dtypes in both `H5WasmApi` and `H5GroveApi`. Mostly, I remove a bunch of type guards that are not necessary and I move some functional utilities out of the classes. I recommend reviewing commit by commit.