### PR TITLE
Parse metadata of committed datatypes with h5grove

### DIFF
--- a/packages/app/src/providers/h5grove/models.ts
+++ b/packages/app/src/providers/h5grove/models.ts
@@ -1,8 +1,4 @@
-import type {
-  AttributeValues,
-  EntityKind,
-  Filter,
-} from '@h5web/shared/hdf5-models';
+import type { AttributeValues, Filter } from '@h5web/shared/hdf5-models';
 
 export type H5GroveEntityResponse = H5GroveEntity;
 export type H5GroveDataResponse = unknown;
@@ -16,6 +12,7 @@ export interface H5GroveErrorResponse {
 export type H5GroveEntity =
   | H5GroveGroup
   | H5GroveDataset
+  | H5GroveDatatype
   | H5GroveSoftLink
   | H5GroveExternalLink;
 
@@ -25,17 +22,23 @@ export interface H5GroveBaseEntity {
 }
 
 export interface H5GroveGroup extends H5GroveBaseEntity {
-  kind: EntityKind.Group;
+  kind: 'group';
   children?: H5GroveEntity[];
   attributes: H5GroveAttribute[];
 }
 
 export interface H5GroveDataset extends H5GroveBaseEntity {
-  kind: EntityKind.Dataset;
+  kind: 'dataset';
   shape: number[];
   type: H5GroveType;
   chunks: number[] | null;
   filters: Filter[] | null;
+  attributes: H5GroveAttribute[];
+}
+
+export interface H5GroveDatatype extends H5GroveBaseEntity {
+  kind: 'datatype';
+  type: H5GroveType;
   attributes: H5GroveAttribute[];
 }
 

--- a/packages/app/src/providers/h5grove/utils.ts
+++ b/packages/app/src/providers/h5grove/utils.ts
@@ -52,7 +52,7 @@ export function parseEntity(
   const { name } = h5gEntity;
   const baseEntity = { name, path };
 
-  if (h5gEntity.kind === EntityKind.Group) {
+  if (h5gEntity.kind === 'group') {
     const { children = [], attributes: attrsMetadata } = h5gEntity;
     const attributes = parseAttributes(attrsMetadata);
     const baseGroup: Group = {
@@ -74,7 +74,7 @@ export function parseEntity(
     };
   }
 
-  if (h5gEntity.kind === EntityKind.Dataset) {
+  if (h5gEntity.kind === 'dataset') {
     const {
       attributes: attrsMetadata,
       type,
@@ -90,6 +90,17 @@ export function parseEntity(
       rawType: type,
       ...(chunks && { chunks }),
       ...(filters && { filters }),
+      attributes: parseAttributes(attrsMetadata),
+    };
+  }
+
+  if (h5gEntity.kind === 'datatype') {
+    const { attributes: attrsMetadata, type } = h5gEntity;
+    return {
+      ...baseEntity,
+      kind: EntityKind.Datatype,
+      type: parseDType(type),
+      rawType: type,
       attributes: parseAttributes(attrsMetadata),
     };
   }


### PR DESCRIPTION
[h5grove@2.3.0](https://github.com/silx-kit/h5grove/releases/tag/v2.3.0) now returns the metadata of committed datatypes, so we just need to parse it.

![image](https://github.com/user-attachments/assets/94235d09-2587-4f55-9573-6bc722963f25)

With this PR, committed datatypes are now fully supported in all providers, which fixes #1699.