### PR TITLE
Upgrade h5wasm and improve boolean and vlen support

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,13 @@
     "wait-on": "7.2.0"
   },
   "pnpm": {
+    "packageExtensions": {
+      "@typescript-eslint/eslint-plugin": {
+        "dependencies": {
+          "typescript": "5.0.3"
+        }
+      }
+    },
     "peerDependencyRules": {
       "allowedVersions": {
         "@phenomnomnominal/tsquery>typescript": "5.x",

--- a/packages/app/src/providers/h5grove/__snapshots__/h5grove-api.test.ts.snap
+++ b/packages/app/src/providers/h5grove/__snapshots__/h5grove-api.test.ts.snap
@@ -1895,6 +1895,37 @@ exports[`test file matches snapshot 1`] = `
     ],
   },
   {
+    "name": "vlen_float32_1D",
+    "rawType": {
+      "base": {
+        "class": 1,
+        "dtype": "<f4",
+        "order": 0,
+        "size": 4,
+      },
+      "class": 9,
+      "dtype": "|O",
+      "size": 16,
+    },
+    "shape": [
+      2,
+    ],
+    "type": {
+      "base": {
+        "class": "Float",
+        "endianness": "little-endian",
+        "size": 32,
+      },
+      "class": "Array (variable length)",
+    },
+    "value": [
+      [],
+      [
+        0,
+      ],
+    ],
+  },
+  {
     "name": "vlen_int64_1D",
     "rawType": {
       "base": {

--- a/packages/app/src/vis-packs/core/matrix/utils.ts
+++ b/packages/app/src/vis-packs/core/matrix/utils.ts
@@ -1,6 +1,12 @@
 import { Notation } from '@h5web/lib';
-import { isComplexType, isEnumType, isNumericType } from '@h5web/shared/guards';
+import {
+  isBoolType,
+  isComplexType,
+  isEnumType,
+  isNumericType,
+} from '@h5web/shared/guards';
 import type {
+  BooleanType,
   ComplexType,
   NumericType,
   PrintableCompoundType,
@@ -11,6 +17,7 @@ import type { ValueFormatter } from '@h5web/shared/vis-models';
 import {
   createComplexFormatter,
   createEnumFormatter,
+  formatBool,
 } from '@h5web/shared/vis-utils';
 import { format } from 'd3-format';
 
@@ -50,11 +57,15 @@ export function getFormatter(
     return createNumericFormatter(notation);
   }
 
+  if (isBoolType(type)) {
+    return formatBool as ValueFormatter<BooleanType>;
+  }
+
   if (isEnumType(type)) {
     return createEnumFormatter(type.mapping);
   }
 
-  return (val) => (val as string | boolean).toString();
+  return (val) => (val as string).toString(); // call `toString()` for safety, in case type cast is wrong
 }
 
 export function getCellWidth(

--- a/packages/app/src/vis-packs/core/scalar/utils.ts
+++ b/packages/app/src/vis-packs/core/scalar/utils.ts
@@ -1,12 +1,14 @@
-import { hasComplexType, hasEnumType } from '@h5web/shared/guards';
+import { hasBoolType, hasComplexType, hasEnumType } from '@h5web/shared/guards';
 import type {
   ArrayShape,
+  BooleanType,
   Dataset,
   PrintableType,
 } from '@h5web/shared/hdf5-models';
 import type { ValueFormatter } from '@h5web/shared/vis-models';
 import {
   createEnumFormatter,
+  formatBool,
   formatScalarComplex,
 } from '@h5web/shared/vis-utils';
 
@@ -17,9 +19,13 @@ export function getFormatter(
     return formatScalarComplex;
   }
 
+  if (hasBoolType(dataset)) {
+    return formatBool as ValueFormatter<BooleanType>;
+  }
+
   if (hasEnumType(dataset)) {
     return createEnumFormatter(dataset.type.mapping);
   }
 
-  return (val) => (val as number | string | boolean).toString();
+  return (val) => (val as number | string).toString();
 }

--- a/packages/h5wasm/package.json
+++ b/packages/h5wasm/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "comlink": "4.4.1",
-    "h5wasm": "0.7.5",
+    "h5wasm": "0.7.6",
     "nanoid": "5.0.7"
   },
   "devDependencies": {

--- a/packages/h5wasm/src/__snapshots__/h5wasm-api.test.ts.snap
+++ b/packages/h5wasm/src/__snapshots__/h5wasm-api.test.ts.snap
@@ -1636,7 +1636,7 @@ exports[`test file matches snapshot 1`] = `
     },
     "value": [
       [
-        true,
+        1,
         [
           1,
           2,
@@ -1680,6 +1680,13 @@ exports[`test file matches snapshot 1`] = `
             "size": 8,
             "type": 9,
             "vlen": false,
+            "vlen_type": {
+              "littleEndian": true,
+              "signed": false,
+              "size": 8,
+              "type": 0,
+              "vlen": false,
+            },
           },
         ],
         "nmembers": 2,
@@ -1710,7 +1717,9 @@ exports[`test file matches snapshot 1`] = `
         },
         "vlen": {
           "base": {
-            "class": "Unknown",
+            "class": "Integer (unsigned)",
+            "endianness": "little-endian",
+            "size": 64,
           },
           "class": "Array (variable length)",
         },
@@ -1722,21 +1731,30 @@ exports[`test file matches snapshot 1`] = `
           0,
           1,
         ],
-        "Uint8Array (unstable)",
+        [
+          0,
+        ],
       ],
       [
         [
           2,
           3,
         ],
-        "Uint8Array (unstable)",
+        [
+          0,
+          1,
+        ],
       ],
       [
         [
           4,
           5,
         ],
-        "Uint8Array (unstable)",
+        [
+          0,
+          1,
+          2,
+        ],
       ],
     ],
   },
@@ -1820,7 +1838,7 @@ exports[`test file matches snapshot 1`] = `
     "type": {
       "class": "Boolean",
     },
-    "value": false,
+    "value": 0,
   },
   {
     "name": "bool_true_scalar",
@@ -1844,7 +1862,7 @@ exports[`test file matches snapshot 1`] = `
     "type": {
       "class": "Boolean",
     },
-    "value": true,
+    "value": 1,
   },
   {
     "name": "bool_2D",
@@ -1871,15 +1889,15 @@ exports[`test file matches snapshot 1`] = `
     "type": {
       "class": "Boolean",
     },
-    "value": [
-      true,
-      false,
-      true,
-      true,
-      false,
-      false,
-      true,
-      false,
+    "value": Int8Array [
+      1,
+      0,
+      1,
+      1,
+      0,
+      0,
+      1,
+      0,
     ],
   },
   {
@@ -2064,15 +2082,62 @@ exports[`test file matches snapshot 1`] = `
       "total_size": 1,
       "type": 9,
       "vlen": false,
+      "vlen_type": {
+        "littleEndian": true,
+        "signed": true,
+        "size": 1,
+        "type": 0,
+        "vlen": false,
+      },
     },
     "shape": [],
     "type": {
       "base": {
-        "class": "Unknown",
+        "class": "Integer",
+        "endianness": "little-endian",
+        "size": 8,
       },
       "class": "Array (variable length)",
     },
-    "value": "Uint8Array (unstable)",
+    "value": Int8Array [
+      0,
+      1,
+    ],
+  },
+  {
+    "name": "vlen_float32_1D",
+    "rawType": {
+      "littleEndian": true,
+      "signed": false,
+      "size": 8,
+      "total_size": 2,
+      "type": 9,
+      "vlen": false,
+      "vlen_type": {
+        "littleEndian": true,
+        "signed": false,
+        "size": 4,
+        "type": 1,
+        "vlen": false,
+      },
+    },
+    "shape": [
+      2,
+    ],
+    "type": {
+      "base": {
+        "class": "Float",
+        "endianness": "little-endian",
+        "size": 32,
+      },
+      "class": "Array (variable length)",
+    },
+    "value": [
+      Float32Array [],
+      Float32Array [
+        0,
+      ],
+    ],
   },
   {
     "name": "vlen_int64_1D",
@@ -2083,17 +2148,39 @@ exports[`test file matches snapshot 1`] = `
       "total_size": 3,
       "type": 9,
       "vlen": false,
+      "vlen_type": {
+        "littleEndian": true,
+        "signed": true,
+        "size": 8,
+        "type": 0,
+        "vlen": false,
+      },
     },
     "shape": [
       3,
     ],
     "type": {
       "base": {
-        "class": "Unknown",
+        "class": "Integer",
+        "endianness": "little-endian",
+        "size": 64,
       },
       "class": "Array (variable length)",
     },
-    "value": "Uint8Array (unstable)",
+    "value": [
+      [
+        0,
+      ],
+      [
+        0,
+        1,
+      ],
+      [
+        0,
+        1,
+        2,
+      ],
+    ],
   },
   {
     "name": "vlen_utf8_1D",
@@ -2104,17 +2191,41 @@ exports[`test file matches snapshot 1`] = `
       "total_size": 3,
       "type": 9,
       "vlen": false,
+      "vlen_type": {
+        "cset": 1,
+        "littleEndian": true,
+        "signed": false,
+        "size": 4,
+        "strpad": 0,
+        "type": 3,
+        "vlen": true,
+      },
     },
     "shape": [
       3,
     ],
     "type": {
       "base": {
-        "class": "Unknown",
+        "charSet": "UTF-8",
+        "class": "String",
+        "strPad": "null-terminated",
       },
       "class": "Array (variable length)",
     },
-    "value": "Uint8Array (unstable)",
+    "value": [
+      [
+        "a",
+      ],
+      [
+        "a",
+        "bc",
+      ],
+      [
+        "a",
+        "bc",
+        "def",
+      ],
+    ],
   },
 ]
 `;

--- a/packages/h5wasm/src/h5wasm-api.test.ts
+++ b/packages/h5wasm/src/h5wasm-api.test.ts
@@ -61,20 +61,12 @@ test.skipIf(SKIP)('test file matches snapshot', async () => {
   expect(children).toMatchSnapshot();
 });
 
-// Hide unstable uint8 value arrays for H5T_VLEN and H5T_REFERENCE datasets from snapshot
 function processValue(value: unknown, child: Dataset): unknown {
-  const { name, type } = child;
+  const { type } = child;
 
-  if (type.class === DTypeClass.Reference || type.class === DTypeClass.VLen) {
+  // Hide unstable H5T_REFERENCE values from snapshot
+  if (type.class === DTypeClass.Reference) {
     return `Uint8Array (unstable)`;
-  }
-
-  // Special case for compound dataset with H5T_VLEN field
-  if (name === 'compound_array_vlen_1D') {
-    return (value as [number[], Uint8Array][]).map((item) => [
-      item[0],
-      `Uint8Array (unstable)`,
-    ]);
   }
 
   return value;

--- a/packages/h5wasm/src/utils.ts
+++ b/packages/h5wasm/src/utils.ts
@@ -18,7 +18,11 @@ export const PLUGINS_BY_FILTER_ID: Record<number, Plugin> = {
 };
 
 export function hasBigInts(type: DType): boolean {
-  if (type.class === DTypeClass.Array || type.class === DTypeClass.Enum) {
+  if (
+    type.class === DTypeClass.Enum ||
+    type.class === DTypeClass.Array ||
+    type.class === DTypeClass.VLen
+  ) {
     return hasBigInts(type.base);
   }
 

--- a/packages/h5wasm/src/worker-utils.ts
+++ b/packages/h5wasm/src/worker-utils.ts
@@ -273,10 +273,9 @@ function parseDType(metadata: Metadata): DType {
   }
 
   if (h5tClass === H5T_CLASS.VLEN) {
-    // Not currently provided, so unable to know base type
-    // const { array_type } = metadata;
-    // assertDefined(array_type);
-    return arrayType(unknownType());
+    const { vlen_type } = metadata;
+    assertDefined(vlen_type);
+    return arrayType(parseDType(vlen_type));
   }
 
   if (h5tClass === H5T_CLASS.ARRAY) {

--- a/packages/lib/src/vis/raw/RawVis.tsx
+++ b/packages/lib/src/vis/raw/RawVis.tsx
@@ -1,3 +1,5 @@
+import { isTypedArray } from '@h5web/shared/guards';
+
 import type { ClassStyleAttrs } from '../models';
 import styles from './RawVis.module.css';
 
@@ -10,10 +12,9 @@ interface Props extends ClassStyleAttrs {
 function RawVis(props: Props) {
   const { value, className = '', style } = props;
 
-  const valueAsStr =
-    value instanceof Uint8Array
-      ? `Uint8Array [ ${value.toString()} ]`
-      : JSON.stringify(value, null, 2);
+  const valueAsStr = isTypedArray(value)
+    ? `${value.constructor.name} [ ${value.toString()} ]`
+    : JSON.stringify(value, null, 2);
 
   return (
     <div className={`${styles.root} ${className}`} style={style}>

--- a/packages/shared/src/guards.ts
+++ b/packages/shared/src/guards.ts
@@ -85,9 +85,9 @@ function assertNum(val: unknown): asserts val is number {
   }
 }
 
-function assertBool(val: unknown): asserts val is boolean {
-  if (typeof val !== 'boolean') {
-    throw new TypeError('Expected boolean');
+function assertNumOrBool(val: unknown): asserts val is number | boolean {
+  if (typeof val !== 'number' && typeof val !== 'boolean') {
+    throw new TypeError('Expected boolean or number');
   }
 }
 
@@ -430,7 +430,7 @@ function assertPrimitiveValue<D extends Dataset>(
   } else if (hasStringType(dataset)) {
     assertStr(value);
   } else if (hasBoolType(dataset)) {
-    assertBool(value);
+    assertNumOrBool(value);
   } else if (hasComplexType(dataset)) {
     assertComplex(value);
   }

--- a/packages/shared/src/hdf5-models.ts
+++ b/packages/shared/src/hdf5-models.ts
@@ -208,7 +208,7 @@ export type Primitive<T extends DType> = T extends NumericType | EnumType
   : T extends StringType
     ? string
     : T extends BooleanType
-      ? boolean
+      ? number | boolean // let providers choose
       : T extends ComplexType
         ? H5WebComplex
         : T extends PrintableCompoundType
@@ -217,7 +217,7 @@ export type Primitive<T extends DType> = T extends NumericType | EnumType
 
 export type ArrayValue<T extends DType> =
   | Primitive<T>[]
-  | (T extends NumericType | EnumType ? TypedArray : never);
+  | (T extends NumericType | BooleanType | EnumType ? TypedArray : never);
 
 export type Value<D extends Dataset> =
   D extends Dataset<infer S, infer T>

--- a/packages/shared/src/vis-utils.ts
+++ b/packages/shared/src/vis-utils.ts
@@ -4,7 +4,12 @@ import ndarray from 'ndarray';
 import { assign } from 'ndarray-ops';
 
 import { assertLength, isNdArray } from './guards';
-import type { ComplexType, EnumType } from './hdf5-models';
+import type {
+  BooleanType,
+  ComplexType,
+  EnumType,
+  Primitive,
+} from './hdf5-models';
 import type {
   AnyNumArray,
   AxisScaleType,
@@ -52,6 +57,10 @@ export function formatTick(val: number | { valueOf(): number }): string {
   }
 
   return str;
+}
+
+export function formatBool(value: Primitive<BooleanType>): string {
+  return (typeof value === 'number' ? !!value : value).toString();
 }
 
 export function createComplexFormatter(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,8 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+packageExtensionsChecksum: 757916d57980a910c06fe422bd21fc26
+
 importers:
 
   .:
@@ -107,7 +109,7 @@ importers:
         version: 5.3.5(@types/node@20.12.11)
       vite-css-modules:
         specifier: 1.4.2
-        version: 1.4.2(postcss@8.4.40)(rollup@4.20.0)(vite@5.3.5(@types/node@20.12.11))
+        version: 1.4.2(postcss@8.4.41)(rollup@4.20.0)(vite@5.3.5(@types/node@20.12.11))
       vite-plugin-checker:
         specifier: 0.7.2
         version: 0.7.2(eslint@8.57.0)(optionator@0.9.4)(typescript@5.4.5)(vite@5.3.5(@types/node@20.12.11))
@@ -340,7 +342,7 @@ importers:
         version: 5.3.5(@types/node@20.12.11)
       vite-css-modules:
         specifier: 1.4.2
-        version: 1.4.2(postcss@8.4.40)(rollup@4.20.0)(vite@5.3.5(@types/node@20.12.11))
+        version: 1.4.2(postcss@8.4.41)(rollup@4.20.0)(vite@5.3.5(@types/node@20.12.11))
       vitest:
         specifier: 2.0.5
         version: 2.0.5(@types/node@20.12.11)(jsdom@24.1.1)
@@ -351,8 +353,8 @@ importers:
         specifier: 4.4.1
         version: 4.4.1
       h5wasm:
-        specifier: 0.7.5
-        version: 0.7.5
+        specifier: 0.7.6
+        version: 0.7.6
       nanoid:
         specifier: 5.0.7
         version: 5.0.7
@@ -567,7 +569,7 @@ importers:
         version: 5.3.5(@types/node@20.12.11)
       vite-css-modules:
         specifier: 1.4.2
-        version: 1.4.2(postcss@8.4.40)(rollup@4.20.0)(vite@5.3.5(@types/node@20.12.11))
+        version: 1.4.2(postcss@8.4.41)(rollup@4.20.0)(vite@5.3.5(@types/node@20.12.11))
       vitest:
         specifier: 2.0.5
         version: 2.0.5(@types/node@20.12.11)(jsdom@24.1.1)
@@ -2654,10 +2656,6 @@ packages:
     peerDependencies:
       '@typescript-eslint/parser': ^5.0.0
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   '@typescript-eslint/experimental-utils@5.62.0':
     resolution: {integrity: sha512-RTXpeB3eMkpoclG3ZHft6vG/Z30azNHuqY6wKPBHlVMZFuEvrtlEDe8gMqDb+SO+9hjC/pLekeSCryf9vMZlCw==}
@@ -4344,8 +4342,8 @@ packages:
   h5wasm@0.6.10:
     resolution: {integrity: sha512-GxBWGVxBftyq67kAbS4WPmTH3a8hGKigdMm+IVJ7tLY7BHj+nqDTUKO9RmmPBHy6Pvq5uW1YpIJr/oGanw+RyQ==}
 
-  h5wasm@0.7.5:
-    resolution: {integrity: sha512-gkIAs6pyn3c5r2q9Y2gYAUqL6AgtxUSVYe0L7mFTu5NNSFlTPtidOfJxQQLYEm31Zp0+OKbLXhfuI4PSHf4+Rw==}
+  h5wasm@0.7.6:
+    resolution: {integrity: sha512-+c9XEb94Vwb1D+rkMbf8eGNJbV2umJ2ubwFyk8kwOhrbaPiewHh9Pl0B465Rj2eEloD7rPKzhyl0X+53B8rZ1Q==}
 
   handlebars@4.7.8:
     resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
@@ -5642,6 +5640,10 @@ packages:
 
   postcss@8.4.40:
     resolution: {integrity: sha512-YF2kKIUzAofPMpfH6hOi2cGnv/HrUlfucspc7pDyvv7kGdqXrfj8SCl/t8owkEgKEuu8ZcRjSOxFxVLqwChZ2Q==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.4.41:
+    resolution: {integrity: sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   potpack@1.0.2:
@@ -9495,7 +9497,7 @@ snapshots:
       '@types/node': 20.12.11
     optional: true
 
-  '@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3)':
+  '@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
       '@typescript-eslint/parser': 5.56.0(eslint@8.57.0)(typescript@5.0.3)
@@ -9509,7 +9511,6 @@ snapshots:
       natural-compare-lite: 1.4.0
       semver: 7.6.0
       tsutils: 3.21.0(typescript@5.0.3)
-    optionalDependencies:
       typescript: 5.0.3
     transitivePeerDependencies:
       - supports-color
@@ -10855,17 +10856,17 @@ snapshots:
       '@babel/eslint-parser': 7.21.3(@babel/core@7.21.4)(eslint@8.57.0)
       '@babel/preset-react': 7.18.6(@babel/core@7.21.4)
       '@next/eslint-plugin-next': 13.2.4
-      '@typescript-eslint/eslint-plugin': 5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3)
+      '@typescript-eslint/eslint-plugin': 5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)
       '@typescript-eslint/parser': 5.56.0(eslint@8.57.0)(typescript@5.0.3)
       confusing-browser-globals: 1.0.11
       eslint: 8.57.0
       eslint-config-prettier: 8.8.0(eslint@8.57.0)
       eslint-import-resolver-jsconfig: 1.1.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.5.4(eslint-plugin-import@2.27.5)(eslint@8.57.0)
       eslint-plugin-etc: 2.0.2(eslint@8.57.0)(typescript@5.0.3)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-jest: 27.2.1(@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.0.3))(eslint-import-resolver-typescript@3.5.4)(eslint@8.57.0)
+      eslint-plugin-jest: 27.2.1(@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0))(eslint@8.57.0)(typescript@5.0.3)
       eslint-plugin-jest-dom: 4.0.3(eslint@8.57.0)
       eslint-plugin-jest-formatting: 3.1.0(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.57.0)
@@ -10915,12 +10916,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5)(eslint@8.57.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.16.0
       eslint: 8.57.0
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.0.3))(eslint-import-resolver-typescript@3.5.4)(eslint@8.57.0)
       get-tsconfig: 4.7.3
       globby: 13.2.2
       is-core-module: 2.13.1
@@ -10929,14 +10930,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.0.3))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5)(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
       '@typescript-eslint/parser': 5.56.0(eslint@8.57.0)(typescript@5.0.3)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.5.4(eslint-plugin-import@2.27.5)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10953,7 +10954,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.0.3))(eslint-import-resolver-typescript@3.5.4)(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.flat: 1.3.2
@@ -10962,7 +10963,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.0.3))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.4(eslint-plugin-import@2.27.5)(eslint@8.57.0))(eslint@8.57.0)
       has: 1.0.4
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -10989,12 +10990,12 @@ snapshots:
     dependencies:
       eslint: 8.57.0
 
-  eslint-plugin-jest@27.2.1(@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3):
+  eslint-plugin-jest@27.2.1(@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0))(eslint@8.57.0)(typescript@5.0.3):
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.0.3)
       eslint: 8.57.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3)
+      '@typescript-eslint/eslint-plugin': 5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -11652,7 +11653,7 @@ snapshots:
 
   h5wasm@0.6.10: {}
 
-  h5wasm@0.7.5: {}
+  h5wasm@0.7.6: {}
 
   handlebars@4.7.8:
     dependencies:
@@ -11751,9 +11752,9 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  icss-utils@5.1.0(postcss@8.4.40):
+  icss-utils@5.1.0(postcss@8.4.41):
     dependencies:
-      postcss: 8.4.40
+      postcss: 8.4.41
 
   ieee754@1.2.1: {}
 
@@ -12986,49 +12987,49 @@ snapshots:
 
   possible-typed-array-names@1.0.0: {}
 
-  postcss-import@15.1.0(postcss@8.4.40):
+  postcss-import@15.1.0(postcss@8.4.41):
     dependencies:
-      postcss: 8.4.40
+      postcss: 8.4.41
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.8
 
-  postcss-js@4.0.1(postcss@8.4.40):
+  postcss-js@4.0.1(postcss@8.4.41):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.4.40
+      postcss: 8.4.41
 
-  postcss-load-config@4.0.2(postcss@8.4.40):
+  postcss-load-config@4.0.2(postcss@8.4.41):
     dependencies:
       lilconfig: 3.1.2
       yaml: 2.5.0
     optionalDependencies:
-      postcss: 8.4.40
+      postcss: 8.4.41
 
-  postcss-modules-extract-imports@3.0.0(postcss@8.4.40):
+  postcss-modules-extract-imports@3.0.0(postcss@8.4.41):
     dependencies:
-      postcss: 8.4.40
+      postcss: 8.4.41
 
-  postcss-modules-local-by-default@4.0.4(postcss@8.4.40):
+  postcss-modules-local-by-default@4.0.4(postcss@8.4.41):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.40)
-      postcss: 8.4.40
+      icss-utils: 5.1.0(postcss@8.4.41)
+      postcss: 8.4.41
       postcss-selector-parser: 6.0.16
       postcss-value-parser: 4.2.0
 
