### PR TITLE
Add way to reset fetch cache of relevant providers

### DIFF
--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -286,16 +286,14 @@ specific export scenarios. In this case, or if you don't provide a function at
 all, `H5GroveProvider` falls back to generating URLs based on the `/data`
 endpoint and `format` query param.
 
-#### `key?: Key` (optional)
+#### `resetKeys?: unknown[]` (optional)
 
-If the content of the current file changes and you want to ensure that the
-viewer refetches the latest metadata and dataset values, you can take advantage
-of
-[React's `key` attribute](https://react.dev/reference/react/useState#resetting-state-with-a-key).
-Changing the value of the `key` will force a remount of `H5GroveProvider` and
-clear its internal fetching cache.
+You can pass variables in `resetKeys` that, when changed, will reset the
+provider's internal fetch cache. You may want to do this, for instance, when the
+content of the current file changes and you want the viewer to refetch the
+latest metadata and dataset values.
 
-It is up to you to decide what sort of `key` to use and when to update it. For
+It is up to you to decide what sort of keys to use and when to update them. For
 instance:
 
 - Your server could send over a hash of the file via WebSocket.
@@ -313,7 +311,7 @@ function MyApp() {
       <button type="button" onClick={incrementKey}>
         Refresh
       </button>
-      <H5GroveProvider key={key} /* ... */>
+      <H5GroveProvider resetKeys={[key]} /* ... */>
         <App />
       </H5GroveProvider>
     </>
@@ -359,10 +357,10 @@ See
 this time, so if you don't provide your own, the export menu will remain
 disabled in the toolbar.
 
-#### `key?: Key` (optional)
+#### `resetKeys?: unknown[]` (optional)
 
 See
-[`H5GroveProvider#key`](https://github.com/silx-kit/h5web/blob/main/packages/app/README.md#key-key-optional).
+[`H5GroveProvider#resetKeys`](https://github.com/silx-kit/h5web/blob/main/packages/app/README.md#resetkeys-unknown-optional).
 
 ### `MockProvider`
 

--- a/packages/app/src/providers/h5grove/H5GroveProvider.tsx
+++ b/packages/app/src/providers/h5grove/H5GroveProvider.tsx
@@ -10,15 +10,23 @@ interface Props {
   url: string;
   filepath: string;
   axiosConfig?: AxiosRequestConfig;
+  resetKeys?: unknown[];
   getExportURL?: DataProviderApi['getExportURL'];
 }
 
 function H5GroveProvider(props: PropsWithChildren<Props>) {
-  const { url, filepath, axiosConfig, getExportURL, children } = props;
+  const {
+    url,
+    filepath,
+    axiosConfig,
+    resetKeys = [],
+    getExportURL,
+    children,
+  } = props;
 
   const api = useMemo(
     () => new H5GroveApi(url, filepath, axiosConfig, getExportURL),
-    [filepath, url, axiosConfig, getExportURL],
+    [filepath, url, axiosConfig, ...resetKeys, getExportURL], // eslint-disable-line react-hooks/exhaustive-deps
   );
 
   return <DataProvider api={api}>{children}</DataProvider>;

--- a/packages/app/src/providers/hsds/HsdsProvider.tsx
+++ b/packages/app/src/providers/hsds/HsdsProvider.tsx
@@ -10,15 +10,24 @@ interface Props {
   username: string;
   password: string;
   filepath: string;
+  resetKeys?: unknown[];
   getExportURL?: DataProviderApi['getExportURL'];
 }
 
 function HsdsProvider(props: PropsWithChildren<Props>) {
-  const { url, username, password, filepath, getExportURL, children } = props;
+  const {
+    url,
+    username,
+    password,
+    filepath,
+    resetKeys = [],
+    getExportURL,
+    children,
+  } = props;
 
   const api = useMemo(
     () => new HsdsApi(url, username, password, filepath, getExportURL),
-    [filepath, password, url, username, getExportURL],
+    [filepath, password, url, username, ...resetKeys, getExportURL], // eslint-disable-line react-hooks/exhaustive-deps
   );
 
   return <DataProvider api={api}>{children}</DataProvider>;

--- a/packages/h5wasm/README.md
+++ b/packages/h5wasm/README.md
@@ -182,6 +182,11 @@ async function getPlugin(name: Plugin): Promise<ArrayBuffer | undefined> {
 }
 ```
 
+#### `resetKeys?: unknown[]` (optional)
+
+See
+[`H5GroveProvider#resetKeys`](https://github.com/silx-kit/h5web/blob/main/packages/app/README.md#resetkeys-unknown-optional).
+
 ### `H5WasmBufferProvider`
 
 - `filename: string` (required) - the name of the file

--- a/packages/h5wasm/src/H5WasmLocalFileProvider.tsx
+++ b/packages/h5wasm/src/H5WasmLocalFileProvider.tsx
@@ -9,12 +9,13 @@ import { getH5WasmRemote } from './remote';
 
 interface Props {
   file: File;
+  resetKeys?: unknown[];
   getExportURL?: DataProviderApi['getExportURL'];
   getPlugin?: (name: Plugin) => Promise<ArrayBuffer | undefined>;
 }
 
 function H5WasmLocalFileProvider(props: PropsWithChildren<Props>) {
-  const { file, getExportURL, getPlugin, children } = props;
+  const { file, resetKeys = [], getExportURL, getPlugin, children } = props;
 
   const prevApiRef = useRef<H5WasmApi>();
 
@@ -34,7 +35,7 @@ function H5WasmLocalFileProvider(props: PropsWithChildren<Props>) {
     prevApiRef.current = newApi;
 
     return newApi;
-  }, [file, getExportURL, getPlugin]);
+  }, [file, ...resetKeys, getExportURL, getPlugin]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return <DataProvider api={api}>{children}</DataProvider>;
 }


### PR DESCRIPTION
Addresses https://github.com/silx-kit/h5web/discussions/1553#discussioncomment-9787236

I was wrong about `key` not resetting the state of children components, so I'm adding a `resetKeys` array prop to three providers: `H5GroveProvider`, `HsdsProvider` and `H5WasmLocalFileProvider` to allow resetting the fetch cache manually. This prop is inspired from react-error-boundary.

I've tested and it works great: the suspense fallbacks in the explorer and in the visualizer are triggered again as expected. This even works with local files, which will benefit the VS Code extension.