### PR TITLE
Decrease debounce delay dynamically on slices that are already cached

### DIFF
--- a/packages/app/src/dimension-mapper/AxisMapper.tsx
+++ b/packages/app/src/dimension-mapper/AxisMapper.tsx
@@ -7,15 +7,14 @@ import type { DimensionMapping } from './models';
 
 interface Props {
   axis: Axis;
-  rawDims: number[];
   axisLabels: AxisMapping<string> | undefined;
-  mapperState: DimensionMapping;
+  dimMapping: DimensionMapping;
   onChange: (mapperState: DimensionMapping) => void;
 }
 
 function AxisMapper(props: Props) {
-  const { axis, rawDims, axisLabels, mapperState, onChange } = props;
-  const selectedDim = mapperState.indexOf(axis);
+  const { axis, axisLabels, dimMapping, onChange } = props;
+  const selectedDim = dimMapping.indexOf(axis);
 
   if (selectedDim === -1) {
     return null;
@@ -31,23 +30,23 @@ function AxisMapper(props: Props) {
         onChange={(val) => {
           const newDim = Number(val);
           if (selectedDim !== newDim) {
-            const newMapperState = [...mapperState];
+            const newMapping = [...dimMapping];
 
             // Invert mappings or reset slicing index of previously selected dimension
-            newMapperState[selectedDim] =
-              typeof mapperState[newDim] === 'number' ? 0 : mapperState[newDim];
-            newMapperState[newDim] = axis; // assign axis to newly selected dimension
+            newMapping[selectedDim] =
+              typeof dimMapping[newDim] === 'number' ? 0 : dimMapping[newDim];
+            newMapping[newDim] = axis; // assign axis to newly selected dimension
 
-            onChange(newMapperState);
+            onChange(newMapping);
           }
         }}
       >
-        {Object.keys(rawDims).map((dimKey, index) => (
+        {dimMapping.map((_, i) => (
           <ToggleGroup.Btn
-            key={dimKey}
-            label={`D${dimKey}`}
-            value={dimKey}
-            hint={axisLabels?.[index]}
+            key={i} // eslint-disable-line react/no-array-index-key
+            label={`D${i}`}
+            value={i.toString()}
+            hint={axisLabels?.[i]}
           />
         ))}
       </ToggleGroup>

--- a/packages/app/src/dimension-mapper/DimensionMapper.tsx
+++ b/packages/app/src/dimension-mapper/DimensionMapper.tsx
@@ -9,11 +9,12 @@ interface Props {
   dims: number[];
   axisLabels?: AxisMapping<string>;
   dimMapping: DimensionMapping;
+  isCached?: (dimMapping: DimensionMapping) => boolean;
   onChange: (d: DimensionMapping) => void;
 }
 
 function DimensionMapper(props: Props) {
-  const { dims, axisLabels, dimMapping, onChange } = props;
+  const { dims, axisLabels, dimMapping, isCached, onChange } = props;
   const mappableDims = dims.slice(0, dimMapping.length);
 
   return (
@@ -52,6 +53,14 @@ function DimensionMapper(props: Props) {
               dimension={index}
               length={dims[index]}
               initialValue={val}
+              isFastSlice={
+                isCached &&
+                ((newVal) => {
+                  const newMapping = [...dimMapping];
+                  newMapping[index] = newVal;
+                  return isCached(newMapping);
+                })
+              }
               onChange={(newVal) => {
                 const newMapping = [...dimMapping];
                 newMapping[index] = newVal;

--- a/packages/app/src/dimension-mapper/DimensionMapper.tsx
+++ b/packages/app/src/dimension-mapper/DimensionMapper.tsx
@@ -6,14 +6,15 @@ import type { DimensionMapping } from './models';
 import SlicingSlider from './SlicingSlider';
 
 interface Props {
-  rawDims: number[];
+  dims: number[];
   axisLabels?: AxisMapping<string>;
-  mapperState: DimensionMapping;
+  dimMapping: DimensionMapping;
   onChange: (d: DimensionMapping) => void;
 }
 
 function DimensionMapper(props: Props) {
-  const { rawDims, axisLabels, mapperState, onChange } = props;
+  const { dims, axisLabels, dimMapping, onChange } = props;
+  const mappableDims = dims.slice(0, dimMapping.length);
 
   return (
     <div className={styles.mapper}>
@@ -22,9 +23,9 @@ function DimensionMapper(props: Props) {
           <span className={styles.dimsLabel}>
             <abbr title="Number of elements in each dimension">n</abbr>
           </span>
-          {rawDims.map((d, i) => (
+          {mappableDims.map((d, i) => (
             // eslint-disable-next-line react/no-array-index-key
-            <span key={`${i}${d}`} className={styles.dimSize}>
+            <span key={i} className={styles.dimSize}>
               {' '}
               {d}
             </span>
@@ -32,31 +33,29 @@ function DimensionMapper(props: Props) {
         </div>
         <AxisMapper
           axis="x"
-          rawDims={rawDims}
           axisLabels={axisLabels}
-          mapperState={mapperState}
+          dimMapping={dimMapping}
           onChange={onChange}
         />
         <AxisMapper
           axis="y"
-          rawDims={rawDims}
           axisLabels={axisLabels}
-          mapperState={mapperState}
+          dimMapping={dimMapping}
           onChange={onChange}
         />
       </div>
       <div className={styles.sliders}>
-        {mapperState.map((val, index) =>
+        {dimMapping.map((val, index) =>
           typeof val === 'number' ? (
             <SlicingSlider
-              key={`${index}`} // eslint-disable-line react/no-array-index-key
+              key={index} // eslint-disable-line react/no-array-index-key
               dimension={index}
-              maxIndex={rawDims[index] - 1}
+              length={dims[index]}
               initialValue={val}
-              onChange={(newVal: number) => {
-                const newMapperState = [...mapperState];
-                newMapperState[index] = newVal;
-                onChange(newMapperState);
+              onChange={(newVal) => {
+                const newMapping = [...dimMapping];
+                newMapping[index] = newVal;
+                onChange(newMapping);
               }}
             />
           ) : undefined,

--- a/packages/app/src/dimension-mapper/SlicingSlider.tsx
+++ b/packages/app/src/dimension-mapper/SlicingSlider.tsx
@@ -10,13 +10,13 @@ const SLICING_DEBOUNCE_DELAY = 250;
 
 interface Props {
   dimension: number;
-  maxIndex: number;
+  length: number;
   initialValue: number;
   onChange: (value: number) => void;
 }
 
 function SlicingSlider(props: Props) {
-  const { dimension, maxIndex, initialValue, onChange } = props;
+  const { dimension, length, initialValue, onChange } = props;
 
   const [value, setValue] = useState(initialValue);
   const onDebouncedChange = useDebouncedCallback(
@@ -33,17 +33,17 @@ function SlicingSlider(props: Props) {
       <span id={sliderLabelId} className={styles.label}>
         D{dimension}
       </span>
-      <span className={styles.sublabel}>0:{maxIndex}</span>
-      {maxIndex > 0 ? (
+      <span className={styles.sublabel}>0:{length - 1}</span>
+      {length > 1 ? (
         <ReactSlider
           className={styles.slider}
           ariaLabelledby={sliderLabelId}
           min={0}
-          max={maxIndex}
+          max={length - 1}
           step={1}
           marks={
             containerSize &&
-            containerSize.height / (maxIndex + 1) >= MIN_HEIGHT_PER_MARK
+            containerSize.height / length >= MIN_HEIGHT_PER_MARK
           }
           markClassName={styles.mark}
           orientation="vertical"

--- a/packages/app/src/dimension-mapper/SlicingSlider.tsx
+++ b/packages/app/src/dimension-mapper/SlicingSlider.tsx
@@ -1,28 +1,31 @@
-import { useDebouncedCallback, useMeasure } from '@react-hookz/web';
+import { useMeasure } from '@react-hookz/web';
 import { useState } from 'react';
 import ReactSlider from 'react-slider';
 
 import styles from './SlicingSlider.module.css';
+import { useDynamicDebouncedCallback } from './utils';
 
 const ID = 'h5w-slider';
 const MIN_HEIGHT_PER_MARK = 25;
-const SLICING_DEBOUNCE_DELAY = 250;
+const SHORT_DELAY = 20;
+const LONG_DELAY = 250;
 
 interface Props {
   dimension: number;
   length: number;
   initialValue: number;
+  isFastSlice?: (value: number) => boolean;
   onChange: (value: number) => void;
 }
 
 function SlicingSlider(props: Props) {
-  const { dimension, length, initialValue, onChange } = props;
+  const { dimension, length, initialValue, isFastSlice, onChange } = props;
 
   const [value, setValue] = useState(initialValue);
-  const onDebouncedChange = useDebouncedCallback(
+  const onDebouncedChange = useDynamicDebouncedCallback(
     onChange,
     [onChange],
-    SLICING_DEBOUNCE_DELAY,
+    (val) => (isFastSlice?.(val) ? SHORT_DELAY : LONG_DELAY),
   );
 
   const [containerSize, containerRef] = useMeasure<HTMLDivElement>();

--- a/packages/app/src/dimension-mapper/utils.ts
+++ b/packages/app/src/dimension-mapper/utils.ts
@@ -1,5 +1,62 @@
 import type { Axis } from '@h5web/shared/vis-models';
+import { useSyncedRef, useUnmountEffect } from '@react-hookz/web';
+import type { DependencyList } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
 export function isAxis(elem: number | Axis): elem is Axis {
   return typeof elem !== 'number';
+}
+
+// Debounced callback with a delay that can be adjusted on every invocation
+export function useDynamicDebouncedCallback<
+  Fn extends (...args: any[]) => void, // eslint-disable-line @typescript-eslint/no-explicit-any
+>(
+  callback: Fn,
+  deps: DependencyList,
+  getDelay: (...args: Parameters<Fn>) => number,
+): (...args: Parameters<Fn>) => void {
+  const timeout = useRef<ReturnType<typeof setTimeout>>();
+  const cb = useRef(callback);
+  const getDelayRef = useSyncedRef(getDelay);
+  const lastCallArgs = useRef<Parameters<Fn>>();
+
+  function clear() {
+    if (timeout.current) {
+      clearTimeout(timeout.current);
+      timeout.current = undefined;
+    }
+  }
+
+  // Cancel scheduled execution on unmount
+  useUnmountEffect(clear);
+
+  useEffect(() => {
+    cb.current = callback;
+  }, deps); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return useMemo(() => {
+    function execute() {
+      clear();
+
+      if (!lastCallArgs.current) {
+        return;
+      }
+
+      const context = lastCallArgs.current;
+      lastCallArgs.current = undefined;
+
+      cb.current(...context);
+    }
+
+    return (...args) => {
+      if (timeout.current) {
+        clearTimeout(timeout.current);
+      }
+
+      lastCallArgs.current = args;
+
+      // Plan regular execution
+      timeout.current = setTimeout(execute, getDelayRef.current(...args));
+    };
+  }, deps); // eslint-disable-line react-hooks/exhaustive-deps
 }

--- a/packages/app/src/vis-packs/core/complex/ComplexLineVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/complex/ComplexLineVisContainer.tsx
@@ -30,8 +30,8 @@ function ComplexLineVisContainer(props: VisContainerProps) {
   return (
     <>
       <DimensionMapper
-        rawDims={dims}
-        mapperState={dimMapping}
+        dims={dims}
+        dimMapping={dimMapping}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping} isSlice={selection !== undefined}>

--- a/packages/app/src/vis-packs/core/complex/ComplexLineVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/complex/ComplexLineVisContainer.tsx
@@ -8,6 +8,7 @@ import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useDimMappingState } from '../../../dimension-mapper/hooks';
 import type { VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
+import { useValuesInCache } from '../hooks';
 import { useLineConfig } from '../line/config';
 import { getSliceSelection } from '../utils';
 import ValueFetcher from '../ValueFetcher';
@@ -32,6 +33,7 @@ function ComplexLineVisContainer(props: VisContainerProps) {
       <DimensionMapper
         dims={dims}
         dimMapping={dimMapping}
+        isCached={useValuesInCache(entity)}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping} isSlice={selection !== undefined}>

--- a/packages/app/src/vis-packs/core/complex/ComplexVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/complex/ComplexVisContainer.tsx
@@ -32,8 +32,8 @@ function ComplexVisContainer(props: VisContainerProps) {
   return (
     <>
       <DimensionMapper
-        rawDims={dims}
-        mapperState={dimMapping}
+        dims={dims}
+        dimMapping={dimMapping}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping} isSlice={selection !== undefined}>

--- a/packages/app/src/vis-packs/core/complex/ComplexVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/complex/ComplexVisContainer.tsx
@@ -10,6 +10,7 @@ import { useDimMappingState } from '../../../dimension-mapper/hooks';
 import type { VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
 import { useHeatmapConfig } from '../heatmap/config';
+import { useValuesInCache } from '../hooks';
 import { getSliceSelection } from '../utils';
 import ValueFetcher from '../ValueFetcher';
 import { useComplexConfig } from './config';
@@ -34,6 +35,7 @@ function ComplexVisContainer(props: VisContainerProps) {
       <DimensionMapper
         dims={dims}
         dimMapping={dimMapping}
+        isCached={useValuesInCache(entity)}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping} isSlice={selection !== undefined}>

--- a/packages/app/src/vis-packs/core/compound/CompoundMatrixVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/compound/CompoundMatrixVisContainer.tsx
@@ -9,6 +9,7 @@ import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useDimMappingState } from '../../../dimension-mapper/hooks';
 import type { VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
+import { useValuesInCache } from '../hooks';
 import { useMatrixConfig } from '../matrix/config';
 import { getSliceSelection } from '../utils';
 import ValueFetcher from '../ValueFetcher';
@@ -32,6 +33,7 @@ function CompoundMatrixVisContainer(props: VisContainerProps) {
       <DimensionMapper
         dims={dims}
         dimMapping={dimMapping}
+        isCached={useValuesInCache(entity)}
         onChange={setDimMapping}
       />
       <VisBoundary isSlice={selection !== undefined}>

--- a/packages/app/src/vis-packs/core/compound/CompoundMatrixVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/compound/CompoundMatrixVisContainer.tsx
@@ -30,8 +30,8 @@ function CompoundMatrixVisContainer(props: VisContainerProps) {
   return (
     <>
       <DimensionMapper
-        rawDims={dims}
-        mapperState={dimMapping}
+        dims={dims}
+        dimMapping={dimMapping}
         onChange={setDimMapping}
       />
       <VisBoundary isSlice={selection !== undefined}>

--- a/packages/app/src/vis-packs/core/heatmap/HeatmapVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/HeatmapVisContainer.tsx
@@ -33,8 +33,8 @@ function HeatmapVisContainer(props: VisContainerProps) {
   return (
     <>
       <DimensionMapper
-        rawDims={dims}
-        mapperState={dimMapping}
+        dims={dims}
+        dimMapping={dimMapping}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping} isSlice={selection !== undefined}>

--- a/packages/app/src/vis-packs/core/heatmap/HeatmapVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/HeatmapVisContainer.tsx
@@ -9,7 +9,7 @@ import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useDimMappingState } from '../../../dimension-mapper/hooks';
 import type { VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
-import { useIgnoreFillValue } from '../hooks';
+import { useIgnoreFillValue, useValuesInCache } from '../hooks';
 import { getSliceSelection } from '../utils';
 import ValueFetcher from '../ValueFetcher';
 import { useHeatmapConfig } from './config';
@@ -27,14 +27,15 @@ function HeatmapVisContainer(props: VisContainerProps) {
 
   const config = useHeatmapConfig();
 
-  const ignoreValue = useIgnoreFillValue(entity);
   const selection = getSliceSelection(dimMapping);
+  const ignoreValue = useIgnoreFillValue(entity);
 
   return (
     <>
       <DimensionMapper
         dims={dims}
         dimMapping={dimMapping}
+        isCached={useValuesInCache(entity)}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping} isSlice={selection !== undefined}>

--- a/packages/app/src/vis-packs/core/hooks.ts
+++ b/packages/app/src/vis-packs/core/hooks.ts
@@ -15,9 +15,26 @@ import type { DimensionMapping } from '../../dimension-mapper/models';
 import { isAxis } from '../../dimension-mapper/utils';
 import { useDataContext } from '../../providers/DataProvider';
 import { typedArrayFromDType } from '../../providers/utils';
-import { applyMapping, getBaseArray, toNumArray } from './utils';
+import {
+  applyMapping,
+  getBaseArray,
+  getSliceSelection,
+  toNumArray,
+} from './utils';
 
 export const useToNumArray = createMemo(toNumArray);
+
+export function useValuesInCache(
+  ...datasets: (Dataset<ArrayShape> | undefined)[]
+): (dimMapping: DimensionMapping) => boolean {
+  const { valuesStore } = useDataContext();
+  return (dimMapping) => {
+    const selection = getSliceSelection(dimMapping);
+    return datasets.every(
+      (dataset) => !dataset || valuesStore.has({ dataset, selection }),
+    );
+  };
+}
 
 export function usePrefetchValues(
   datasets: (Dataset<ScalarShape | ArrayShape> | undefined)[],

--- a/packages/app/src/vis-packs/core/line/LineVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/line/LineVisContainer.tsx
@@ -30,8 +30,8 @@ function LineVisContainer(props: VisContainerProps) {
   return (
     <>
       <DimensionMapper
-        rawDims={dims}
-        mapperState={dimMapping}
+        dims={dims}
+        dimMapping={dimMapping}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping} isSlice={selection !== undefined}>

--- a/packages/app/src/vis-packs/core/line/LineVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/line/LineVisContainer.tsx
@@ -8,7 +8,7 @@ import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useDimMappingState } from '../../../dimension-mapper/hooks';
 import type { VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
-import { useIgnoreFillValue } from '../hooks';
+import { useIgnoreFillValue, useValuesInCache } from '../hooks';
 import { getSliceSelection } from '../utils';
 import ValueFetcher from '../ValueFetcher';
 import { useLineConfig } from './config';
@@ -32,6 +32,7 @@ function LineVisContainer(props: VisContainerProps) {
       <DimensionMapper
         dims={dims}
         dimMapping={dimMapping}
+        isCached={useValuesInCache(entity)}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping} isSlice={selection !== undefined}>

--- a/packages/app/src/vis-packs/core/matrix/MatrixVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/matrix/MatrixVisContainer.tsx
@@ -29,8 +29,8 @@ function MatrixVisContainer(props: VisContainerProps) {
   return (
     <>
       <DimensionMapper
-        rawDims={dims}
-        mapperState={dimMapping}
+        dims={dims}
+        dimMapping={dimMapping}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping} isSlice={selection !== undefined}>

--- a/packages/app/src/vis-packs/core/matrix/MatrixVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/matrix/MatrixVisContainer.tsx
@@ -8,6 +8,7 @@ import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useDimMappingState } from '../../../dimension-mapper/hooks';
 import type { VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
+import { useValuesInCache } from '../hooks';
 import { getSliceSelection } from '../utils';
 import ValueFetcher from '../ValueFetcher';
 import { useMatrixConfig } from './config';
@@ -31,6 +32,7 @@ function MatrixVisContainer(props: VisContainerProps) {
       <DimensionMapper
         dims={dims}
         dimMapping={dimMapping}
+        isCached={useValuesInCache(entity)}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping} isSlice={selection !== undefined}>

--- a/packages/app/src/vis-packs/core/rgb/RgbVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/rgb/RgbVisContainer.tsx
@@ -10,6 +10,7 @@ import { useDimMappingState } from '../../../dimension-mapper/hooks';
 import { useDataContext } from '../../../providers/DataProvider';
 import type { VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
+import { useValuesInCache } from '../hooks';
 import { getSliceSelection } from '../utils';
 import ValueFetcher from '../ValueFetcher';
 import { useRgbConfig } from './config';
@@ -44,6 +45,7 @@ function RgbVisContainer(props: VisContainerProps) {
       <DimensionMapper
         dims={dims}
         dimMapping={dimMapping}
+        isCached={useValuesInCache(entity)}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping} isSlice={selection !== undefined}>

--- a/packages/app/src/vis-packs/core/rgb/RgbVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/rgb/RgbVisContainer.tsx
@@ -42,8 +42,8 @@ function RgbVisContainer(props: VisContainerProps) {
   return (
     <>
       <DimensionMapper
-        rawDims={mappableDims}
-        mapperState={dimMapping}
+        dims={dims}
+        dimMapping={dimMapping}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping} isSlice={selection !== undefined}>

--- a/packages/app/src/vis-packs/core/surface/SurfaceVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/surface/SurfaceVisContainer.tsx
@@ -30,8 +30,8 @@ function SurfaceVisContainer(props: VisContainerProps) {
   return (
     <>
       <DimensionMapper
-        rawDims={dims}
-        mapperState={dimMapping}
+        dims={dims}
+        dimMapping={dimMapping}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping} isSlice={selection !== undefined}>

--- a/packages/app/src/vis-packs/core/surface/SurfaceVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/surface/SurfaceVisContainer.tsx
@@ -9,6 +9,7 @@ import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useDimMappingState } from '../../../dimension-mapper/hooks';
 import type { VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
+import { useValuesInCache } from '../hooks';
 import { getSliceSelection } from '../utils';
 import ValueFetcher from '../ValueFetcher';
 import { useSurfaceConfig } from './config';
@@ -32,6 +33,7 @@ function SurfaceVisContainer(props: VisContainerProps) {
       <DimensionMapper
         dims={dims}
         dimMapping={dimMapping}
+        isCached={useValuesInCache(entity)}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping} isSlice={selection !== undefined}>

--- a/packages/app/src/vis-packs/nexus/containers/NxComplexImageContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxComplexImageContainer.tsx
@@ -39,9 +39,9 @@ function NxComplexImageContainer(props: VisContainerProps) {
   return (
     <>
       <DimensionMapper
-        rawDims={dims}
+        dims={dims}
         axisLabels={axisLabels}
-        mapperState={dimMapping}
+        dimMapping={dimMapping}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping}>

--- a/packages/app/src/vis-packs/nexus/containers/NxComplexImageContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxComplexImageContainer.tsx
@@ -9,7 +9,7 @@ import { getSliceSelection } from '../../core/utils';
 import type { VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
 import { assertComplexNxData } from '../guards';
-import { useNxData } from '../hooks';
+import { useNxData, useNxValuesCached } from '../hooks';
 import NxValuesFetcher from '../NxValuesFetcher';
 import { guessKeepRatio } from '../utils';
 
@@ -42,6 +42,7 @@ function NxComplexImageContainer(props: VisContainerProps) {
         dims={dims}
         axisLabels={axisLabels}
         dimMapping={dimMapping}
+        isCached={useNxValuesCached(nxData)}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping}>

--- a/packages/app/src/vis-packs/nexus/containers/NxComplexSpectrumContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxComplexSpectrumContainer.tsx
@@ -10,7 +10,7 @@ import { getSliceSelection } from '../../core/utils';
 import type { VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
 import { assertComplexNxData } from '../guards';
-import { useNxData } from '../hooks';
+import { useNxData, useNxValuesCached } from '../hooks';
 import NxValuesFetcher from '../NxValuesFetcher';
 
 function NxComplexSpectrumContainer(props: VisContainerProps) {
@@ -42,6 +42,7 @@ function NxComplexSpectrumContainer(props: VisContainerProps) {
         dims={signalDims}
         axisLabels={axisLabels}
         dimMapping={dimMapping}
+        isCached={useNxValuesCached(nxData)}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping}>

--- a/packages/app/src/vis-packs/nexus/containers/NxComplexSpectrumContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxComplexSpectrumContainer.tsx
@@ -39,9 +39,9 @@ function NxComplexSpectrumContainer(props: VisContainerProps) {
   return (
     <>
       <DimensionMapper
-        rawDims={signalDims}
+        dims={signalDims}
         axisLabels={axisLabels}
-        mapperState={dimMapping}
+        dimMapping={dimMapping}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping}>

--- a/packages/app/src/vis-packs/nexus/containers/NxImageContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxImageContainer.tsx
@@ -1,4 +1,5 @@
 import { assertGroup, assertMinDims } from '@h5web/shared/guards';
+import type { NumericType } from '@h5web/shared/hdf5-models';
 import { useState } from 'react';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
@@ -9,7 +10,8 @@ import { getSliceSelection } from '../../core/utils';
 import type { VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
 import { assertNumericNxData } from '../guards';
-import { useNxData } from '../hooks';
+import { useNxData, useNxValuesCached } from '../hooks';
+import type { NxData } from '../models';
 import NxSignalPicker from '../NxSignalPicker';
 import NxValuesFetcher from '../NxValuesFetcher';
 import { guessKeepRatio } from '../utils';
@@ -37,7 +39,7 @@ function NxImageContainer(props: VisContainerProps) {
     keepRatio: guessKeepRatio(xAxisDef, yAxisDef),
   });
 
-  const nxDataToFetch = {
+  const nxDataToFetch: NxData<NumericType> = {
     ...nxData,
     signalDef: selectedDef,
     auxDefs: [], // fetch selected signal only
@@ -59,6 +61,7 @@ function NxImageContainer(props: VisContainerProps) {
         dims={dims}
         axisLabels={axisLabels}
         dimMapping={dimMapping}
+        isCached={useNxValuesCached(nxData)}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping}>

--- a/packages/app/src/vis-packs/nexus/containers/NxImageContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxImageContainer.tsx
@@ -56,9 +56,9 @@ function NxImageContainer(props: VisContainerProps) {
         />
       )}
       <DimensionMapper
-        rawDims={dims}
+        dims={dims}
         axisLabels={axisLabels}
-        mapperState={dimMapping}
+        dimMapping={dimMapping}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping}>

--- a/packages/app/src/vis-packs/nexus/containers/NxRgbContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxRgbContainer.tsx
@@ -8,7 +8,7 @@ import { getSliceSelection } from '../../core/utils';
 import type { VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
 import { assertNumericNxData } from '../guards';
-import { useNxData } from '../hooks';
+import { useNxData, useNxValuesCached } from '../hooks';
 import NxValuesFetcher from '../NxValuesFetcher';
 
 function NxRgbContainer(props: VisContainerProps) {
@@ -38,6 +38,7 @@ function NxRgbContainer(props: VisContainerProps) {
         dims={dims}
         axisLabels={axisLabels}
         dimMapping={dimMapping}
+        isCached={useNxValuesCached(nxData)}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping}>

--- a/packages/app/src/vis-packs/nexus/containers/NxRgbContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxRgbContainer.tsx
@@ -35,9 +35,9 @@ function NxRgbContainer(props: VisContainerProps) {
   return (
     <>
       <DimensionMapper
-        rawDims={mappableDims}
+        dims={dims}
         axisLabels={axisLabels}
-        mapperState={dimMapping}
+        dimMapping={dimMapping}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping}>

--- a/packages/app/src/vis-packs/nexus/containers/NxSpectrumContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxSpectrumContainer.tsx
@@ -44,9 +44,9 @@ function NxSpectrumContainer(props: VisContainerProps) {
   return (
     <>
       <DimensionMapper
-        rawDims={signalDims}
+        dims={signalDims}
         axisLabels={axisLabels}
-        mapperState={dimMapping}
+        dimMapping={dimMapping}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping}>

--- a/packages/app/src/vis-packs/nexus/containers/NxSpectrumContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxSpectrumContainer.tsx
@@ -9,7 +9,7 @@ import { getSliceSelection } from '../../core/utils';
 import type { VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
 import { assertNumericNxData } from '../guards';
-import { useNxData } from '../hooks';
+import { useNxData, useNxValuesCached } from '../hooks';
 import NxValuesFetcher from '../NxValuesFetcher';
 import { areSameDims } from '../utils';
 
@@ -47,6 +47,7 @@ function NxSpectrumContainer(props: VisContainerProps) {
         dims={signalDims}
         axisLabels={axisLabels}
         dimMapping={dimMapping}
+        isCached={useNxValuesCached(nxData)}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping}>

--- a/packages/app/src/vis-packs/nexus/hooks.ts
+++ b/packages/app/src/vis-packs/nexus/hooks.ts
@@ -1,7 +1,9 @@
 import { isDefined } from '@h5web/shared/guards';
 import type { GroupWithChildren } from '@h5web/shared/hdf5-models';
 
+import type { DimensionMapping } from '../../dimension-mapper/models';
 import { useDataContext } from '../../providers/DataProvider';
+import { useValuesInCache } from '../core/hooks';
 import type { NxData } from './models';
 import {
   assertNxDataGroup,
@@ -45,4 +47,16 @@ export function useNxData(group: GroupWithChildren): NxData {
     ),
     silxStyle: getSilxStyle(group, attrValuesStore),
   };
+}
+
+export function useNxValuesCached(
+  nxData: NxData,
+): (dimMapping: DimensionMapping) => boolean {
+  const { signalDef, auxDefs } = nxData;
+
+  return useValuesInCache(
+    signalDef.dataset,
+    signalDef.errorDataset,
+    ...auxDefs.flatMap((def) => [def?.dataset, def?.errorDataset]),
+  );
 }

--- a/packages/shared/src/react-suspense-fetch.ts
+++ b/packages/shared/src/react-suspense-fetch.ts
@@ -12,6 +12,7 @@ interface Instance<Result> {
 }
 
 export interface FetchStore<Input, Result> {
+  has: (input: Input) => boolean;
   prefetch: (input: Input) => void;
   get: (input: Input) => Result;
   preset: (input: Input, result: Result) => void;
@@ -28,6 +29,7 @@ export function createFetchStore<Input, Result>(
   const cache = createCache<Input, Instance<Result>>(areEqual);
 
   return {
+    has: (input: Input): boolean => cache.has(input),
     prefetch: (input: Input): void => {
       if (!cache.has(input)) {
         cache.set(input, createInstance(input, fetchFunc));


### PR DESCRIPTION
Finally something that truly feels promising for #1578 :partying_face: 

Here's the gist:

- Add a way to check if a slice is already cached (or being fetched) in the store.
- Replace `useDebouncedCallback` with custom `useDynamicDebouncedCallback` in `SlicingSlider` that can adjust the debouncing delay on every call.
- If the user slides to a slice that is already in the fetch cache, set the debounce delay to 20ms; if it's not, set it to 250ms.

How to test this in practice:

1. Move the slider thumb one value at a time relatively slowly to request multiple slices
2. You can now "replay" the fetched slices very quickly

![ezgif-4-69da353371](https://github.com/silx-kit/h5web/assets/2936402/0f97904c-c6b3-47a6-aab2-4f1160ce356f)

Why this is awesome:

- No need to fetch an entire dataset or dimension to start seeing benefits
- Benefits all providers and visualizations the same way
- No arbitrary heuristics involved
- No config needed

Next up, I'll play with prefetching a bit. I reckon if we can cleverly prefetch slices (like the next/previous 10, if they're not too big), we can get a "movie-like" feel. This will of course involve heuristics and maybe also provider-based configuration (i.e. `viewerConfig`). Either way, this feels very beneficial already!