### PR TITLE
Reduce delay when slicing with h5wasm through viewer config

### DIFF
--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -286,6 +286,17 @@ specific export scenarios. In this case, or if you don't provide a function at
 all, `H5GroveProvider` falls back to generating URLs based on the `/data`
 endpoint and `format` query param.
 
+#### `viewerConfig: Partial<ViewerConfig>` (optional)
+
+Customise the behaviour of the viewer:
+
+- `slicingTiming: number` – debounce delay for the dimension slicing sliders
+  (default: 250)
+
+  Should be high-enough to not overload your h5grove server and to give enough
+  time for the data to reach the client. This depends on the size of your users'
+  datasets, on your users' bandwidths, and on the performance of your server.
+
 #### `key?: Key` (optional)
 
 If the content of the current file changes and you want to ensure that the
@@ -359,6 +370,17 @@ See
 this time, so if you don't provide your own, the export menu will remain
 disabled in the toolbar.
 
+#### `viewerConfig: Partial<ViewerConfig>` (optional)
+
+Customise the behaviour of the viewer:
+
+- `slicingTiming: number` – debounce delay for the dimension slicing sliders
+  (default: 250)
+
+  Should be high-enough to not overload your HSDS server and to give enough time
+  for the data to reach the client. This depends on the size of your users'
+  datasets, on your users' bandwidths, and on the performance of your server.
+
 #### `key?: Key` (optional)
 
 See
@@ -381,6 +403,13 @@ See
 
 `MockProvider` provides a very basic fallback implementation of `getExportURL`
 that can generate only client-side CSV exports of 1D datasets.
+
+#### `viewerConfig: Partial<ViewerConfig>` (optional)
+
+Customise the behaviour of the viewer:
+
+- `slicingTiming: number` – debounce delay for the dimension slicing sliders
+  (default: 20)
 
 ### Utilities
 

--- a/packages/app/src/dimension-mapper/SlicingSlider.tsx
+++ b/packages/app/src/dimension-mapper/SlicingSlider.tsx
@@ -2,11 +2,11 @@ import { useDebouncedCallback, useMeasure } from '@react-hookz/web';
 import { useState } from 'react';
 import ReactSlider from 'react-slider';
 
+import { useViewerConfig } from '../providers/DataProvider';
 import styles from './SlicingSlider.module.css';
 
 const ID = 'h5w-slider';
 const MIN_HEIGHT_PER_MARK = 25;
