### PR TITLE
Tweak camera frustrum to provide wider `z` range

### DIFF
--- a/apps/storybook/src/Utilities.mdx
+++ b/apps/storybook/src/Utilities.mdx
@@ -405,6 +405,16 @@ writing your own geometries:
 - `ScatterPointsGeometry`, used in [`ScatterPoints`](https://h5web-docs.panosc.eu/?path=/docs/visualizations-scattervis--docs) (undocumented)
 - `SurfaceMeshGeometry`, used in [`SurfaceMesh`](https://h5web-docs.panosc.eu/?path=/docs/experimental-surfacevis--docs) (experimental)
 
+### Constants
+
+#### `Z_MIN = 0`, `Z_MAX = 1000`
+
+R3F/Three objects inside `VisCanvas` with a `z` position in the range `[Z_MIN Z_MAX]`
+are in view of the scene's orthographic camera. Objects positioned further than `Z_MIN`
+(`z < 0`) or closer than `Z_MAX` (`z > 1000`, i.e. behind the camera) are not in view of
+the camera, and therefore not rendered at all. By default, objects are positioned in view
+of the camera, at `z = 0`.
+
 ### Mock values
 
 The `mockValues` object can be used to generate mock ndarrays for testing purposes:

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -146,7 +146,7 @@ export { default as ErrorCapsGeometry } from './vis/line/errorCapsGeometry';
 
 // Constants
 export { COLOR_SCALE_TYPES, AXIS_SCALE_TYPES } from '@h5web/shared/vis-utils';
-export { CAMERA_FAR } from './vis/utils';
+export { Z_MIN, Z_MAX } from './vis/utils';
 export { INTERPOLATORS } from './vis/heatmap/interpolators';
 
 // Enums

--- a/packages/lib/src/vis/line/errorBarsGeometry.ts
+++ b/packages/lib/src/vis/line/errorBarsGeometry.ts
@@ -3,7 +3,7 @@ import type { NumArray } from '@h5web/shared/vis-models';
 
 import type { AxisScale } from '../models';
 import H5WebGeometry from '../shared/h5webGeometry';
-import { CAMERA_FAR, createBufferAttr } from '../utils';
+import { createBufferAttr, Z_OUT } from '../utils';
 
 interface Params {
   abscissas: NumArray;
@@ -35,8 +35,8 @@ class ErrorBarsGeometry extends H5WebGeometry<'position', Params> {
     const bufferIndex = index * 2;
 
     if (isIgnored) {
-      this.attributes.position.setXYZ(bufferIndex, 0, 0, CAMERA_FAR);
-      this.attributes.position.setXYZ(bufferIndex + 1, 0, 0, CAMERA_FAR);
+      this.attributes.position.setXYZ(bufferIndex, 0, 0, Z_OUT);
+      this.attributes.position.setXYZ(bufferIndex + 1, 0, 0, Z_OUT);
       return;
     }
 
@@ -44,8 +44,8 @@ class ErrorBarsGeometry extends H5WebGeometry<'position', Params> {
     const y = ordinateScale(value);
 
     if (!Number.isFinite(x) || !Number.isFinite(y)) {
-      this.attributes.position.setXYZ(bufferIndex, 0, 0, CAMERA_FAR);
-      this.attributes.position.setXYZ(bufferIndex + 1, 0, 0, CAMERA_FAR);
+      this.attributes.position.setXYZ(bufferIndex, 0, 0, Z_OUT);
+      this.attributes.position.setXYZ(bufferIndex + 1, 0, 0, Z_OUT);
       return;
     }
 

--- a/packages/lib/src/vis/line/errorCapsGeometry.ts
+++ b/packages/lib/src/vis/line/errorCapsGeometry.ts
@@ -3,7 +3,7 @@ import type { NumArray } from '@h5web/shared/vis-models';
 
 import type { AxisScale } from '../models';
 import H5WebGeometry from '../shared/h5webGeometry';
-import { CAMERA_FAR, createBufferAttr } from '../utils';
+import { createBufferAttr, Z_OUT } from '../utils';
 
 interface Params {
   abscissas: NumArray;
@@ -35,8 +35,8 @@ class ErrorCapsGeometry extends H5WebGeometry<'position', Params> {
     const bufferIndex = index * 2;
 
     if (isIgnored) {
-      this.attributes.position.setXYZ(bufferIndex, 0, 0, CAMERA_FAR);
-      this.attributes.position.setXYZ(bufferIndex + 1, 0, 0, CAMERA_FAR);
+      this.attributes.position.setXYZ(bufferIndex, 0, 0, Z_OUT);
+      this.attributes.position.setXYZ(bufferIndex + 1, 0, 0, Z_OUT);
       return;
     }
 
@@ -44,8 +44,8 @@ class ErrorCapsGeometry extends H5WebGeometry<'position', Params> {
     const y = ordinateScale(value);
 
     if (!Number.isFinite(x) || !Number.isFinite(y)) {
-      this.attributes.position.setXYZ(bufferIndex, 0, 0, CAMERA_FAR);
-      this.attributes.position.setXYZ(bufferIndex + 1, 0, 0, CAMERA_FAR);
+      this.attributes.position.setXYZ(bufferIndex, 0, 0, Z_OUT);
+      this.attributes.position.setXYZ(bufferIndex + 1, 0, 0, Z_OUT);
       return;
     }
 
@@ -56,13 +56,13 @@ class ErrorCapsGeometry extends H5WebGeometry<'position', Params> {
     if (Number.isFinite(yBottom)) {
       this.attributes.position.setXYZ(bufferIndex, x, yBottom, 0);
     } else {
-      this.attributes.position.setXYZ(bufferIndex, 0, 0, CAMERA_FAR);
+      this.attributes.position.setXYZ(bufferIndex, 0, 0, Z_OUT);
     }
 
     if (Number.isFinite(yTop)) {
       this.attributes.position.setXYZ(bufferIndex + 1, x, yTop, 0);
     } else {
-      this.attributes.position.setXYZ(bufferIndex + 1, 0, 0, CAMERA_FAR);
+      this.attributes.position.setXYZ(bufferIndex + 1, 0, 0, Z_OUT);
     }
   }
 }

--- a/packages/lib/src/vis/line/glyphsGeometry.ts
+++ b/packages/lib/src/vis/line/glyphsGeometry.ts
@@ -3,7 +3,7 @@ import type { NumArray } from '@h5web/shared/vis-models';
 
 import type { AxisScale } from '../models';
 import H5WebGeometry from '../shared/h5webGeometry';
-import { CAMERA_FAR, createBufferAttr } from '../utils';
+import { createBufferAttr, Z_OUT } from '../utils';
 
 interface Params {
   abscissas: NumArray;
@@ -27,7 +27,7 @@ class GlyphsGeometry extends H5WebGeometry<'position', Params> {
     const isIgnored = ignoreValue ? ignoreValue(value) : false;
 
     if (isIgnored) {
-      this.attributes.position.setXYZ(index, 0, 0, CAMERA_FAR);
+      this.attributes.position.setXYZ(index, 0, 0, Z_OUT);
       return;
     }
 
@@ -35,7 +35,7 @@ class GlyphsGeometry extends H5WebGeometry<'position', Params> {
     const y = ordinateScale(value);
 
     if (!Number.isFinite(x) || !Number.isFinite(y)) {
-      this.attributes.position.setXYZ(index, 0, 0, CAMERA_FAR);
+      this.attributes.position.setXYZ(index, 0, 0, Z_OUT);
       return;
     }
 

--- a/packages/lib/src/vis/line/lineGeometry.ts
+++ b/packages/lib/src/vis/line/lineGeometry.ts
@@ -3,7 +3,7 @@ import type { NumArray } from '@h5web/shared/vis-models';
 
 import type { AxisScale } from '../models';
 import H5WebGeometry from '../shared/h5webGeometry';
-import { CAMERA_FAR, createBufferAttr } from '../utils';
+import { createBufferAttr, Z_OUT } from '../utils';
 
 interface Params {
   abscissas: NumArray;
@@ -27,7 +27,7 @@ class LineGeometry extends H5WebGeometry<'position', Params> {
     const isIgnored = ignoreValue ? ignoreValue(value) : false;
 
     if (isIgnored) {
-      this.attributes.position.setXYZ(index, 0, 0, CAMERA_FAR);
+      this.attributes.position.setXYZ(index, 0, 0, Z_OUT);
       return;
     }
 
@@ -35,7 +35,7 @@ class LineGeometry extends H5WebGeometry<'position', Params> {
     const y = ordinateScale(value);
 
     if (!Number.isFinite(x) || !Number.isFinite(y)) {
-      this.attributes.position.setXYZ(index, 0, 0, CAMERA_FAR);
+      this.attributes.position.setXYZ(index, 0, 0, Z_OUT);
       return;
     }
 

--- a/packages/lib/src/vis/scatter/scatterPointsGeometry.ts
+++ b/packages/lib/src/vis/scatter/scatterPointsGeometry.ts
@@ -5,7 +5,7 @@ import { rgb } from 'd3-color';
 import type { D3Interpolator } from '../heatmap/models';
 import type { AxisScale, Scale } from '../models';
 import H5WebGeometry from '../shared/h5webGeometry';
-import { CAMERA_FAR, createBufferAttr } from '../utils';
+import { createBufferAttr, Z_OUT } from '../utils';
 
 interface Params {
   abscissas: NumArray;
@@ -42,7 +42,7 @@ class ScatterPointsGeometry extends H5WebGeometry<
     const y = ordinateScale(ordinates[index]);
 
     if (!Number.isFinite(x) || !Number.isFinite(y)) {
-      this.attributes.position.setXYZ(index, 0, 0, CAMERA_FAR);
+      this.attributes.position.setXYZ(index, 0, 0, Z_OUT);
       this.attributes.color.setXYZ(index, 0, 0, 0);
       return;
     }

--- a/packages/lib/src/vis/shared/R3FCanvas.tsx
+++ b/packages/lib/src/vis/shared/R3FCanvas.tsx
@@ -1,6 +1,8 @@
 import { Canvas } from '@react-three/fiber';
 import type { PropsWithChildren } from 'react';
 
+import { CAMERA_FAR, CAMERA_NEAR, CAMERA_Z } from '../utils';
+
 interface Props {
   className?: string;
   orthographic?: boolean;
@@ -18,6 +20,12 @@ function R3FCanvas(props: PropsWithChildren<Props>) {
       dpr={[1, 3]} // https://discoverthreejs.com/tips-and-tricks/#performance
       resize={{ debounce: { scroll: 20, resize: 200 }, scroll: false }} // https://github.com/pmndrs/react-three-fiber/discussions/1906
       gl={{ preserveDrawingBuffer: true }} // for "Save Image As..." and snapshot feature to work
+      camera={{
+        // Customize visible `z` range: https://github.com/silx-kit/h5web/issues/1626
+        near: CAMERA_NEAR,
+        far: CAMERA_FAR,
+        position: [0, 0, CAMERA_Z],
+      }}
     >
       <ambientLight />
       {children}

--- a/packages/lib/src/vis/utils.ts
+++ b/packages/lib/src/vis/utils.ts
@@ -39,13 +39,20 @@ import type {
 } from './models';
 import { scaleGamma } from './scaleGamma';
 
-export const DEFAULT_DOMAIN: Domain = [0.1, 1];
+// Orthographic camera configuration (cf. `R3FCanvas.tsx`)
+export const CAMERA_NEAR = 0;
+export const CAMERA_FAR = 1000;
+export const CAMERA_Z = CAMERA_FAR;
 
-/* Use this constant in geometry code to render points outside of the camera's
- * field of view (and therefore hide them from the visualization). This is useful
- * for points with NaN/Infinity coordinates (e.g. because of log scale), as Three
- * logs a warning to the console when rendering such points. */
-export const CAMERA_FAR = 1000; // R3F's default
+// Resulting visible `z` range for objects in the scene
+export const Z_MIN = CAMERA_Z - CAMERA_FAR; // 0
+export const Z_MAX = CAMERA_Z - CAMERA_NEAR; // 1000
+
+/* `z` position located outside of the camera's frustrum (too far).
+ * Used to hide points with NaN/infinite coordinates without Three warnings. */
+export const Z_OUT = Z_MIN - 1;
+
+export const DEFAULT_DOMAIN: Domain = [0.1, 1];
 
 const DEFAULT_AXIS_OFFSETS = { left: 80, right: 24, top: 16, bottom: 34 };
 const TITLE_OFFSET = 28;


### PR DESCRIPTION
Fix #1626

I went with `{ near: 0, far: 1000, position: [0, 0, 1000] }` to give a visible `z` range of `[0 1000]` as explained in https://github.com/silx-kit/h5web/issues/1626#issuecomment-2082921944.

To make the relation between the camera frustrum/position settings and the visible `z` range, I've defined three constants and exported/documented them in `@h5web/lib`.