### PR TITLE
Fix `grid-area` regression

### DIFF
--- a/packages/app/src/vis-packs/core/complex/MappedComplexVis.tsx
+++ b/packages/app/src/vis-packs/core/complex/MappedComplexVis.tsx
@@ -11,6 +11,7 @@ import { useMemo } from 'react';
 import { createPortal } from 'react-dom';
 
 import type { DimensionMapping } from '../../../dimension-mapper/models';
+import visualizerStyles from '../../../visualizer/Visualizer.module.css';
 import type { HeatmapConfig } from '../heatmap/config';
 import {
   useBaseArray,
@@ -97,6 +98,7 @@ function MappedComplexVis(props: Props) {
         )}
 
       <HeatmapVis
+        className={visualizerStyles.vis}
         dataArray={dataArray}
         domain={safeDomain}
         title={`${title} (${visType.toLowerCase()})`}

--- a/packages/app/src/vis-packs/core/compound/MappedCompoundMatrixVis.tsx
+++ b/packages/app/src/vis-packs/core/compound/MappedCompoundMatrixVis.tsx
@@ -10,6 +10,7 @@ import { createPortal } from 'react-dom';
 
 import type { DimensionMapping } from '../../../dimension-mapper/models';
 import { useDataContext } from '../../../providers/DataProvider';
+import visualizerStyles from '../../../visualizer/Visualizer.module.css';
 import { useMappedArray, useSlicedDimsAndMapping } from '../hooks';
 import type { MatrixVisConfig } from '../matrix/config';
 import MatrixToolbar from '../matrix/MatrixToolbar';
@@ -63,6 +64,7 @@ function MappedCompoundMatrixVis(props: Props) {
           toolbarContainer,
         )}
       <MatrixVis
+        className={visualizerStyles.vis}
         dataArray={mappedArray}
         formatter={(val, colIndex) => fieldFormatters[colIndex](val)}
         cellWidth={customCellWidth ?? cellWidth}

--- a/packages/app/src/vis-packs/core/heatmap/MappedHeatmapVis.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/MappedHeatmapVis.tsx
@@ -11,6 +11,7 @@ import { createPortal } from 'react-dom';
 
 import type { DimensionMapping } from '../../../dimension-mapper/models';
 import { useDataContext } from '../../../providers/DataProvider';
+import visualizerStyles from '../../../visualizer/Visualizer.module.css';
 import {
   useMappedArray,
   useSlicedDimsAndMapping,
@@ -89,6 +90,7 @@ function MappedHeatmapVis(props: Props) {
         )}
 
       <HeatmapVis
+        className={visualizerStyles.vis}
         dataArray={dataArray}
         title={title}
         dtype={dataset && formatNumLikeType(dataset.type)}

--- a/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
+++ b/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
@@ -11,6 +11,7 @@ import { createPortal } from 'react-dom';
 
 import type { DimensionMapping } from '../../../dimension-mapper/models';
 import { useDataContext } from '../../../providers/DataProvider';
+import visualizerStyles from '../../../visualizer/Visualizer.module.css';
 import {
   useMappedArray,
   useMappedArrays,
@@ -112,6 +113,7 @@ function MappedLineVis(props: Props) {
         )}
 
       <LineVis
+        className={visualizerStyles.vis}
         dataArray={dataArray}
         domain={combinedDomain}
         scaleType={yScaleType}

--- a/packages/app/src/vis-packs/core/matrix/MappedMatrixVis.tsx
+++ b/packages/app/src/vis-packs/core/matrix/MappedMatrixVis.tsx
@@ -9,6 +9,7 @@ import { createPortal } from 'react-dom';
 
 import type { DimensionMapping } from '../../../dimension-mapper/models';
 import { useDataContext } from '../../../providers/DataProvider';
+import visualizerStyles from '../../../visualizer/Visualizer.module.css';
 import { useMappedArray, useSlicedDimsAndMapping } from '../hooks';
 import { getSliceSelection } from '../utils';
 import type { MatrixVisConfig } from './config';
