### PR TITLE
Fix trying to close file twice in strict mode

### DIFF
--- a/packages/h5wasm/src/H5WasmProvider.tsx
+++ b/packages/h5wasm/src/H5WasmProvider.tsx
@@ -1,7 +1,7 @@
 import type { DataProviderApi } from '@h5web/app';
 import { DataProvider } from '@h5web/app';
 import type { PropsWithChildren } from 'react';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef } from 'react';
 
 import { H5WasmApi } from './h5wasm-api';
 import type { Plugin } from './models';
@@ -16,16 +16,16 @@ interface Props {
 function H5WasmProvider(props: PropsWithChildren<Props>) {
   const { filename, buffer, getExportURL, getPlugin, children } = props;
 
-  const api = useMemo(
-    () => new H5WasmApi(filename, buffer, getExportURL, getPlugin),
-    [buffer, filename, getExportURL, getPlugin],
-  );
+  const prevApiRef = useRef<H5WasmApi>();
 
-  const [prevApi, setPrevApi] = useState(api);
-  if (prevApi !== api) {
-    setPrevApi(api);
-    void prevApi.cleanUp(); // https://github.com/silx-kit/h5web/pull/1568
-  }
+  const api = useMemo(() => {
+    const newApi = new H5WasmApi(filename, buffer, getExportURL, getPlugin);
+
+    void prevApiRef.current?.cleanUp();
+    prevApiRef.current = newApi;
+
+    return newApi;
+  }, [buffer, filename, getExportURL, getPlugin]);
 
   return <DataProvider api={api}>{children}</DataProvider>;
 }

--- a/packages/h5wasm/src/h5wasm-api.ts
+++ b/packages/h5wasm/src/h5wasm-api.ts
@@ -116,8 +116,10 @@ export class H5WasmApi extends DataProviderApi {
   }
 
   public async cleanUp(): Promise<void> {
+    const module = await h5wasmReady;
     const file = await this.file;
-    file.close();
+    // `file.close()` flushes the file, which is not needed
+    module.ccall('H5Fclose', 'number', ['bigint'], [file.file_id]);
   }
 
   private async initH5Wasm(): Promise<typeof Module> {

--- a/packages/h5wasm/src/local/worker.ts
+++ b/packages/h5wasm/src/local/worker.ts
@@ -38,7 +38,6 @@ async function openFile(file: File): Promise<bigint> {
 
 async function closeFile(fileId: bigint): Promise<number> {
   const h5wasm = await h5wasmReady;
-  h5wasm.flush(fileId);
   return h5wasm.ccall('H5Fclose', 'number', ['bigint'], [fileId]);
 }
 


### PR DESCRIPTION
Following the stale state issue in myHDF5 that was fixed in #1568, I started seeing HDF5 warnings in development: the h5wasm provider was trying to close the same file twice.

That's because when React in strict mode re-renders a second time to detect side effects, it doesn't update the state (i.e. `setPrevApi(api)` has no effect) so `prevApi !== api` evaluates to `true` again and `prevApi.cleanUp()` is called again.

Now that HDF5 errors are thrown instead of logged as warnings, they really stand out in the console. So I thought I'd try to get rid of them.

None of the React-y solutions (which involve either a `key` or a `useEffect` with a clean-up function) are satisfactory, as explained in #1568. In the end, all I want is to call the clean-up function when the `useMemo` callback is re-invoked, which can be done by just storing the previous API instance in a ref instead of a state.