### PR TITLE
Fix jitter when resizing explorer sidebar on Matrix vis

### DIFF
--- a/packages/lib/src/toolbar/controls/CellWidthInput.module.css
+++ b/packages/lib/src/toolbar/controls/CellWidthInput.module.css
@@ -6,6 +6,7 @@
 .label {
   color: var(--h5w-toolbar-label--color, royalblue);
   margin: 0 0.25rem;
+  white-space: nowrap;
 }
 
 .input {

--- a/packages/lib/src/toolbar/controls/Selector/Selector.module.css
+++ b/packages/lib/src/toolbar/controls/Selector/Selector.module.css
@@ -5,6 +5,7 @@
     --h5w-selector-label--color,
     var(--h5w-toolbar-label--color, royalblue)
   );
+  white-space: nowrap;
 }
 
 .groups {

--- a/packages/lib/src/vis/matrix/MatrixVis.module.css
+++ b/packages/lib/src/vis/matrix/MatrixVis.module.css
@@ -1,6 +1,7 @@
 .wrapper {
   flex: 1; /* fill height if inside flex container in consumer app */
   position: relative;
+  overflow: hidden; /* when resizing */
 }
 
 .grid {


### PR DESCRIPTION
This fixes two jittering issues when resizing the explorer sidebar:

- Some control labels would sometimes wrap onto two lines. I noticed this with the _Cell width_ control on the _Matrix_ vis, but the same could most likely happen with `Selector` labels. I now prevent wrapping in both cases.
- The _Matrix_ visualization would overflow and cause sidebars to appear and disappear quickly.

| BEFORE | AFTER |
| --- | --- |
| ![matrix-resize-jitter](https://github.com/user-attachments/assets/89b5b1bc-a89d-45cb-9ab3-e89b156efb9b) | ![matrix-resize-jitter-fixed](https://github.com/user-attachments/assets/a9dfa596-9c28-4a1b-855f-b8557a9a00d7) |