### PR TITLE
Add prefetch buttons below dimension sliders

### DIFF
--- a/packages/app/src/dimension-mapper/DimensionMapper.tsx
+++ b/packages/app/src/dimension-mapper/DimensionMapper.tsx
@@ -3,6 +3,7 @@ import type { AxisMapping } from '@h5web/shared/nexus-models';
 import AxisMapper from './AxisMapper';
 import styles from './DimensionMapper.module.css';
 import type { DimensionMapping } from './models';
+import PrefetchBtn from './PrefetchBtn';
 import SlicingSlider from './SlicingSlider';
 
 interface Props {
@@ -10,10 +11,11 @@ interface Props {
   axisLabels?: AxisMapping<string>;
   mapperState: DimensionMapping;
   onChange: (d: DimensionMapping) => void;
+  onPrefetchDim?: (index: number) => void;
 }
 
 function DimensionMapper(props: Props) {
-  const { rawDims, axisLabels, mapperState, onChange } = props;
+  const { rawDims, axisLabels, mapperState, onChange, onPrefetchDim } = props;
 
   return (
     <div className={styles.mapper}>
@@ -46,21 +48,25 @@ function DimensionMapper(props: Props) {
         />
       </div>
       <div className={styles.sliders}>
-        {mapperState.map((val, index) =>
-          typeof val === 'number' ? (
-            <SlicingSlider
-              key={`${index}`} // eslint-disable-line react/no-array-index-key
-              dimension={index}
-              maxIndex={rawDims[index] - 1}
-              initialValue={val}
-              onChange={(newVal: number) => {
-                const newMapperState = [...mapperState];
-                newMapperState[index] = newVal;
-                onChange(newMapperState);
-              }}
-            />
-          ) : undefined,
-        )}
+        {mapperState.map((val, index) => {
+          return (
+            typeof val === 'number' && (
+              <SlicingSlider
+                key={index} // eslint-disable-line react/no-array-index-key
+                dimension={index}
+                maxIndex={rawDims[index] - 1}
+                initialValue={val}
+                onChange={(newVal: number) => {
+                  const newMapperState = [...mapperState];
+                  newMapperState[index] = newVal;
+                  onChange(newMapperState);
+                }}
+              >
+                <PrefetchBtn onClick={() => onPrefetchDim?.(index)} />
+              </SlicingSlider>
+            )
+          );
+        })}
       </div>
     </div>
   );

--- a/packages/app/src/dimension-mapper/PrefetchBtn.module.css
+++ b/packages/app/src/dimension-mapper/PrefetchBtn.module.css
@@ -1,0 +1,7 @@
+.prefetchBtn {
+  --h5w-btn--height: 2.5em;
+  align-self: center;
+  margin-top: 0.375rem;
+  padding: 0;
+  font-size: 90%;
+}

--- a/packages/app/src/dimension-mapper/PrefetchBtn.tsx
+++ b/packages/app/src/dimension-mapper/PrefetchBtn.tsx
@@ -1,0 +1,23 @@
+import { Btn } from '@h5web/lib';
+import { FiZap } from 'react-icons/fi';
+
+import styles from './PrefetchBtn.module.css';
+
+interface Props {
+  onClick: () => void;
+}
+
+function PrefetchBtn(props: Props) {
+  const { onClick } = props;
+  return (
+    <Btn
+      className={styles.prefetchBtn}
+      icon={FiZap}
+      iconOnly
+      label="Load entire dimension"
+      onClick={() => onClick()}
+    />
+  );
+}
+
+export default PrefetchBtn;

--- a/packages/app/src/dimension-mapper/SlicingSlider.module.css
+++ b/packages/app/src/dimension-mapper/SlicingSlider.module.css
@@ -2,7 +2,7 @@
   flex: 0 1 4rem;
   display: flex;
   flex-direction: column;
-  padding: 0 0.5rem;
+  padding-top: 0.5rem;
   --thumb-height: 1.5rem;
   --mark-height: 0.5rem;
 }

--- a/packages/app/src/dimension-mapper/SlicingSlider.tsx
+++ b/packages/app/src/dimension-mapper/SlicingSlider.tsx
@@ -1,4 +1,5 @@
 import { useDebouncedCallback, useMeasure } from '@react-hookz/web';
+import type { PropsWithChildren } from 'react';
 import { useState } from 'react';
 import ReactSlider from 'react-slider';
 
@@ -15,8 +16,8 @@ interface Props {
   onChange: (value: number) => void;
 }
 
-function SlicingSlider(props: Props) {
-  const { dimension, maxIndex, initialValue, onChange } = props;
+function SlicingSlider(props: PropsWithChildren<Props>) {
+  const { dimension, maxIndex, initialValue, children, onChange } = props;
 
   const [value, setValue] = useState(initialValue);
   const onDebouncedChange = useDebouncedCallback(
@@ -29,48 +30,52 @@ function SlicingSlider(props: Props) {
   const sliderLabelId = `${ID}-${dimension}-label`;
 
   return (
-    <div key={dimension} ref={containerRef} className={styles.container}>
+    <div ref={containerRef} className={styles.container}>
       <span id={sliderLabelId} className={styles.label}>
         D{dimension}
       </span>
       <span className={styles.sublabel}>0:{maxIndex}</span>
-      {maxIndex > 0 ? (
-        <ReactSlider
-          className={styles.slider}
-          ariaLabelledby={sliderLabelId}
-          min={0}
-          max={maxIndex}
-          step={1}
-          marks={
-            containerSize &&
-            containerSize.height / (maxIndex + 1) >= MIN_HEIGHT_PER_MARK
-          }
-          markClassName={styles.mark}
-          orientation="vertical"
-          invert
-          value={value}
-          onChange={(newValue) => {
-            setValue(newValue);
-            onDebouncedChange(newValue);
-          }}
-          /* When slicing in E2E tests, `onChange` is called with the old value.
+
+      {maxIndex > 0 && (
+        <>
+          <ReactSlider
+            className={styles.slider}
+            ariaLabelledby={sliderLabelId}
+            min={0}
+            max={maxIndex}
+            step={1}
+            marks={
+              containerSize &&
+              containerSize.height / (maxIndex + 1) >= MIN_HEIGHT_PER_MARK
+            }
+            markClassName={styles.mark}
+            orientation="vertical"
+            invert
+            value={value}
+            onChange={(newValue) => {
+              setValue(newValue);
+              onDebouncedChange(newValue);
+            }}
+            /* When slicing in E2E tests, `onChange` is called with the old value.
              The `onChange` event is fired via a `setState` callback in `ReactSlider`:
              https://github.com/zillow/react-slider/blob/master/src/components/ReactSlider/ReactSlider.jsx#L908
              Adding `onAfterChange` fixes the issue for now with react-slider@2.0.4, but not with react-slider@2.0.5+ */
-          onAfterChange={(newValue) => {
-            setValue(newValue);
-            onDebouncedChange(newValue);
-          }}
-          renderThumb={({ key, ...thumbProps }, state) => (
-            <div key={key} {...thumbProps} className={styles.thumb}>
-              {state.valueNow}
-            </div>
-          )}
-          renderTrack={({ key }, { index }) =>
-            index === 0 ? <div key={key} className={styles.track} /> : null
-          }
-        />
-      ) : null}
+            onAfterChange={(newValue) => {
+              setValue(newValue);
+              onDebouncedChange(newValue);
+            }}
+            renderThumb={({ key, ...thumbProps }, state) => (
+              <div key={key} {...thumbProps} className={styles.thumb}>
+                {state.valueNow}
+              </div>
+            )}
+            renderTrack={({ key }, { index }) =>
+              index === 0 ? <div key={key} className={styles.track} /> : null
+            }
+          />
+          {children}
+        </>
+      )}
     </div>
   );
 }

--- a/packages/app/src/dimension-mapper/hooks.ts
+++ b/packages/app/src/dimension-mapper/hooks.ts
@@ -1,5 +1,8 @@
+import type { ArrayShape, Dataset } from '@h5web/shared/hdf5-models';
 import { useState } from 'react';
 
+import { useDataContext } from '..';
+import { getSliceSelection } from '../vis-packs/core/utils';
 import type { DimensionMapping } from './models';
 
 export function useDimMappingState(dims: number[], axesCount: number) {
@@ -7,4 +10,23 @@ export function useDimMappingState(dims: number[], axesCount: number) {
     ...Array.from({ length: dims.length - axesCount }, () => 0),
     ...['y' as const, 'x' as const].slice(-axesCount),
   ]);
+}
+
+export function useDimPrefetcher(
+  dataset: Dataset<ArrayShape>,
+  rawDims: number[],
+  mapperState: DimensionMapping,
+) {
+  const { valuesStore } = useDataContext();
+
+  return (index: number) => {
+    const tempMapperState = [...mapperState];
+    for (let i = 0; i < rawDims[index]; i += 1) {
+      tempMapperState[index] = i;
+      valuesStore.prefetch({
+        dataset,
+        selection: getSliceSelection(tempMapperState),
+      });
+    }
+  };
 }

--- a/packages/app/src/vis-packs/core/heatmap/HeatmapVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/HeatmapVisContainer.tsx
@@ -6,7 +6,10 @@ import {
 } from '@h5web/shared/guards';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
-import { useDimMappingState } from '../../../dimension-mapper/hooks';
+import {
+  useDimMappingState,
+  useDimPrefetcher,
+} from '../../../dimension-mapper/hooks';
 import type { VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
 import { useIgnoreFillValue } from '../hooks';
@@ -24,6 +27,7 @@ function HeatmapVisContainer(props: VisContainerProps) {
 
   const { shape: dims } = entity;
   const [dimMapping, setDimMapping] = useDimMappingState(dims, 2);
+  const handlePrefetchDim = useDimPrefetcher(entity, dims, dimMapping);
 
   const config = useHeatmapConfig();
 
@@ -35,6 +39,7 @@ function HeatmapVisContainer(props: VisContainerProps) {
         rawDims={dims}
         mapperState={dimMapping}
         onChange={setDimMapping}
+        onPrefetchDim={handlePrefetchDim}
       />
       <VisBoundary resetKey={dimMapping} loadingMessage="Loading current slice">
         <ValueFetcher

--- a/packages/app/src/vis-packs/nexus/containers/NxImageContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxImageContainer.tsx
@@ -2,7 +2,10 @@ import { assertGroup, assertMinDims } from '@h5web/shared/guards';
 import { useState } from 'react';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
-import { useDimMappingState } from '../../../dimension-mapper/hooks';
+import {
+  useDimMappingState,
+  useDimPrefetcher,
+} from '../../../dimension-mapper/hooks';
 import { useHeatmapConfig } from '../../core/heatmap/config';
 import MappedHeatmapVis from '../../core/heatmap/MappedHeatmapVis';
 import { getSliceSelection } from '../../core/utils';
@@ -27,6 +30,12 @@ function NxImageContainer(props: VisContainerProps) {
 
   const { shape: dims } = selectedDef.dataset;
   const [dimMapping, setDimMapping] = useDimMappingState(dims, 2);
+
+  const handlePrefetchDim = useDimPrefetcher(
+    selectedDef.dataset,
+    dims,
+    dimMapping,
+  );
 
   const axisLabels = axisDefs.map((def) => def?.label);
   const xAxisDef = axisDefs[dimMapping.indexOf('x')];
@@ -60,6 +69,7 @@ function NxImageContainer(props: VisContainerProps) {
         axisLabels={axisLabels}
         mapperState={dimMapping}
         onChange={setDimMapping}
+        onPrefetchDim={handlePrefetchDim}
       />
       <VisBoundary resetKey={dimMapping}>
         <NxValuesFetcher

--- a/packages/lib/src/toolbar/controls/Btn.tsx
+++ b/packages/lib/src/toolbar/controls/Btn.tsx
@@ -3,6 +3,7 @@ import type { AriaAttributes, ComponentType, SVGAttributes } from 'react';
 import styles from '../Toolbar.module.css';
 
 interface Props extends AriaAttributes {
+  className?: string;
   label: string;
   icon?: ComponentType<SVGAttributes<SVGElement>>;
   iconOnly?: boolean;
@@ -14,6 +15,7 @@ interface Props extends AriaAttributes {
 
 function Btn(props: Props) {
   const {
+    className = '',
     label,
     icon: Icon,
     iconOnly,
@@ -26,7 +28,7 @@ function Btn(props: Props) {
 
   return (
     <button
-      className={styles.btn}
+      className={`${className} ${styles.btn}`}
       type="button"
       title={iconOnly ? label : undefined}
       aria-label={iconOnly ? label : undefined}


### PR DESCRIPTION
This is another experiment for #1578

I add a button below every dimension slider to prefetch the entire dimension. This lacks polish, obviously, but it shows what a user-controlled UI for prefetching entire dimensions could look like and feel like:

![Peek 2024-05-06 09-23](https://github.com/silx-kit/h5web/assets/2936402/c2805e5d-620a-4167-a99a-11f72a979ac3)

One major limitation of our data provider architecture, currently, is that we have no way to know whether a slice has already been fetched and is available in the cache. This means we can't, for instance, reduce the debouncing delay (or switch to throttling) and disable the prefetch button when the entire dimension is already cached.

Technically, it is doable with the latest version of [react-suspense-fetch](https://github.com/dai-shi/react-suspense-fetch) (by calling `store.get()` and wrapping it with try/catch), but very hacky. Also, since the library is no longer maintained, I would prefer switching to another, more robust, suspense-based fetching library instead.