### PR TITLE
Improve dtype parsing with h5wasm

### DIFF
--- a/packages/h5wasm/src/__snapshots__/h5wasm-api.test.ts.snap
+++ b/packages/h5wasm/src/__snapshots__/h5wasm-api.test.ts.snap
@@ -876,7 +876,8 @@ exports[`test file matches snapshot 1`] = `
     },
     "shape": [],
     "type": {
-      "class": "Unknown",
+      "class": "Opaque",
+      "tag": "",
     },
     "value": Uint8Array [
       0,
@@ -897,7 +898,8 @@ exports[`test file matches snapshot 1`] = `
     },
     "shape": [],
     "type": {
-      "class": "Unknown",
+      "class": "Opaque",
+      "tag": "",
     },
     "value": Uint8Array [
       150,
@@ -923,7 +925,8 @@ exports[`test file matches snapshot 1`] = `
     },
     "shape": [],
     "type": {
-      "class": "Unknown",
+      "class": "Opaque",
+      "tag": "",
     },
     "value": Uint8Array [
       0,
@@ -1724,7 +1727,10 @@ exports[`test file matches snapshot 1`] = `
           ],
         },
         "vlen": {
-          "class": "Unknown",
+          "base": {
+            "class": "Unknown",
+          },
+          "class": "Array (variable length)",
         },
       },
     },
