### PR TITLE
Remove debounce on dimension mapping state to reduce lag

### DIFF
--- a/packages/app/src/__tests__/DimensionMapper.test.tsx
+++ b/packages/app/src/__tests__/DimensionMapper.test.tsx
@@ -1,5 +1,5 @@
 import { screen, within } from '@testing-library/react';
-import { expect, test, vi } from 'vitest';
+import { expect, test } from 'vitest';
 
 import { renderApp, waitForAllLoaders } from '../test-utils';
 import { Vis } from '../vis-packs/core/visualizations';
@@ -30,7 +30,7 @@ test('control mapping for X axis when visualizing 2D dataset as Line', async () 
 
   // Change mapping from [0, 'x'] to ['x', 0]
   await user.click(xDimsButtons[0]);
-  await vi.waitFor(() => expect(xDimsButtons[0]).toBeChecked());
+  expect(xDimsButtons[0]).toBeChecked();
   expect(xDimsButtons[1]).not.toBeChecked();
 
   // Ensure that the dimension slider is now for D1
@@ -63,7 +63,7 @@ test('control mapping for X and Y axes when visualizing 2D dataset as Heatmap', 
 
   // Change mapping from ['y', 'x'] to ['x', 'y']
   await user.click(xD0Button);
-  await vi.waitFor(() => expect(xD0Button).toBeChecked());
+  expect(xD0Button).toBeChecked();
   expect(xD1Button).not.toBeChecked();
   expect(yD0Button).not.toBeChecked();
   expect(yD1Button).toBeChecked();

--- a/packages/app/src/dimension-mapper/hooks.ts
+++ b/packages/app/src/dimension-mapper/hooks.ts
@@ -1,13 +1,10 @@
-import { useDebouncedState } from '@react-hookz/web';
+import { useState } from 'react';
 
 import type { DimensionMapping } from './models';
 
 export function useDimMappingState(dims: number[], axesCount: number) {
-  return useDebouncedState<DimensionMapping>(
-    [
-      ...Array.from({ length: dims.length - axesCount }, () => 0),
-      ...['y' as const, 'x' as const].slice(-axesCount),
-    ],
-    100,
-  );
+  return useState<DimensionMapping>([
+    ...Array.from({ length: dims.length - axesCount }, () => 0),
+    ...['y' as const, 'x' as const].slice(-axesCount),
+  ]);
 }


### PR DESCRIPTION
Baby step to address #1578

1. We first added debouncing on the dimension mapping state in #888 to address #879.
2. In #920, we then realised that this also debounced the axis mappers (the D0/D1/.../Dn button groups), so we opened #975 with the goal of moving the debounce to the sliders.
3. Turns out that in that PR, we added debouncing to the sliders without actually removing it on the dimension mapping state... So we ended up with two debounces, for a total of 350 ms.

In this PR, I therefore remove the debounce on the dimension mapping state, thus saving 100ms both when slicing and changing axis dimensions.