### PR TITLE
Make variable-length string types explicit in metadata viewer

### DIFF
--- a/packages/app/src/metadata-viewer/utils.ts
+++ b/packages/app/src/metadata-viewer/utils.ts
@@ -34,8 +34,8 @@ export function renderType(type: DType): string {
 
   if (type.class === DTypeClass.String) {
     const { length, charSet } = type;
-    return `${charSet ? `${charSet} string` : 'String'}${
-      length !== undefined ? `, ${length} characters` : ''
+    return `${charSet ? `${charSet} string` : 'String'}, ${
+      length === undefined ? 'variable length' : `${length} characters`
     }`;
   }
 


### PR DESCRIPTION
Addresses the first part of #1612.

Before, we would show only "ASCII string" or "UTF-8 string":

![image](https://github.com/silx-kit/h5web/assets/2936402/4563e735-9d07-47a8-af93-f417a5b0b8f5)