@@ -54,6 +55,7 @@ function MappedMatrixVis(props: Props) {
         )}
 
       <MatrixVis
+        className={visualizerStyles.vis}
         dataArray={mappedArray}
         formatter={formatter}
         cellWidth={customCellWidth ?? cellWidth}

--- a/packages/app/src/vis-packs/core/raw/RawVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/raw/RawVisContainer.tsx
@@ -3,6 +3,7 @@ import { assertDataset, assertNonNullShape } from '@h5web/shared/guards';
 import { createPortal } from 'react-dom';
 
 import { useDataContext } from '../../../providers/DataProvider';
+import visualizerStyles from '../../../visualizer/Visualizer.module.css';
 import type { VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
 import ValueFetcher from '../ValueFetcher';
@@ -31,7 +32,11 @@ function RawVisContainer(props: VisContainerProps) {
                 />,
                 toolbarContainer,
               )}
-            <RawVis value={value} title={entity.name} />
+            <RawVis
+              className={visualizerStyles.vis}
+              value={value}
+              title={entity.name}
+            />
           </>
         )}
       />

--- a/packages/app/src/vis-packs/core/rgb/MappedRgbVis.tsx
+++ b/packages/app/src/vis-packs/core/rgb/MappedRgbVis.tsx
@@ -6,6 +6,7 @@ import type { TypedArray } from 'ndarray';
 import { createPortal } from 'react-dom';
 
 import type { DimensionMapping } from '../../../dimension-mapper/models';
+import visualizerStyles from '../../../visualizer/Visualizer.module.css';
 import { useMappedArray, useSlicedDimsAndMapping } from '../hooks';
 import type { RgbVisConfig } from './config';
 import RgbToolbar from './RgbToolbar';
@@ -47,6 +48,7 @@ function MappedRgbVis(props: Props) {
       {toolbarContainer &&
         createPortal(<RgbToolbar config={config} />, toolbarContainer)}
       <RgbVis
+        className={visualizerStyles.vis}
         dataArray={dataArray}
         title={title}
         showGrid={showGrid}

--- a/packages/app/src/vis-packs/core/scalar/ScalarVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/scalar/ScalarVisContainer.tsx
@@ -5,6 +5,7 @@ import {
   assertScalarShape,
 } from '@h5web/shared/guards';
 
+import visualizerStyles from '../../../visualizer/Visualizer.module.css';
 import type { VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
 import ValueFetcher from '../ValueFetcher';
@@ -22,7 +23,13 @@ function ScalarVisContainer(props: VisContainerProps) {
     <VisBoundary>
       <ValueFetcher
         dataset={entity}
-        render={(value) => <ScalarVis value={value} formatter={formatter} />}
+        render={(value) => (
+          <ScalarVis
+            className={visualizerStyles.vis}
+            value={value}
+            formatter={formatter}
+          />
+        )}
       />
     </VisBoundary>
   );

--- a/packages/app/src/vis-packs/core/scatter/MappedScatterVis.tsx
+++ b/packages/app/src/vis-packs/core/scatter/MappedScatterVis.tsx
@@ -4,6 +4,7 @@ import type { AxisMapping } from '@h5web/shared/nexus-models';
 import type { NumArray } from '@h5web/shared/vis-models';
 import { createPortal } from 'react-dom';
 
+import visualizerStyles from '../../../visualizer/Visualizer.module.css';
 import { useBaseArray } from '../hooks';
 import { DEFAULT_DOMAIN } from '../utils';
 import type { ScatterConfig } from './config';
@@ -50,6 +51,7 @@ function MappedScatterVis(props: Props) {
           toolbarContainer,
         )}
       <ScatterVis
+        className={visualizerStyles.vis}
         abscissaParams={{ label: xLabel, value: xValue, scaleType: xScaleType }}
         ordinateParams={{ label: yLabel, value: yValue, scaleType: yScaleType }}
         dataArray={dataArray}

--- a/packages/app/src/vis-packs/core/surface/MappedSurfaceVis.tsx
+++ b/packages/app/src/vis-packs/core/surface/MappedSurfaceVis.tsx
@@ -4,6 +4,7 @@ import type { TypedArray } from 'ndarray';
 import { createPortal } from 'react-dom';
 
 import type { DimensionMapping } from '../../../dimension-mapper/models';
+import visualizerStyles from '../../../visualizer/Visualizer.module.css';
 import { useMappedArray, useSlicedDimsAndMapping } from '../hooks';
 import { DEFAULT_DOMAIN } from '../utils';
 import type { SurfaceConfig } from './config';
@@ -39,6 +40,7 @@ function MappedSurfaceVis(props: Props) {
         )}
 
       <SurfaceVis
