### PR TITLE
Enforce stricter types for formatters in `MappedMatrixVis`

### DIFF
--- a/packages/app/src/vis-packs/core/compound/MappedCompoundVis.tsx
+++ b/packages/app/src/vis-packs/core/compound/MappedCompoundVis.tsx
@@ -14,7 +14,7 @@ import visualizerStyles from '../../../visualizer/Visualizer.module.css';
 import { useMappedArray, useSlicedDimsAndMapping } from '../hooks';
 import type { MatrixVisConfig } from '../matrix/config';
 import MatrixToolbar from '../matrix/MatrixToolbar';
-import { getCellWidth, getFormatter } from '../matrix/utils';
+import { getCellFormatter, getCellWidth } from '../matrix/utils';
 import { getSliceSelection } from '../utils';
 
 interface Props {
@@ -46,7 +46,7 @@ function MappedCompoundVis(props: Props) {
   );
 
   const fieldFormatters = Object.values(fields).map((field) =>
-    getFormatter(field, notation),
+    getCellFormatter(mappedArray, field, notation),
   );
 
   const { getExportURL } = useDataContext();
@@ -70,9 +70,7 @@ function MappedCompoundVis(props: Props) {
       <MatrixVis
         className={visualizerStyles.vis}
         dims={mappedArray.shape}
-        cellFormatter={(row, col) =>
-          fieldFormatters[col](mappedArray.get(row, col))
-        }
+        cellFormatter={(row, col) => fieldFormatters[col](row, col)}
         cellWidth={customCellWidth ?? cellWidth}
         columnHeaders={fieldNames}
         sticky={sticky}

--- a/packages/app/src/vis-packs/core/matrix/MappedMatrixVis.tsx
+++ b/packages/app/src/vis-packs/core/matrix/MappedMatrixVis.tsx
@@ -14,7 +14,7 @@ import { useMappedArray, useSlicedDimsAndMapping } from '../hooks';
 import { getSliceSelection } from '../utils';
 import type { MatrixVisConfig } from './config';
 import MatrixToolbar from './MatrixToolbar';
-import { getCellWidth, getFormatter } from './utils';
+import { getCellFormatter, getCellWidth } from './utils';
 
 interface Props {
   dataset: Dataset<ArrayShape, PrintableType>;
@@ -32,7 +32,7 @@ function MappedMatrixVis(props: Props) {
   const [slicedDims, slicedMapping] = useSlicedDimsAndMapping(dims, dimMapping);
   const mappedArray = useMappedArray(value, slicedDims, slicedMapping);
 
-  const formatter = getFormatter(type, notation);
+  const cellFormatter = getCellFormatter(mappedArray, type, notation);
   const cellWidth = getCellWidth(type);
 
   const { getExportURL } = useDataContext();
@@ -57,9 +57,7 @@ function MappedMatrixVis(props: Props) {
       <MatrixVis
         className={visualizerStyles.vis}
         dims={mappedArray.shape}
-        cellFormatter={(row: number, col: number) =>
-          formatter(mappedArray.get(row, col))
-        }
+        cellFormatter={cellFormatter}
         cellWidth={customCellWidth ?? cellWidth}
         sticky={sticky}
       />

--- a/packages/shared/src/guards.ts
+++ b/packages/shared/src/guards.ts
@@ -2,6 +2,7 @@ import type { Data, NdArray, TypedArray } from 'ndarray';
 
 import type {
   ArrayShape,
+  ArrayValue,
   BooleanType,
   ComplexArray,
   ComplexType,
@@ -435,6 +436,15 @@ function assertPrimitiveValue<T extends DType>(
     assertComplex(value);
   } else if (isCompoundType(type)) {
     assertArray(value);
+  }
+}
+
+export function assertNdArrayValue<T extends DType>(
+  type: T,
+  value: NdArray<unknown[] | TypedArray>,
+): asserts value is NdArray<ArrayValue<T>> {
+  if (value.data.length > 0) {
+    assertPrimitiveValue(type, value.data[0]);
   }
 }
 


### PR DESCRIPTION
Follows #1702 

As planned, the problem became much simpler: all the typing complexity related to formatters in `MappedMatrixVis` can now be moved into the `getFormatter` utility function, now called `getCellFormatter`.

I add a type guard called `assertNdArrayValue` that allows narrowing down an `NdArray` given an already narrowed-down `DType`. After this type guard, `dataArray.get(row, col)` is properly typed and we can pass the value to a strictly typed formatter without any casting.

I'll do something similar in `ScalarVis`.

---

The broader issue is that every time we narrow down a dataset object (e.g. `Dataset<ArrayShape, PrintableType>` => `Dataset<ArrayShape, EnumType>`), we have to narrow down the value right after with `assertArrayValue`/`assertNdArrayValue`/`assertPrimitiveValue` (e.g. `ArrayValue<PrintableType>` => `ArrayValue<EnumType>`). This is because we don't store dataset values within dataset objects. Maybe I'll try to tackle this one day.