### PR TITLE
Lazy-load H5Wasm demo

### DIFF
--- a/apps/demo/src/DemoApp.tsx
+++ b/apps/demo/src/DemoApp.tsx
@@ -1,10 +1,13 @@
+import { lazy, Suspense } from 'react';
 import { Redirect, Route, Switch } from 'wouter';
 
 import H5GroveApp from './H5GroveApp';
-import H5WasmApp from './h5wasm/H5WasmApp';
 import Home from './Home';
 import HsdsApp from './HsdsApp';
 import MockApp from './MockApp';
+
+// Split H5Wasm demo into its own bundle, and load it only when the demo is first visited
+const H5WasmApp = lazy(() => import('./h5wasm/H5WasmApp'));
 
 const query = new URLSearchParams(document.location.search);
 // @ts-expect-error
@@ -12,16 +15,18 @@ window.H5WEB_EXPERIMENTAL = query.has('experimental');
 
 function DemoApp() {
   return (
-    <Switch>
-      <Route path="/" component={Home} />
-      <Route path="/h5grove" component={H5GroveApp} />
-      <Route path="/mock" component={MockApp} />
-      <Route path="/hsds" component={HsdsApp} />
-      <Route path="/h5wasm" component={H5WasmApp} />
-      <Route>
-        <Redirect to="/" replace />
-      </Route>
-    </Switch>
+    <Suspense fallback={null}>
+      <Switch>
+        <Route path="/" component={Home} />
+        <Route path="/h5grove" component={H5GroveApp} />
+        <Route path="/mock" component={MockApp} />
+        <Route path="/hsds" component={HsdsApp} />
+        <Route path="/h5wasm" component={H5WasmApp} />
+        <Route>
+          <Redirect to="/" replace />
+        </Route>
+      </Switch>
+    </Suspense>
   );
 }
 

--- a/eslint.shared.cjs
+++ b/eslint.shared.cjs
@@ -16,8 +16,9 @@ module.exports = {
       enableJavaScriptSpecificRulesInTypeScriptProject: true, // to lint `.eslintrc.js` files and the like
       rules: {
         'sort-keys-fix/sort-keys-fix': 'off', // keys should be sorted based on significance
-        'import/no-default-export': 'off', // default exports are common in React
         'simple-import-sort/exports': 'off', // can make package entry files with numerous exports difficult to read
+        'import/no-default-export': 'off', // default exports are common in React
+        'import/dynamic-import-chunkname': 'off', // Vite generates human-readable chunk names
 
         // Ternaries are sometimes more readable when `true` branch is most significant branch
         'no-negated-condition': 'off',


### PR DESCRIPTION
The H5Wasm demo bundle weighs almost 10 MB, so it seems a shame to load that every time, even for users who just want to look at the mock and H5Grove demos.

![image](https://github.com/silx-kit/h5web/assets/2936402/33492d98-91b1-4c19-8832-0e01a28b6341)