+        className={visualizerStyles.vis}
         dataArray={dataArray}
         domain={safeDomain}
         colorMap={colorMap}

--- a/packages/app/src/visualizer/Visualizer.module.css
+++ b/packages/app/src/visualizer/Visualizer.module.css
@@ -27,3 +27,7 @@
 .fallback {
   composes: fallback from global;
 }
+
+.vis {
+  grid-area: vis;
+}

--- a/packages/lib/src/vis/heatmap/HeatmapVis.module.css
+++ b/packages/lib/src/vis/heatmap/HeatmapVis.module.css
@@ -1,6 +1,5 @@
 .root {
-  grid-area: vis; /* when inside `visArea` in viewer */
-  flex: 1; /* when inside flex container in consumer app */
+  flex: 1; /* fill height if inside flex container in consumer app */
   display: flex;
   min-width: 0;
   min-height: 0;

--- a/packages/lib/src/vis/heatmap/HeatmapVis.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapVis.tsx
@@ -9,7 +9,12 @@ import type { DefaultInteractionsConfig } from '../../interactions/DefaultIntera
 import DefaultInteractions from '../../interactions/DefaultInteractions';
 import ResetZoomButton from '../../toolbar/floating/ResetZoomButton';
 import { useAxisDomain, useValueToIndexScale } from '../hooks';
-import type { Aspect, AxisParams, VisScaleType } from '../models';
+import type {
+  Aspect,
+  AxisParams,
+  ClassStyleAttrs,
+  VisScaleType,
+} from '../models';
 import TooltipMesh from '../shared/TooltipMesh';
 import VisCanvas from '../shared/VisCanvas';
 import { DEFAULT_DOMAIN } from '../utils';
@@ -19,7 +24,7 @@ import styles from './HeatmapVis.module.css';
 import { useMask, usePixelEdgeValues, useTextureSafeNdArray } from './hooks';
 import type { ColorMap, TooltipData } from './models';
 
-interface Props {
+interface Props extends ClassStyleAttrs {
   dataArray: NdArray<NumArray>;
   domain: Domain | undefined;
   colorMap?: ColorMap;
@@ -60,6 +65,8 @@ function HeatmapVis(props: Props) {
     children,
     interactions,
     ignoreValue,
+    className = '',
+    style,
   } = props;
   const { label: abscissaLabel, value: abscissaValue } = abscissaParams;
   const { label: ordinateLabel, value: ordinateValue } = ordinateParams;
@@ -81,7 +88,12 @@ function HeatmapVis(props: Props) {
   const maskArray = useMask(dataArray, ignoreValue);
 
   return (
-    <figure className={styles.root} aria-label={title} data-keep-canvas-colors>
+    <figure
+      className={`${styles.root} ${className}`}
+      style={style}
+      aria-label={title}
+      data-keep-canvas-colors
+    >
       <VisCanvas
         title={title}
         aspect={aspect}

--- a/packages/lib/src/vis/line/LineVis.module.css
+++ b/packages/lib/src/vis/line/LineVis.module.css
@@ -1,6 +1,5 @@
 .root {
-  grid-area: vis; /* when inside `visArea` in viewer */
-  flex: 1; /* when inside flex container in consumer app */
+  flex: 1; /* fill height if inside flex container in consumer app */
   display: flex;
   min-width: 0;
   min-height: 0;

--- a/packages/lib/src/vis/line/LineVis.tsx
+++ b/packages/lib/src/vis/line/LineVis.tsx
@@ -10,7 +10,7 @@ import type { DefaultInteractionsConfig } from '../../interactions/DefaultIntera
 import DefaultInteractions from '../../interactions/DefaultInteractions';
 import ResetZoomButton from '../../toolbar/floating/ResetZoomButton';
 import { useAxisDomain, useCssColors, useValueToIndexScale } from '../hooks';
-import type { AxisParams } from '../models';
+import type { AxisParams, ClassStyleAttrs } from '../models';
 import TooltipMesh from '../shared/TooltipMesh';
 import VisCanvas from '../shared/VisCanvas';
 import { DEFAULT_DOMAIN, extendDomain } from '../utils';
@@ -20,7 +20,7 @@ import styles from './LineVis.module.css';
 import type { AuxiliaryParams, TooltipData } from './models';
 import { CurveType } from './models';
 
-interface Props {
+interface Props extends ClassStyleAttrs {
   dataArray: NdArray<NumArray>;
   domain: Domain | undefined;
   scaleType?: AxisScaleType;
@@ -59,6 +59,8 @@ function LineVis(props: Props) {
     interactions,
     testid,
     ignoreValue,
+    className = '',
+    style,
   } = props;
 
   const {
@@ -91,7 +93,8 @@ function LineVis(props: Props) {
   return (
     <figure
       ref={rootRef}
-      className={styles.root}
+      className={`${styles.root} ${className}`}
+      style={style}
       aria-label={title}
       data-keep-canvas-colors
       data-testid={testid}

--- a/packages/lib/src/vis/matrix/Grid.tsx
+++ b/packages/lib/src/vis/matrix/Grid.tsx
@@ -2,19 +2,25 @@ import { useMeasure } from '@react-hookz/web';
 import { useContext } from 'react';
 import { FixedSizeGrid as IndexedGrid } from 'react-window';
 
+import type { ClassStyleAttrs } from '../models';
 import Cell from './Cell';
 import { SettingsContext } from './context';
 import styles from './MatrixVis.module.css';
 import StickyGrid from './StickyGrid';
 
-function Grid() {
+function Grid(props: ClassStyleAttrs) {
+  const { className = '', style } = props;
   const { rowCount, columnCount, cellSize, setRenderedItems } =
     useContext(SettingsContext);
 
   const [wrapperSize, wrapperRef] = useMeasure<HTMLDivElement>();
 
   return (
-    <div ref={wrapperRef} className={styles.wrapper}>
+    <div
+      ref={wrapperRef}
+      className={`${styles.wrapper} ${className}`}
+      style={style}
+    >
       {wrapperSize && (
         <IndexedGrid
           className={styles.grid}

--- a/packages/lib/src/vis/matrix/MatrixVis.module.css
+++ b/packages/lib/src/vis/matrix/MatrixVis.module.css
@@ -1,6 +1,5 @@
 .wrapper {
-  grid-area: vis; /* when inside `visArea` in viewer */
-  flex: 1; /* when inside flex container in consumer app */
+  flex: 1; /* fill height if inside flex container in consumer app */
   position: relative;
 }
 

--- a/packages/lib/src/vis/matrix/MatrixVis.tsx
+++ b/packages/lib/src/vis/matrix/MatrixVis.tsx
@@ -1,14 +1,14 @@
 import type { ArrayValue, Primitive } from '@h5web/shared/hdf5-models';
 import type { NdArray } from 'ndarray';
 
-import type { PrintableType } from '../models';
+import type { ClassStyleAttrs, PrintableType } from '../models';
 import GridProvider from './context';
 import Grid from './Grid';
 
 const ROW_HEADERS_WIDTH = 80;
 const CELL_HEIGHT = 32;
 
-interface Props {
+interface Props extends ClassStyleAttrs {
   dataArray: NdArray<ArrayValue<PrintableType>>;
   formatter: (value: Primitive<PrintableType>, colIndex: number) => string;
   cellWidth: number;
@@ -23,6 +23,8 @@ function MatrixVis(props: Props) {
     cellWidth,
     sticky = true,
     columnHeaders,
+    className = '',
+    style,
   } = props;
   const dims = dataArray.shape;
 
@@ -43,7 +45,7 @@ function MatrixVis(props: Props) {
       rowHeaderCellsWidth={ROW_HEADERS_WIDTH}
       columnHeaders={columnHeaders}
     >
-      <Grid />
+      <Grid className={className} style={style} />
     </GridProvider>
   );
 }

--- a/packages/lib/src/vis/models.ts
+++ b/packages/lib/src/vis/models.ts
@@ -12,6 +12,7 @@ import type {
   ScaleType,
 } from '@h5web/shared/vis-models';
 import type { PickD3Scale, PickScaleConfigWithoutType } from '@visx/scale';
+import type { HTMLAttributes } from 'react';
 
 import type { ColorMap } from './heatmap/models';
 import type { ScaleGamma } from './scaleGamma';
@@ -99,3 +100,8 @@ export interface HistogramParams {
   colorMap?: ColorMap;
   invertColorMap?: boolean;
 }
+
+export type ClassStyleAttrs = Pick<
+  HTMLAttributes<HTMLElement>,
+  'className' | 'style'
+>;

--- a/packages/lib/src/vis/raw/RawVis.module.css
+++ b/packages/lib/src/vis/raw/RawVis.module.css
@@ -1,6 +1,5 @@
 .root {
-  grid-area: vis; /* when inside `visArea` in viewer */
-  flex: 1; /* when inside flex container in consumer app */
+  flex: 1; /* fill height if inside flex container in consumer app */
   overflow: auto;
 }
 

--- a/packages/lib/src/vis/raw/RawVis.tsx
+++ b/packages/lib/src/vis/raw/RawVis.tsx
@@ -1,15 +1,16 @@
+import type { ClassStyleAttrs } from '../models';
 import styles from './RawVis.module.css';
 import { isImage } from './utils';
 
 const LARGE_THRESHOLD = 1_000_000;
 
-interface Props {
+interface Props extends ClassStyleAttrs {
   value: unknown;
   title?: string;
 }
 
 function RawVis(props: Props) {
-  const { value, title } = props;
+  const { value, title, className = '', style } = props;
 
   if (value instanceof Uint8Array && isImage(value)) {
     return (
@@ -25,7 +26,7 @@ function RawVis(props: Props) {
       : JSON.stringify(value, null, 2);
 
   return (
-    <div className={styles.root}>
+    <div className={`${styles.root} ${className}`} style={style}>
       {valueAsStr.length < LARGE_THRESHOLD ? (
         <pre className={styles.raw}>{valueAsStr}</pre>
       ) : (

--- a/packages/lib/src/vis/rgb/RgbVis.tsx
+++ b/packages/lib/src/vis/rgb/RgbVis.tsx
@@ -11,13 +11,13 @@ import ResetZoomButton from '../../toolbar/floating/ResetZoomButton';
 import styles from '../heatmap/HeatmapVis.module.css';
 import { usePixelEdgeValues } from '../heatmap/hooks';
 import { useAxisDomain } from '../hooks';
-import type { Aspect, AxisParams } from '../models';
+import type { Aspect, AxisParams, ClassStyleAttrs } from '../models';
 import VisCanvas from '../shared/VisCanvas';
 import { ImageType } from './models';
 import RgbMesh from './RgbMesh';
 import { toRgbSafeNdArray } from './utils';
 
-interface Props {
+interface Props extends ClassStyleAttrs {
   dataArray: NdArray<NumArray>;
   aspect?: Aspect;
   showGrid?: boolean;
@@ -40,6 +40,8 @@ function RgbVis(props: Props) {
     ordinateParams = {},
     children,
     interactions,
+    className = '',
+    style,
   } = props;
 
   const { label: abscissaLabel, value: abscissaValue } = abscissaParams;
@@ -57,7 +59,12 @@ function RgbVis(props: Props) {
   const safeDataArray = useMemo(() => toRgbSafeNdArray(dataArray), [dataArray]);
 
   return (
-    <figure className={styles.root} aria-label={title} data-keep-canvas-colors>
+    <figure
+      className={`${styles.root} ${className}`}
+      style={style}
+      aria-label={title}
+      data-keep-canvas-colors
+    >
       <VisCanvas
         title={title}
         aspect={aspect}

--- a/packages/lib/src/vis/scalar/ScalarVis.module.css
+++ b/packages/lib/src/vis/scalar/ScalarVis.module.css
@@ -1,6 +1,5 @@
 .root {
-  grid-area: vis; /* when inside `visArea` in viewer */
-  flex: 1; /* when inside flex container in consumer app */
+  flex: 1; /* fill height if inside flex container in consumer app */
   overflow: auto;
 }
 

--- a/packages/lib/src/vis/scalar/ScalarVis.tsx
+++ b/packages/lib/src/vis/scalar/ScalarVis.tsx
@@ -1,17 +1,18 @@
 import type { Primitive, PrintableType } from '@h5web/shared/hdf5-models';
 
+import type { ClassStyleAttrs } from '../models';
 import styles from './ScalarVis.module.css';
 
-interface Props {
+interface Props extends ClassStyleAttrs {
   value: Primitive<PrintableType>;
   formatter: (value: Primitive<PrintableType>) => string;
 }
 
 function ScalarVis(props: Props) {
-  const { value, formatter } = props;
+  const { value, formatter, className = '', style } = props;
 
   return (
-    <div className={styles.root}>
+    <div className={`${styles.root} ${className}`} style={style}>
       <pre className={styles.scalar}>{formatter(value)}</pre>
     </div>
   );

--- a/packages/lib/src/vis/scatter/ScatterVis.module.css
+++ b/packages/lib/src/vis/scatter/ScatterVis.module.css
@@ -1,6 +1,5 @@
 .root {
-  grid-area: vis; /* when inside `visArea` in viewer */
-  flex: 1; /* when inside flex container in consumer app */
+  flex: 1; /* fill height if inside flex container in consumer app */
   display: flex;
   min-width: 0;
   min-height: 0;

--- a/packages/lib/src/vis/scatter/ScatterVis.tsx
+++ b/packages/lib/src/vis/scatter/ScatterVis.tsx
@@ -17,13 +17,14 @@ import ResetZoomButton from '../../toolbar/floating/ResetZoomButton';
 import ColorBar from '../heatmap/ColorBar';
 import type { ColorMap } from '../heatmap/models';
 import { useAxisDomain } from '../hooks';
+import type { ClassStyleAttrs } from '../models';
 import TooltipOverlay from '../shared/TooltipOverlay';
 import VisCanvas from '../shared/VisCanvas';
 import type { ScatterAxisParams } from './models';
 import ScatterPoints from './ScatterPoints';
 import styles from './ScatterVis.module.css';
 
-interface Props {
+interface Props extends ClassStyleAttrs {
   abscissaParams: ScatterAxisParams;
   ordinateParams: ScatterAxisParams;
   dataArray: NdArray<NumArray>;
@@ -54,6 +55,8 @@ function ScatterVis(props: Props) {
     children,
     interactions,
     onPointClick,
+    className = '',
+    style,
   } = props;
 
   const {
@@ -85,7 +88,12 @@ function ScatterVis(props: Props) {
   } = useTooltip<number>();
 
   return (
-    <figure className={styles.root} aria-label={title} data-keep-canvas-colors>
+    <figure
+      className={`${styles.root} ${className}`}
+      style={style}
+      aria-label={title}
+      data-keep-canvas-colors
+    >
       <VisCanvas
         abscissaConfig={{
           visDomain: abscissaDomain,

--- a/packages/lib/src/vis/surface/SurfaceMesh.tsx
+++ b/packages/lib/src/vis/surface/SurfaceMesh.tsx
@@ -1,15 +1,28 @@
+import type {
+  ColorScaleType,
+  Domain,
+  NumArray,
+} from '@h5web/shared/vis-models';
 import { getDims } from '@h5web/shared/vis-utils';
+import type { NdArray } from 'ndarray';
 import { LinearFilter } from 'three';
 
 import HeatmapMaterial from '../heatmap/HeatmapMaterial';
 import { useTextureSafeNdArray } from '../heatmap/hooks';
+import type { ColorMap } from '../heatmap/models';
 import { useGeometry } from '../hooks';
 import GlyphMaterial from '../line/GlyphMaterial';
 import { GlyphType } from '../line/models';
 import SurfaceMeshGeometry from './surfaceMeshGeometry';
-import type { SurfaceVisProps } from './SurfaceVis';
 
-type Props = Required<SurfaceVisProps>;
+interface Props {
+  dataArray: NdArray<NumArray>;
+  domain: Domain;
+  scaleType: ColorScaleType;
+  colorMap: ColorMap;
+  invertColorMap: boolean;
+  showPoints: boolean;
+}
 
 function SurfaceMesh(props: Props) {
   const { dataArray, domain, colorMap, invertColorMap, scaleType, showPoints } =

--- a/packages/lib/src/vis/surface/SurfaceVis.module.css
+++ b/packages/lib/src/vis/surface/SurfaceVis.module.css
@@ -1,6 +1,5 @@
 .root {
-  grid-area: vis; /* when inside `visArea` in viewer */
-  flex: 1; /* when inside flex container in consumer app */
+  flex: 1; /* fill height if inside flex container in consumer app */
   display: flex;
   min-width: 0;
   min-height: 0;

--- a/packages/lib/src/vis/surface/SurfaceVis.tsx
+++ b/packages/lib/src/vis/surface/SurfaceVis.tsx
@@ -9,11 +9,12 @@ import type { PropsWithChildren } from 'react';
 
 import ColorBar from '../heatmap/ColorBar';
 import type { ColorMap } from '../heatmap/models';
+import type { ClassStyleAttrs } from '../models';
 import R3FCanvas from '../shared/R3FCanvas';
 import SurfaceMesh from './SurfaceMesh';
 import styles from './SurfaceVis.module.css';
 
-interface Props {
+interface Props extends ClassStyleAttrs {
   dataArray: NdArray<NumArray>;
   domain: Domain;
   scaleType?: ColorScaleType;
@@ -31,10 +32,16 @@ function SurfaceVis(props: PropsWithChildren<Props>) {
     invertColorMap = false,
     showPoints = false,
     children,
+    className = '',
+    style,
   } = props;
 
   return (
-    <figure className={styles.root} data-keep-canvas-colors>
+    <figure
+      className={`${styles.root} ${className}`}
+      style={style}
+      data-keep-canvas-colors
+    >
       <R3FCanvas className={styles.canvas}>
         <SurfaceMesh
           dataArray={dataArray}


### PR DESCRIPTION
Specifying `grid-area: vis` in the visualizations did introduce a regression in the end. Turns out that if a [grid area identifier](https://devdocs.io/css/grid-area#custom-ident) is not defined in the parent grid, the cell ends up on a new row/column for reasons that I [don't quite clearly understand](https://stackoverflow.com/a/57750033/758806)... Since we wrap all our stories with `display: grid` in Storybook, the high-level visualization stories were all messed up.

So I went ahead with the plan I had to pass the `grid-area: vis` style from `@h5web/app` down to the visualizations in `@h5web/lib` via a custom `className` prop. I've also added a `style` prop to all the visualizations.