### PR TITLE
Improve h5grove/h5wasm API testing set-up

### DIFF
--- a/packages/app/.env.test
+++ b/packages/app/.env.test
@@ -3,5 +3,11 @@
 # Copy and configure the variables below in your own `.env.test.local` file
 #####
 
+# URL of h5grove support server
 VITEST_H5GROVE_URL=http://localhost:8888
+
+# Name of test file
 VITEST_H5GROVE_TEST_FILE=sample.h5
+
+# Set to `true` to skip testing h5grove API
+VITEST_H5GROVE_SKIP=

--- a/packages/app/.env.test
+++ b/packages/app/.env.test
@@ -1,0 +1,7 @@
+#####
+# VITEST CONFIGURATION
+# Copy and configure the variables below in your own `.env.test.local` file
+#####
+
+VITEST_H5GROVE_URL=http://localhost:8888
+VITEST_H5GROVE_TEST_FILE=sample.h5

--- a/packages/app/src/providers/h5grove/h5grove-api.test.ts
+++ b/packages/app/src/providers/h5grove/h5grove-api.test.ts
@@ -1,5 +1,6 @@
 import {
   assertDataset,
+  assertEnvVar,
   assertGroup,
   assertGroupWithChildren,
   hasNonNullShape,
@@ -9,8 +10,10 @@ import { expect, test } from 'vitest';
 import { getValueOrError } from '../utils';
 import { H5GroveApi } from './h5grove-api';
 
-const H5GROVE_URL = 'http://localhost:8888'; // when running `pnpm support:h5grove`
-const TEST_FILE = 'sample.h5';
+const H5GROVE_URL = import.meta.env.VITEST_H5GROVE_URL;
+const TEST_FILE = import.meta.env.VITEST_H5GROVE_TEST_FILE;
+assertEnvVar(H5GROVE_URL, 'VITE_H5GROVE_URL');
+assertEnvVar(TEST_FILE, 'VITE_TEST_FILE');
 
 test('test file matches snapshot', async () => {
   const api = new H5GroveApi(H5GROVE_URL, TEST_FILE, {

--- a/packages/app/src/providers/h5grove/h5grove-api.test.ts
+++ b/packages/app/src/providers/h5grove/h5grove-api.test.ts
@@ -11,6 +11,7 @@ import { assertListeningAt } from '../../test-utils';
 import { getValueOrError } from '../utils';
 import { H5GroveApi } from './h5grove-api';
 
+const SKIP = import.meta.env.VITEST_H5GROVE_SKIP === 'true';
 const H5GROVE_URL = import.meta.env.VITEST_H5GROVE_URL;
 const TEST_FILE = import.meta.env.VITEST_H5GROVE_TEST_FILE;
 assertEnvVar(H5GROVE_URL, 'VITE_H5GROVE_URL');
@@ -20,7 +21,7 @@ beforeAll(async () => {
   await assertListeningAt(H5GROVE_URL);
 });
 
-test('test file matches snapshot', async () => {
+test.skipIf(SKIP)('test file matches snapshot', async () => {
   const api = new H5GroveApi(H5GROVE_URL, TEST_FILE, {
     params: { file: TEST_FILE },
   });

--- a/packages/app/src/providers/h5grove/h5grove-api.test.ts
+++ b/packages/app/src/providers/h5grove/h5grove-api.test.ts
@@ -5,8 +5,9 @@ import {
   assertGroupWithChildren,
   hasNonNullShape,
 } from '@h5web/shared/guards';
-import { expect, test } from 'vitest';
+import { beforeAll, expect, test } from 'vitest';
 
+import { assertListeningAt } from '../../test-utils';
 import { getValueOrError } from '../utils';
 import { H5GroveApi } from './h5grove-api';
 
@@ -14,6 +15,10 @@ const H5GROVE_URL = import.meta.env.VITEST_H5GROVE_URL;
 const TEST_FILE = import.meta.env.VITEST_H5GROVE_TEST_FILE;
 assertEnvVar(H5GROVE_URL, 'VITE_H5GROVE_URL');
 assertEnvVar(TEST_FILE, 'VITE_TEST_FILE');
+
+beforeAll(async () => {
+  await assertListeningAt(H5GROVE_URL);
+});
 
 test('test file matches snapshot', async () => {
   const api = new H5GroveApi(H5GROVE_URL, TEST_FILE, {

--- a/packages/app/src/test-utils.tsx
+++ b/packages/app/src/test-utils.tsx
@@ -129,3 +129,14 @@ export function mockConsoleMethod(
     }
   });
 }
+
+export async function assertListeningAt(
+  url: string,
+  message = `Expected server listening at ${url}`,
+) {
+  try {
+    await fetch(url);
+  } catch {
+    throw new Error(message);
+  }
+}

--- a/packages/app/vite.config.js
+++ b/packages/app/vite.config.js
@@ -1,6 +1,7 @@
 import react from '@vitejs/plugin-react-swc';
 import fs from 'fs';
 import path from 'path';
+import { loadEnv } from 'vite';
 import { patchCssModules } from 'vite-css-modules';
 import { defineProject } from 'vitest/config';
 
@@ -33,6 +34,7 @@ export default defineProject({
   test: {
     setupFiles: ['src/setupTests.ts'],
     environment: 'jsdom',
+    env: loadEnv('test', import.meta.dirname, 'VITEST_'),
     restoreMocks: true,
     testTimeout: 15_000,
     server: {

--- a/packages/h5wasm/.env.test
+++ b/packages/h5wasm/.env.test
@@ -1,0 +1,7 @@
+#####
+# VITEST CONFIGURATION
+# Copy and configure the variables below in your own `.env.test.local` file
+#####
+
+# Path to HDF5 test file, relative to the root of the monorepo
+VITEST_H5WASM_TEST_FILE=support/sample/dist/sample.h5

--- a/packages/h5wasm/.env.test
+++ b/packages/h5wasm/.env.test
@@ -5,3 +5,6 @@
 
 # Path to HDF5 test file, relative to the root of the monorepo
 VITEST_H5WASM_TEST_FILE=support/sample/dist/sample.h5
+
+# Set to `true` to skip testing h5wasm API
+VITEST_H5WASM_SKIP=

--- a/packages/h5wasm/src/h5wasm-api.test.ts
+++ b/packages/h5wasm/src/h5wasm-api.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { getValueOrError } from '@h5web/app';
 import {
   assertDataset,
+  assertEnvVar,
   assertGroup,
   assertGroupWithChildren,
   hasNonNullShape,
@@ -13,7 +14,10 @@ import { expect, test } from 'vitest';
 
 import { H5WasmApi } from './h5wasm-api';
 
-const TEST_FILE = path.resolve(process.cwd(), 'support/sample/dist/sample.h5');
+const H5WASM_TEST_FILE = import.meta.env.VITEST_H5WASM_TEST_FILE;
+assertEnvVar(H5WASM_TEST_FILE, 'VITEST_H5WASM_TEST_FILE');
+
+const TEST_FILE = path.resolve(process.cwd(), H5WASM_TEST_FILE);
 
 test('test file matches snapshot', async () => {
   if (!existsSync(TEST_FILE)) {

--- a/packages/h5wasm/src/h5wasm-api.test.ts
+++ b/packages/h5wasm/src/h5wasm-api.test.ts
@@ -10,7 +10,7 @@ import {
   assertGroupWithChildren,
   hasNonNullShape,
 } from '@h5web/shared/guards';
-import { expect, test } from 'vitest';
+import { beforeAll, expect, test } from 'vitest';
 
 import { H5WasmApi } from './h5wasm-api';
 
@@ -19,11 +19,13 @@ assertEnvVar(H5WASM_TEST_FILE, 'VITEST_H5WASM_TEST_FILE');
 
 const TEST_FILE = path.resolve(process.cwd(), H5WASM_TEST_FILE);
 
-test('test file matches snapshot', async () => {
+beforeAll(() => {
   if (!existsSync(TEST_FILE)) {
     throw new Error("Sample file doesn't exist");
   }
+});
 
+test('test file matches snapshot', async () => {
   const buffer = await readFile(TEST_FILE);
   const api = new H5WasmApi('sample.h5', buffer);
 

--- a/packages/h5wasm/src/h5wasm-api.test.ts
+++ b/packages/h5wasm/src/h5wasm-api.test.ts
@@ -14,6 +14,7 @@ import { beforeAll, expect, test } from 'vitest';
 
 import { H5WasmApi } from './h5wasm-api';
 
+const SKIP = import.meta.env.VITEST_H5WASM_SKIP === 'true';
 const H5WASM_TEST_FILE = import.meta.env.VITEST_H5WASM_TEST_FILE;
 assertEnvVar(H5WASM_TEST_FILE, 'VITEST_H5WASM_TEST_FILE');
 
@@ -25,7 +26,7 @@ beforeAll(() => {
   }
 });
 
-test('test file matches snapshot', async () => {
+test.skipIf(SKIP)('test file matches snapshot', async () => {
   const buffer = await readFile(TEST_FILE);
   const api = new H5WasmApi('sample.h5', buffer);
 

--- a/packages/h5wasm/vite.config.js
+++ b/packages/h5wasm/vite.config.js
@@ -1,6 +1,7 @@
 import react from '@vitejs/plugin-react-swc';
 import fs from 'fs';
 import path from 'path';
+import { loadEnv } from 'vite';
 import { defineProject } from 'vitest/config';
 
 const [pkg, appPkg, sharedPkg] = ['.', '../app', '../shared']
@@ -29,6 +30,7 @@ export default defineProject({
     sourcemap: true,
   },
   test: {
+    env: loadEnv('test', import.meta.dirname, 'VITEST_'),
     server: {
       deps: { inline: ['react-suspense-fetch'] },
     },


### PR DESCRIPTION
- I was following an issue on the Vitest repo and finally saw a way to move test configuration to environment variables.
- While I'm at it, I add two env vars to be able to skip running the h5grove/h5wasm API tests (they always fail on my laptop because of the lack of `float128` support)
- And I add a check to make sure that the h5grove support server is running before the test starts (to get a clearer error message).