### PR TITLE
Bring in `react-suspense-fetch` into codebase

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -25,7 +25,6 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-icons": "5.2.1",
-    "react-suspense-fetch": "0.4.1",
     "three": "0.164.1"
   },
   "devDependencies": {

--- a/apps/storybook/src/TiledHeatmapMesh/checkerboard-api.ts
+++ b/apps/storybook/src/TiledHeatmapMesh/checkerboard-api.ts
@@ -1,9 +1,9 @@
 import type { Size } from '@h5web/lib';
 import { getLayerSizes, TilesApi } from '@h5web/lib';
+import { createFetchStore } from '@h5web/shared/react-suspense-fetch';
 import greenlet from 'greenlet';
 import type { NdArray } from 'ndarray';
 import ndarray from 'ndarray';
-import { createFetchStore } from 'react-suspense-fetch';
 import type { Vector2 } from 'three';
 import { MathUtils } from 'three';
 
@@ -22,33 +22,30 @@ export class CheckerboardTilesApi extends TilesApi {
   public constructor(size: Size, tileSize: Size) {
     super(tileSize, getLayerSizes(size, tileSize));
 
-    this.store = createFetchStore(
-      async (tile: TileParams) => {
-        const { layer, offset } = tile;
-        const layerSize = this.layerSizes[layer];
+    this.store = createFetchStore(async (tile: TileParams) => {
+      const { layer, offset } = tile;
+      const layerSize = this.layerSizes[layer];
 
-        // Clip slice to size of the level
-        const width = MathUtils.clamp(
-          layerSize.width - offset.x,
-          0,
-          this.tileSize.width,
-        );
-        const height = MathUtils.clamp(
-          layerSize.height - offset.y,
-          0,
-          this.tileSize.height,
-        );
+      // Clip slice to size of the level
+      const width = MathUtils.clamp(
+        layerSize.width - offset.x,
+        0,
+        this.tileSize.width,
+      );
+      const height = MathUtils.clamp(
+        layerSize.height - offset.y,
+        0,
+        this.tileSize.height,
+      );
 
-        const value = Math.abs(
-          (Math.floor(offset.x / this.tileSize.width) % 2) -
-            (Math.floor(offset.y / this.tileSize.height) % 2),
-        );
+      const value = Math.abs(
+        (Math.floor(offset.x / this.tileSize.width) % 2) -
+          (Math.floor(offset.y / this.tileSize.height) % 2),
+      );
 
-        const arr = await getCheckerboardArray(width * height, value);
-        return ndarray(arr, [height, width]);
-      },
-      { type: 'Map', areEqual: areTilesEqual },
-    );
+      const arr = await getCheckerboardArray(width * height, value);
+      return ndarray(arr, [height, width]);
+    }, areTilesEqual);
   }
 
   public get(layer: number, offset: Vector2): NdArray<Uint8Array> {

--- a/apps/storybook/src/TiledHeatmapMesh/mandlebrot-api.ts
+++ b/apps/storybook/src/TiledHeatmapMesh/mandlebrot-api.ts
@@ -1,10 +1,10 @@
 import type { Size } from '@h5web/lib';
 import { getLayerSizes, TilesApi } from '@h5web/lib';
+import { createFetchStore } from '@h5web/shared/react-suspense-fetch';
 import type { Domain } from '@h5web/shared/vis-models';
 import greenlet from 'greenlet';
 import type { NdArray } from 'ndarray';
 import ndarray from 'ndarray';
-import { createFetchStore } from 'react-suspense-fetch';
 import type { Vector2 } from 'three';
 import { MathUtils } from 'three';
 
@@ -71,39 +71,36 @@ export class MandelbrotTilesApi extends TilesApi {
     this.xDomain = xDomain;
     this.yDomain = yDomain;
 
-    this.store = createFetchStore(
-      async (tile: TileParams) => {
-        const { layer, offset } = tile;
-        const layerSize = this.layerSizes[layer];
+    this.store = createFetchStore(async (tile: TileParams) => {
+      const { layer, offset } = tile;
+      const layerSize = this.layerSizes[layer];
 
-        // Clip slice to size of the level
-        const width = MathUtils.clamp(
-          layerSize.width - offset.x,
-          0,
-          this.tileSize.width,
-        );
-        const height = MathUtils.clamp(
-          layerSize.height - offset.y,
-          0,
-          this.tileSize.height,
-        );
+      // Clip slice to size of the level
+      const width = MathUtils.clamp(
+        layerSize.width - offset.x,
+        0,
+        this.tileSize.width,
+      );
+      const height = MathUtils.clamp(
+        layerSize.height - offset.y,
+        0,
+        this.tileSize.height,
+      );
 
-        const xScale = (this.xDomain[1] - this.xDomain[0]) / layerSize.width;
-        const xRange: Domain = [
-          this.xDomain[0] + xScale * offset.x,
-          this.xDomain[0] + xScale * (offset.x + width),
-        ];
-        const yScale = (this.yDomain[1] - this.yDomain[0]) / layerSize.height;
-        const yRange: Domain = [
-          this.yDomain[0] + yScale * offset.y,
-          this.yDomain[0] + yScale * (offset.y + height),
-        ];
+      const xScale = (this.xDomain[1] - this.xDomain[0]) / layerSize.width;
+      const xRange: Domain = [
+        this.xDomain[0] + xScale * offset.x,
+        this.xDomain[0] + xScale * (offset.x + width),
+      ];
+      const yScale = (this.yDomain[1] - this.yDomain[0]) / layerSize.height;
+      const yRange: Domain = [
+        this.yDomain[0] + yScale * offset.y,
+        this.yDomain[0] + yScale * (offset.y + height),
+      ];
 
-        const arr = await mandlebrot(50, xRange, yRange, width, height);
-        return ndarray(arr, [height, width]);
-      },
-      { type: 'Map', areEqual: areTilesEqual },
-    );
+      const arr = await mandlebrot(50, xRange, yRange, width, height);
+      return ndarray(arr, [height, width]);
+    }, areTilesEqual);
   }
 
   public get(layer: number, offset: Vector2): NdArray<Float32Array> {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -60,7 +60,6 @@
     "react-icons": "5.2.1",
     "react-reflex": "4.2.6",
     "react-slider": "2.0.4",
-    "react-suspense-fetch": "0.4.1",
     "three": "0.164.1",
     "zustand": "4.5.2"
   },

--- a/packages/app/src/providers/DataProvider.tsx
+++ b/packages/app/src/providers/DataProvider.tsx
@@ -1,5 +1,5 @@
 import { isGroup } from '@h5web/shared/guards';
-import type { ChildEntity, Entity, Group } from '@h5web/shared/hdf5-models';
+import type { Entity } from '@h5web/shared/hdf5-models';
 import { getNameFromPath } from '@h5web/shared/hdf5-utils';
 import { createFetchStore } from '@h5web/shared/react-suspense-fetch';
 import type { PropsWithChildren } from 'react';
@@ -43,21 +43,14 @@ function DataProvider(props: PropsWithChildren<Props>) {
   const { api, children } = props;
 
   const entitiesStore = useMemo(() => {
-    const childCache = new Map<string, Exclude<ChildEntity, Group>>();
-
     const store = createFetchStore(async (path: string) => {
-      const cachedEntity = childCache.get(path);
-      if (cachedEntity) {
-        return cachedEntity;
-      }
-
       const entity = await api.getEntity(path);
 
       if (isGroup(entity)) {
         // Cache non-group children (datasets, datatypes and links)
         entity.children.forEach((child) => {
           if (!isGroup(child)) {
-            childCache.set(child.path, child);
+            store.preset(child.path, child);
           }
         });
       }

--- a/packages/app/src/providers/DataProvider.tsx
+++ b/packages/app/src/providers/DataProvider.tsx
@@ -1,9 +1,9 @@
 import { isGroup } from '@h5web/shared/guards';
 import type { ChildEntity, Entity, Group } from '@h5web/shared/hdf5-models';
 import { getNameFromPath } from '@h5web/shared/hdf5-utils';
+import { createFetchStore } from '@h5web/shared/react-suspense-fetch';
 import type { PropsWithChildren } from 'react';
 import { createContext, useContext, useMemo } from 'react';
-import { createFetchStore } from 'react-suspense-fetch';
 
 import { hasAttribute } from '../utils';
 import type { DataProviderApi } from './api';
@@ -70,10 +70,8 @@ function DataProvider(props: PropsWithChildren<Props>) {
   }, [api]);
 
   const valuesStore = useMemo(() => {
-    const store = createFetchStore(api.getValue.bind(api), {
-      type: 'Map',
-      areEqual: (a, b) =>
-        a.dataset.path === b.dataset.path && a.selection === b.selection,
+    const store = createFetchStore(api.getValue.bind(api), (a, b) => {
+      return a.dataset.path === b.dataset.path && a.selection === b.selection;
     });
 
     return Object.assign(store, {
@@ -88,10 +86,10 @@ function DataProvider(props: PropsWithChildren<Props>) {
   }, [api]);
 
   const attrValuesStore = useMemo(() => {
-    const store = createFetchStore(api.getAttrValues.bind(api), {
-      type: 'Map',
-      areEqual: (a, b) => a.path === b.path,
-    });
+    const store = createFetchStore(
+      api.getAttrValues.bind(api),
+      (a, b) => a.path === b.path,
+    );
 
     return Object.assign(store, {
       getSingle: (entity: Entity, attrName: AttrName) => {

--- a/packages/app/src/providers/models.ts
+++ b/packages/app/src/providers/models.ts
@@ -6,16 +6,16 @@ import type {
   ProvidedEntity,
   ScalarShape,
 } from '@h5web/shared/hdf5-models';
-import type { FetchStore } from 'react-suspense-fetch';
+import type { FetchStore } from '@h5web/shared/react-suspense-fetch';
 
 import type { ImageAttribute } from '../vis-packs/core/models';
 import type { NxAttribute } from '../vis-packs/nexus/models';
 
-export type EntitiesStore = FetchStore<ProvidedEntity, string>;
+export type EntitiesStore = FetchStore<string, ProvidedEntity>;
 
 export type AttrName = NxAttribute | ImageAttribute | '_FillValue';
 
-export interface ValuesStore extends FetchStore<unknown, ValuesStoreParams> {
+export interface ValuesStore extends FetchStore<ValuesStoreParams, unknown> {
   cancelOngoing: () => void;
   evictCancelled: () => void;
 }
@@ -25,7 +25,7 @@ export interface ValuesStoreParams {
   selection?: string | undefined;
 }
 
-export interface AttrValuesStore extends FetchStore<AttributeValues, Entity> {
+export interface AttrValuesStore extends FetchStore<Entity, AttributeValues> {
   getSingle: (entity: Entity, attrName: AttrName) => unknown;
 }
 

--- a/packages/app/vite.config.js
+++ b/packages/app/vite.config.js
@@ -37,8 +37,5 @@ export default defineProject({
     env: loadEnv('test', import.meta.dirname, 'VITEST_'),
     restoreMocks: true,
     testTimeout: 15_000,
-    server: {
-      deps: { inline: ['react-suspense-fetch'] },
-    },
   },
 });

--- a/packages/h5wasm/vite.config.js
+++ b/packages/h5wasm/vite.config.js
@@ -31,8 +31,5 @@ export default defineProject({
   },
   test: {
     env: loadEnv('test', import.meta.dirname, 'VITEST_'),
-    server: {
-      deps: { inline: ['react-suspense-fetch'] },
-    },
   },
 });

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -18,6 +18,7 @@
     "./mock-models": "./src/mock-models.ts",
     "./mock-utils": "./src/mock-utils.ts",
     "./mock-values": "./src/mock-values.ts",
+    "./react-suspense-fetch": "./src/react-suspense-fetch.ts",
     "./styles.css": "./src/styles.css",
     ".": "./src/index.ts"
   },

--- a/packages/shared/src/react-suspense-fetch.ts
+++ b/packages/shared/src/react-suspense-fetch.ts
@@ -1,0 +1,120 @@
+type FetchFunc<Input, Result> = (
+  input: Input,
+  options: { signal: AbortSignal },
+) => Promise<Result>;
+
+type AreEqual<Input> = (a: Input, b: Input) => boolean;
+
+interface Instance<Result> {
+  get: () => Result;
+  abort: () => void;
+}
+
+export interface FetchStore<Input, Result> {
+  prefetch: (input: Input) => void;
+  get: (input: Input) => Result;
+  evict: (input: Input) => void;
+  abort: (input: Input) => void;
+}
+
+export function createFetchStore<Input, Result>(
+  fetchFunc: FetchFunc<Input, Result>,
+  areEqual?: AreEqual<Input>,
+) {
+  const cache = createCache<Input, Result>(areEqual);
+
+  return {
+    prefetch: (input: Input): void => {
+      if (!cache.has(input)) {
+        cache.set(input, createInstance(input, fetchFunc));
+      }
+    },
+    get: (input: Input): Result => {
+      const instance = cache.get(input) || createInstance(input, fetchFunc);
+      cache.set(input, instance);
+      return instance.get();
+    },
+    evict: (input: Input): void => {
+      cache.delete(input);
+    },
+    abort: (input: Input): void => {
+      cache.get(input)?.abort();
+    },
+  };
+}
+
+function createCache<Input, Result>(areEqual?: AreEqual<Input>) {
+  if (!areEqual) {
+    return new Map<Input, Instance<Result>>();
+  }
+
+  return createMapLikeWithComparator<Input, Instance<Result>>(areEqual);
+}
+
+function createMapLikeWithComparator<K, V>(areEqual: AreEqual<K>) {
+  const map = new Map<K, V>();
+
+  return {
+    set: (key: K, value: V) => {
+      map.set(key, value);
+    },
+    has: (key: K) => {
+      for (const [k] of map) {
+        if (areEqual(k, key)) {
+          return true;
+        }
+      }
+      return false;
+    },
+    get: (key: K) => {
+      for (const [k, v] of map) {
+        if (areEqual(k, key)) {
+          return v;
+        }
+      }
+      return undefined;
+    },
+    delete: (key: K) => {
+      for (const [k] of map) {
+        if (areEqual(k, key)) {
+          map.delete(k);
+        }
+      }
+    },
+  };
+}
+
+function createInstance<Input, Result>(
+  input: Input,
+  fetchFunc: FetchFunc<Input, Result>,
+): Instance<Result> {
+  let promise: Promise<void> | null = null;
+  let result: Result | null = null;
+  let error: unknown = null;
+  const controller = new AbortController();
+
+  promise = (async () => {
+    try {
+      result = await fetchFunc(input, { signal: controller.signal });
+    } catch (error_) {
+      error = error_;
+    } finally {
+      promise = null;
+    }
+  })();
+
+  return {
+    get: () => {
+      if (promise) {
+        throw promise; // eslint-disable-line @typescript-eslint/no-throw-literal
+      }
+      if (error !== null) {
+        throw error; // eslint-disable-line @typescript-eslint/no-throw-literal
+      }
+      return result as Result;
+    },
+    abort: () => {
+      controller.abort();
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,9 +156,6 @@ importers:
       react-icons:
         specifier: 5.2.1
         version: 5.2.1(react@18.3.1)
-      react-suspense-fetch:
-        specifier: 0.4.1
-        version: 0.4.1
       three:
         specifier: 0.164.1
         version: 0.164.1
@@ -259,9 +256,6 @@ importers:
       react-slider:
         specifier: 2.0.4
         version: 2.0.4(react@18.3.1)
-      react-suspense-fetch:
-        specifier: 0.4.1
-        version: 0.4.1
       three:
         specifier: 0.164.1
         version: 0.164.1
@@ -5645,9 +5639,6 @@ packages:
     peerDependencies:
       react: ^16 || ^17 || ^18
 
-  react-suspense-fetch@0.4.1:
-    resolution: {integrity: sha512-Kc8VzZUjDjvWfoOBzPEhniaJwgwOPqW0x94ec8e3GGhLe6SlZDU2YhYgoLqM9L8xzXeGR6nhP7/PnjvI1KoTlA==}
-
   react-use-measure@2.1.1:
     resolution: {integrity: sha512-nocZhN26cproIiIduswYpV5y5lQpSQS1y/4KuvUCjSKmw7ZWIS/+g3aFnX3WdBkyuGUtTLif3UTqnLLhbDoQig==}
     peerDependencies:
@@ -9243,7 +9234,7 @@ snapshots:
       '@types/node': 20.12.11
     optional: true
 
-  '@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3)':
+  '@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
       '@typescript-eslint/parser': 5.56.0(eslint@8.57.0)(typescript@5.0.3)
@@ -9258,7 +9249,7 @@ snapshots:
       semver: 7.6.0
       tsutils: 3.21.0(typescript@5.0.3)
     optionalDependencies:
-      typescript: 5.0.3
+      typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
@@ -10587,17 +10578,17 @@ snapshots:
       '@babel/eslint-parser': 7.21.3(@babel/core@7.21.4)(eslint@8.57.0)
       '@babel/preset-react': 7.18.6(@babel/core@7.21.4)
       '@next/eslint-plugin-next': 13.2.4
-      '@typescript-eslint/eslint-plugin': 5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3)
+      '@typescript-eslint/eslint-plugin': 5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
       '@typescript-eslint/parser': 5.56.0(eslint@8.57.0)(typescript@5.0.3)
       confusing-browser-globals: 1.0.11
       eslint: 8.57.0
       eslint-config-prettier: 8.8.0(eslint@8.57.0)
       eslint-import-resolver-jsconfig: 1.1.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.5.4(eslint-plugin-import@2.27.5)(eslint@8.57.0)
       eslint-plugin-etc: 2.0.2(eslint@8.57.0)(typescript@5.0.3)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-jest: 27.2.1(@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.4)(eslint@8.57.0)
+      eslint-plugin-jest: 27.2.1(@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3)
       eslint-plugin-jest-dom: 4.0.3(eslint@8.57.0)
       eslint-plugin-jest-formatting: 3.1.0(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.57.0)
@@ -10647,12 +10638,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5)(eslint@8.57.0):
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       enhanced-resolve: 5.16.0
       eslint: 8.57.0
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.4)(eslint@8.57.0)
       get-tsconfig: 4.7.3
       globby: 13.2.2
       is-core-module: 2.13.1
@@ -10661,14 +10652,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.0.3))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5)(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
       '@typescript-eslint/parser': 5.56.0(eslint@8.57.0)(typescript@5.0.3)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.5.4(eslint-plugin-import@2.27.5)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10685,7 +10676,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.4)(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.flat: 1.3.2
@@ -10694,7 +10685,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.0.3))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5)(eslint@8.57.0))(eslint@8.57.0)
       has: 1.0.4
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -10721,12 +10712,12 @@ snapshots:
     dependencies:
       eslint: 8.57.0
 
-  eslint-plugin-jest@27.2.1(@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3):
+  eslint-plugin-jest@27.2.1(@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3):
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.0.3)
       eslint: 8.57.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3)
+      '@typescript-eslint/eslint-plugin': 5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -12941,8 +12932,6 @@ snapshots:
     dependencies:
       prop-types: 15.8.1
       react: 18.3.1
-
-  react-suspense-fetch@0.4.1: {}
 
   react-use-measure@2.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9234,7 +9234,7 @@ snapshots:
       '@types/node': 20.12.11
     optional: true
 
-  '@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)':
+  '@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
       '@typescript-eslint/parser': 5.56.0(eslint@8.57.0)(typescript@5.0.3)
@@ -9249,7 +9249,7 @@ snapshots:
       semver: 7.6.0
       tsutils: 3.21.0(typescript@5.0.3)
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -10578,17 +10578,17 @@ snapshots:
       '@babel/eslint-parser': 7.21.3(@babel/core@7.21.4)(eslint@8.57.0)
       '@babel/preset-react': 7.18.6(@babel/core@7.21.4)
       '@next/eslint-plugin-next': 13.2.4
-      '@typescript-eslint/eslint-plugin': 5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/eslint-plugin': 5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3)
       '@typescript-eslint/parser': 5.56.0(eslint@8.57.0)(typescript@5.0.3)
       confusing-browser-globals: 1.0.11
       eslint: 8.57.0
       eslint-config-prettier: 8.8.0(eslint@8.57.0)
       eslint-import-resolver-jsconfig: 1.1.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.4(eslint-plugin-import@2.27.5)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-etc: 2.0.2(eslint@8.57.0)(typescript@5.0.3)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.4)(eslint@8.57.0)
-      eslint-plugin-jest: 27.2.1(@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-jest: 27.2.1(@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3)
       eslint-plugin-jest-dom: 4.0.3(eslint@8.57.0)
       eslint-plugin-jest-formatting: 3.1.0(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.57.0)
@@ -10638,12 +10638,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5)(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       enhanced-resolve: 5.16.0
       eslint: 8.57.0
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.4)(eslint@8.57.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       get-tsconfig: 4.7.3
       globby: 13.2.2
       is-core-module: 2.13.1
@@ -10652,14 +10652,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.0.3))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5)(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
       '@typescript-eslint/parser': 5.56.0(eslint@8.57.0)(typescript@5.0.3)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.4(eslint-plugin-import@2.27.5)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10676,7 +10676,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.4)(eslint@8.57.0):
+  eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.flat: 1.3.2
@@ -10685,7 +10685,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.0.3))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       has: 1.0.4
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -10712,12 +10712,12 @@ snapshots:
     dependencies:
       eslint: 8.57.0
 
-  eslint-plugin-jest@27.2.1(@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3):
+  eslint-plugin-jest@27.2.1(@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3):
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.0.3)
       eslint: 8.57.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/eslint-plugin': 5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3)
     transitivePeerDependencies:
       - supports-color
       - typescript


### PR DESCRIPTION
Since [`react-suspense-fetch`](https://github.com/dai-shi/react-suspense-fetch) is no longer maintained but provides a good abstraction for our data providers (probably even after the next [React 19](https://react.dev/reference/react/use) upgrade), and since we would really benefit from being able to introspect the internal cache of the `valueStore` to address #1578 properly once and for all, I bring in the library's source code into our codebase.

Of course, I also tweak it to my liking a bit:

- I swap the `Input` and `Result` generics (`<Result, Input>` just felt unnecessarily confusing).
- I remove the restriction to always have to call `prefetch` before `get`.
- I take advantage of the new `preset` method, which was added in a recent version we hadn't upgraded to because of the previous point, to remove our own cache for group children in `DataProvider`.

In my next PR, I'll try to use the stores' built-in features to cancel requests and evict aborted responses from the cache, instead of our own complicated code in `DataProviderApi`.