### PR TITLE
Assert compound values

### DIFF
--- a/packages/app/src/vis-packs/core/compound/MappedCompoundVis.tsx
+++ b/packages/app/src/vis-packs/core/compound/MappedCompoundVis.tsx
@@ -1,8 +1,9 @@
 import { MatrixVis } from '@h5web/lib';
 import type {
   ArrayShape,
+  CompoundType,
   Dataset,
-  PrintableCompoundType,
+  PrintableType,
   ScalarShape,
   Value,
 } from '@h5web/shared/hdf5-models';
@@ -18,7 +19,7 @@ import { getCellWidth, getFormatter } from '../matrix/utils';
 import { getSliceSelection } from '../utils';
 
 interface Props {
-  dataset: Dataset<ScalarShape | ArrayShape, PrintableCompoundType>;
+  dataset: Dataset<ScalarShape | ArrayShape, CompoundType<PrintableType>>;
   value: Value<Props['dataset']>;
   dimMapping: DimensionMapping;
   toolbarContainer: HTMLDivElement | undefined;

--- a/packages/app/src/vis-packs/core/matrix/utils.ts
+++ b/packages/app/src/vis-packs/core/matrix/utils.ts
@@ -8,8 +8,8 @@ import {
 import type {
   BooleanType,
   ComplexType,
+  CompoundType,
   NumericType,
-  PrintableCompoundType,
   PrintableType,
 } from '@h5web/shared/hdf5-models';
 import { DTypeClass } from '@h5web/shared/hdf5-models';
@@ -69,7 +69,7 @@ export function getFormatter(
 }
 
 export function getCellWidth(
-  type: PrintableType | PrintableCompoundType,
+  type: PrintableType | CompoundType<PrintableType>,
 ): number {
   if (type.class === DTypeClass.Compound) {
     return Math.max(...Object.values(type.fields).map(getCellWidth));

--- a/packages/shared/src/guards.ts
+++ b/packages/shared/src/guards.ts
@@ -17,7 +17,6 @@ import type {
   NumericLikeType,
   NumericType,
   Primitive,
-  PrintableCompoundType,
   PrintableType,
   ScalarShape,
   Shape,
@@ -401,14 +400,14 @@ export function assertCompoundType<S extends Shape>(
 
 export function hasPrintableCompoundType<S extends Shape>(
   dataset: Dataset<S, CompoundType>,
-): dataset is Dataset<S, PrintableCompoundType> {
+): dataset is Dataset<S, CompoundType<PrintableType>> {
   const { fields } = dataset.type;
   return Object.values(fields).every((f) => PRINTABLE_DTYPES.has(f.class));
 }
 
 export function assertPrintableCompoundType<S extends Shape>(
   dataset: Dataset<S, CompoundType>,
-): asserts dataset is Dataset<S, PrintableCompoundType> {
+): asserts dataset is Dataset<S, CompoundType<PrintableType>> {
   if (!hasPrintableCompoundType(dataset)) {
     throw new Error('Expected compound dataset to have printable types');
   }
@@ -435,6 +434,9 @@ function assertPrimitiveValue<T extends DType>(
     assertComplex(value);
   } else if (isCompoundType(type)) {
     assertArray(value);
+    Object.values(type.fields).forEach((fieldType, index) => {
+      assertPrimitiveValue(fieldType, value[index]);
+    });
   }
 }
 

--- a/packages/shared/src/hdf5-models.ts
+++ b/packages/shared/src/hdf5-models.ts
@@ -157,14 +157,10 @@ export interface StringType {
   length?: number;
 }
 
-export interface CompoundType<
-  F extends Record<string, DType> = Record<string, DType>,
-> {
+export interface CompoundType<T extends DType = DType> {
   class: DTypeClass.Compound;
-  fields: F;
+  fields: Record<string, T>;
 }
-
-export type PrintableCompoundType = CompoundType<Record<string, PrintableType>>;
 
 export interface ArrayType<T extends DType = DType> {
   class: DTypeClass.Array | DTypeClass.VLen;
@@ -211,13 +207,13 @@ export type Primitive<T extends DType> = T extends NumericType | EnumType
       ? number | boolean // let providers choose
       : T extends ComplexType
         ? H5WebComplex
-        : T extends PrintableCompoundType
-          ? Primitive<PrintableType>[]
+        : T extends CompoundType<infer TFields>
+          ? Primitive<TFields>[]
           : unknown;
 
 export type ArrayValue<T extends DType> =
   | Primitive<T>[]
-  | (T extends NumericType | BooleanType | EnumType ? TypedArray : never);
+  | (T extends NumericLikeType ? TypedArray : never);
 
 export type Value<D extends Dataset> =
   D extends Dataset<infer S, infer T>

--- a/packages/shared/src/hdf5-utils.ts
+++ b/packages/shared/src/hdf5-utils.ts
@@ -109,19 +109,17 @@ export function cplxType(
   return { class: DTypeClass.Complex, realType, imagType };
 }
 
-export function compoundType<F extends Record<string, DType>>(
-  fields: F,
-): CompoundType<F> {
+export function compoundType<T extends DType>(
+  fields: Record<string, T>,
+): CompoundType<T> {
   return { class: DTypeClass.Compound, fields };
 }
 
-export const printableCompoundType = compoundType<
-  Record<string, PrintableType>
->;
+export const printableCompoundType = compoundType<PrintableType>;
 
-export function compoundOrCplxType<F extends Record<string, DType>>(
-  fields: F,
-): CompoundType<F> | ComplexType {
+export function compoundOrCplxType<T extends DType>(
+  fields: Record<string, T>,
+): CompoundType<T> | ComplexType {
   const { r, i } = fields;
   if (r && isNumericType(r) && i && isNumericType(i)) {
     return cplxType(r, i);


### PR DESCRIPTION
`Primitive<PrintableCompoundType>` resolves to `(string | number | boolean | H5WebComplex)[]` but we weren't actually asserting for this fully in `assertPrimitiveValue`. I'm correcting this and also generalising things a bit:

- Resolve `Primitive<CompoundType>` to `unknown[]` instead of `unknown` (to match the existing array assertion in `assertPrimitiveValue`)
- Change the generic of `CompoundType` to extend `DType` instead of `Record<string, DType>` to simplify usage (notably when inferring the generic in `Primitive`) and to remove the need for `PrintableCompoundType` (now replaced with just `CompoundType<PrintableType>`)