-  postcss-modules-scope@3.1.1(postcss@8.4.40):
+  postcss-modules-scope@3.1.1(postcss@8.4.41):
     dependencies:
-      postcss: 8.4.40
+      postcss: 8.4.41
       postcss-selector-parser: 6.0.16
 
-  postcss-modules-values@4.0.0(postcss@8.4.40):
+  postcss-modules-values@4.0.0(postcss@8.4.41):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.40)
-      postcss: 8.4.40
+      icss-utils: 5.1.0(postcss@8.4.41)
+      postcss: 8.4.41
 
-  postcss-nested@6.2.0(postcss@8.4.40):
+  postcss-nested@6.2.0(postcss@8.4.41):
     dependencies:
-      postcss: 8.4.40
+      postcss: 8.4.41
       postcss-selector-parser: 6.1.1
 
   postcss-selector-parser@6.0.16:
@@ -13050,6 +13051,12 @@ snapshots:
       source-map-js: 1.0.2
 
   postcss@8.4.40:
+    dependencies:
+      nanoid: 3.3.7
+      picocolors: 1.0.1
+      source-map-js: 1.2.0
+
+  postcss@8.4.41:
     dependencies:
       nanoid: 3.3.7
       picocolors: 1.0.1
@@ -13856,11 +13863,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.0.1
-      postcss: 8.4.40
-      postcss-import: 15.1.0(postcss@8.4.40)
-      postcss-js: 4.0.1(postcss@8.4.40)
-      postcss-load-config: 4.0.2(postcss@8.4.40)
-      postcss-nested: 6.2.0(postcss@8.4.40)
+      postcss: 8.4.41
+      postcss-import: 15.1.0(postcss@8.4.41)
+      postcss-js: 4.0.1(postcss@8.4.41)
+      postcss-load-config: 4.0.2(postcss@8.4.41)
+      postcss-nested: 6.2.0(postcss@8.4.41)
       postcss-selector-parser: 6.1.1
       resolve: 1.22.8
       sucrase: 3.35.0
