### PR TITLE
Update h5grove snapshot following fix for `complex256` numbers

### DIFF
--- a/packages/app/src/providers/h5grove/__snapshots__/h5grove-api.test.ts.snap
+++ b/packages/app/src/providers/h5grove/__snapshots__/h5grove-api.test.ts.snap
@@ -907,8 +907,8 @@ exports[`test file matches snapshot 1`] = `
       },
     },
     "value": [
-      1.1754943508222875e-38,
-      3.4028234663852886e+38,
+      1.1754944e-38,
+      3.4028235e+38,
     ],
   },
   {
@@ -1140,7 +1140,10 @@ exports[`test file matches snapshot 1`] = `
         "size": 128,
       },
     },
-    "value": [AxiosError: Request failed with status code 500],
+    "value": [
+      0,
+      null,
+    ],
   },
   {
     "name": "complex256_2D",
@@ -1180,7 +1183,24 @@ exports[`test file matches snapshot 1`] = `
         "size": 128,
       },
     },
-    "value": [AxiosError: Request failed with status code 500],
+    "value": [
+      [
+        1,
+        2,
+      ],
+      [
+        3,
+        4,
+      ],
+      [
+        5,
+        6,
+      ],
+      [
+        7,
+        8,
+      ],
+    ],
   },
   {
     "name": "compound_scalar",


### PR DESCRIPTION
Following https://github.com/silx-kit/h5grove/pull/91, h5grove no longer responds with 500 errors when fetching `complex256` datasets. I've upgraded h5grove on Bosquet, so I'm now updating the test snapshots here.

Note that h5grove also no longer casts the `float32` real/imag parts of `complex64` numbers to `float64` when serializing to JSON.

We still have the issue that any `float128` number that overflows the `float64` range is cast to `inf` and serialised to JSON as `null` (cf. #641), which breaks the visualizations. The best way around this would be to fetch complex numbers as binary, but that's a problem for another day.