### PR TITLE
Upgrade GitHub actions to v4 and bump pnpm on CI

### DIFF
--- a/.github/workflows/approve-snapshots.yml
+++ b/.github/workflows/approve-snapshots.yml
@@ -18,12 +18,12 @@ jobs:
           pr-id: ${{ github.event.issue.number }}
 
       - name: Checkout 🏷️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ steps.getBranchName.outputs.branch }}
 
       - name: Set up Node 🕹️
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: 'package.json'
 
@@ -33,7 +33,7 @@ jobs:
           version: 8.x
 
       - name: Restore cache 📌
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/setup-pnpm/node_modules/.bin/store
@@ -43,7 +43,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Install dependencies ⚙️
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Build packages 📦
         run: pnpm packages

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🏷️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node 🕹️
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: 'package.json'
           registry-url: 'https://registry.npmjs.org'
@@ -26,7 +26,7 @@ jobs:
           version: 8.x
 
       - name: Restore cache 📌
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/setup-pnpm/node_modules/.bin/store
@@ -36,7 +36,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Install dependencies ⚙️
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Build Storybook 🛠️
         run: pnpm build:storybook

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout 🏷️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node 🕹️
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: 'package.json'
 
@@ -28,7 +28,7 @@ jobs:
           version: 8.x
 
       - name: Restore cache 📌
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/setup-pnpm/node_modules/.bin/store
@@ -38,7 +38,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Install dependencies ⚙️
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Lint 🤓
         run: pnpm prettier && pnpm lint
@@ -50,10 +50,10 @@ jobs:
 
     steps:
       - name: Checkout 🏷️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node 🕹️
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: 'package.json'
 
@@ -63,7 +63,7 @@ jobs:
           version: 8.x
 
       - name: Restore cache 📌
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/setup-pnpm/node_modules/.bin/store
@@ -73,7 +73,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Install dependencies ⚙️
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Test 👓
         run: pnpm test -- --reporter default --reporter vitest-github-actions-reporter
@@ -85,10 +85,10 @@ jobs:
 
     steps:
       - name: Checkout 🏷️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node 🕹️
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: 'package.json'
 
@@ -98,7 +98,7 @@ jobs:
           version: 8.x
 
       - name: Restore cache 📌
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/setup-pnpm/node_modules/.bin/store
@@ -108,7 +108,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Install dependencies ⚙️
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Build packages 📦
         run: pnpm packages
@@ -120,10 +120,10 @@ jobs:
 
     steps:
       - name: Checkout 🏷️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node 🕹️
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: 'package.json'
 
@@ -133,7 +133,7 @@ jobs:
           version: 8.x
 
       - name: Restore cache 📌
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/setup-pnpm/node_modules/.bin/store
@@ -143,7 +143,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Install dependencies ⚙️
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Build demo 🛠️
         run: pnpm build

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout 🏷️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Match tag to package version 🧐
         id: packageVersion
@@ -22,7 +22,7 @@ jobs:
           TAG_PREFIX: v
 
       - name: Set up Node 🕹️
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: 'package.json'
           registry-url: 'https://registry.npmjs.org'
@@ -33,7 +33,7 @@ jobs:
           version: 8.x
 
       - name: Restore cache 📌
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/setup-pnpm/node_modules/.bin/store
@@ -43,7 +43,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Install dependencies ⚙️
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Build packages 📦
         run: pnpm packages

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": "20.x",
     "pnpm": "8.x"
   },
-  "packageManager": "pnpm@8.12.1",
+  "packageManager": "pnpm@8.15.1",
   "type": "module",
   "scripts": {
     "start": "pnpm --filter demo start",


### PR DESCRIPTION
GitHub was showing a warning:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-node@v3, pnpm/action-setup@v2, actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

We'll still get a warning for `pnpm/action-setup@v2` as this one is still on Node 16.