### PR TITLE
Abort requests with signal via fetch store

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -40,8 +40,8 @@ function App(props: Props) {
   const { valuesStore } = useDataContext();
   function onSelectPath(path: string) {
     setSelectedPath(path);
-    valuesStore.cancelOngoing();
-    valuesStore.evictCancelled();
+    valuesStore.abortAll('entity changed');
+    valuesStore.evictErrors();
   }
 
   return (

--- a/packages/app/src/providers/DataProvider.tsx
+++ b/packages/app/src/providers/DataProvider.tsx
@@ -63,18 +63,8 @@ function DataProvider(props: PropsWithChildren<Props>) {
   }, [api]);
 
   const valuesStore = useMemo(() => {
-    const store = createFetchStore(api.getValue.bind(api), (a, b) => {
+    return createFetchStore(api.getValue.bind(api), (a, b) => {
       return a.dataset.path === b.dataset.path && a.selection === b.selection;
-    });
-
-    return Object.assign(store, {
-      cancelOngoing: () => api.cancelValueRequests(),
-      evictCancelled: () => {
-        api.cancelledValueRequests.forEach(({ storeParams }) => {
-          valuesStore.evict(storeParams);
-        });
-        api.cancelledValueRequests.clear();
-      },
     });
   }, [api]);
 

--- a/packages/app/src/providers/hsds/hsds-api.ts
+++ b/packages/app/src/providers/hsds/hsds-api.ts
@@ -123,11 +123,14 @@ export class HsdsApi extends DataProviderApi {
     return entity;
   }
 
-  public override async getValue(params: ValuesStoreParams): Promise<unknown> {
+  public override async getValue(
+    params: ValuesStoreParams,
+    signal?: AbortSignal,
+  ): Promise<unknown> {
     const { dataset } = params;
     assertHsdsDataset(dataset);
 
-    const value = await this.fetchValue(dataset.id, params);
+    const value = await this.fetchValue(dataset.id, params, signal);
 
     // https://github.com/HDFGroup/hsds/issues/88
     // HSDS does not reduce the number of dimensions when selecting indices
@@ -212,12 +215,14 @@ export class HsdsApi extends DataProviderApi {
   private async fetchValue(
     entityId: HsdsId,
     params: ValuesStoreParams,
+    signal?: AbortSignal,
   ): Promise<HsdsValueResponse> {
     const { selection } = params;
     const { data } = await this.cancellableFetchValue(
       `/datasets/${entityId}/value`,
       params,
       { select: selection && `[${selection}]` },
+      signal,
     );
     return data.value;
   }

--- a/packages/app/src/providers/models.ts
+++ b/packages/app/src/providers/models.ts
@@ -12,13 +12,7 @@ import type { ImageAttribute } from '../vis-packs/core/models';
 import type { NxAttribute } from '../vis-packs/nexus/models';
 
 export type EntitiesStore = FetchStore<string, ProvidedEntity>;
-
-export type AttrName = NxAttribute | ImageAttribute | '_FillValue';
-
-export interface ValuesStore extends FetchStore<ValuesStoreParams, unknown> {
-  cancelOngoing: () => void;
-  evictCancelled: () => void;
-}
+export type ValuesStore = FetchStore<ValuesStoreParams, unknown>;
 
 export interface ValuesStoreParams {
   dataset: Dataset<ScalarShape | ArrayShape>;
@@ -28,6 +22,8 @@ export interface ValuesStoreParams {
 export interface AttrValuesStore extends FetchStore<Entity, AttributeValues> {
   getSingle: (entity: Entity, attrName: AttrName) => unknown;
 }
+
+export type AttrName = NxAttribute | ImageAttribute | '_FillValue';
 
 export type ExportFormat = 'json' | 'csv' | 'npy' | 'tiff';
 export type ExportURL = URL | (() => Promise<URL | Blob>) | undefined;

--- a/packages/app/src/vis-packs/ValueLoader.tsx
+++ b/packages/app/src/vis-packs/ValueLoader.tsx
@@ -2,6 +2,7 @@ import { useTimeoutEffect, useToggle } from '@react-hookz/web';
 import { useEffect, useState } from 'react';
 
 import { useDataContext } from '../providers/DataProvider';
+import { CANCELLED_ERROR_MSG } from '../providers/utils';
 import styles from './ValueLoader.module.css';
 
 const MAX_PROGRESS_BARS = 3;
@@ -53,7 +54,7 @@ function ValueLoader(props: Props) {
             <button
               className={styles.cancelBtn}
               type="button"
-              onClick={() => valuesStore.cancelOngoing()}
+              onClick={() => valuesStore.abortAll(CANCELLED_ERROR_MSG)}
             >
               Cancel?
             </button>

--- a/packages/app/src/vis-packs/VisBoundary.tsx
+++ b/packages/app/src/vis-packs/VisBoundary.tsx
@@ -23,7 +23,7 @@ function VisBoundary(props: Props) {
       fallbackRender={(args) => (
         <ErrorFallback className={visualizerStyles.vis} {...args} />
       )}
-      onError={() => valuesStore.evictCancelled()}
+      onError={() => valuesStore.evictErrors()}
     >
       <Suspense fallback={<ValueLoader message={loadingMessage} />}>
         {children}

--- a/packages/app/src/visualizer/VisManager.tsx
+++ b/packages/app/src/visualizer/VisManager.tsx
@@ -31,8 +31,8 @@ function VisManager(props: Props) {
   const { valuesStore } = useDataContext();
   function onVisChange(index: number) {
     setActiveVis(index);
-    valuesStore.cancelOngoing();
-    valuesStore.evictCancelled();
+    valuesStore.abortAll('visualization changed');
+    valuesStore.evictErrors();
   }
 
   return (


### PR DESCRIPTION
We used to set up our own axios `CancelToken` to cancel value requests but it's [deprecated](https://github.com/axios/axios?tab=readme-ov-file#canceltoken-deprecated) in favour of the web platform's [AbortController](https://github.com/axios/axios?tab=readme-ov-file#abortcontroller).

Moreover, in newer versions, react-suspense-fetch creates its own `AbortController` for each request and passes it on to the store's fetch function. This allows aborting requests (and then evicting them) through the stores instead of having to keep track of ongoing and cancelled requests ourselves in `DataProviderApi`.

The challenge was that react-suspense-fetch was not providing a way to tell which requests have been aborted in order to evict them from the cache when after the error boundary appears. So I had to tweak things a bit.