### PR TITLE
Remove useless fragments

### DIFF
--- a/apps/storybook/src/Annotation.stories.tsx
+++ b/apps/storybook/src/Annotation.stories.tsx
@@ -162,6 +162,5 @@ function PointerTracker(props: {
     setCoords([x, y]);
   });
 
-  // eslint-disable-next-line react/jsx-no-useless-fragment
-  return <>{coords ? children(...coords) : null}</>;
+  return coords ? children(...coords) : null;
 }

--- a/apps/storybook/src/SelectionTool.stories.tsx
+++ b/apps/storybook/src/SelectionTool.stories.tsx
@@ -89,7 +89,7 @@ export const ModifierKey = {
 export const Validation = {
   ...Rectangle,
   args: {
-    validate: ({ html }) => Box.fromPoints(...html).hasMinSize(100),
+    validate: ({ html }) => Box.fromPoints(...(html as Rect)).hasMinSize(100),
   },
 } satisfies Story;
 

--- a/packages/app/src/VisConfigProvider.tsx
+++ b/packages/app/src/VisConfigProvider.tsx
@@ -22,15 +22,9 @@ interface Props {
 function VisConfigProvider(props: Props) {
   const { children } = props;
 
-  return (
-    <>
-      {[...allConfigProviders].reduce(
-        (accChildren, NextProvider) => (
-          <NextProvider>{accChildren}</NextProvider>
-        ),
-        children,
-      )}
-    </>
+  return [...allConfigProviders].reduce(
+    (accChildren, NextProvider) => <NextProvider>{accChildren}</NextProvider>,
+    children,
   );
 }
 

--- a/packages/app/src/metadata-viewer/AttributeLink.tsx
+++ b/packages/app/src/metadata-viewer/AttributeLink.tsx
@@ -41,7 +41,7 @@ function AttributeLink(props: Props) {
     );
   }
 
-  return <>{JSON.stringify(value)}</>;
+  return JSON.stringify(value);
 }
 
 export default AttributeLink;

--- a/packages/app/src/metadata-viewer/AttributesInfo.tsx
+++ b/packages/app/src/metadata-viewer/AttributesInfo.tsx
@@ -23,27 +23,23 @@ function AttributesInfo(props: Props) {
   const { attrValuesStore } = useDataContext();
   const attrValues = attrValuesStore.get(entity);
 
-  return (
-    <>
-      {entity.attributes.map(({ name, type }) => {
-        const value = attrValues[name];
-        return (
-          <tr key={name}>
-            <th scope="row">{name}</th>
-            <td>
-              {FOLLOWABLE_ATTRS.has(name) ? (
-                <AttributeLink onFollowPath={onFollowPath} value={value} />
-              ) : isComplexValue(type, value) ? (
-                renderComplex(value)
-              ) : (
-                JSON.stringify(value)
-              )}
-            </td>
-          </tr>
-        );
-      })}
-    </>
-  );
+  return entity.attributes.map(({ name, type }) => {
+    const value = attrValues[name];
+    return (
+      <tr key={name}>
+        <th scope="row">{name}</th>
+        <td>
+          {FOLLOWABLE_ATTRS.has(name) ? (
+            <AttributeLink onFollowPath={onFollowPath} value={value} />
+          ) : isComplexValue(type, value) ? (
+            renderComplex(value)
+          ) : (
+            JSON.stringify(value)
+          )}
+        </td>
+      </tr>
+    );
+  });
 }
 
 export default AttributesInfo;

--- a/packages/app/src/metadata-viewer/FiltersInfo.tsx
+++ b/packages/app/src/metadata-viewer/FiltersInfo.tsx
@@ -7,20 +7,16 @@ interface Props {
 function FiltersInfo(props: Props) {
   const { filters } = props;
 
-  return (
-    <>
-      {filters.map((filter) => {
-        const { name, id } = filter;
+  return filters.map((filter) => {
+    const { name, id } = filter;
 
-        return (
-          <tr key={id}>
-            <th scope="row">{id}</th>
-            <td>{name}</td>
-          </tr>
-        );
-      })}
-    </>
-  );
+    return (
+      <tr key={id}>
+        <th scope="row">{id}</th>
+        <td>{name}</td>
+      </tr>
+    );
+  });
 }
 
 export default FiltersInfo;

--- a/packages/app/src/vis-packs/core/ValueFetcher.tsx
+++ b/packages/app/src/vis-packs/core/ValueFetcher.tsx
@@ -20,7 +20,7 @@ function ValueFetcher<D extends Dataset<ArrayShape | ScalarShape>>(
   const { dataset, selection, render } = props;
 
   const value = useDatasetValue(dataset, selection);
-  return <>{render(value)}</>;
+  return render(value);
 }
 
 export default ValueFetcher;

--- a/packages/app/src/vis-packs/nexus/NxValuesFetcher.tsx
+++ b/packages/app/src/vis-packs/nexus/NxValuesFetcher.tsx
@@ -40,9 +40,7 @@ function NxValuesFetcher<T extends NumericType | ComplexType>(props: Props<T>) {
   const auxErrors = useDatasetValues(auxErrorDatasets, selection);
   const axisValues = useDatasetValues(axisDatasets);
 
-  return (
-    <>{render({ title, signal, errors, auxValues, auxErrors, axisValues })}</>
-  );
+  return render({ title, signal, errors, auxValues, auxErrors, axisValues });
 }
 
 export default NxValuesFetcher;

--- a/packages/lib/src/interactions/SelectionTool.tsx
+++ b/packages/lib/src/interactions/SelectionTool.tsx
@@ -45,6 +45,7 @@ interface Props extends CommonInteractionProps {
   ) => ReactNode;
 }
 
+// eslint-disable-next-line sonarjs/cognitive-complexity
 function SelectionTool(props: Props) {
   const {
     id = 'Selection',
@@ -213,7 +214,7 @@ function SelectionTool(props: Props) {
   }
 
   assertDefined(rawSelection);
-  return <>{children(selection, rawSelection, isValid)}</>;
+  return children(selection, rawSelection, isValid);
 }
 
 export type { Props as SelectionToolProps };

--- a/packages/lib/src/vis/matrix/HeaderCells.tsx
+++ b/packages/lib/src/vis/matrix/HeaderCells.tsx
@@ -16,24 +16,20 @@ function HeaderCells(props: Props) {
   const { indexMin, indexMax, width, transform, headers } = props;
   const { cellSize } = useContext(SettingsContext);
 
-  return (
-    <>
-      {range(indexMin, indexMax + 1).map((index) => (
-        <div
-          key={index.toString()}
-          className={styles.indexCell}
-          style={{
-            width: width || cellSize.width,
-            height: cellSize.height,
-            transform,
-          }}
-          data-bg={index % 2 === 1 ? '' : undefined}
-        >
-          {index >= 0 && headers ? headers[index] : index}
-        </div>
-      ))}
-    </>
-  );
+  return range(indexMin, indexMax + 1).map((index) => (
+    <div
+      key={index.toString()}
+      className={styles.indexCell}
+      style={{
+        width: width || cellSize.width,
+        height: cellSize.height,
+        transform,
+      }}
+      data-bg={index % 2 === 1 ? '' : undefined}
+    >
+      {index >= 0 && headers ? headers[index] : index}
+    </div>
+  ));
 }
 
 export default HeaderCells;

--- a/packages/lib/src/vis/rgb/utils.ts
+++ b/packages/lib/src/vis/rgb/utils.ts
@@ -26,7 +26,7 @@ export function toRgbSafeNdArray(
 
   if (ndArr.dtype === 'int8') {
     return ndarray(
-      Uint8Array.from([...ndArr.data].map((val) => val + 128)),
+      Uint8Array.from(ndArr.data.map((val) => val + 128)),
       ndArr.shape,
     );
   }

--- a/packages/lib/src/vis/shared/DataToHtml.tsx
+++ b/packages/lib/src/vis/shared/DataToHtml.tsx
@@ -19,7 +19,7 @@ function DataToHtml<T extends Vector3[]>(props: Props<T>) {
     [points, dataToHtml],
   );
 
-  return <>{children(...htmlPoints)}</>;
+  return children(...htmlPoints);
 }
 
 export type { Props as DataToHtmlProps };


### PR DESCRIPTION
I found an old stash from a past attempt at upgrading TypeScript from 5.0 to 5.2. Turns out I missed this refactoring opportunity when I looked at it again in #1636.

I had also taken some notes of interesting changes in 5.1 and 5.2 in case this is of interest:

### [Typescript 5.1](https://devblogs.microsoft.com/typescript/announcing-typescript-5-1/)

- [Easier Implicit Returns for undefined-Returning Functions](https://devblogs.microsoft.com/typescript/announcing-typescript-5-1/#easier-implicit-returns-for-undefined-returning-functions): a `return` statement is still required for all code paths, and it feels weird having `return;` at the end of a function; I much prefer the explicitness of `return undefined;`. Might help simplify other cases that I'm not seeing. 🤷‍♀️
- [Decoupled Type-Checking Between JSX Elements and JSX Tag Types](https://devblogs.microsoft.com/typescript/announcing-typescript-5-1/#decoupled-type-checking-between-jsx-elements-and-jsx-tag-types) - at last, no more wrapping stuff in unnecessary fragments, like `return <>{children}</>`! 🎉
- [Linked Cursors for JSX Tags](https://devblogs.microsoft.com/typescript/announcing-typescript-5-1/#linked-cursors-for-jsx-tags) 🎉
- [Avoiding Unnecessary Type Instantiation](https://devblogs.microsoft.com/typescript/announcing-typescript-5-1/#avoiding-unnecessary-type-instantiation) - FYI, type checking performance improvements, notably for MUI

### [TypeScript 5.2](https://devblogs.microsoft.com/typescript/announcing-typescript-5-2/)

- [Easier Method Usage for Unions of Arrays](https://devblogs.microsoft.com/typescript/announcing-typescript-5-2/#easier-method-usage-for-unions-of-arrays) - we can finally loop through arrays of type ~`number[] | TypedArray`~ `number[] | string[]` with  `filter`, `map`, etc. but now that I'm looking through the code, I can no longer recall a specific case where we had to work around this limitation... EDIT: we encountered this in `getBounds` with `NumArray`, a union of plain and typed arrays, which isn't covered here.
- [Copying Array Methods](https://devblogs.microsoft.com/typescript/announcing-typescript-5-2/#copying-array-methods) - immutable `arr.toReversed()`, `arr.toSorted()`, etc. are now supported by TS ... but they still need to be polyfilled for older browsers, so not worth using yet.
- [Comma Completions for Object Members](https://devblogs.microsoft.com/typescript/announcing-typescript-5-2/#comma-completions-for-object-members) - nice!
- [Inline Variable Refactoring](https://devblogs.microsoft.com/typescript/announcing-typescript-5-2/#comma-completions-for-object-members) - cool also
