### PR TITLE
Fix styling of raw JPEG/PNG images in some contexts

### DIFF
--- a/packages/lib/src/vis/raw/RawVis.module.css
+++ b/packages/lib/src/vis/raw/RawVis.module.css
@@ -6,14 +6,20 @@
 .raw {
   min-width: fit-content; /* fix missing padding-right */
   margin: 0;
-  padding: 1rem 1.5rem !important; /* Overwritten by JupyterLab if not !important */
+  padding: 1rem 1.5rem !important; /* overridden by JupyterLab if not !important */
   color: inherit;
   font-family: var(--monospace);
   font-size: inherit;
 }
 
-.root > img {
+.img {
   display: block;
+
+  /* Ensure image size is not restricted, since container can scroll.
+    (This notably overrides VS Code's default webview styles, which include
+    `img { max-width/height: 100%; }`.)  */
+  max-width: none;
+  max-height: none;
 }
 
 .fallback {

--- a/packages/lib/src/vis/raw/RawVis.tsx
+++ b/packages/lib/src/vis/raw/RawVis.tsx
@@ -14,8 +14,12 @@ function RawVis(props: Props) {
 
   if (value instanceof Uint8Array && isImage(value)) {
     return (
-      <div className={styles.root}>
-        <img src={URL.createObjectURL(new Blob([value]))} alt={title} />
+      <div className={`${styles.root} ${className}`} style={style}>
+        <img
+          className={styles.img}
+          src={URL.createObjectURL(new Blob([value]))}
+          alt={title}
+        />
       </div>
     );
   }


### PR DESCRIPTION
- Images in _Raw_ vis were being shrunk to a size of (0,0) in VS Code. I had to add [a little workaround](https://github.com/silx-kit/vscode-h5web/pull/38/files#diff-e8229257c26c02255a32a87e829e98b608a3114b349e59d4958e8ba456a438e7).
- I also noticed that the root container for raw images was not receiving the `grid-area: vis` style.

Neither issue prevented the release of a new version of the VS Code extension, but at least it will be cleaner in the next.