### PR TITLE
Bump `pnpm/action-setup` so it runs on Node 20

### DIFF
--- a/.github/workflows/approve-snapshots.yml
+++ b/.github/workflows/approve-snapshots.yml
@@ -28,7 +28,7 @@ jobs:
           node-version-file: 'package.json'
 
       - name: Install pnpm ⚙️
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
         with:
           version: 8.x
 

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -21,7 +21,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install pnpm ⚙️
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
         with:
           version: 8.x
 

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -23,7 +23,7 @@ jobs:
           node-version-file: 'package.json'
 
       - name: Install pnpm ⚙️
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
         with:
           version: 8.x
 
@@ -58,7 +58,7 @@ jobs:
           node-version-file: 'package.json'
 
       - name: Install pnpm ⚙️
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
         with:
           version: 8.x
 
@@ -93,7 +93,7 @@ jobs:
           node-version-file: 'package.json'
 
       - name: Install pnpm ⚙️
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
         with:
           version: 8.x
 
@@ -128,7 +128,7 @@ jobs:
           node-version-file: 'package.json'
 
       - name: Install pnpm ⚙️
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
         with:
           version: 8.x
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -28,7 +28,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install pnpm ⚙️
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
         with:
           version: 8.x
 


### PR DESCRIPTION
v3 was just released: https://github.com/pnpm/action-setup/releases/tag/v3.0.0

This should get rid of the Node 16 warning in the CI entirely.