### PR TITLE
Improve handling of HDF5 errors

### DIFF
--- a/packages/app/src/App.module.css
+++ b/packages/app/src/App.module.css
@@ -154,6 +154,20 @@
   margin-left: 0.5rem;
 }
 
+.detailedError {
+  composes: error from global;
+  overflow: auto;
+  scrollbar-width: thin;
+}
+
+.detailedError > summary {
+  cursor: pointer;
+}
+
+.detailedError > pre {
+  font-size: 0.875em;
+}
+
 .retryBtn {
   composes: btnClean btnLink from global;
 }

--- a/packages/app/src/ErrorFallback.tsx
+++ b/packages/app/src/ErrorFallback.tsx
@@ -6,6 +6,16 @@ import { CANCELLED_ERROR_MSG } from './providers/utils';
 function ErrorFallback(props: FallbackProps) {
   const { error, resetErrorBoundary } = props;
 
+  if (error.cause || error.cause instanceof Error) {
+    const { message } = error.cause;
+    return (
+      <details className={styles.detailedError}>
+        <summary>{error.message}</summary>
+        <pre>{message}</pre>
+      </details>
+    );
+  }
+
   return (
     <p className={styles.error}>
       {error.message}

--- a/packages/app/src/visualizer/Visualizer.module.css
+++ b/packages/app/src/visualizer/Visualizer.module.css
@@ -21,7 +21,7 @@
   grid-template:
     'dimMapper bar' auto
     'dimMapper vis' 1fr
-    / auto 1fr;
+    / min-content 1fr;
 }
 
 .fallback {

--- a/packages/h5wasm/package.json
+++ b/packages/h5wasm/package.json
@@ -46,7 +46,7 @@
     }
   },
   "dependencies": {
-    "h5wasm": "0.7.1",
+    "h5wasm": "0.7.2",
     "nanoid": "5.0.5"
   },
   "devDependencies": {

--- a/packages/h5wasm/src/models.ts
+++ b/packages/h5wasm/src/models.ts
@@ -3,3 +3,10 @@ import type { Group as H5WasmGroup } from 'h5wasm';
 export type H5WasmEntity = ReturnType<H5WasmGroup['get']>;
 
 export type H5WasmAttributes = H5WasmGroup['attrs'];
+
+export interface HDF5Diag {
+  major: string;
+  minor: string;
+  message: string;
+  origin: string;
+}

--- a/packages/h5wasm/src/utils.test.ts
+++ b/packages/h5wasm/src/utils.test.ts
@@ -1,0 +1,56 @@
+/* eslint-disable sonarjs/no-duplicate-string */
+import { describe, expect, it } from 'vitest';
+
+import { parseDiagnostics } from './utils';
+
+const HDF5_ERROR_MESSAGE = `HDF5-DIAG: Error detected in HDF5 (1.14.2) thread 0:
+  #000: /__w/libhdf5-wasm/libhdf5-wasm/build/1.14.2/_deps/hdf5-src/src/H5D.c line 1061 in H5Dread(): can't synchronously read data
+    major: Dataset
+    minor: Read failed
+  #001: /__w/libhdf5-wasm/libhdf5-wasm/build/1.14.2/_deps/hdf5-src/src/H5VLcallback.c line 2092 in H5VL_dataset_read_direct(): dataset read failed
+    major: Virtual Object Layer
+    minor: Read failed
+  #002: /__w/libhdf5-wasm/libhdf5-wasm/build/1.14.2/_deps/hdf5-src/src/H5Dchunk.c line 4468 in H5D__chunk_lock(): data pipeline read failed
+    major: Dataset
+    minor: Filter operation failed
+  #003: /__w/libhdf5-wasm/libhdf5-wasm/build/1.14.2/_deps/hdf5-src/src/H5Z.c line 1356 in H5Z_pipeline(): required filter 'SZ3 compressor/decompressor for floating-point data.' is not registered
+    major: Data filters
+    minor: Read failed
+`;
+
+describe('parseDiagnostics', () => {
+  it('should parse HDF5 error message and return diagnostics', () => {
+    const diagnostics = parseDiagnostics(HDF5_ERROR_MESSAGE);
+    expect(diagnostics).toEqual([
+      {
+        major: 'Dataset',
+        minor: 'Read failed',
+        message: "Can't synchronously read data",
+        origin:
+          '/__w/libhdf5-wasm/libhdf5-wasm/build/1.14.2/_deps/hdf5-src/src/H5D.c line 1061 in H5Dread()',
+      },
+      {
+        major: 'Virtual Object Layer',
+        minor: 'Read failed',
+        message: 'Dataset read failed',
+        origin:
+          '/__w/libhdf5-wasm/libhdf5-wasm/build/1.14.2/_deps/hdf5-src/src/H5VLcallback.c line 2092 in H5VL_dataset_read_direct()',
+      },
+      {
+        major: 'Dataset',
+        minor: 'Filter operation failed',
+        message: 'Data pipeline read failed',
+        origin:
+          '/__w/libhdf5-wasm/libhdf5-wasm/build/1.14.2/_deps/hdf5-src/src/H5Dchunk.c line 4468 in H5D__chunk_lock()',
+      },
+      {
+        major: 'Data filters',
+        minor: 'Read failed',
+        message:
+          "Required filter 'SZ3 compressor/decompressor for floating-point data.' is not registered",
+        origin:
+          '/__w/libhdf5-wasm/libhdf5-wasm/build/1.14.2/_deps/hdf5-src/src/H5Z.c line 1356 in H5Z_pipeline()',
+      },
+    ]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -351,8 +351,8 @@ importers:
   packages/h5wasm:
     dependencies:
       h5wasm:
-        specifier: 0.7.1
-        version: 0.7.1
+        specifier: 0.7.2
+        version: 0.7.2
       nanoid:
         specifier: 5.0.5
         version: 5.0.5
@@ -2996,13 +2996,32 @@ packages:
       '@jridgewell/trace-mapping': 0.3.19
     dev: true
 
+  /@jridgewell/gen-mapping@0.3.5:
+    resolution: {integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      '@jridgewell/set-array': 1.2.1
+      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/trace-mapping': 0.3.24
+    dev: true
+
   /@jridgewell/resolve-uri@3.1.1:
     resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
     engines: {node: '>=6.0.0'}
     dev: true
 
+  /@jridgewell/resolve-uri@3.1.2:
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
   /@jridgewell/set-array@1.1.2:
     resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
+  /@jridgewell/set-array@1.2.1:
+    resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
     engines: {node: '>=6.0.0'}
     dev: true
 
@@ -3021,6 +3040,13 @@ packages:
     resolution: {integrity: sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==}
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
+
+  /@jridgewell/trace-mapping@0.3.24:
+    resolution: {integrity: sha512-+VaWXDa6+l6MhflBvVXjIEAzb59nQ2JUK3bwRp2zRpPtU+8TFRy9Gg/5oIcNlkEL5PGlBFGfemUVvIgLnTzq7Q==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
@@ -5080,7 +5106,7 @@ packages:
     resolution: {integrity: sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==}
     dependencies:
       expect: 29.6.1
-      pretty-format: 29.6.1
+      pretty-format: 29.7.0
     dev: true
 
   /@types/json-schema@7.0.15:
@@ -9188,8 +9214,8 @@ packages:
     resolution: {integrity: sha512-GxBWGVxBftyq67kAbS4WPmTH3a8hGKigdMm+IVJ7tLY7BHj+nqDTUKO9RmmPBHy6Pvq5uW1YpIJr/oGanw+RyQ==}
     dev: false
 
-  /h5wasm@0.7.1:
-    resolution: {integrity: sha512-/mLmL35/vSJXgK6zPpHPINj8nxLYlqqnt4ScVZe2W8L9e1ZhVg+a1/4aBBmjfW8AiTbYsEn9Yu3nEOB+CuOyLw==}
+  /h5wasm@0.7.2:
+    resolution: {integrity: sha512-+jbCShZ5kzQVV0oJBiMiyh3updPHD3mpEAHFpPp8erhkSSZ+MoZuNzaJX2s3UO+8QUQigbHpNzeqDePLcjX61Q==}
     dev: false
 
   /handlebars@4.7.8:
@@ -9281,6 +9307,13 @@ packages:
 
   /hasown@2.0.0:
     resolution: {integrity: sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      function-bind: 1.1.2
+    dev: true
+
+  /hasown@2.0.1:
+    resolution: {integrity: sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==}
     engines: {node: '>= 0.4'}
     dependencies:
       function-bind: 1.1.2
@@ -9582,7 +9615,7 @@ packages:
   /is-core-module@2.13.1:
     resolution: {integrity: sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==}
     dependencies:
-      hasown: 2.0.0
+      hasown: 2.0.1
     dev: true
 
   /is-date-object@1.0.5:
@@ -10239,8 +10272,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /lilconfig@3.0.0:
-    resolution: {integrity: sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g==}
+  /lilconfig@3.1.1:
+    resolution: {integrity: sha512-O18pf7nyvHTckunPWCV1XUNXU1piu01y2b7ATJ0ppkUkk8ocqVWBrYjJBCwHDjD/ZWcfyrA0P4gKhzWGi5EINQ==}
     engines: {node: '>=14'}
     dev: true
 
@@ -11688,9 +11721,9 @@ packages:
       ts-node:
         optional: true
     dependencies:
-      lilconfig: 3.0.0
+      lilconfig: 3.1.1
       postcss: 8.4.35
-      yaml: 2.3.4
+      yaml: 2.4.0
     dev: true
 
   /postcss-nested@6.0.1(postcss@8.4.35):
@@ -11766,15 +11799,6 @@ packages:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
-    dev: true
-
-  /pretty-format@29.6.1:
-    resolution: {integrity: sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@jest/schemas': 29.6.3
-      ansi-styles: 5.2.0
-      react-is: 18.2.0
     dev: true
 
   /pretty-format@29.7.0:
@@ -13137,7 +13161,7 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.3
+      '@jridgewell/gen-mapping': 0.3.5
       commander: 4.1.1
       glob: 10.3.10
       lines-and-columns: 1.2.4
@@ -14667,9 +14691,10 @@ packages:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
     dev: true
 
-  /yaml@2.3.4:
-    resolution: {integrity: sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==}
+  /yaml@2.4.0:
+    resolution: {integrity: sha512-j9iR8g+/t0lArF4V6NE/QCfT+CO7iLqrXAHZbJdo+LfjqP1vR8Fg5bSiaq6Q2lOD1AUEVrEVIgABvBFYojJVYQ==}
     engines: {node: '>= 14'}
+    hasBin: true
     dev: true
 
   /yargs-parser@21.1.1:


### PR DESCRIPTION
Fix #1570 

Thanks to @bmaranville and [h5wasm@0.7.2](https://github.com/usnistgov/h5wasm/releases/tag/v0.7.2), we can now configure the HDF5 library to throw errors instead of just logging them to the console with `console.error`. This will hopefully help surface bugs much faster (like the one fixed in #1568).

Another benefit is that we can now take advantage of the propagated errors when it makes sense, like when a compression plugin is not supported, instead of trying to detect the situation ahead of time.

Summary of changes:

- I bump h5wasm and configure HDF5 to throw errors
- When an error is thrown by HDF5 when reading a dataset's value (or slice):
  - I catch the error and rethrow a more readable error with the original HDF5 error as [`cause`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause).
  - If one of the diagnostic entries of the HDF5 error relates to a filter not being available, I use that diagnostic message as the message of the rethrown error; otherwise, I use the fallback message "Error detected in HDF5".
- In `ErrorFallback`, if an error has a cause, I render a `details` element with a `pre` containing the cause. This gives access to the original HDF5 error message for debugging purposes.

Of course, we might uncover other HDF5 errors that we'll need to handle more specifically; this just provides robust foundations. I'm also planning to wrap other h5wasm calls with try/catch (like when reading attributes) in my next PR.

### Filter not registered

With dataset `sz3` in `filters.h5`:

- http://localhost:5173/h5wasm?url=https%3A%2F%2Fwww.silx.org%2Fpub%2Fh5web%2Ffilters.h5
- https://h5web.panosc.eu/h5wasm?url=https%3A%2F%2Fwww.silx.org%2Fpub%2Fh5web%2Ffilters.h5

![Screenshot 2024-03-01 at 11-59-22 H5Web](https://github.com/silx-kit/h5web/assets/2936402/33243c58-a5ab-4c86-b30c-b23f46bc9120)

![Screenshot 2024-03-01 at 11-59-12 H5Web](https://github.com/silx-kit/h5web/assets/2936402/2b2dd106-5bb3-4f7d-b965-dbad599df585)

### Fallback error

Same file as above, but after commenting out the detection of filter-related errors.

![Screenshot 2024-03-01 at 11-57-53 H5Web](https://github.com/silx-kit/h5web/assets/2936402/6c32c424-de39-4a27-9c74-386c0d84e2bf)

### No more error for `fcidecomp` dataset

Before/after screenshots that show that our attempt at predicting when a filter was not supported was causing false positives:

![Screenshot 2024-03-01 120023](https://github.com/silx-kit/h5web/assets/2936402/85ad3857-c2fa-4e04-9908-e6f67be2f615)

![Screenshot 2024-03-01 at 11-59-41 H5Web](https://github.com/silx-kit/h5web/assets/2936402/3389d5a1-b98f-4588-81e2-9b3fd19ef42d)


