### PR TITLE
Fix React warning with `useGeometry` deps array

### DIFF
--- a/apps/storybook/src/Utilities.mdx
+++ b/apps/storybook/src/Utilities.mdx
@@ -378,20 +378,24 @@ useGeometry<
 >(
   Ctor: new (len: number) => H5WebGeometry<AttributeNames, Params>,
   dataLength: number,
-  params: Params | false | undefined, // skip updates by passing `false` or `undefined`
-  isInteractive = false, // `true` to recompute bounding sphere on every update for raycasting purposes
+  params: Params,
+  config?: {
+    skipUpdates?: boolean; // set to `true` when R3F object is hidden
+    isInteractive?: boolean; // set to `true` to keep bounding sphere up to date for raycaster
+  },
 ): H5WebGeometry<AttributeNames, Params>
 
 const lineGeometry = useGeometry(
   LineGeometry,
   ordinates.length,
-  visible && {
+  {
     abscissas,
     ordinates,
     abscissaScale,
     ordinateScale,
     ignoreValue,
   },
+  { skipUpdates: !visible }
 );
 ```
 

--- a/packages/lib/src/vis/line/ErrorBars.tsx
+++ b/packages/lib/src/vis/line/ErrorBars.tsx
@@ -20,7 +20,7 @@ function ErrorBars(props: Props) {
   const { abscissas, ordinates, errors, color, visible, ignoreValue } = props;
   const { abscissaScale, ordinateScale } = useVisCanvasContext();
 
-  const geometryParams = visible && {
+  const geometryParams = {
     abscissas,
     ordinates,
     errors,
@@ -33,12 +33,14 @@ function ErrorBars(props: Props) {
     ErrorBarsGeometry,
     ordinates.length,
     geometryParams,
+    { skipUpdates: !visible },
   );
 
   const capsGeometry = useGeometry(
     ErrorCapsGeometry,
     ordinates.length,
     geometryParams,
+    { skipUpdates: !visible },
   );
 
   return (

--- a/packages/lib/src/vis/line/Glyphs.tsx
+++ b/packages/lib/src/vis/line/Glyphs.tsx
@@ -35,14 +35,17 @@ function Glyphs(props: Props) {
   const geometry = useGeometry(
     GlyphsGeometry,
     ordinates.length,
-    visible && {
+    {
       abscissas,
       ordinates,
       abscissaScale,
       ordinateScale,
       ignoreValue,
     },
-    hasR3FEventHandlers(pointsProps),
+    {
+      skipUpdates: !visible,
+      isInteractive: hasR3FEventHandlers(pointsProps),
+    },
   );
 
   return (

--- a/packages/lib/src/vis/line/Line.tsx
+++ b/packages/lib/src/vis/line/Line.tsx
@@ -41,14 +41,17 @@ function Line(props: Props) {
   const geometry = useGeometry(
     LineGeometry,
     ordinates.length,
-    visible && {
+    {
       abscissas,
       ordinates,
       abscissaScale,
       ordinateScale,
       ignoreValue,
     },
-    hasR3FEventHandlers(lineProps),
+    {
+      skipUpdates: !visible,
+      isInteractive: hasR3FEventHandlers(lineProps),
+    },
   );
 
   return (

--- a/packages/lib/src/vis/scatter/ScatterPoints.tsx
+++ b/packages/lib/src/vis/scatter/ScatterPoints.tsx
@@ -96,7 +96,7 @@ function ScatterPoints(props: Props) {
       colorScale,
       interpolator,
     },
-    true,
+    { isInteractive: true },
   );
 
   return (


### PR DESCRIPTION
Introducing a **breaking change** in the signature of the `useGeometry` hook to fix #1684

The problem came from passing `false` or `undefined` as the value of the `params` parameter in order to skip updating the geometry (e.g. when the R3F object is hidden). I change the signature of the hook to decouple this feature from the `params` parameter: the hook now accepts a `config` object as fourth argument (which also makes the `isInteractive` boolean more explicit).