### PR TITLE
Remove axios from `DataProviderApi` base class and refactor axios error handling

### DIFF
--- a/packages/app/src/ErrorFallback.tsx
+++ b/packages/app/src/ErrorFallback.tsx
@@ -10,7 +10,27 @@ interface Props extends FallbackProps {
 function ErrorFallback(props: Props) {
   const { className = '', error, resetErrorBoundary } = props;
 
-  if (error.cause || error.cause instanceof Error) {
+  if (error.message === CANCELLED_ERROR_MSG) {
+    return (
+      <p className={`${styles.error} ${className}`}>
+        {CANCELLED_ERROR_MSG}
+        <span>–</span>
+        <button
+          className={styles.retryBtn}
+          type="button"
+          onClick={() => resetErrorBoundary()}
+        >
+          Retry?
+        </button>
+      </p>
+    );
+  }
+
+  if (
+    error.cause &&
+    error.cause instanceof Error &&
+    error.message !== error.cause.message
+  ) {
     const { message } = error.cause;
     return (
       <details className={`${styles.detailedError} ${className}`}>
@@ -20,23 +40,7 @@ function ErrorFallback(props: Props) {
     );
   }
 
-  return (
-    <p className={`${styles.error} ${className}`}>
-      {error.message}
-      {error.message === CANCELLED_ERROR_MSG && (
-        <>
-          <span>–</span>
-          <button
-            className={styles.retryBtn}
-            type="button"
-            onClick={() => resetErrorBoundary()}
-          >
-            Retry?
-          </button>
-        </>
-      )}
-    </p>
-  );
+  return <p className={`${styles.error} ${className}`}>{error.message}</p>;
 }
 
 export default ErrorFallback;

--- a/packages/app/src/providers/api.ts
+++ b/packages/app/src/providers/api.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/member-ordering */
 import type {
   ArrayShape,
   AttributeValues,
@@ -7,75 +8,11 @@ import type {
   Value,
 } from '@h5web/shared/hdf5-models';
 import type { OnProgress } from '@h5web/shared/react-suspense-fetch';
-import type {
-  AxiosInstance,
-  AxiosProgressEvent,
-  AxiosRequestConfig,
-  AxiosResponse,
-  ResponseType,
-} from 'axios';
-import axios from 'axios';
 
 import type { ExportFormat, ExportURL, ValuesStoreParams } from './models';
 
 export abstract class DataProviderApi {
-  protected readonly client: AxiosInstance;
-
-  public constructor(
-    public readonly filepath: string,
-    config?: AxiosRequestConfig,
-  ) {
-    this.client = axios.create(config);
-  }
-
-  /**
-   * Provide an export URL for the given format and dataset/slice.
-   * The following return types are supported:
-   * - `URL`                  Provider has dedicated endpoint for generating server-side exports
-   * - `() => Promise<URL>`   Provider generates single-use export URLs (i.e. signed one-time tokens)
-   * - `() => Promise<Blob>`  Export is to be generated client-side
-   * - `undefined`            Export scenario is not supported
-   */
-  public getExportURL?<D extends Dataset<ArrayShape>>(
-    format: ExportFormat,
-    dataset: D,
-    selection: string | undefined,
-    value: Value<D>,
-  ): ExportURL;
-
-  public getSearchablePaths?(path: string): Promise<string[]>;
-
-  protected async cancellableFetchValue(
-    endpoint: string,
-    queryParams: Record<string, string | boolean | undefined>,
-    signal?: AbortSignal,
-    onProgress?: OnProgress,
-    responseType?: ResponseType,
-  ): Promise<AxiosResponse> {
-    try {
-      return await this.client.get(endpoint, {
-        signal,
-        params: queryParams,
-        responseType,
-        onDownloadProgress:
-          onProgress &&
-          ((evt: AxiosProgressEvent) => {
-            if (evt.total !== undefined && evt.total > 0) {
-              onProgress(evt.loaded / evt.total);
-            }
-          }),
-      });
-    } catch (error) {
-      if (axios.isCancel(error)) {
-        // Throw abort reason instead of axios `CancelError`
-        // https://github.com/axios/axios/issues/5758
-        throw new Error(
-          typeof signal?.reason === 'string' ? signal.reason : 'cancelled',
-        );
-      }
-      throw error;
-    }
-  }
+  public constructor(public readonly filepath: string) {}
 
   public abstract getEntity(path: string): Promise<ProvidedEntity>;
 
@@ -86,4 +23,21 @@ export abstract class DataProviderApi {
   ): Promise<unknown>;
 
   public abstract getAttrValues(entity: Entity): Promise<AttributeValues>;
+
+  /**
+   * Provide an export URL for the given format and dataset/slice.
+   * The following return types are supported:
+   * - `URL`                  Provider has dedicated endpoint for generating server-side exports
+   * - `() => Promise<URL>`   Provider generates single-use export URLs (i.e. signed one-time tokens)
+   * - `() => Promise<Blob>`  Export is generated client-side
+   * - `undefined`            Export scenario is not supported
+   */
+  public getExportURL?<D extends Dataset<ArrayShape>>( // optional, so can't be abstract
+    format: ExportFormat,
+    dataset: D,
+    selection: string | undefined,
+    value: Value<D>,
+  ): ExportURL;
+
+  public getSearchablePaths?(path: string): Promise<string[]>; // optional, so can't be abstract
 }

--- a/packages/app/src/providers/h5grove/h5grove-api.ts
+++ b/packages/app/src/providers/h5grove/h5grove-api.ts
@@ -9,11 +9,12 @@ import type {
 } from '@h5web/shared/hdf5-models';
 import { DTypeClass } from '@h5web/shared/hdf5-models';
 import type { OnProgress } from '@h5web/shared/react-suspense-fetch';
-import type { AxiosRequestConfig } from 'axios';
+import type { AxiosInstance, AxiosRequestConfig } from 'axios';
+import axios from 'axios';
 
 import { DataProviderApi } from '../api';
 import type { ExportFormat, ExportURL, ValuesStoreParams } from '../models';
-import { handleAxiosError } from '../utils';
+import { createAxiosProgressHandler, processAxiosError } from '../utils';
 import type {
   H5GroveAttrValuesResponse,
   H5GroveDataResponse,
@@ -22,11 +23,13 @@ import type {
 } from './models';
 import {
   h5groveTypedArrayFromDType,
-  hasErrorMessage,
   parseEntity,
+  processFetchEntityError,
 } from './utils';
 
 export class H5GroveApi extends DataProviderApi {
+  private readonly client: AxiosInstance;
+
   /* API compatible with h5grove@2.1.0 */
   public constructor(
     url: string,
@@ -34,7 +37,13 @@ export class H5GroveApi extends DataProviderApi {
     axiosConfig?: AxiosRequestConfig,
     private readonly _getExportURL?: DataProviderApi['getExportURL'],
   ) {
-    super(filepath, { adapter: 'fetch', baseURL: url, ...axiosConfig });
+    super(filepath);
+
+    this.client = axios.create({
+      adapter: 'fetch',
+      baseURL: url,
+      ...axiosConfig,
+    });
   }
 
   public override async getEntity(path: string): Promise<ProvidedEntity> {
@@ -49,25 +58,36 @@ export class H5GroveApi extends DataProviderApi {
   ): Promise<H5GroveDataResponse> {
     const { dataset } = params;
 
-    if (dataset.type.class === DTypeClass.Opaque) {
-      return new Uint8Array(
-        await this.fetchBinaryData(params, signal, onProgress),
-      );
-    }
+    try {
+      if (dataset.type.class === DTypeClass.Opaque) {
+        return new Uint8Array(
+          await this.fetchBinaryData(params, signal, onProgress),
+        );
+      }
 
-    const DTypedArray = h5groveTypedArrayFromDType(dataset.type);
-    if (DTypedArray) {
-      const buffer = await this.fetchBinaryData(
-        params,
-        signal,
-        onProgress,
-        true,
-      );
-      const array = new DTypedArray(buffer);
-      return hasScalarShape(dataset) ? array[0] : array;
-    }
+      const DTypedArray = h5groveTypedArrayFromDType(dataset.type);
+      if (DTypedArray) {
+        const buffer = await this.fetchBinaryData(
+          params,
+          signal,
+          onProgress,
+          true,
+        );
+        const array = new DTypedArray(buffer);
+        return hasScalarShape(dataset) ? array[0] : array;
+      }
 
-    return this.fetchData(params, signal, onProgress);
+      return await this.fetchData(params, signal, onProgress);
+    } catch (error) {
+      throw processAxiosError(error, (axiosError) => {
+        return (
+          axios.isCancel(axiosError) &&
+          // Throw abort reason instead of axios `CancelError`
+          // https://github.com/axios/axios/issues/5758
+          (typeof signal?.reason === 'string' ? signal.reason : 'cancelled')
+        );
+      });
+    }
   }
 
   public override async getAttrValues(
@@ -114,32 +134,14 @@ export class H5GroveApi extends DataProviderApi {
   }
 
   private async fetchEntity(path: string): Promise<H5GroveEntityResponse> {
-    const { data } = await handleAxiosError(
-      () =>
-        this.client.get<H5GroveEntityResponse>(`/meta/`, { params: { path } }),
-      (_, errorData) => {
-        if (!hasErrorMessage(errorData)) {
-          return undefined;
-        }
-        const { message } = errorData;
-
-        if (message.includes('File not found')) {
-          return `File not found: '${this.filepath}'`;
-        }
-        if (message.includes('Permission denied')) {
-          return `Cannot read file '${this.filepath}': Permission denied`;
-        }
-        if (message.includes('not a valid path')) {
-          return `No entity found at ${path}`;
-        }
-        if (message.includes('Cannot resolve')) {
-          return `Could not resolve soft link at ${path}`;
-        }
-
-        return undefined;
-      },
-    );
-    return data;
+    try {
+      const { data } = await this.client.get<H5GroveEntityResponse>(`/meta/`, {
+        params: { path },
+      });
+      return data;
+    } catch (error) {
+      throw processFetchEntityError(error, path, this.filepath);
+    }
   }
 
   private async fetchAttrValues(
@@ -154,42 +156,38 @@ export class H5GroveApi extends DataProviderApi {
 
   private async fetchData(
     params: ValuesStoreParams,
-    signal?: AbortSignal,
-    onProgress?: OnProgress,
+    signal: AbortSignal | undefined,
+    onProgress: OnProgress | undefined,
   ): Promise<H5GroveDataResponse> {
-    const { data } = await this.cancellableFetchValue(
-      `/data/`,
-      {
+    const { data } = await this.client.get<H5GroveDataResponse>('/data/', {
+      params: {
         path: params.dataset.path,
         selection: params.selection,
         flatten: true,
       },
       signal,
-      onProgress,
-    );
-
+      onDownloadProgress: createAxiosProgressHandler(onProgress),
+    });
     return data;
   }
 
   private async fetchBinaryData(
     params: ValuesStoreParams,
-    signal?: AbortSignal,
-    onProgress?: OnProgress,
+    signal: AbortSignal | undefined,
+    onProgress: OnProgress | undefined,
     safe = false,
   ): Promise<ArrayBuffer> {
-    const { data } = await this.cancellableFetchValue(
-      '/data/',
-      {
+    const { data } = await this.client.get<ArrayBuffer>('/data/', {
+      responseType: 'arraybuffer',
+      params: {
         path: params.dataset.path,
         selection: params.selection,
         format: 'bin',
         dtype: safe ? 'safe' : undefined,
       },
       signal,
-      onProgress,
-      'arraybuffer',
-    );
-
+      onDownloadProgress: createAxiosProgressHandler(onProgress),
+    });
     return data;
   }
 }

--- a/packages/app/src/providers/h5grove/models.ts
+++ b/packages/app/src/providers/h5grove/models.ts
@@ -9,6 +9,10 @@ export type H5GroveDataResponse = unknown;
 export type H5GroveAttrValuesResponse = AttributeValues;
 export type H5GrovePathsResponse = string[];
 
+export interface H5GroveErrorResponse {
+  message: string;
+}
+
 export type H5GroveEntity =
   | H5GroveGroup
   | H5GroveDataset

--- a/packages/app/src/providers/h5grove/utils.ts
+++ b/packages/app/src/providers/h5grove/utils.ts
@@ -24,7 +24,7 @@ import {
 } from '@h5web/shared/hdf5-utils';
 import type { TypedArrayConstructor } from '@h5web/shared/vis-models';
 
-import { processAxiosError, typedArrayFromDType } from '../utils';
+import { typedArrayFromDType } from '../utils';
 import type {
   H5GroveAttribute,
   H5GroveEntity,
@@ -134,46 +134,15 @@ function parseAttributes(attrsMetadata: H5GroveAttribute[]): Attribute[] {
   }));
 }
 
-function isH5GroveError(payload: unknown): payload is H5GroveErrorResponse {
+export function isH5GroveError(
+  payload: unknown,
+): payload is H5GroveErrorResponse {
   return (
     !!payload &&
     typeof payload === 'object' &&
     'message' in payload &&
     typeof payload.message === 'string'
   );
-}
-
-export function processFetchEntityError(
-  error: unknown,
-  entityPath: string,
-  filePath: string,
-): unknown {
-  return processAxiosError(error, (axiosError) => {
-    if (!axiosError.response) {
-      return undefined;
-    }
-
-    const { data } = axiosError.response;
-    if (!isH5GroveError(data)) {
-      return undefined;
-    }
-
-    const { message } = data;
-    if (message.includes('File not found')) {
-      return `File not found: '${filePath}'`;
-    }
-    if (message.includes('Permission denied')) {
-      return `Cannot read file '${filePath}': Permission denied`;
-    }
-    if (message.includes('not a valid path')) {
-      return `No entity found at ${entityPath}`;
-    }
-    if (message.includes('Cannot resolve')) {
-      return `Could not resolve soft link at ${entityPath}`;
-    }
-
-    return undefined;
-  });
 }
 
 export function parseDType(type: H5GroveType): DType {

--- a/packages/app/src/providers/utils.ts
+++ b/packages/app/src/providers/utils.ts
@@ -8,7 +8,6 @@ import type {
 import { DTypeClass } from '@h5web/shared/hdf5-models';
 import type { OnProgress } from '@h5web/shared/react-suspense-fetch';
 import type { AxiosProgressEvent } from 'axios';
-import { AxiosError } from 'axios';
 
 import type { DataProviderApi } from './api';
 
@@ -75,20 +74,6 @@ export async function getValueOrError(
   } catch (error) {
     return error;
   }
-}
-
-export function processAxiosError(
-  error: unknown,
-  getMessageToThrow: (error: AxiosError) => string | false | undefined,
-): unknown {
-  if (error instanceof AxiosError) {
-    const messageToThrow = getMessageToThrow(error);
-    if (messageToThrow) {
-      return new Error(messageToThrow, { cause: error });
-    }
-  }
-
-  return error;
 }
 
 export function createAxiosProgressHandler(onProgress: OnProgress | undefined) {

--- a/packages/app/src/providers/utils.ts
+++ b/packages/app/src/providers/utils.ts
@@ -6,31 +6,13 @@ import type {
   ScalarShape,
 } from '@h5web/shared/hdf5-models';
 import { DTypeClass } from '@h5web/shared/hdf5-models';
+import type { OnProgress } from '@h5web/shared/react-suspense-fetch';
+import type { AxiosProgressEvent } from 'axios';
 import { AxiosError } from 'axios';
 
 import type { DataProviderApi } from './api';
 
 export const CANCELLED_ERROR_MSG = 'Request cancelled';
-
-export async function handleAxiosError<T>(
-  func: () => Promise<T>,
-  getErrorToThrow: (status: number, errorData: unknown) => string | undefined,
-): Promise<T> {
-  try {
-    return await func();
-  } catch (error) {
-    if (error instanceof AxiosError && error.response) {
-      const { status, data } = error.response;
-      const errorToThrow = getErrorToThrow(status, data);
-
-      if (errorToThrow) {
-        throw new Error(errorToThrow);
-      }
-    }
-
-    throw error;
-  }
-}
 
 export function typedArrayFromDType(dtype: DType) {
   if (isEnumType(dtype)) {
@@ -93,4 +75,29 @@ export async function getValueOrError(
   } catch (error) {
     return error;
   }
+}
+
+export function processAxiosError(
+  error: unknown,
+  getMessageToThrow: (error: AxiosError) => string | false | undefined,
+): unknown {
+  if (error instanceof AxiosError) {
+    const messageToThrow = getMessageToThrow(error);
+    if (messageToThrow) {
+      return new Error(messageToThrow, { cause: error });
+    }
+  }
+
+  return error;
+}
+
+export function createAxiosProgressHandler(onProgress: OnProgress | undefined) {
+  return (
+    onProgress &&
+    ((evt: AxiosProgressEvent) => {
+      if (evt.total !== undefined && evt.total > 0) {
+        onProgress(evt.loaded / evt.total);
+      }
+    })
+  );
 }


### PR DESCRIPTION
In this PR, I'm finally removing the `cancellableFetchValue` method from the `DataProviderApi` base class. This method made little sense ever since the arrival of h5wasm, which doesn't require making HTTP requests at all.

This should get rid of `axios` from consumer bundles that use `H5WasmBufferProvider` or `H5WasmLocalFileProvider`. It also means that if we expose `DataProviderApi` in the future, consumers may be able to develop their own network-based provider without having to use `axios` as the fetching library.

So it's now up to `H5GroveProvider` and `HsdsProvider` to initialise and use their own axios client. I had to refactor axios error handling a bit to make this a bit more palatable, but  overall I find the result less convoluted than before. I especially like that the `DataProviderApi` base class no longer has any method implementations.