@@ -1792,7 +1798,7 @@ exports[`test file matches snapshot 1`] = `
     },
     "shape": [],
     "type": {
-      "class": "Unknown",
+      "class": "Reference",
     },
     "value": Uint8Array [
       214,
@@ -1818,7 +1824,7 @@ exports[`test file matches snapshot 1`] = `
     },
     "shape": [],
     "type": {
-      "class": "Unknown",
+      "class": "Reference",
     },
     "value": Uint8Array [
       34,
@@ -2028,7 +2034,10 @@ exports[`test file matches snapshot 1`] = `
     },
     "shape": [],
     "type": {
-      "class": "Unknown",
+      "base": {
+        "class": "Unknown",
+      },
+      "class": "Array (variable length)",
     },
     "value": Uint8Array [
       2,
@@ -2056,7 +2065,10 @@ exports[`test file matches snapshot 1`] = `
       3,
     ],
     "type": {
-      "class": "Unknown",
+      "base": {
+        "class": "Unknown",
+      },
+      "class": "Array (variable length)",
     },
     "value": Uint8Array [
       1,

--- a/packages/h5wasm/src/guards.ts
+++ b/packages/h5wasm/src/guards.ts
@@ -1,70 +1,15 @@
 import { isCompoundType } from '@h5web/shared/guards';
 import type { Dataset, DType } from '@h5web/shared/hdf5-models';
 import { DTypeClass } from '@h5web/shared/hdf5-models';
-import type { Metadata } from 'h5wasm';
 import { Dataset as H5WasmDataset } from 'h5wasm';
 
-import type {
-  CompoundMetadata,
-  EnumMetadata,
-  H5WasmEntity,
-  NumericMetadata,
-} from './models';
+import type { H5WasmEntity } from './models';
 
 export function assertH5WasmDataset(
-  entity: H5WasmEntity,
-): asserts entity is H5WasmDataset {
-  if (!(entity instanceof H5WasmDataset)) {
+  h5wEntity: NonNullable<H5WasmEntity>,
+): asserts h5wEntity is H5WasmDataset {
+  if (!(h5wEntity instanceof H5WasmDataset)) {
     throw new TypeError('Expected H5Wasm entity to be dataset');
-  }
-}
-
-// See H5T_class_t in https://github.com/usnistgov/h5wasm/blob/main/src/hdf5_util_helpers.d.ts
-export function isIntegerMetadata(metadata: Metadata) {
-  return metadata.type === 0;
-}
-
-export function isFloatMetadata(metadata: Metadata) {
-  return metadata.type === 1;
-}
-
-export function isNumericMetadata(
-  metadata: Metadata,
-): metadata is NumericMetadata {
-  return isIntegerMetadata(metadata) || isFloatMetadata(metadata);
-}
-
-export function isStringMetadata(metadata: Metadata) {
-  return metadata.type === 3;
-}
-
-export function isArrayMetadata(metadata: Metadata) {
-  return metadata.type === 10;
-}
-
-export function isCompoundMetadata(
-  metadata: Metadata,
-): metadata is CompoundMetadata {
-  return metadata.type === 6;
-}
-
-export function isEnumMetadata(metadata: Metadata): metadata is EnumMetadata {
-  return metadata.type === 8;
-}
-
-export function assertCompoundMetadata(
-  metadata: Metadata,
-): asserts metadata is CompoundMetadata {
-  if (!isCompoundMetadata(metadata)) {
-    throw new Error('Expected H5Wasm compound metadata');
-  }
-}
-
-export function assertNumericMetadata(
-  metadata: Metadata,
-): asserts metadata is NumericMetadata {
-  if (!isNumericMetadata(metadata)) {
-    throw new Error('Expected H5Wasm numeric metadata');
   }
 }
 

--- a/packages/h5wasm/src/models.ts
+++ b/packages/h5wasm/src/models.ts
@@ -1,22 +1,5 @@
-import type {
-  CompoundTypeMetadata,
-  EnumTypeMetadata,
-  Group as H5WasmGroup,
-  Metadata,
-} from 'h5wasm';
+import type { Group as H5WasmGroup } from 'h5wasm';
 
 export type H5WasmEntity = ReturnType<H5WasmGroup['get']>;
 
 export type H5WasmAttributes = H5WasmGroup['attrs'];
-
-export interface CompoundMetadata extends Metadata {
-  compound_type: CompoundTypeMetadata;
-}
-
-export interface NumericMetadata extends Metadata {
-  type: 0 | 1;
-}
-
-export interface EnumMetadata extends Metadata {
-  enum_type: EnumTypeMetadata;
-}

--- a/packages/shared/src/hdf5-models.ts
+++ b/packages/shared/src/hdf5-models.ts
@@ -90,6 +90,10 @@ export enum DTypeClass {
   Array = 'Array',
   VLen = 'Array (variable length)',
   Enum = 'Enumeration',
+  Time = 'Time',
+  Bitfield = 'Bitfield',
+  Opaque = 'Opaque',
+  Reference = 'Reference',
   Unknown = 'Unknown',
 }
 
@@ -98,11 +102,17 @@ export enum Endianness {
   BE = 'big-endian',
 }
 
+export type CharSet = 'UTF-8' | 'ASCII';
+
 export type DType =
   | PrintableType
   | CompoundType
   | ArrayType
   | EnumType
+  | TimeType
+  | BitfieldType
+  | OpaqueType
+  | ReferenceType
   | UnknownType;
 
 export type PrintableType =
@@ -131,7 +141,7 @@ export interface ComplexType {
 
 export interface StringType {
   class: DTypeClass.String;
-  charSet: 'UTF-8' | 'ASCII';
+  charSet: CharSet;
   length?: number;
 }
 
@@ -154,6 +164,24 @@ export interface EnumType {
   class: DTypeClass.Enum;
   base: NumericType; // technically, only int/uint
   mapping: Record<string, number>;
+}
+
+export interface TimeType {
+  class: DTypeClass.Time;
+}
+
+export interface BitfieldType {
+  class: DTypeClass.Bitfield;
+  endianness?: Endianness;
+}
+
+export interface ReferenceType {
+  class: DTypeClass.Reference;
+}
+
+export interface OpaqueType {
+  class: DTypeClass.Opaque;
+  tag: string;
 }
 
 export interface UnknownType {
@@ -195,4 +223,28 @@ export type ComplexArray = (ComplexArray | H5WebComplex)[];
 export interface Filter {
   id: number;
   name: string;
+}
+
+/* ------------------- */
+/* ---- H5T ENUMS ---- */
+
+// https://docs.hdfgroup.org/hdf5/develop/_h5_tpublic_8h.html#title3
+
+export enum H5TClass {
+  Integer = 0,
+  Float = 1,
+  Time = 2,
+  String = 3,
+  Bitfield = 4,
+  Opaque = 5,
+  Compound = 6,
+  Reference = 7,
+  Enum = 8,
+  Vlen = 9,
+  Array = 10,
+}
+
+export enum H5TCharSet {
+  ASCII = 0,
+  UTF8 = 1,
 }


### PR DESCRIPTION
See test snapshot for detailed improvements. I'm also refactoring the `parseDType` function to remove the need for type guards.