@@ -14247,18 +14254,18 @@ snapshots:
       unist-util-stringify-position: 4.0.0
       vfile-message: 4.0.2
 
-  vite-css-modules@1.4.2(postcss@8.4.40)(rollup@4.20.0)(vite@5.3.5(@types/node@20.12.11)):
+  vite-css-modules@1.4.2(postcss@8.4.41)(rollup@4.20.0)(vite@5.3.5(@types/node@20.12.11)):
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@rollup/pluginutils': 5.1.0(rollup@4.20.0)
       generic-names: 4.0.0
-      icss-utils: 5.1.0(postcss@8.4.40)
+      icss-utils: 5.1.0(postcss@8.4.41)
       magic-string: 0.30.8
-      postcss: 8.4.40
-      postcss-modules-extract-imports: 3.0.0(postcss@8.4.40)
-      postcss-modules-local-by-default: 4.0.4(postcss@8.4.40)
-      postcss-modules-scope: 3.1.1(postcss@8.4.40)
-      postcss-modules-values: 4.0.0(postcss@8.4.40)
+      postcss: 8.4.41
+      postcss-modules-extract-imports: 3.0.0(postcss@8.4.41)
+      postcss-modules-local-by-default: 4.0.4(postcss@8.4.41)
+      postcss-modules-scope: 3.1.1(postcss@8.4.41)
+      postcss-modules-values: 4.0.0(postcss@8.4.41)
       vite: 5.3.5(@types/node@20.12.11)
     transitivePeerDependencies:
       - rollup

