### PR TITLE
Normalise H5T enums and use them to initialise types

### DIFF
--- a/packages/app/src/providers/h5grove/utils.test.ts
+++ b/packages/app/src/providers/h5grove/utils.test.ts
@@ -1,4 +1,4 @@
-import { Endianness } from '@h5web/shared/hdf5-models';
+import { H5T_CSET, H5T_ORDER } from '@h5web/shared/h5t';
 import {
   arrayType,
   bitfieldType,
@@ -23,35 +23,35 @@ import { parseDType } from './utils';
 describe('parseDType', () => {
   it('should convert integer types', () => {
     expect(parseDType({ class: 0, size: 1, order: 0, sign: 1 })).toStrictEqual(
-      intType(8, Endianness.LE),
+      intType(8, H5T_ORDER.LE),
     );
     expect(parseDType({ class: 0, size: 8, order: 1, sign: 0 })).toStrictEqual(
-      uintType(64, Endianness.BE),
+      uintType(64, H5T_ORDER.BE),
     );
   });
 
   it('should convert float types', () => {
     expect(parseDType({ class: 1, size: 4, order: 0 })).toStrictEqual(
-      floatType(32, Endianness.LE),
+      floatType(32, H5T_ORDER.LE),
     );
     expect(parseDType({ class: 1, size: 8, order: 1 })).toStrictEqual(
-      floatType(64, Endianness.BE),
+      floatType(64, H5T_ORDER.BE),
     );
   });
 
   it('should convert string types', () => {
     expect(
       parseDType({ class: 3, size: 6, cset: 0, vlen: false }),
-    ).toStrictEqual(strType('ASCII', 6));
+    ).toStrictEqual(strType(H5T_CSET.ASCII, 6));
     expect(
       parseDType({ class: 3, size: 6, cset: 0, vlen: true }),
-    ).toStrictEqual(strType('ASCII'));
+    ).toStrictEqual(strType(H5T_CSET.ASCII));
     expect(
       parseDType({ class: 3, size: 6, cset: 1, vlen: false }),
-    ).toStrictEqual(strType('UTF-8', 6));
+    ).toStrictEqual(strType(H5T_CSET.UTF8, 6));
     expect(
       parseDType({ class: 3, size: 6, cset: 1, vlen: true }),
-    ).toStrictEqual(strType('UTF-8'));
+    ).toStrictEqual(strType(H5T_CSET.UTF8));
   });
 
   it('should convert compound and complex types', () => {
@@ -117,7 +117,7 @@ describe('parseDType', () => {
   it('should convert other types', () => {
     expect(parseDType({ class: 2, size: 1 })).toStrictEqual(timeType());
     expect(parseDType({ class: 4, size: 1, order: 0 })).toStrictEqual(
-      bitfieldType(Endianness.LE),
+      bitfieldType(H5T_ORDER.LE),
     );
     expect(parseDType({ class: 5, size: 1, tag: 'foo' })).toStrictEqual(
       opaqueType('foo'),

--- a/packages/app/src/providers/h5grove/utils.ts
+++ b/packages/app/src/providers/h5grove/utils.ts
@@ -1,4 +1,5 @@
 import { isNumericType } from '@h5web/shared/guards';
+import { H5T_CLASS } from '@h5web/shared/h5t';
 import type {
   Attribute,
   ChildEntity,
@@ -6,12 +7,7 @@ import type {
   Group,
   ProvidedEntity,
 } from '@h5web/shared/hdf5-models';
-import {
-  DTypeClass,
-  EntityKind,
-  H5TClass,
-  H5TSign,
-} from '@h5web/shared/hdf5-models';
+import { DTypeClass, EntityKind } from '@h5web/shared/hdf5-models';
 import {
   arrayType,
   bitfieldType,
@@ -24,8 +20,6 @@ import {
   referenceType,
   strType,
   timeType,
-  toCharSet,
-  toEndianness,
   unknownType,
 } from '@h5web/shared/hdf5-utils';
 import type { TypedArrayConstructor } from '@h5web/shared/vis-models';
@@ -142,36 +136,32 @@ export function hasErrorMessage(error: unknown): error is { message: string } {
 export function parseDType(type: H5GroveType): DType {
   const { class: h5tClass, size } = type;
 
-  if (h5tClass === H5TClass.Integer) {
-    return intOrUintType(
-      type.sign === H5TSign.Signed,
-      size * 8,
-      toEndianness(type.order),
-    );
+  if (h5tClass === H5T_CLASS.INTEGER) {
+    return intOrUintType(type.sign, size * 8, type.order);
   }
 
-  if (h5tClass === H5TClass.Float) {
-    return floatType(size * 8, toEndianness(type.order));
+  if (h5tClass === H5T_CLASS.FLOAT) {
+    return floatType(size * 8, type.order);
   }
 
-  if (h5tClass === H5TClass.Time) {
+  if (h5tClass === H5T_CLASS.TIME) {
     return timeType();
   }
 
-  if (h5tClass === H5TClass.String) {
+  if (h5tClass === H5T_CLASS.STRING) {
     const { cset, vlen } = type;
-    return strType(toCharSet(cset), vlen ? undefined : size);
+    return strType(cset, vlen ? undefined : size);
   }
 
-  if (h5tClass === H5TClass.Bitfield) {
+  if (h5tClass === H5T_CLASS.BITFIELD) {
     return bitfieldType();
   }
 
-  if (h5tClass === H5TClass.Opaque) {
+  if (h5tClass === H5T_CLASS.OPAQUE) {
     return opaqueType(type.tag);
   }
 
-  if (h5tClass === H5TClass.Compound) {
+  if (h5tClass === H5T_CLASS.COMPOUND) {
     return compoundOrCplxType(
       Object.fromEntries(
         Object.entries(type.members).map(([mName, mType]) => [
@@ -182,11 +172,11 @@ export function parseDType(type: H5GroveType): DType {
     );
   }
 
-  if (h5tClass === H5TClass.Reference) {
+  if (h5tClass === H5T_CLASS.REFERENCE) {
     return referenceType();
   }
 
-  if (h5tClass === H5TClass.Enum) {
+  if (h5tClass === H5T_CLASS.ENUM) {
     const base = parseDType(type.base);
     if (!isNumericType(base)) {
       throw new Error('Expected enum type to have numeric base type');
@@ -195,11 +185,11 @@ export function parseDType(type: H5GroveType): DType {
     return enumOrBoolType(base, type.members);
   }
 
-  if (h5tClass === H5TClass.Vlen) {
+  if (h5tClass === H5T_CLASS.VLEN) {
     return arrayType(parseDType(type.base));
   }
 
-  if (h5tClass === H5TClass.Array) {
+  if (h5tClass === H5T_CLASS.ARRAY) {
     return arrayType(parseDType(type.base), type.dims);
   }
 

--- a/packages/app/src/providers/hsds/utils.test.ts
+++ b/packages/app/src/providers/hsds/utils.test.ts
@@ -1,5 +1,5 @@
+import { H5T_CSET, H5T_ORDER } from '@h5web/shared/h5t';
 import type { DType } from '@h5web/shared/hdf5-models';
-import { Endianness } from '@h5web/shared/hdf5-models';
 import {
   arrayType,
   boolType,
@@ -29,22 +29,22 @@ interface TestType {
 
 const leInt = {
   hsds: { class: 'H5T_INTEGER', base: 'H5T_STD_I8LE' },
-  hdf5: intType(8, Endianness.LE),
+  hdf5: intType(8, H5T_ORDER.LE),
 } satisfies TestType;
 
 const beUint = {
   hsds: { class: 'H5T_INTEGER', base: 'H5T_STD_U64BE' },
-  hdf5: uintType(64, Endianness.BE),
+  hdf5: uintType(64, H5T_ORDER.BE),
 } satisfies TestType;
 
 const leFloat = {
   hsds: { class: 'H5T_FLOAT', base: 'H5T_IEEE_F32LE' },
-  hdf5: floatType(32, Endianness.LE),
+  hdf5: floatType(32, H5T_ORDER.LE),
 } satisfies TestType;
 
 const beFloat = {
   hsds: { class: 'H5T_FLOAT', base: 'H5T_IEEE_F64BE' },
-  hdf5: floatType(64, Endianness.BE),
+  hdf5: floatType(64, H5T_ORDER.BE),
 } satisfies TestType;
 
 describe('convertHsdsType', () => {
@@ -55,7 +55,9 @@ describe('convertHsdsType', () => {
       length: 25,
     };
 
-    expect(convertHsdsType(asciiStr)).toStrictEqual(strType('ASCII', 25));
+    expect(convertHsdsType(asciiStr)).toStrictEqual(
+      strType(H5T_CSET.ASCII, 25),
+    );
   });
 
   it('should convert variable-length UTF-8 string type', () => {
@@ -65,7 +67,7 @@ describe('convertHsdsType', () => {
       length: 'H5T_VARIABLE',
     };
 
-    expect(convertHsdsType(unicodeStr)).toStrictEqual(strType('UTF-8'));
+    expect(convertHsdsType(unicodeStr)).toStrictEqual(strType(H5T_CSET.UTF8));
   });
 
   it('should convert integer types', () => {

--- a/packages/app/src/providers/mock/mock-file.ts
+++ b/packages/app/src/providers/mock/mock-file.ts
@@ -1,3 +1,4 @@
+import { H5T_CSET } from '@h5web/shared/h5t';
 import type { GroupWithChildren } from '@h5web/shared/hdf5-models';
 import {
   arrayType,
@@ -60,10 +61,16 @@ export function makeMockFile(): GroupWithChildren {
           attributes: [scalarAttr('attr', cplx(1, 5))],
         }),
         scalar('scalar_compound', ['foo', 2], {
-          type: compoundType({ str: strType('ASCII', 3), int: intType(8) }),
+          type: compoundType({
+            str: strType(H5T_CSET.ASCII, 3),
+            int: intType(8),
+          }),
           attributes: [
             scalarAttr('attr', ['foo', 2], {
-              type: compoundType({ str: strType('UTF-8'), int: intType(8) }),
+              type: compoundType({
+                str: strType(H5T_CSET.UTF8),
+                int: intType(8),
+              }),
             }),
           ],
         }),

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,6 +9,7 @@
   "exports": {
     "./createMemo": "./src/createMemo.ts",
     "./guards": "./src/guards.ts",
+    "./h5t": "./src/h5t.ts",
     "./hdf5-models": "./src/hdf5-models.ts",
     "./hdf5-utils": "./src/hdf5-utils.ts",
     "./nexus-models": "./src/nexus-models.ts",

--- a/packages/shared/src/h5t.ts
+++ b/packages/shared/src/h5t.ts
@@ -1,0 +1,53 @@
+/* ------------------- */
+/* ---- H5T ENUMS ---- */
+
+// https://docs.hdfgroup.org/hdf5/v1_14/_h5_tpublic_8h.html#title3
+
+export enum H5T_CLASS {
+  INTEGER = 0,
+  FLOAT = 1,
+  TIME = 2,
+  STRING = 3,
+  BITFIELD = 4,
+  OPAQUE = 5,
+  COMPOUND = 6,
+  REFERENCE = 7,
+  ENUM = 8,
+  VLEN = 9,
+  ARRAY = 10,
+}
+
+export enum H5T_ORDER {
+  LE = 0,
+  BE = 1,
+  VAX = 2,
+  MIXED = 3,
+  NONE = 4,
+}
+
+export enum H5T_SIGN {
+  NONE = 0, // unsigned
+  SIGN_2 = 1, // signed
+  NSGN = 2,
+}
+
+export enum H5T_CSET {
+  ASCII = 0,
+  UTF8 = 1,
+}
+
+/* ---------------------- */
+/* ---- H5T MAPPINGS ---- */
+
+export const H5T_TO_ENDIANNESS = {
+  [H5T_ORDER.LE]: 'little-endian',
+  [H5T_ORDER.BE]: 'big-endian',
+  [H5T_ORDER.VAX]: 'VAX',
+  [H5T_ORDER.MIXED]: 'mixed',
+  [H5T_ORDER.NONE]: 'none',
+} as const;
+
+export const H5T_TO_CHAR_SET = {
+  [H5T_CSET.ASCII]: 'ASCII',
+  [H5T_CSET.UTF8]: 'UTF-8',
+} as const;

--- a/packages/shared/src/hdf5-models.ts
+++ b/packages/shared/src/hdf5-models.ts
@@ -3,6 +3,13 @@
 
 import type { TypedArray } from 'ndarray';
 
+import type {
+  H5T_CSET,
+  H5T_ORDER,
+  H5T_TO_CHAR_SET,
+  H5T_TO_ENDIANNESS,
+} from './h5t';
+
 export enum EntityKind {
   Group = 'group',
   Dataset = 'dataset',
@@ -97,12 +104,8 @@ export enum DTypeClass {
   Unknown = 'Unknown',
 }
 
-export enum Endianness {
-  LE = 'little-endian',
-  BE = 'big-endian',
-}
-
-export type CharSet = 'UTF-8' | 'ASCII';
+export type Endianness = (typeof H5T_TO_ENDIANNESS)[H5T_ORDER];
+export type CharSet = (typeof H5T_TO_CHAR_SET)[H5T_CSET];
 
 export type DType =
   | PrintableType
@@ -128,7 +131,7 @@ export interface BooleanType {
 export interface NumericType {
   class: DTypeClass.Integer | DTypeClass.Unsigned | DTypeClass.Float;
   size: number;
-  endianness?: Endianness;
+  endianness: Endianness | undefined;
 }
 
 export type NumericLikeType = NumericType | BooleanType;
@@ -141,7 +144,7 @@ export interface ComplexType {
 
 export interface StringType {
   class: DTypeClass.String;
-  charSet: CharSet;
+  charSet: CharSet | undefined;
   length?: number;
 }
 
@@ -172,7 +175,7 @@ export interface TimeType {
 
 export interface BitfieldType {
   class: DTypeClass.Bitfield;
-  endianness?: Endianness;
+  endianness: Endianness | undefined;
 }
 
 export interface ReferenceType {
@@ -224,38 +227,4 @@ export type ComplexArray = (ComplexArray | H5WebComplex)[];
 export interface Filter {
   id: number;
   name: string;
-}
-
-/* ------------------- */
-/* ---- H5T ENUMS ---- */
-
-// https://docs.hdfgroup.org/hdf5/develop/_h5_tpublic_8h.html#title3
-
-export enum H5TClass {
-  Integer = 0,
-  Float = 1,
-  Time = 2,
-  String = 3,
-  Bitfield = 4,
-  Opaque = 5,
-  Compound = 6,
-  Reference = 7,
-  Enum = 8,
-  Vlen = 9,
-  Array = 10,
-}
-
-export enum H5TOrder {
-  LE = 0,
-  BE = 1,
-}
-
-export enum H5TSign {
-  Unsigned = 0,
-  Signed = 1,
-}
-
-export enum H5TCharSet {
-  ASCII = 0,
-  UTF8 = 1,
 }

--- a/packages/shared/src/hdf5-utils.ts
+++ b/packages/shared/src/hdf5-utils.ts
@@ -1,9 +1,15 @@
 import { isNumericType } from './guards';
+import {
+  H5T_CSET,
+  H5T_ORDER,
+  H5T_SIGN,
+  H5T_TO_CHAR_SET,
+  H5T_TO_ENDIANNESS,
+} from './h5t';
 import type {
   ArrayType,
   BitfieldType,
   BooleanType,
-  CharSet,
   ChildEntity,
   ComplexType,
   CompoundType,
@@ -19,7 +25,7 @@ import type {
   TimeType,
   UnknownType,
 } from './hdf5-models';
-import { DTypeClass, Endianness, H5TCharSet, H5TOrder } from './hdf5-models';
+import { DTypeClass } from './hdf5-models';
 
 export function getChildEntity(
   group: GroupWithChildren,
@@ -44,34 +50,46 @@ export function getNameFromPath(path: string) {
 /* ----------------- */
 /* ----- TYPES ----- */
 
-export function intType(size = 32, endianness = Endianness.LE): NumericType {
-  return { class: DTypeClass.Integer, endianness, size };
+export function intType(size = 32, h5tOrder = H5T_ORDER.LE): NumericType {
+  return {
+    class: DTypeClass.Integer,
+    endianness: H5T_TO_ENDIANNESS[h5tOrder],
+    size,
+  };
 }
 
-export function uintType(size = 32, endianness = Endianness.LE): NumericType {
-  return { class: DTypeClass.Unsigned, endianness, size };
+export function uintType(size = 32, h5tOrder = H5T_ORDER.LE): NumericType {
+  return {
+    class: DTypeClass.Unsigned,
+    endianness: H5T_TO_ENDIANNESS[h5tOrder],
+    size,
+  };
 }
 
 export function intOrUintType(
-  isSigned: boolean,
+  h5tSign: H5T_SIGN,
   size = 32,
-  endianness = Endianness.LE,
+  h5tOrder = H5T_ORDER.LE,
 ) {
-  const func = isSigned ? intType : uintType;
-  return func(size, endianness);
+  const func = h5tSign === H5T_SIGN.SIGN_2 ? intType : uintType;
+  return func(size, h5tOrder);
 }
 
-export function floatType(size = 32, endianness = Endianness.LE): NumericType {
-  return { class: DTypeClass.Float, endianness, size };
+export function floatType(size = 32, h5tOrder = H5T_ORDER.LE): NumericType {
+  return {
+    class: DTypeClass.Float,
+    endianness: H5T_TO_ENDIANNESS[h5tOrder],
+    size,
+  };
 }
 
 export function strType(
-  charSet: CharSet = 'ASCII',
+  h5tCharSet = H5T_CSET.ASCII,
   length?: number,
 ): StringType {
   return {
     class: DTypeClass.String,
-    charSet,
+    charSet: H5T_TO_CHAR_SET[h5tCharSet],
     ...(length !== undefined && { length }),
   };
 }
@@ -150,8 +168,11 @@ export function timeType(): TimeType {
   return { class: DTypeClass.Time };
 }
 
-export function bitfieldType(endianness = Endianness.LE): BitfieldType {
-  return { class: DTypeClass.Bitfield, endianness };
+export function bitfieldType(h5tOrder = H5T_ORDER.LE): BitfieldType {
+  return {
+    class: DTypeClass.Bitfield,
+    endianness: H5T_TO_ENDIANNESS[h5tOrder],
+  };
 }
 
 export function opaqueType(tag = ''): OpaqueType {
@@ -171,15 +192,4 @@ export function unknownType(): UnknownType {
 
 export function cplx(real: number, imag: number): H5WebComplex {
   return [real, imag];
-}
-
-/* ------------------------- */
-/* --- HDF5 ENUM HELPERS --- */
-
-export function toEndianness(h5tOrder: number): Endianness {
-  return h5tOrder === H5TOrder.BE ? Endianness.BE : Endianness.LE;
-}
-
-export function toCharSet(h5tCharSet: number): CharSet {
-  return h5tCharSet === H5TCharSet.ASCII ? 'ASCII' : 'UTF-8';
 }


### PR DESCRIPTION
[h5wasm@0.7.5](https://github.com/usnistgov/h5wasm/releases) has just been released with the new `strpad` metadata property to address #1621.

Since this is another case where we need to map an [H5T enum](https://docs.hdfgroup.org/hdf5/v1_14/_h5_tpublic_8h.html#title3) number to a more readable string, and since both h5grove and h5wasm expose a few of those raw enum values now (dtype class, charset, sign, order), I thought I'd first normalise things a bit...

1. I create a `h5t.ts` file in the shared package to hold the H5T enums and their mappings to readable strings. 
The enums and their keys are named as closely to the HDF5 spec as possible (though I don't specify keys for errors (`-1`) and reserved values — I'll explain why in a comment.)
2. I refactor the dtype factories (`stringType()`, `intType()`, etc.) to accept H5T enum values; it is now there responsibility to convert those values to readable strings (`'little-endian'`, etc.) using the mappings in `h5t.ts` instead of the providers.

Hopefully this makes sense. I'll add some more comments.