### PR TITLE
Pass formatted value to `ScalarVis`

### DIFF
--- a/packages/app/src/vis-packs/core/scalar/ScalarVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/scalar/ScalarVisContainer.tsx
@@ -26,8 +26,7 @@ function ScalarVisContainer(props: VisContainerProps) {
         render={(value) => (
           <ScalarVis
             className={visualizerStyles.vis}
-            value={value}
-            formatter={formatter}
+            value={formatter(value)}
           />
         )}
       />

--- a/packages/lib/src/vis/scalar/ScalarVis.tsx
+++ b/packages/lib/src/vis/scalar/ScalarVis.tsx
@@ -1,19 +1,16 @@
-import type { Primitive, PrintableType } from '@h5web/shared/hdf5-models';
-
 import type { ClassStyleAttrs } from '../models';
 import styles from './ScalarVis.module.css';
 
 interface Props extends ClassStyleAttrs {
-  value: Primitive<PrintableType>;
-  formatter: (value: Primitive<PrintableType>) => string;
+  value: string;
 }
 
 function ScalarVis(props: Props) {
-  const { value, formatter, className = '', style } = props;
+  const { value, className = '', style } = props;
 
   return (
     <div className={`${styles.root} ${className}`} style={style}>
-      <pre className={styles.scalar}>{formatter(value)}</pre>
+      <pre className={styles.scalar}>{value}</pre>
     </div>
   );
 }


### PR DESCRIPTION
Following #1702, I now pass a formatted value to `ScalarVis` to remove the risk of passing a formatter that doesn't match the type of the value. An alternative would have been to add a generic to the `Props` interface of `ScalarVis` (which would have probably worked, unlike when I tried it with `MatrixVis` because of ndarray), but I honestly don't see the benefit of calling `formatter` inside `ScalarVis` anymore. It's a misdirection that also unnecessarily restricts the types of values that can be formatted and displayed.

**Breaking change** `[ScalarVis]` Remove prop `formatter` and change type of prop `value` to accept only strings. Typical refactoring:

```tsx
// BEFORE
<ScalarVis value={true} formatter={(val /* number | string | ... */ => (val as boolean).toString()} />
<ScalarVis value={bool} formatter={unsafeFormatBool} />

// AFTER
<ScalarVis value="true" />
<ScalarVis value={safeFormatBool(bool)} />
```