--- a/support/sample/create_h5_sample.py
+++ b/support/sample/create_h5_sample.py
@@ -266,6 +266,13 @@ with h5py.File(os.path.join(DIST_PATH, "sample.h5"), "w") as h5:
     vlen_scalar[()] = [0, 1]
 
     vlen_array = add_array(
+        h5, "vlen_float32", shape=(2,), dtype=h5py.vlen_dtype(np.float32)
+    )
+    # Skip to make sure providers fill the gap with an empty array
+    # vlen_array[0] = []
+    vlen_array[1] = [0]
+
+    vlen_array = add_array(
         h5, "vlen_int64", shape=(3,), dtype=h5py.vlen_dtype(np.int64)
     )
     vlen_array[0] = [0]


### PR DESCRIPTION
Two changes in [h5wasm v0.7.6](https://github.com/usnistgov/h5wasm/releases/tag/v0.7.6):

### Full support for the `H5T_VLEN` datatype (metadata + value)

This brings h5wasm in line with h5grove. The only difference is that, for numeric vlen datasets, h5wasm is able to return an array of vlen typed arrays (`TypedArray[]`), whereas h5grove is forced to return an array of plain arrays (`number[][]`) -- this doesn't make any difference, in the viewer though.

![image](https://github.com/user-attachments/assets/9fade487-c390-44a9-a806-b8024fca6ffc)
![image](https://github.com/user-attachments/assets/f072bf03-3aab-45e6-a0db-c0e0b142a548)

> See https://github.com/usnistgov/h5wasm/issues/78 and https://github.com/usnistgov/h5wasm/pull/77

### Booleans are now returned as numbers (like enums)

This removes the unnecessary `number->boolean->number` conversion for the line and heatmap vis.

Since h5grove and HSDS still return booleans for now, I decided to allow for both throughout (`Primitive<BooleanType` => `number | boolean`). As a result:

- If `MappedLineVis` and `MappedHeatmapVis` receive booleans, they convert them to numbers as before (via `useToNumArray`).
- If the _Scalar_ and _Matrix_ vis receive numbers, they put them through a new formatter called `formatBool` to convert them to strings (just like they do with enums). This is quite beneficial for the _Matrix_ vis, since it means only the values rendered on the screen are converted.

> See https://github.com/usnistgov/h5wasm/pull/76