### PR TITLE
Change image mock dataset attr

### DIFF
--- a/packages/shared/src/mock-utils.ts
+++ b/packages/shared/src/mock-utils.ts
@@ -88,7 +88,7 @@ export function withAttr<T extends Entity>(
 export function withImageAttr<T extends Entity>(entity: T): T {
   return withAttr(entity, [
     scalarAttr('CLASS', 'IMAGE'),
-    scalarAttr('IMAGE_VERSION', '1.2'),
+    scalarAttr('IMAGE_SUBCLASS', 'IMAGE_TRUECOLOR'),
   ]);
 }
 


### PR DESCRIPTION
`IMAGE_VERSION` is actually not checked/relevant

The only thing we check is that `CLASS` is `IMAGE` and that if there is a `IMAGE_SUBCLASS` attribute, it is equal to `IMAGE_TRUECOLOR`.