### PR TITLE
Fetch opaque datasets with h5grove as binary

### DIFF
--- a/packages/app/src/App.module.css
+++ b/packages/app/src/App.module.css
@@ -148,6 +148,7 @@
 
 .error {
   composes: error from global;
+  grid-area: vis;
 }
 
 .error > span {

--- a/packages/app/src/providers/h5grove/__snapshots__/h5grove-api.test.ts.snap
+++ b/packages/app/src/providers/h5grove/__snapshots__/h5grove-api.test.ts.snap
@@ -796,7 +796,11 @@ exports[`test file matches snapshot 1`] = `
       "class": "Opaque",
       "tag": "",
     },
-    "value": " "",
+    "value": Uint8Array [
+      0,
+      17,
+      34,
+    ],
   },
   {
     "name": "byte_string_1D",
@@ -813,10 +817,10 @@ exports[`test file matches snapshot 1`] = `
       "class": "Opaque",
       "tag": "",
     },
-    "value": [
-      " ",
-      "",
-      """,
+    "value": Uint8Array [
+      0,
+      17,
+      34,
     ],
   },
   {
@@ -832,7 +836,16 @@ exports[`test file matches snapshot 1`] = `
       "class": "Opaque",
       "tag": "",
     },
-    "value": [AxiosError: Request failed with status code 500],
+    "value": Uint8Array [
+      150,
+      177,
+      135,
+      93,
+      0,
+      0,
+      0,
+      0,
+    ],
   },
   {
     "name": "datetime64_not-a-time_scalar",
@@ -847,7 +860,16 @@ exports[`test file matches snapshot 1`] = `
       "class": "Opaque",
       "tag": "",
     },
-    "value": [AxiosError: Request failed with status code 500],
+    "value": Uint8Array [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      128,
+    ],
   },
   {
     "name": "complex64_scalar",

--- a/packages/lib/src/vis/raw/RawVis.tsx
+++ b/packages/lib/src/vis/raw/RawVis.tsx
@@ -8,7 +8,11 @@ interface Props {
 
 function RawVis(props: Props) {
   const { value } = props;
-  const valueAsStr = JSON.stringify(value, null, 2);
+
+  const valueAsStr =
+    value instanceof Uint8Array
+      ? `Uint8Array [ ${value.toString()} ]`
+      : JSON.stringify(value, null, 2);
 
   return (
     <div className={styles.root}>


### PR DESCRIPTION
This change is in preparation for #1554.

Opaque datasets were so far fetched with h5grove as JSON, which led to back-end errors for datasets that cannot be encoded to strings (like `datetime64_scalar`).

I now fetch opaque datasets as binary and return `UInt8Array` values from `H5GroveProvider` for consistency with `H5WasmProvider`.

With h5grove@2.0.0, this change leads to 422 errors for all opaque datasets. This will be fixed with https://github.com/silx-kit/h5grove/pull/89 and a new release of h5grove. This PR therefore constitutes a breaking change.

While I'm at it, I also improve the display of `UInt8Array` values slightly in `RawVis` by simply calling `toString()` instead of `JSON.stringify()`:

![image](https://github.com/silx-kit/h5web/assets/2936402/10acfa1c-2d94-42e2-bd30-815e64b9c1d8) ![image](https://github.com/silx-kit/h5web/assets/2936402/3d387d4c-9da3-4ebf-842d-c0ab56a4aa57)
