### PR TITLE
Use zustand store inside suspense fetch store to track progress

### DIFF
--- a/packages/app/src/__tests__/Explorer.test.tsx
+++ b/packages/app/src/__tests__/Explorer.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react';
 import { expect, test } from 'vitest';
 
-import { SLOW_TIMEOUT } from '../providers/mock/mock-api';
+import { SLOW_TIMEOUT } from '../providers/mock/utils';
 import { renderApp } from '../test-utils';
 
 test('select root group by default', async () => {

--- a/packages/app/src/__tests__/NexusPack.test.tsx
+++ b/packages/app/src/__tests__/NexusPack.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react';
 import { expect, test } from 'vitest';
 
-import { SLOW_TIMEOUT } from '../providers/mock/mock-api';
+import { SLOW_TIMEOUT } from '../providers/mock/utils';
 import {
   getSelectedVisTab,
   getVisTabs,

--- a/packages/app/src/__tests__/Visualizer.test.tsx
+++ b/packages/app/src/__tests__/Visualizer.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react';
 import { expect, test } from 'vitest';
 
-import { SLOW_TIMEOUT } from '../providers/mock/mock-api';
+import { SLOW_TIMEOUT } from '../providers/mock/utils';
 import { mockConsoleMethod, renderApp } from '../test-utils';
 import { Vis } from '../vis-packs/core/visualizations';
 

--- a/packages/app/src/providers/DataProvider.tsx
+++ b/packages/app/src/providers/DataProvider.tsx
@@ -11,7 +11,6 @@ import type {
   AttrName,
   AttrValuesStore,
   EntitiesStore,
-  ProgressCallback,
   ValuesStore,
 } from './models';
 
@@ -24,8 +23,6 @@ export interface DataContextValue {
 
   // Undocumented
   getExportURL?: DataProviderApi['getExportURL'];
-  addProgressListener: (cb: ProgressCallback) => void;
-  removeProgressListener: (cb: ProgressCallback) => void;
   getSearchablePaths?: DataProviderApi['getSearchablePaths'];
 }
 
@@ -92,8 +89,6 @@ function DataProvider(props: PropsWithChildren<Props>) {
         valuesStore,
         attrValuesStore,
         getExportURL: api.getExportURL?.bind(api),
-        addProgressListener: api.addProgressListener.bind(api),
-        removeProgressListener: api.removeProgressListener.bind(api),
         getSearchablePaths: api.getSearchablePaths?.bind(api),
       }}
     >

--- a/packages/app/src/providers/hsds/hsds-api.ts
+++ b/packages/app/src/providers/hsds/hsds-api.ts
@@ -17,6 +17,7 @@ import type {
 } from '@h5web/shared/hdf5-models';
 import { EntityKind } from '@h5web/shared/hdf5-models';
 import { buildEntityPath, getChildEntity } from '@h5web/shared/hdf5-utils';
+import type { OnProgress } from '@h5web/shared/react-suspense-fetch';
 
 import { DataProviderApi } from '../api';
 import type { ExportFormat, ExportURL, ValuesStoreParams } from '../models';
@@ -127,11 +128,12 @@ export class HsdsApi extends DataProviderApi {
   public override async getValue(
     params: ValuesStoreParams,
     signal?: AbortSignal,
+    onProgress?: OnProgress,
   ): Promise<unknown> {
     const { dataset } = params;
     assertHsdsDataset(dataset);
 
-    const value = await this.fetchValue(dataset.id, params, signal);
+    const value = await this.fetchValue(dataset.id, params, signal, onProgress);
 
     // https://github.com/HDFGroup/hsds/issues/88
     // HSDS does not reduce the number of dimensions when selecting indices
@@ -217,13 +219,14 @@ export class HsdsApi extends DataProviderApi {
     entityId: HsdsId,
     params: ValuesStoreParams,
     signal?: AbortSignal,
+    onProgress?: OnProgress,
   ): Promise<HsdsValueResponse> {
     const { selection } = params;
     const { data } = await this.cancellableFetchValue(
       `/datasets/${entityId}/value`,
-      params,
       { select: selection && `[${selection}]` },
       signal,
+      onProgress,
     );
     return data.value;
   }

--- a/packages/app/src/vis-packs/ValueLoader.tsx
+++ b/packages/app/src/vis-packs/ValueLoader.tsx
@@ -1,5 +1,5 @@
 import { useTimeoutEffect, useToggle } from '@react-hookz/web';
-import { useEffect, useState } from 'react';
+import { useStore } from 'zustand';
 
 import { useDataContext } from '../providers/DataProvider';
 import { CANCELLED_ERROR_MSG } from '../providers/utils';
@@ -13,19 +13,14 @@ interface Props {
 
 function ValueLoader(props: Props) {
   const { isSlice = false } = props;
-  const { valuesStore, addProgressListener, removeProgressListener } =
-    useDataContext();
-
-  const [progress, setProgress] = useState<number[]>();
-
-  useEffect(() => {
-    addProgressListener(setProgress);
-    return () => removeProgressListener(setProgress);
-  }, [addProgressListener, removeProgressListener, setProgress]);
+  const { valuesStore } = useDataContext();
 
   // Wait a bit before showing loader to avoid flash
   const [isReady, toggleReady] = useToggle();
   useTimeoutEffect(toggleReady, 100);
+
+  // Track progress
+  const { ongoing } = useStore(valuesStore.progressStore);
 
   return (
     <div className={styles.loader} data-testid="LoadingDatasetValue">
@@ -42,13 +37,17 @@ function ValueLoader(props: Props) {
             <div />
             <div />
           </div>
-          {progress && (
-            <div className={styles.progressBars}>
-              {progress.slice(0, MAX_PROGRESS_BARS).map((val, index) => (
-                <progress className={styles.progress} key={index} value={val} /> // eslint-disable-line react/no-array-index-key
+          <div className={styles.progressBars}>
+            {[...ongoing.entries()]
+              .slice(0, MAX_PROGRESS_BARS)
+              .map(([key, val]) => (
+                <progress
+                  className={styles.progress}
+                  key={`${key.dataset.path}_${key.selection || ''}`}
+                  value={val}
+                />
               ))}
-            </div>
-          )}
+          </div>
           <p>{isSlice ? 'Loading current slice' : 'Loading data'}...</p>
           <p>
             <button

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -35,6 +35,9 @@
     "ndarray-ops": "1.2.2",
     "react": ">=18"
   },
+  "optionalDependencies": {
+    "zustand": "4.5.4"
+  },
   "devDependencies": {
     "@types/d3-array": "~3.2.1",
     "@types/d3-format": "~3.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -579,6 +579,10 @@ importers:
       d3-array:
         specifier: 3.2.4
         version: 3.2.4
+    optionalDependencies:
+      zustand:
+        specifier: 4.5.4
+        version: 4.5.4(@types/react@18.3.3)(react@18.3.1)
     devDependencies:
       '@types/d3-array':
         specifier: ~3.2.1


### PR DESCRIPTION
This replaces the pub-sub pattern I had implemented in `DataProviderApi`, and considerably simplifies subscribing to the progress state in `ValueLoader`.

Basically, every fetch store now initialises a zustand store to track progress. Each "fetch input" (e.g. dataset+selection for `valuesStore`) is associated with a progress percentage in the zustand store, and the store can be subscribed to with zustand's `useStore` hook.