### PR TITLE
Fix minor linting and type-checking configuration issues

### DIFF
--- a/apps/storybook/.eslintignore
+++ b/apps/storybook/.eslintignore
@@ -1,2 +1,3 @@
 /build/
 /node_modules/
+!/.storybook/

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -1,6 +1,7 @@
+import type { StorybookConfig } from '@storybook/react-vite';
 import remarkGfm from 'remark-gfm';
 
-export default {
+const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.tsx'],
   framework: '@storybook/react-vite',
   addons: [
@@ -19,3 +20,5 @@ export default {
   ],
   docs: { autodocs: true },
 };
+
+export default config;

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src"]
+  "include": [".storybook/**/*", "src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,6 @@
     "ignoreDeprecations": "5.0",
     "useDefineForClassFields": true,
     "useUnknownInCatchVariables": true
-  }
+  },
+  "include": ["*", "cypress", "apps/*/*", "packages/*/*"]
 }


### PR DESCRIPTION
Whenever I was opening a file at the root of the repo, like `cypress.config.ts`, VS Code would notify me to properly configure excluded files in `tsconfig.json`.

I used [this technique](https://github.com/microsoft/TypeScript/issues/53492#issuecomment-1876072922) to find out which files were included by the root `tsconfig.json`. Since we didn't use to specify `include` or `exclude`, the defaults applied as expected, which meant that `node_modules` folders were properly excluded but not build folders.

Keeping with our approach of using `include` over `exclude` to specify files to type-check, I add an `include` array in the root `tsconfig.json` that includes all the files that are not included by other `tsconfig.json` files:

- `*` = root TS/JS files
- `apps/*/*`, `packages/*/*` = files at the root of every project directory (e.g. `.eslintrc.cjs`)
- `cypress` = files in the Cypress folder

> Technically, the Cypress files are already included by their own `tsconfig.json`, but I had to include them in the root `tsconfig.json` as well because of ESLint.

While I was debugging included files, I also noticed that the `apps/storybook/.storybook` folder was neither linted nor type-checked. [This comment](https://github.com/microsoft/TypeScript/issues/49555#issuecomment-2009166185) helped me solve the issue.

> For future reference:
> - to list files included by TS, use flag `--listFilesOnly`
> - to list files linted by ESLint, use environment variable `DEBUG=eslint:cli-engine`