### PR TITLE
Install `vite-css-modules` plugin in lib/app packages

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -90,6 +90,7 @@
     "rollup-plugin-dts": "6.1.0",
     "typescript": "5.0.4",
     "vite": "5.1.6",
+    "vite-css-modules": "1.4.2",
     "vitest": "1.3.1"
   }
 }

--- a/packages/app/vite.config.js
+++ b/packages/app/vite.config.js
@@ -2,6 +2,7 @@ import react from '@vitejs/plugin-react';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath, URL } from 'url';
+import { patchCssModules } from 'vite-css-modules';
 import { defineProject } from 'vitest/config';
 
 const dirname = fileURLToPath(new URL('.', import.meta.url));
@@ -19,7 +20,7 @@ export const externals = new Set([
 ]);
 
 export default defineProject({
-  plugins: [react()],
+  plugins: [react(), patchCssModules()],
   build: {
     lib: {
       entry: path.resolve('src/index.ts'),

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -106,6 +106,7 @@
     "three": "0.162.0",
     "typescript": "5.0.4",
     "vite": "5.1.6",
+    "vite-css-modules": "1.4.2",
     "vitest": "1.3.1"
   }
 }

--- a/packages/lib/vite.config.js
+++ b/packages/lib/vite.config.js
@@ -2,6 +2,7 @@ import react from '@vitejs/plugin-react';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath, URL } from 'url';
+import { patchCssModules } from 'vite-css-modules';
 import { defineProject } from 'vitest/config';
 
 const dirname = fileURLToPath(new URL('.', import.meta.url));
@@ -17,7 +18,7 @@ export const externals = new Set([
 ]);
 
 export default defineProject({
-  plugins: [react()],
+  plugins: [react(), patchCssModules()],
   build: {
     lib: {
       entry: path.resolve('src/index.ts'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,7 +110,7 @@ importers:
         version: 5.1.6(@types/node@20.11.28)
       vite-css-modules:
         specifier: 1.4.2
-        version: 1.4.2(postcss@8.4.35)(vite@5.1.6)
+        version: 1.4.2(postcss@8.4.35)(rollup@4.13.0)(vite@5.1.6)
       vite-plugin-checker:
         specifier: 0.6.4
         version: 0.6.4(eslint@8.57.0)(typescript@5.0.4)(vite@5.1.6)
@@ -347,6 +347,9 @@ importers:
       vite:
         specifier: 5.1.6
         version: 5.1.6(@types/node@20.11.28)
+      vite-css-modules:
+        specifier: 1.4.2
+        version: 1.4.2(postcss@8.4.35)(rollup@4.13.0)(vite@5.1.6)
       vitest:
         specifier: 1.3.1
         version: 1.3.1(@types/node@20.11.28)(@vitest/ui@1.3.1)(jsdom@24.0.0)
@@ -571,6 +574,9 @@ importers:
       vite:
         specifier: 5.1.6
         version: 5.1.6(@types/node@20.11.28)
+      vite-css-modules:
+        specifier: 1.4.2
+        version: 1.4.2(postcss@8.4.35)(rollup@4.13.0)(vite@5.1.6)
       vitest:
         specifier: 1.3.1
         version: 1.3.1(@types/node@20.11.28)(@vitest/ui@1.3.1)(jsdom@24.0.0)
@@ -2984,7 +2990,7 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /@rollup/pluginutils@5.1.0:
+  /@rollup/pluginutils@5.1.0(rollup@4.13.0):
     resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -2996,6 +3002,7 @@ packages:
       '@types/estree': 1.0.5
       estree-walker: 2.0.2
       picomatch: 2.3.1
+      rollup: 4.13.0
     dev: true
 
   /@rollup/rollup-android-arm-eabi@4.13.0:
@@ -3726,7 +3733,7 @@ packages:
       vite: ^4.0.0 || ^5.0.0
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.3.0(typescript@5.0.4)(vite@5.1.6)
-      '@rollup/pluginutils': 5.1.0
+      '@rollup/pluginutils': 5.1.0(rollup@4.13.0)
       '@storybook/builder-vite': 8.0.0(typescript@5.0.4)(vite@5.1.6)
       '@storybook/node-logger': 8.0.0
       '@storybook/react': 8.0.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)
@@ -12472,7 +12479,7 @@ packages:
       vfile-message: 4.0.2
     dev: true
 
-  /vite-css-modules@1.4.2(postcss@8.4.35)(vite@5.1.6):
+  /vite-css-modules@1.4.2(postcss@8.4.35)(rollup@4.13.0)(vite@5.1.6):
     resolution: {integrity: sha512-WDTgxeSZ6Z0RR1dU+Y+0utFR98g0F4yRspBN4em8tUUIbv70knajR26marzJbkRyX0+Erhd4OKT3Zq0fKzu1rg==}
     peerDependencies:
       lightningcss: ^1.23.0
@@ -12483,7 +12490,7 @@ packages:
         optional: true
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@rollup/pluginutils': 5.1.0
+      '@rollup/pluginutils': 5.1.0(rollup@4.13.0)
       generic-names: 4.0.0
       icss-utils: 5.1.0(postcss@8.4.35)
       magic-string: 0.30.8


### PR DESCRIPTION
Fix #1598 

So... fun story, I forgot to add the `vite-css-modules` plugin to the Vite configs of `@h5web/app` and `@h5web/lib`. :sweat_smile: 