### PR TITLE
Fix style ordering issues caused by composing from imported CSS modules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@
     - [DefinitelyTyped packages](#definitelytyped-packages)
     - [Workspace dependencies](#workspace-dependencies)
   - [Icon set](#icon-set)
+  - [CSS Modules](#css-modules)
 - [Build](#build)
   - [Package builds](#package-builds)
 - [Code quality](#code-quality)
@@ -113,6 +114,89 @@ this problem in the form of the
 
 H5Web uses the [Feather icon set](https://react-icons.netlify.com/#/icons/fi).
 Icons can be imported as React components from `react-icons/fi`.
+
+### CSS Modules
+
+Styles are written with
+[CSS Modules](https://github.com/css-modules/css-modules). Global styles should
+be avoided.
+
+In most cases, a component that needs styling should come with its own CSS
+Modules file - e.g. `MyComponent.module.css`. If multiple components need to use
+the same style rules, they may import the same CSS Modules file:
+
+```tsx
+import styles from './ThisComponent.module.css';
+import otherComponentStyles from './OtherComponent.module.css';
+```
+
+However, it is better to write reusable components or take advantage of a CSS
+Modules feature called **composition**:
+
+```css
+/* utils.module.css */
+.baseBtn {
+  color: green;
+}
+
+/* ThisComponent.module.css */
+.thisBtn {
+  composes: baseBtn from './utils.module.css';
+  color: blue;
+}
+
+.selectedBtn {
+  composes: thisBtn;
+  color: red;
+}
+```
+
+To avoid
+[style ordering issues](https://github.com/privatenumber/vite-css-modules/issues/7),
+modules that are composed from other modules (`utils.module.css` in the example
+above) should be used solely for composition and never be imported. In other
+words, you should never compose from a class located in the CSS Modules file of
+another React component:
+
+```css
+/*
+  >>> BAD <<<
+  If `OtherComponent.module.css` gets imported after `ThisComponent.module.css,
+  the `.baseBtn` rule will end up after `.thisBtn` and `color: blue` will be applied.
+*/
+
+/* OtherComponent.module.css */
+.baseBtn {
+  color: blue;
+}
+
+/* ThisComponent.module.css */
+.thisBtn {
+  composes: baseBtn from './OtherComponent.module.css';
+  color: red;
+}
+
+/*
+  >>> GOOD <<<
+  Move `.baseBtn` to a utility module.
+*/
+
+/* utils.module.css */
+.baseBtn {
+  color: blue;
+}
+
+/* OtherComponent.module.css */
+.otherBtn {
+  composes: baseBtn from './utils.module.css';
+}
+
+/* ThisComponent.module.css */
+.thisBtn {
+  composes: baseBtn from './utils.module.css';
+  color: red;
+}
+```
 
 ## Build
 

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -34,6 +34,7 @@
     "eslint-config-galex": "4.5.2",
     "typescript": "5.0.4",
     "vite": "5.1.6",
+    "vite-css-modules": "1.4.2",
     "vite-plugin-checker": "0.6.4",
     "vite-plugin-eslint": "1.8.1"
   }

--- a/apps/demo/src/Home.module.css
+++ b/apps/demo/src/Home.module.css
@@ -36,21 +36,7 @@
 }
 
 .ctaBtn {
-  text-decoration: none;
-  background-color: var(--primary);
-  margin-right: 0.5em;
-  padding: 0.5em 1em;
-  border-radius: 0.75em 0.25em;
-  color: inherit;
-}
-
-.ctaBtn:hover,
-.ctaBtn:focus-visible {
-  background-color: var(--secondary);
-}
-
-.ctaBtn:hover {
-  text-decoration: underline;
+  composes: ctaBtn from './utils.module.css';
 }
 
 .demos {

--- a/apps/demo/src/h5wasm/H5WasmApp.module.css
+++ b/apps/demo/src/h5wasm/H5WasmApp.module.css
@@ -84,7 +84,7 @@
 
 .urlBtn {
   composes: btnClean from global;
-  composes: ctaBtn from '../Home.module.css';
+  composes: ctaBtn from '../utils.module.css';
   margin-left: 0.5rem;
   margin-right: 0;
 }

--- a/apps/demo/src/utils.module.css
+++ b/apps/demo/src/utils.module.css
@@ -1,0 +1,17 @@
+.ctaBtn {
+  text-decoration: none;
+  background-color: var(--primary);
+  margin-right: 0.5em;
+  padding: 0.5em 1em;
+  border-radius: 0.75em 0.25em;
+  color: inherit;
+}
+
+.ctaBtn:hover,
+.ctaBtn:focus-visible {
+  background-color: var(--secondary);
+}
+
+.ctaBtn:hover {
+  text-decoration: underline;
+}

--- a/apps/demo/vite.config.js
+++ b/apps/demo/vite.config.js
@@ -1,5 +1,6 @@
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
+import { patchCssModules } from 'vite-css-modules';
 import { checker } from 'vite-plugin-checker';
 import eslintPlugin from 'vite-plugin-eslint';
 
@@ -7,6 +8,7 @@ export default defineConfig({
   server: { open: true },
   plugins: [
     react(),
+    patchCssModules(),
     { ...eslintPlugin(), apply: 'serve' }, // dev only to reduce build time
     { ...checker({ typescript: true }), apply: 'serve' }, // dev only to reduce build time
   ],

--- a/packages/lib/src/toolbar/MeasuredControl.module.css
+++ b/packages/lib/src/toolbar/MeasuredControl.module.css
@@ -1,0 +1,13 @@
+.controlWrapper[data-measured='false'] {
+  position: relative;
+  overflow: hidden; /* hide controls while they are being measured */
+}
+
+.controlWrapper[data-measured='false'] > .control {
+  position: absolute;
+}
+
+.controlWrapper,
+.control {
+  display: flex;
+}

--- a/packages/lib/src/toolbar/MeasuredControl.tsx
+++ b/packages/lib/src/toolbar/MeasuredControl.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import Measure from 'react-measure';
 
-import styles from './Toolbar.module.css';
+import styles from './MeasuredControl.module.css';
 
 interface Props {
   children: ReactElement;

--- a/packages/lib/src/toolbar/OverflowMenu.module.css
+++ b/packages/lib/src/toolbar/OverflowMenu.module.css
@@ -3,25 +3,13 @@
   display: flex;
 }
 
-.btn {
-  composes: btn from './Toolbar.module.css';
-}
-
-.btnLike {
-  composes: btnLike from './Toolbar.module.css';
-}
-
-.icon {
-  composes: icon from './Toolbar.module.css';
-}
-
 .menu {
-  composes: popup from './Toolbar.module.css';
+  composes: popup from './utils.module.css';
   right: 0.25rem;
 }
 
 .menuList {
-  composes: popupInner from './Toolbar.module.css';
+  composes: popupInner from './utils.module.css';
   display: grid;
   grid-template-columns: 1fr;
   grid-gap: 0.25rem;

--- a/packages/lib/src/toolbar/OverflowMenu.tsx
+++ b/packages/lib/src/toolbar/OverflowMenu.tsx
@@ -6,6 +6,7 @@ import flattenChildren from 'react-keyed-flatten-children';
 
 import styles from './OverflowMenu.module.css';
 import Separator from './Separator';
+import toolbarStyles from './Toolbar.module.css';
 
 interface Props {}
 
@@ -31,7 +32,7 @@ function OverflowMenu(props: PropsWithChildren<Props>) {
       <Separator />
       <div ref={rootRef} className={styles.root}>
         <button
-          className={styles.btn}
+          className={toolbarStyles.btn}
           type="button"
           aria-label="More controls"
           aria-haspopup="menu"
@@ -39,8 +40,8 @@ function OverflowMenu(props: PropsWithChildren<Props>) {
           aria-expanded={isOverflowMenuOpen}
           onClick={toggleOverflowMenu}
         >
-          <span className={styles.btnLike}>
-            <FiMenu className={styles.icon} />
+          <span className={toolbarStyles.btnLike}>
+            <FiMenu className={toolbarStyles.icon} />
           </span>
         </button>
 

--- a/packages/lib/src/toolbar/Toolbar.module.css
+++ b/packages/lib/src/toolbar/Toolbar.module.css
@@ -37,109 +37,25 @@
 }
 
 .btn {
-  composes: btnClean from global;
-  display: flex;
-  align-items: center;
-  padding: 0 0.25rem;
-}
-
-a.btn {
-  color: inherit;
-  text-decoration: none;
-}
-
-.btn[data-small] {
-  padding: 0 0.125rem;
+  composes: btn from './utils.module.css';
 }
 
 .btnLike {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: var(--h5w-btn--height, 1.875rem);
-  padding: 0 0.5rem;
-  border-radius: 0.5rem;
-  transition:
-    background-color 0.05s ease-in-out,
-    box-shadow 0.05s ease-in-out;
-  white-space: nowrap;
-}
-
-.btn[data-small] > .btnLike {
-  height: calc(var(--h5w-btn--height, 1.875rem) - 0.125rem);
-  border-radius: 0.875rem;
-  font-size: 0.875em;
-}
-
-.btn[data-raised] > .btnLike {
-  box-shadow:
-    0 0 1px inset var(--h5w-btnRaised--shadowColor, gray),
-    -1px -1px 2px inset var(--h5w-btnRaised--shadowColor, gray);
+  composes: btnLike from './utils.module.css';
 }
 
 .icon {
-  font-size: 1.5em;
-  padding-top: 1px;
-}
-
-.btn[data-small] .icon {
-  font-size: 1.375em;
-}
-
-.icon:not(:last-child) {
-  margin-right: 0.375rem;
-}
-
-.btn[data-small] .icon:not(:last-child) {
-  margin-right: 0.25rem;
+  composes: icon from './utils.module.css';
 }
 
 .label {
-  margin-right: 0.125rem;
-  line-height: 1.5em;
-}
-
-.btn:hover > .btnLike {
-  background-color: var(--h5w-btn-hover--bgColor, whitesmoke);
-  box-shadow: -1px -1px 2px inset var(--h5w-btn-hover--shadowColor, var(--h5w-btnRaised--shadowColor, gray));
-}
-
-.btn[data-raised]:hover > .btnLike {
-  box-shadow:
-    0 0 1px inset var(--h5w-btnRaised-hover--shadowColor, dimgray),
-    -1px -1px 2px inset var(--h5w-btnRaised-hover--shadowColor, dimgray);
-}
-
-.btn:active > .btnLike,
-.btn[data-raised]:active > .btnLike,
-.btn[aria-pressed='true'] > .btnLike, /* toggle buttons, domain widget "edit" button */
-.btn[aria-checked='true'] > .btnLike, /* toggle group buttons */
-.btn[aria-haspopup][aria-expanded='true'] > .btnLike  /* selectors and overflow menu buttons */ {
-  background-color: var(--h5w-btnPressed--bgColor, white);
-  box-shadow: 1px 1px 2px inset
-    var(--h5w-btnPressed--shadowColor, var(--h5w-btnRaised--shadowColor, gray));
-}
-
-.btn[aria-pressed='true']:hover > .btnLike,
-.btn[aria-checked='true']:hover > .btnLike,
-.btn[aria-haspopup][aria-expanded='true']:hover > .btnLike {
-  box-shadow: 1px 1px 2px inset
-    var(
-      --h5w-btnPressed-hover--shadowColor,
-      var(--h5w-btnRaised-hover--shadowColor, dimgray)
-    );
+  composes: label from './utils.module.css';
 }
 
 .popup {
-  position: absolute;
-  bottom: 1px; /* guarantees overlap with toolbar for hover-only popup */
-  padding-top: calc(0.375rem + 1px);
-  transform: translateY(100%);
+  composes: popup from './utils.module.css';
 }
 
 .popupInner {
-  background-color: var(--h5w-toolbar-popup--bgColor, rgba(255, 255, 255, 0.9));
-  box-shadow:
-    rgba(0, 0, 0, 0.1) 0px 0px 0px 1px,
-    rgba(0, 0, 0, 0.1) 0px 4px 11px;
+  composes: popupInner from './utils.module.css';
 }

--- a/packages/lib/src/toolbar/controls/DomainWidget/BoundEditor.module.css
+++ b/packages/lib/src/toolbar/controls/DomainWidget/BoundEditor.module.css
@@ -60,7 +60,3 @@
   );
   outline: none;
 }
-
-.actionBtn {
-  composes: actionBtn from './DomainControls.module.css';
-}

--- a/packages/lib/src/toolbar/controls/DomainWidget/BoundEditor.tsx
+++ b/packages/lib/src/toolbar/controls/DomainWidget/BoundEditor.tsx
@@ -11,6 +11,7 @@ import { FiCheck, FiSlash } from 'react-icons/fi';
 import type { Bound } from '../../../vis/models';
 import { clampBound } from '../../../vis/utils';
 import styles from './BoundEditor.module.css';
+import domainControlsStyles from './DomainControls.module.css';
 
 interface Props {
   bound: Bound;
@@ -100,7 +101,7 @@ const BoundEditor = forwardRef<Handle, Props>((props, ref) => {
       />
 
       <button
-        className={styles.actionBtn}
+        className={domainControlsStyles.actionBtn}
         type="submit"
         disabled={!isEditing}
         aria-label={`Apply ${bound}`}
@@ -108,7 +109,7 @@ const BoundEditor = forwardRef<Handle, Props>((props, ref) => {
         <FiCheck />
       </button>
       <button
-        className={styles.actionBtn}
+        className={domainControlsStyles.actionBtn}
         type="button"
         disabled={!isEditing}
         aria-label={`Cancel ${bound}`}

--- a/packages/lib/src/toolbar/controls/DomainWidget/DomainWidget.module.css
+++ b/packages/lib/src/toolbar/controls/DomainWidget/DomainWidget.module.css
@@ -21,7 +21,7 @@
 }
 
 .popup {
-  composes: popup from '../../Toolbar.module.css';
+  composes: popup from '../../utils.module.css';
   z-index: 2; /* above overflow and selector menus */
   /* Add invisible padding around popup to extend hover area */
   /* (especially for when enabling auto-scaling hides an error message). */
@@ -31,7 +31,7 @@
 }
 
 .popupInner {
-  composes: popupInner from '../../Toolbar.module.css';
+  composes: popupInner from '../../utils.module.css';
   display: flex;
   align-items: center;
   padding: 1rem 0.375rem 1rem 0.75rem;

--- a/packages/lib/src/toolbar/controls/InteractionHelp.module.css
+++ b/packages/lib/src/toolbar/controls/InteractionHelp.module.css
@@ -1,16 +1,4 @@
-.root {
-  composes: root from '../OverflowMenu.module.css';
-}
-
-.menu {
-  composes: menu from '../OverflowMenu.module.css';
-}
-
-.menuList {
-  composes: menuList from '../OverflowMenu.module.css';
-}
-
-.menuList > li {
+.entry {
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/packages/lib/src/toolbar/controls/InteractionHelp.tsx
+++ b/packages/lib/src/toolbar/controls/InteractionHelp.tsx
@@ -3,6 +3,7 @@ import { useRef } from 'react';
 import { FiHelpCircle } from 'react-icons/fi';
 
 import type { InteractionInfo } from '../../interactions/models';
+import overflowMenuStyles from '../OverflowMenu.module.css';
 import styles from './InteractionHelp.module.css';
 import ToggleBtn from './ToggleBtn';
 
@@ -23,7 +24,7 @@ function InteractionHelp(props: Props) {
   });
 
   return (
-    <div className={styles.root} ref={rootRef}>
+    <div className={overflowMenuStyles.root} ref={rootRef}>
       <ToggleBtn
         icon={FiHelpCircle}
         iconOnly
@@ -31,10 +32,10 @@ function InteractionHelp(props: Props) {
         label="Show help"
         value={isHelpMenuOpen}
       />
-      <div className={styles.menu} hidden={!isHelpMenuOpen}>
-        <div className={styles.menuList}>
+      <div className={overflowMenuStyles.menu} hidden={!isHelpMenuOpen}>
+        <div className={overflowMenuStyles.menuList}>
           {interactions.map(({ shortcut, description }) => (
-            <li key={shortcut}>
+            <li key={shortcut} className={styles.entry}>
               <span>{description}</span>{' '}
               <kbd className={styles.shortcut}>{shortcut}</kbd>
             </li>

--- a/packages/lib/src/toolbar/controls/ScaleSelector/ScaleOption.module.css
+++ b/packages/lib/src/toolbar/controls/ScaleSelector/ScaleOption.module.css
@@ -1,0 +1,4 @@
+.option {
+  display: flex;
+  align-items: center;
+}

--- a/packages/lib/src/toolbar/controls/ScaleSelector/ScaleOption.tsx
+++ b/packages/lib/src/toolbar/controls/ScaleSelector/ScaleOption.tsx
@@ -2,8 +2,9 @@ import { ScaleType } from '@h5web/shared/vis-models';
 import type { IconType } from 'react-icons/lib';
 import { MdFilterList, MdFlare, MdSort } from 'react-icons/md';
 
+import toolbarStyles from '../../Toolbar.module.css';
 import MdGraphicEqRotated from './MdGraphicEqRotated';
-import styles from './ScaleSelector.module.css';
+import styles from './ScaleOption.module.css';
 import SqrtIcon from './SqrtIcon';
 
 export const SCALE_OPTIONS = {
@@ -20,7 +21,7 @@ function ScaleOption(props: { option: ScaleType }) {
 
   return (
     <div className={styles.option}>
-      <Icon className={styles.icon} />
+      <Icon className={toolbarStyles.icon} />
       <span>{label}</span>
     </div>
   );

--- a/packages/lib/src/toolbar/controls/ScaleSelector/ScaleSelector.module.css
+++ b/packages/lib/src/toolbar/controls/ScaleSelector/ScaleSelector.module.css
@@ -1,8 +1,0 @@
-.option {
-  display: flex;
-  align-items: center;
-}
-
-.icon {
-  composes: icon from '../../Toolbar.module.css';
-}

--- a/packages/lib/src/toolbar/controls/Selector/Selector.module.css
+++ b/packages/lib/src/toolbar/controls/Selector/Selector.module.css
@@ -17,20 +17,20 @@
 }
 
 .btn {
-  composes: btn from '../../Toolbar.module.css';
+  composes: btn from '../../utils.module.css';
 }
 
 .btnLike {
-  composes: btnLike from '../../Toolbar.module.css';
-  padding: 0 0.375rem 0 0.5625rem !important; /* FIX style ordering issue with Vite */
+  composes: btnLike from '../../utils.module.css';
+  padding: 0 0.375rem 0 0.5625rem;
 }
 
 .icon {
-  composes: icon from '../../Toolbar.module.css';
+  composes: icon from '../../utils.module.css';
 }
 
 .label {
-  composes: label from '../../Toolbar.module.css';
+  composes: label from '../../utils.module.css';
 }
 
 .arrowIcon {
@@ -102,9 +102,9 @@
 }
 
 .linkOption {
-  composes: btn from '../../Toolbar.module.css';
+  composes: btn from '../../utils.module.css';
   composes: option;
-  padding: 0.5rem 0.75rem !important; /* FIX style ordering issue with Vite */
+  padding: 0.5rem 0.75rem;
 }
 
 .option:hover,

--- a/packages/lib/src/toolbar/controls/ToggleGroup.module.css
+++ b/packages/lib/src/toolbar/controls/ToggleGroup.module.css
@@ -4,12 +4,12 @@
 }
 
 .btn {
-  composes: btn from '../Toolbar.module.css';
-  padding: 0 !important; /* FIX style ordering issue with Vite */
+  composes: btn from '../utils.module.css';
+  padding: 0;
 }
 
 .btnLike {
-  composes: btnLike from '../Toolbar.module.css';
+  composes: btnLike from '../utils.module.css';
 }
 
 .btn:not(:first-child) > .btnLike {
@@ -24,11 +24,11 @@
 }
 
 .icon {
-  composes: icon from '../Toolbar.module.css';
+  composes: icon from '../utils.module.css';
 }
 
 .label {
-  composes: label from '../Toolbar.module.css';
+  composes: label from '../utils.module.css';
 }
 
 .btn[data-hint] .label {

--- a/packages/lib/src/toolbar/floating/ResetZoomButton.module.css
+++ b/packages/lib/src/toolbar/floating/ResetZoomButton.module.css
@@ -1,16 +1,12 @@
 .btn {
-  composes: btn from '../Toolbar.module.css';
-  padding: 0.5rem !important; /* FIX style ordering issue with Vite */
+  composes: btn from '../utils.module.css';
+  padding: 0.5rem;
   font-size: 0.75em;
 }
 
-.btn[hidden] {
-  display: none;
-}
-
 .btnLike {
-  composes: btnLike from '../Toolbar.module.css';
-  height: 1.625rem !important;
+  composes: btnLike from '../utils.module.css';
+  height: 1.625rem;
   background-color: rgba(255, 255, 255, 0.7);
   box-shadow:
     rgba(0, 0, 0, 0.1) 0px 0px 0px 1px,

--- a/packages/lib/src/toolbar/utils.module.css
+++ b/packages/lib/src/toolbar/utils.module.css
@@ -1,0 +1,111 @@
+.btn {
+  composes: btnClean from global;
+  display: flex;
+  align-items: center;
+  padding: 0 0.25rem;
+}
+
+.btn[hidden] {
+  display: none;
+}
+
+a.btn {
+  color: inherit;
+  text-decoration: none;
+}
+
+.btn[data-small] {
+  padding: 0 0.125rem;
+}
+
+.btnLike {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: var(--h5w-btn--height, 1.875rem);
+  padding: 0 0.5rem;
+  border-radius: 0.5rem;
+  transition:
+    background-color 0.05s ease-in-out,
+    box-shadow 0.05s ease-in-out;
+  white-space: nowrap;
+}
+
+.btn[data-small] > .btnLike {
+  height: calc(var(--h5w-btn--height, 1.875rem) - 0.125rem);
+  border-radius: 0.875rem;
+  font-size: 0.875em;
+}
+
+.btn[data-raised] > .btnLike {
+  box-shadow:
+    0 0 1px inset var(--h5w-btnRaised--shadowColor, gray),
+    -1px -1px 2px inset var(--h5w-btnRaised--shadowColor, gray);
+}
+
+.icon {
+  font-size: 1.5em;
+  padding-top: 1px;
+}
+
+.icon:not(:last-child) {
+  margin-right: 0.375rem;
+}
+
+.btn[data-small] .icon {
+  font-size: 1.375em;
+}
+
+.btn[data-small] .icon:not(:last-child) {
+  margin-right: 0.25rem;
+}
+
+.label {
+  margin-right: 0.125rem;
+  line-height: 1.5em;
+}
+
+.btn:hover > .btnLike {
+  background-color: var(--h5w-btn-hover--bgColor, whitesmoke);
+  box-shadow: -1px -1px 2px inset var(--h5w-btn-hover--shadowColor, var(--h5w-btnRaised--shadowColor, gray));
+}
+
+.btn[data-raised]:hover > .btnLike {
+  box-shadow:
+    0 0 1px inset var(--h5w-btnRaised-hover--shadowColor, dimgray),
+    -1px -1px 2px inset var(--h5w-btnRaised-hover--shadowColor, dimgray);
+}
+
+.btn:active > .btnLike,
+    .btn[data-raised]:active > .btnLike,
+    .btn[aria-pressed='true'] > .btnLike, /* toggle buttons, domain widget "edit" button */
+    .btn[aria-checked='true'] > .btnLike, /* toggle group buttons */
+    .btn[aria-haspopup][aria-expanded='true'] > .btnLike  /* selectors and overflow menu buttons */ {
+  background-color: var(--h5w-btnPressed--bgColor, white);
+  box-shadow: 1px 1px 2px inset
+    var(--h5w-btnPressed--shadowColor, var(--h5w-btnRaised--shadowColor, gray));
+}
+
+.btn[aria-pressed='true']:hover > .btnLike,
+.btn[aria-checked='true']:hover > .btnLike,
+.btn[aria-haspopup][aria-expanded='true']:hover > .btnLike {
+  box-shadow: 1px 1px 2px inset
+    var(
+      --h5w-btnPressed-hover--shadowColor,
+      var(--h5w-btnRaised-hover--shadowColor, dimgray)
+    );
+}
+
+.popup {
+  position: absolute;
+  bottom: 1px; /* guarantees overlap with toolbar for hover-only popup */
+  padding-top: calc(0.375rem + 1px);
+  transform: translateY(100%);
+}
+
+.popupInner {
+  background-color: var(--h5w-toolbar-popup--bgColor, rgba(255, 255, 255, 0.9));
+  box-shadow:
+    rgba(0, 0, 0, 0.1) 0px 0px 0px 1px,
+    rgba(0, 0, 0, 0.1) 0px 4px 11px;
+}

--- a/packages/lib/src/vis/scatter/ScatterVis.module.css
+++ b/packages/lib/src/vis/scatter/ScatterVis.module.css
@@ -7,5 +7,10 @@
 }
 
 .tooltipValue {
-  composes: tooltipValue from '../shared/TooltipMesh.module.css';
+  margin-top: 0.25rem;
+}
+
+.tooltipValue > strong {
+  font-weight: 600;
+  font-size: 1.125em;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       vite:
         specifier: 5.1.6
         version: 5.1.6(@types/node@20.11.28)
+      vite-css-modules:
+        specifier: 1.4.2
+        version: 1.4.2(postcss@8.4.35)(vite@5.1.6)
       vite-plugin-checker:
         specifier: 0.6.4
         version: 0.6.4(eslint@8.57.0)(typescript@5.0.4)(vite@5.1.6)
@@ -7742,6 +7745,12 @@ packages:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
     dev: true
 
+  /generic-names@4.0.0:
+    resolution: {integrity: sha512-ySFolZQfw9FoDb3ed9d80Cm9f0+r7qj+HJkWjeD9RBfpxEVTlVhol+gvaQB/78WbwYfbnNh8nWHHBSlg072y6A==}
+    dependencies:
+      loader-utils: 3.2.1
+    dev: true
+
   /gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -8210,6 +8219,15 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       safer-buffer: 2.1.2
+    dev: true
+
+  /icss-utils@5.1.0(postcss@8.4.35):
+    resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
+    engines: {node: ^10 || ^12 || >= 14}
+    peerDependencies:
+      postcss: ^8.1.0
+    dependencies:
+      postcss: 8.4.35
     dev: true
 
   /ieee754@1.2.1:
@@ -8958,6 +8976,11 @@ packages:
       rxjs: 7.8.1
       through: 2.3.8
       wrap-ansi: 7.0.0
+    dev: true
+
+  /loader-utils@3.2.1:
+    resolution: {integrity: sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw==}
+    engines: {node: '>= 12.13.0'}
     dev: true
 
   /local-pkg@0.4.3:
@@ -10316,6 +10339,47 @@ packages:
       lilconfig: 3.1.1
       postcss: 8.4.35
       yaml: 2.4.1
+    dev: true
+
+  /postcss-modules-extract-imports@3.0.0(postcss@8.4.35):
+    resolution: {integrity: sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==}
+    engines: {node: ^10 || ^12 || >= 14}
+    peerDependencies:
+      postcss: ^8.1.0
+    dependencies:
+      postcss: 8.4.35
+    dev: true
+
+  /postcss-modules-local-by-default@4.0.4(postcss@8.4.35):
+    resolution: {integrity: sha512-L4QzMnOdVwRm1Qb8m4x8jsZzKAaPAgrUF1r/hjDR2Xj7R+8Zsf97jAlSQzWtKx5YNiNGN8QxmPFIc/sh+RQl+Q==}
+    engines: {node: ^10 || ^12 || >= 14}
+    peerDependencies:
+      postcss: ^8.1.0
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.4.35)
+      postcss: 8.4.35
+      postcss-selector-parser: 6.0.16
+      postcss-value-parser: 4.2.0
+    dev: true
+
+  /postcss-modules-scope@3.1.1(postcss@8.4.35):
+    resolution: {integrity: sha512-uZgqzdTleelWjzJY+Fhti6F3C9iF1JR/dODLs/JDefozYcKTBCdD8BIl6nNPbTbcLnGrk56hzwZC2DaGNvYjzA==}
+    engines: {node: ^10 || ^12 || >= 14}
+    peerDependencies:
+      postcss: ^8.1.0
+    dependencies:
+      postcss: 8.4.35
+      postcss-selector-parser: 6.0.16
+    dev: true
+
+  /postcss-modules-values@4.0.0(postcss@8.4.35):
+    resolution: {integrity: sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==}
+    engines: {node: ^10 || ^12 || >= 14}
+    peerDependencies:
+      postcss: ^8.1.0
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.4.35)
+      postcss: 8.4.35
     dev: true
 
   /postcss-nested@6.0.1(postcss@8.4.35):
@@ -12406,6 +12470,31 @@ packages:
       '@types/unist': 3.0.2
       unist-util-stringify-position: 4.0.0
       vfile-message: 4.0.2
+    dev: true
+
+  /vite-css-modules@1.4.2(postcss@8.4.35)(vite@5.1.6):
+    resolution: {integrity: sha512-WDTgxeSZ6Z0RR1dU+Y+0utFR98g0F4yRspBN4em8tUUIbv70knajR26marzJbkRyX0+Erhd4OKT3Zq0fKzu1rg==}
+    peerDependencies:
+      lightningcss: ^1.23.0
+      postcss: ^8.4.33
+      vite: ^5.0.12
+    peerDependenciesMeta:
+      lightningcss:
+        optional: true
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@rollup/pluginutils': 5.1.0
+      generic-names: 4.0.0
+      icss-utils: 5.1.0(postcss@8.4.35)
+      magic-string: 0.30.8
+      postcss: 8.4.35
+      postcss-modules-extract-imports: 3.0.0(postcss@8.4.35)
+      postcss-modules-local-by-default: 4.0.4(postcss@8.4.35)
+      postcss-modules-scope: 3.1.1(postcss@8.4.35)
+      postcss-modules-values: 4.0.0(postcss@8.4.35)
+      vite: 5.1.6(@types/node@20.11.28)
+    transitivePeerDependencies:
+      - rollup
     dev: true
 
   /vite-node@0.26.3(@types/node@20.11.28):


### PR DESCRIPTION
Vite has a [new plugin](https://github.com/privatenumber/vite-css-modules) that fixes composition of CSS Modules by treating them as JS modules. It is planned to be integrated into Vite core but it may take a while.

There's one case that is not "fixed" by the plugin, which is when composing from a module that is itself imported from a React component. It's all explained here: https://github.com/privatenumber/vite-css-modules/issues/7. To address this, I decided to refactor the code to never compose from a module that is also imported. I've explained and documented this in the `CONTRIBUTING` guide.

The plugin, in addition to the refactoring above, allow us to remove all of our `!important` workarounds and bring much needed explanations and reassurance that there is indeed a way to use CSS Modules safely.