### PR TITLE
Improve local file provider

### DIFF
--- a/apps/demo/src/h5wasm/H5WasmApp.tsx
+++ b/apps/demo/src/h5wasm/H5WasmApp.tsx
@@ -27,7 +27,7 @@ function H5WasmApp() {
 
   if (h5File instanceof File) {
     return (
-      <H5WasmLocalFileProvider file={h5File}>
+      <H5WasmLocalFileProvider file={h5File} getPlugin={getPlugin}>
         <App sidebarOpen={!query.has('wide')} getFeedbackURL={getFeedbackURL} />
       </H5WasmLocalFileProvider>
     );

--- a/packages/h5wasm/src/H5WasmProvider.tsx
+++ b/packages/h5wasm/src/H5WasmProvider.tsx
@@ -4,7 +4,7 @@ import type { PropsWithChildren } from 'react';
 import { useMemo, useState } from 'react';
 
 import { H5WasmApi } from './h5wasm-api';
-import type { Plugin } from './utils';
+import type { Plugin } from './models';
 
 interface Props {
   filename: string;

--- a/packages/h5wasm/src/h5wasm-api.ts
+++ b/packages/h5wasm/src/h5wasm-api.ts
@@ -18,8 +18,7 @@ import {
 import { nanoid } from 'nanoid';
 
 import { assertH5WasmDataset } from './guards';
-import type { H5WasmEntity } from './models';
-import type { Plugin } from './utils';
+import type { H5WasmEntity, Plugin } from './models';
 import {
   getEnhancedError,
   hasBigInts,

--- a/packages/h5wasm/src/index.ts
+++ b/packages/h5wasm/src/index.ts
@@ -1,3 +1,3 @@
 export { default as H5WasmProvider } from './H5WasmProvider';
 export { default as H5WasmLocalFileProvider } from './local/H5WasmLocalFileProvider';
-export { Plugin } from './utils';
+export { Plugin } from './models';

--- a/packages/h5wasm/src/local/H5WasmLocalFileProvider.tsx
+++ b/packages/h5wasm/src/local/H5WasmLocalFileProvider.tsx
@@ -1,3 +1,4 @@
+import type { DataProviderApi } from '@h5web/app';
 import { DataProvider } from '@h5web/app';
 import type { PropsWithChildren } from 'react';
 import { useMemo, useState } from 'react';
@@ -6,12 +7,16 @@ import { H5WasmLocalFileApi } from './h5wasm-local-file-api';
 
 interface Props {
   file: File;
+  getExportURL?: DataProviderApi['getExportURL'];
 }
 
 function H5WasmLocalFileProvider(props: PropsWithChildren<Props>) {
-  const { file, children } = props;
+  const { file, getExportURL, children } = props;
 
-  const api = useMemo(() => new H5WasmLocalFileApi(file), [file]);
+  const api = useMemo(
+    () => new H5WasmLocalFileApi(file, getExportURL),
+    [file, getExportURL],
+  );
 
   const [prevApi, setPrevApi] = useState(api);
   if (prevApi !== api) {

--- a/packages/h5wasm/src/local/H5WasmLocalFileProvider.tsx
+++ b/packages/h5wasm/src/local/H5WasmLocalFileProvider.tsx
@@ -3,19 +3,21 @@ import { DataProvider } from '@h5web/app';
 import type { PropsWithChildren } from 'react';
 import { useMemo, useState } from 'react';
 
+import type { Plugin } from '../models';
 import { H5WasmLocalFileApi } from './h5wasm-local-file-api';
 
 interface Props {
   file: File;
   getExportURL?: DataProviderApi['getExportURL'];
+  getPlugin?: (name: Plugin) => Promise<ArrayBuffer | undefined>;
 }
 
 function H5WasmLocalFileProvider(props: PropsWithChildren<Props>) {
-  const { file, getExportURL, children } = props;
+  const { file, getExportURL, getPlugin, children } = props;
 
   const api = useMemo(
-    () => new H5WasmLocalFileApi(file, getExportURL),
-    [file, getExportURL],
+    () => new H5WasmLocalFileApi(file, getExportURL, getPlugin),
+    [file, getExportURL, getPlugin],
   );
 
   const [prevApi, setPrevApi] = useState(api);

--- a/packages/h5wasm/src/local/h5wasm-local-file-api.ts
+++ b/packages/h5wasm/src/local/h5wasm-local-file-api.ts
@@ -91,6 +91,11 @@ export class H5WasmLocalFileApi extends DataProviderApi {
     return undefined;
   }
 
+  public override async getSearchablePaths(root: string): Promise<string[]> {
+    const fileId = await this.fileId;
+    return this.remote.getDescendantPaths(fileId, root);
+  }
+
   public async cleanUp(): Promise<number> {
     return this.remote.closeFile(await this.fileId);
   }

--- a/packages/h5wasm/src/local/h5wasm-local-file-api.ts
+++ b/packages/h5wasm/src/local/h5wasm-local-file-api.ts
@@ -1,17 +1,25 @@
 import type { ExportFormat, ExportURL, ValuesStoreParams } from '@h5web/app';
 import { DataProviderApi } from '@h5web/app';
+import { isDefined } from '@h5web/shared/guards';
 import type {
   ArrayShape,
   AttributeValues,
   Dataset,
   Entity,
+  Filter,
   ProvidedEntity,
   Value,
 } from '@h5web/shared/hdf5-models';
 import type { Remote } from 'comlink';
+import { transfer } from 'comlink';
 
 import type { Plugin } from '../models';
-import { getEnhancedError, hasBigInts, sanitizeBigInts } from '../utils';
+import {
+  getEnhancedError,
+  hasBigInts,
+  PLUGINS_BY_FILTER_ID,
+  sanitizeBigInts,
+} from '../utils';
 import { getH5WasmRemote } from './remote';
 import type { H5WasmWorkerAPI } from './worker';
 
@@ -22,6 +30,9 @@ export class H5WasmLocalFileApi extends DataProviderApi {
   public constructor(
     file: File,
     private readonly _getExportURL?: DataProviderApi['getExportURL'],
+    private readonly getPlugin?: (
+      name: Plugin,
+    ) => Promise<ArrayBuffer | undefined>,
   ) {
     super(file.name);
 
@@ -36,6 +47,8 @@ export class H5WasmLocalFileApi extends DataProviderApi {
   public override async getValue(params: ValuesStoreParams): Promise<unknown> {
     const { dataset, selection } = params;
     const fileId = await this.fileId;
+
+    await this.processFilters(dataset.filters);
 
     try {
       const value = await this.remote.getValue(fileId, dataset.path, selection);
@@ -80,5 +93,26 @@ export class H5WasmLocalFileApi extends DataProviderApi {
 
   public async cleanUp(): Promise<number> {
     return this.remote.closeFile(await this.fileId);
+  }
+
+  private async processFilters(filters: Filter[] = []): Promise<void> {
+    const pluginsToLoad = filters
+      .map(({ id }) => PLUGINS_BY_FILTER_ID[id])
+      .filter(isDefined);
+
+    for await (const plugin of pluginsToLoad) {
+      if (await this.remote.isPluginLoaded(plugin)) {
+        continue; // plugin already loaded
+      }
+
+      const buffer = await this.getPlugin?.(plugin);
+      if (!buffer) {
+        // eslint-disable-next-line no-console
+        console.warn(`Compression plugin ${plugin} not available`);
+        continue;
+      }
+
+      await this.remote.loadPlugin(plugin, transfer(buffer, [buffer]));
+    }
   }
 }

--- a/packages/h5wasm/src/local/worker.ts
+++ b/packages/h5wasm/src/local/worker.ts
@@ -67,6 +67,13 @@ async function getAttrValue(
   return new Attribute(fileId, path, attrName).json_value;
 }
 
+async function getDescendantPaths(fileId: bigint, rootPath: string) {
+  const h5wasm = await h5wasmReady;
+  return h5wasm
+    .get_names(fileId, rootPath, true)
+    .map((path) => `${rootPath}${path}`);
+}
+
 async function isPluginLoaded(plugin: string): Promise<boolean> {
   const pluginPath = `${PLUGINS_PATH}/libH5Z${plugin}.so`;
 
@@ -87,6 +94,7 @@ const api = {
   getEntity,
   getValue,
   getAttrValue,
+  getDescendantPaths,
   isPluginLoaded,
   loadPlugin,
 };

--- a/packages/h5wasm/src/local/worker.ts
+++ b/packages/h5wasm/src/local/worker.ts
@@ -1,5 +1,6 @@
+import { isTypedArray } from '@h5web/shared/guards';
 import type { ProvidedEntity } from '@h5web/shared/hdf5-models';
-import { expose } from 'comlink';
+import { expose, transfer } from 'comlink';
 import { Attribute, Dataset } from 'h5wasm';
 import { nanoid } from 'nanoid';
 
@@ -54,7 +55,8 @@ async function getValue(
   path: string,
   selection?: string | undefined,
 ): Promise<unknown> {
-  return readSelectedValue(new Dataset(fileId, path), selection);
+  const value = readSelectedValue(new Dataset(fileId, path), selection);
+  return isTypedArray(value) ? transfer(value, [value.buffer]) : value;
 }
 
 async function getAttrValue(

--- a/packages/h5wasm/src/local/worker.utils.ts
+++ b/packages/h5wasm/src/local/worker.utils.ts
@@ -10,11 +10,18 @@ import { ready as h5wasmReady, ready } from 'h5wasm';
 
 import { parseDType } from '../utils';
 
-export async function initH5Wasm(): typeof ready {
+export async function initH5Wasm(pluginsPath: string): typeof ready {
   const module = await ready;
 
   // Throw HDF5 errors instead of just logging them
   module.activate_throwing_error_handler();
+
+  // Replace default plugins path
+  module.remove_plugin_search_path(0);
+  module.insert_plugin_search_path(pluginsPath, 0);
+
+  // Create plugins folder on Emscripten virtual file system
+  module.FS.mkdirTree(pluginsPath);
 
   return module;
 }

--- a/packages/h5wasm/src/models.ts
+++ b/packages/h5wasm/src/models.ts
@@ -10,3 +10,16 @@ export interface HDF5Diag {
   message: string;
   origin: string;
 }
+
+// https://github.com/h5wasm/h5wasm-plugins#included-plugins
+export enum Plugin {
+  Bitshuffle = 'bshuf',
+  Blosc = 'blosc',
+  Blosc2 = 'blosc2',
+  BZIP2 = 'bz2',
+  LZ4 = 'lz4',
+  LZF = 'lzf',
+  SZ = 'szf',
+  ZFP = 'zfp',
+  Zstandard = 'zstd',
+}

--- a/packages/h5wasm/src/utils.ts
+++ b/packages/h5wasm/src/utils.ts
@@ -42,19 +42,7 @@ import {
 } from 'h5wasm';
 
 import type { H5WasmAttributes, H5WasmEntity, HDF5Diag } from './models';
-
-// https://github.com/h5wasm/h5wasm-plugins#included-plugins
-export enum Plugin {
-  Bitshuffle = 'bshuf',
-  Blosc = 'blosc',
-  Blosc2 = 'blosc2',
-  BZIP2 = 'bz2',
-  LZ4 = 'lz4',
-  LZF = 'lzf',
-  SZ = 'szf',
-  ZFP = 'zfp',
-  Zstandard = 'zstd',
-}
+import { Plugin } from './models';
 
 // https://support.hdfgroup.org/services/contributions.html
 export const PLUGINS_BY_FILTER_ID: Record<number, Plugin> = {

--- a/packages/shared/src/guards.ts
+++ b/packages/shared/src/guards.ts
@@ -125,7 +125,7 @@ export function assertArray(val: unknown): asserts val is unknown[] {
   }
 }
 
-function isTypedArray(val: unknown): boolean {
+export function isTypedArray(val: unknown): val is TypedArray {
   return (
     val instanceof Int8Array ||
     val instanceof Int16Array ||


### PR DESCRIPTION
Adding support for:

- reading compressed datasets;
- exporting datasets (to JSON in _Raw_ vis by default, and via consumer-provided `getExportURL` prop);
- searching through entities.

I'm also making sure that any typed array dataset values are "transferred" between the worker thread and the main thread rather than copied. Same with the buffers of the compression plugin files (but the other way around).