-const SLICING_DEBOUNCE_DELAY = 250;
 
 interface Props {
   dimension: number;
@@ -17,12 +17,13 @@ interface Props {
 
 function SlicingSlider(props: Props) {
   const { dimension, maxIndex, initialValue, onChange } = props;
+  const { slicingTiming } = useViewerConfig();
 
   const [value, setValue] = useState(initialValue);
   const onDebouncedChange = useDebouncedCallback(
     onChange,
     [onChange],
-    SLICING_DEBOUNCE_DELAY,
+    slicingTiming,
   );
 
   const [containerSize, containerRef] = useMeasure<HTMLDivElement>();

--- a/packages/app/src/providers/DataProvider.tsx
+++ b/packages/app/src/providers/DataProvider.tsx
@@ -13,6 +13,7 @@ import type {
   EntitiesStore,
   ProgressCallback,
   ValuesStore,
+  ViewerConfig,
 } from './models';
 
 export interface DataContextValue {
@@ -21,6 +22,7 @@ export interface DataContextValue {
   entitiesStore: EntitiesStore;
   valuesStore: ValuesStore;
   attrValuesStore: AttrValuesStore;
+  viewerConfig: ViewerConfig;
 
   // Undocumented
   getExportURL?: DataProviderApi['getExportURL'];
@@ -34,13 +36,17 @@ const DataContext = createContext({} as DataContextValue);
 export function useDataContext() {
   return useContext(DataContext);
 }
+export function useViewerConfig() {
+  return useContext(DataContext).viewerConfig;
+}
 
 interface Props {
   api: DataProviderApi;
+  viewerConfig: ViewerConfig;
 }
 
 function DataProvider(props: PropsWithChildren<Props>) {
-  const { api, children } = props;
+  const { api, viewerConfig, children } = props;
 
   const entitiesStore = useMemo(() => {
     const childCache = new Map<string, Exclude<ChildEntity, Group>>();
@@ -110,6 +116,7 @@ function DataProvider(props: PropsWithChildren<Props>) {
         entitiesStore,
         valuesStore,
         attrValuesStore,
+        viewerConfig,
         getExportURL: api.getExportURL?.bind(api),
         addProgressListener: api.addProgressListener.bind(api),
         removeProgressListener: api.removeProgressListener.bind(api),

--- a/packages/app/src/providers/h5grove/H5GroveProvider.tsx
+++ b/packages/app/src/providers/h5grove/H5GroveProvider.tsx
@@ -4,24 +4,40 @@ import { useMemo } from 'react';
 
 import type { DataProviderApi } from '../api';
 import DataProvider from '../DataProvider';
+import type { ViewerConfig } from '../models';
 import { H5GroveApi } from './h5grove-api';
+
+const DEFAULT_VIEWER_CONFIG: ViewerConfig = {
+  slicingTiming: 250,
+};
 
 interface Props {
   url: string;
   filepath: string;
   axiosConfig?: AxiosRequestConfig;
   getExportURL?: DataProviderApi['getExportURL'];
+  viewerConfig?: Partial<ViewerConfig>;
 }
 
 function H5GroveProvider(props: PropsWithChildren<Props>) {
-  const { url, filepath, axiosConfig, getExportURL, children } = props;
+  const { url, filepath, axiosConfig, getExportURL, viewerConfig, children } =
+    props;
 
   const api = useMemo(
     () => new H5GroveApi(url, filepath, axiosConfig, getExportURL),
     [filepath, url, axiosConfig, getExportURL],
   );
 
-  return <DataProvider api={api}>{children}</DataProvider>;
+  const mergedViewerConfig = useMemo(
+    () => ({ ...DEFAULT_VIEWER_CONFIG, ...viewerConfig }),
+    [viewerConfig],
+  );
+
+  return (
+    <DataProvider api={api} viewerConfig={mergedViewerConfig}>
+      {children}
+    </DataProvider>
+  );
 }
 
 export default H5GroveProvider;

--- a/packages/app/src/providers/hsds/HsdsProvider.tsx
+++ b/packages/app/src/providers/hsds/HsdsProvider.tsx
@@ -3,7 +3,12 @@ import { useMemo } from 'react';
 
 import type { DataProviderApi } from '../api';
 import DataProvider from '../DataProvider';
+import type { ViewerConfig } from '../models';
 import { HsdsApi } from './hsds-api';
+
+const DEFAULT_VIEWER_CONFIG: ViewerConfig = {
+  slicingTiming: 250,
+};
 
 interface Props {
   url: string;
@@ -11,17 +16,35 @@ interface Props {
   password: string;
   filepath: string;
   getExportURL?: DataProviderApi['getExportURL'];
+  viewerConfig?: Partial<ViewerConfig>;
 }
 
 function HsdsProvider(props: PropsWithChildren<Props>) {
-  const { url, username, password, filepath, getExportURL, children } = props;
+  const {
+    url,
+    username,
+    password,
+    filepath,
+    getExportURL,
+    viewerConfig,
+    children,
+  } = props;
 
   const api = useMemo(
     () => new HsdsApi(url, username, password, filepath, getExportURL),
     [filepath, password, url, username, getExportURL],
   );
 
-  return <DataProvider api={api}>{children}</DataProvider>;
+  const mergedViewerConfig = useMemo(
+    () => ({ ...DEFAULT_VIEWER_CONFIG, ...viewerConfig }),
+    [viewerConfig],
+  );
+
+  return (
+    <DataProvider api={api} viewerConfig={mergedViewerConfig}>
+      {children}
+    </DataProvider>
+  );
 }
 
 export default HsdsProvider;

--- a/packages/app/src/providers/mock/MockProvider.tsx
+++ b/packages/app/src/providers/mock/MockProvider.tsx
@@ -3,18 +3,33 @@ import { useMemo } from 'react';
 
 import type { DataProviderApi } from '../api';
 import DataProvider from '../DataProvider';
+import type { ViewerConfig } from '../models';
 import { MockApi } from './mock-api';
+
+const DEFAULT_VIEWER_CONFIG: ViewerConfig = {
+  slicingTiming: 20,
+};
 
 interface Props {
   getExportURL?: DataProviderApi['getExportURL'];
+  viewerConfig?: Partial<ViewerConfig>;
 }
 
 function MockProvider(props: PropsWithChildren<Props>) {
-  const { getExportURL, children } = props;
+  const { getExportURL, viewerConfig, children } = props;
 
   const api = useMemo(() => new MockApi(getExportURL), [getExportURL]);
 
-  return <DataProvider api={api}>{children}</DataProvider>;
+  const mergedViewerConfig = useMemo(
+    () => ({ ...DEFAULT_VIEWER_CONFIG, ...viewerConfig }),
+    [viewerConfig],
+  );
+
+  return (
+    <DataProvider api={api} viewerConfig={mergedViewerConfig}>
+      {children}
+    </DataProvider>
+  );
 }
 
 export default MockProvider;

--- a/packages/app/src/providers/models.ts
+++ b/packages/app/src/providers/models.ts
@@ -29,6 +29,10 @@ export interface AttrValuesStore extends FetchStore<AttributeValues, Entity> {
   getSingle: (entity: Entity, attrName: AttrName) => unknown;
 }
 
+export interface ViewerConfig {
+  slicingTiming: number;
+}
+
 export type ExportFormat = 'json' | 'csv' | 'npy' | 'tiff';
 export type ExportURL = URL | (() => Promise<URL | Blob>) | undefined;
 

--- a/packages/h5wasm/README.md
+++ b/packages/h5wasm/README.md
@@ -184,6 +184,16 @@ async function getPlugin(name: Plugin): Promise<ArrayBuffer | undefined> {
 }
 ```
 
+#### `viewerConfig: Partial<ViewerConfig>` (optional)
+
+Customise the behaviour of the viewer:
+
+- `slicingTiming: number` – debounce delay for the dimension slicing sliders
+  (default: 20)
+
+  You may want to choose a higher number to reduce lag when viewing very large
+  datasets.
+
 ### `H5WasmProvider`
 
 - `filename: string` (required) - the name of the file
@@ -212,3 +222,8 @@ See
 
 See
 [`H5WasmLocalFileProvider#getPlugin`](#getplugin-name-plugin--promisearraybuffer--undefined)
+
+#### `viewerConfig: Partial<ViewerConfig>` (optional)
+
+See
+[`H5WasmLocalFileProvider#viewerConfig`](#viewerconfig-partialviewerconfig-optional)

--- a/packages/h5wasm/src/H5WasmProvider.tsx
+++ b/packages/h5wasm/src/H5WasmProvider.tsx
@@ -1,20 +1,27 @@
 import type { DataProviderApi } from '@h5web/app';
 import { DataProvider } from '@h5web/app';
+import type { ViewerConfig } from '@h5web/app/src/providers/models';
 import type { PropsWithChildren } from 'react';
 import { useMemo, useRef } from 'react';
 
 import { H5WasmApi } from './h5wasm-api';
 import type { Plugin } from './models';
 
+const DEFAULT_VIEWER_CONFIG: ViewerConfig = {
+  slicingTiming: 20,
+};
+
 interface Props {
   filename: string;
   buffer: ArrayBuffer;
   getExportURL?: DataProviderApi['getExportURL'];
   getPlugin?: (name: Plugin) => Promise<ArrayBuffer | undefined>;
+  viewerConfig?: Partial<ViewerConfig>;
 }
 
 function H5WasmProvider(props: PropsWithChildren<Props>) {
-  const { filename, buffer, getExportURL, getPlugin, children } = props;
+  const { filename, buffer, getExportURL, getPlugin, viewerConfig, children } =
+    props;
 
   const prevApiRef = useRef<H5WasmApi>();
 
@@ -27,7 +34,16 @@ function H5WasmProvider(props: PropsWithChildren<Props>) {
     return newApi;
   }, [buffer, filename, getExportURL, getPlugin]);
 
-  return <DataProvider api={api}>{children}</DataProvider>;
+  const mergedViewerConfig = useMemo(
+    () => ({ ...DEFAULT_VIEWER_CONFIG, ...viewerConfig }),
+    [viewerConfig],
+  );
+
+  return (
+    <DataProvider api={api} viewerConfig={mergedViewerConfig}>
+      {children}
+    </DataProvider>
+  );
 }
 
 export default H5WasmProvider;

--- a/packages/h5wasm/src/local/H5WasmLocalFileProvider.tsx
+++ b/packages/h5wasm/src/local/H5WasmLocalFileProvider.tsx
@@ -1,19 +1,25 @@
 import type { DataProviderApi } from '@h5web/app';
 import { DataProvider } from '@h5web/app';
+import type { ViewerConfig } from '@h5web/app/src/providers/models';
 import type { PropsWithChildren } from 'react';
 import { useMemo, useRef } from 'react';
 
 import type { Plugin } from '../models';
 import { H5WasmLocalFileApi } from './h5wasm-local-file-api';
 
+const DEFAULT_VIEWER_CONFIG: ViewerConfig = {
+  slicingTiming: 20,
+};
+
 interface Props {
   file: File;
   getExportURL?: DataProviderApi['getExportURL'];
   getPlugin?: (name: Plugin) => Promise<ArrayBuffer | undefined>;
+  viewerConfig?: Partial<ViewerConfig>;
 }
 
 function H5WasmLocalFileProvider(props: PropsWithChildren<Props>) {
-  const { file, getExportURL, getPlugin, children } = props;
+  const { file, getExportURL, getPlugin, viewerConfig, children } = props;
 
   const prevApiRef = useRef<H5WasmLocalFileApi>();
 
@@ -26,7 +32,16 @@ function H5WasmLocalFileProvider(props: PropsWithChildren<Props>) {
     return newApi;
   }, [file, getExportURL, getPlugin]);
 
-  return <DataProvider api={api}>{children}</DataProvider>;
+  const mergedViewerConfig = useMemo(
+    () => ({ ...DEFAULT_VIEWER_CONFIG, ...viewerConfig }),
+    [viewerConfig],
+  );
+
+  return (
+    <DataProvider api={api} viewerConfig={mergedViewerConfig}>
+      {children}
+    </DataProvider>
+  );
 }
 
 export default H5WasmLocalFileProvider;


### PR DESCRIPTION
Addresses #1578 (not closing for now until we can confirm it's sufficient), and supersedes #1583 and #1635.

Since the debounce behaviour depends directly on the kind of provider used, I ended up injecting a `viewerConfig` object into the `DataContext`. This gives a way for providers to configure the viewer to their liking, and for provider consumers to override the configuration as they see fit through a `viewerConfig` prop.

For now `viewerConfig` has a single property: `slicingTiming` to configure the debounce delay on the slicing sliders. I chose a generic name (instead of `debounceDelay`) in case we need to add a `slicingStrategy` property in the future to allow throttling instead of debouncing.

Some initial testing seems to show that a `slicingTiming` of 20ms for h5wasm providers allows for the slicing to be smooth with small images, and also limits the lag with very large images. Removing the debounce completely or switching to a throttling strategy doesn't yield as good results with large images and doesn't seem needed anyway with small images, but do test @bmaranville and let me know if you disagree.

The dataset you use as a demo in #1578 should work very nicely for testing but if you'd like to test with a stack of large images, I recommend [`kevlar.h5`](http://www.silx.org/pub/h5web/kevlar.h5) (with a log scale for the color map). You'll notice that the UI is a bit laggy when the slider moves while a slice is being rendered (because the visualization takes more than 20ms to render), but I think the amount of lag remains acceptable given the size of the images.

From here on, I need to know three things:

- Does the whole `viewerConfig` approach make sense?
- Is a customisable `slicingTiming` enough to address #1578?
- Is 20ms a good default for h5wasm (i.e. a compromise between smooth slicing for small images and limited lag for large images)?

![Peek 2024-05-30 16-40](https://github.com/silx-kit/h5web/assets/2936402/d7ceae43-ece3-417a-a2d8-614597148833)

![Peek 2024-05-30 16-40-2](https://github.com/silx-kit/h5web/assets/2936402/bfb94617-4b4f-4d49-9e96-2afca03b4348)

> FYI, the debounce delay remains unchanged for [h5grove](https://h5web.panosc.eu/h5grove?file=kevlar.h5) and HSDS (250ms).