### PR TITLE
Import CJS module `react-aria-menubutton` via default export

### DIFF
--- a/packages/lib/src/toolbar/controls/ExportMenu.tsx
+++ b/packages/lib/src/toolbar/controls/ExportMenu.tsx
@@ -1,10 +1,12 @@
-import { Button, Menu, Wrapper } from 'react-aria-menubutton';
+import ram from 'react-aria-menubutton'; // CJS
 import { FiDownload } from 'react-icons/fi';
 import { MdArrowDropDown } from 'react-icons/md';
 
 import type { ExportEntryProps } from './ExportEntry';
 import ExportEntry from './ExportEntry';
 import styles from './Selector/Selector.module.css';
+
+const { Button, Menu, Wrapper } = ram;
 
 interface Props {
   entries: ExportEntryProps[];

--- a/packages/lib/src/toolbar/controls/Selector/OptionList.tsx
+++ b/packages/lib/src/toolbar/controls/Selector/OptionList.tsx
@@ -1,7 +1,9 @@
-import { MenuItem } from 'react-aria-menubutton';
+import ram from 'react-aria-menubutton'; // CJS
 
 import type { OptionComponent } from './models';
 import styles from './Selector.module.css';
+
+const { MenuItem } = ram;
 
 interface Props<T> {
   optionList: T[];

--- a/packages/lib/src/toolbar/controls/Selector/Selector.tsx
+++ b/packages/lib/src/toolbar/controls/Selector/Selector.tsx
@@ -1,10 +1,12 @@
 import { useWindowSize } from '@react-hookz/web';
-import { Button, Menu, Wrapper } from 'react-aria-menubutton';
+import ram from 'react-aria-menubutton'; // CJS
 import { MdArrowDropDown } from 'react-icons/md';
 
 import type { OptionComponent } from './models';
 import OptionList from './OptionList';
 import styles from './Selector.module.css';
+
+const { Button, Menu, Wrapper } = ram;
 
 const MENU_IDEAL_HEIGHT = 320; // 20rem
 const MENU_TOP = 87; // HACK: height of breadcrumbs bar + height of toolbar


### PR DESCRIPTION
...  to work around Vitest warnings in consumer app.

![image](https://github.com/silx-kit/h5web/assets/2936402/fcc5bc43-ee19-4302-927d-b1aad109b139)

This library is unmaintained and replacing it has been on my TODO list for a while. I'll get to it at some point but this seems like a good work around for now.