### PR TITLE
Let each project lint its own setup files

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -84,18 +84,20 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.local
-          key: poetry-0 # increment to reset cache
+          key: poetry-1 # increment to reset cache
 
       - name: Install Poetry 📜
         if: steps.poetry.outputs.cache-hit != 'true'
         uses: snok/install-poetry@v1
+        with:
+          version: 1.8.5
 
       - name: Restore Poetry environments 📌
         id: poetry-venvs
         uses: actions/cache@v4
         with:
           path: ~/.cache/pypoetry/virtualenvs
-          key: poetry-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-1 # increment to reset cache
+          key: poetry-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-3 # increment to reset cache
 
       - name: Create Poetry environments 📜
         if: steps.poetry-venvs.outputs.cache-hit != 'true'

--- a/apps/demo/tsconfig.json
+++ b/apps/demo/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src"]
+  "include": ["*", "src"]
 }

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": [".storybook/**/*", "src"]
+  "include": ["*", ".storybook/**/*", "src"]
 }

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "extends": "../tsconfig.json",
+  "include": ["*", "e2e"],
   "compilerOptions": {
     "isolatedModules": false,
     "sourceMap": false,
@@ -8,6 +9,5 @@
       "@testing-library/cypress",
       "@simonsmith/cypress-image-snapshot/types"
     ]
-  },
-  "include": ["*", "e2e"]
+  }
 }

--- a/packages/app/tsconfig.build.json
+++ b/packages/app/tsconfig.build.json
@@ -1,5 +1,6 @@
 {
   "extends": "./tsconfig.json",
+  "include": ["src"],
   "exclude": ["**/*.test.ts"],
   "compilerOptions": {
     "rootDir": "src",

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src"]
+  "include": ["*", "src"]
 }

--- a/packages/h5wasm/tsconfig.build.json
+++ b/packages/h5wasm/tsconfig.build.json
@@ -1,5 +1,6 @@
 {
   "extends": "./tsconfig.json",
+  "include": ["src"],
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist-ts",

--- a/packages/h5wasm/tsconfig.json
+++ b/packages/h5wasm/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src"]
+  "include": ["*", "src"]
 }

--- a/packages/lib/tsconfig.build.json
+++ b/packages/lib/tsconfig.build.json
@@ -1,5 +1,6 @@
 {
   "extends": "./tsconfig.json",
+  "include": ["src"],
   "exclude": ["**/*.test.ts"],
   "compilerOptions": {
     "rootDir": "src",

--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src"]
+  "include": ["*", "src"]
 }

--- a/packages/shared/tsconfig.build.json
+++ b/packages/shared/tsconfig.build.json
@@ -1,5 +1,6 @@
 {
   "extends": "./tsconfig.json",
+  "include": ["src"],
   "exclude": ["**/*.test.ts"],
   "compilerOptions": {
     "rootDir": "src",

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src"]
+  "include": ["*", "src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,5 +26,5 @@
     "useDefineForClassFields": true,
     "useUnknownInCatchVariables": true
   },
-  "include": ["*", "cypress", "apps/*/*", "packages/*/*"]
+  "include": ["*", "cypress"]
 }


### PR DESCRIPTION
The migration from the Galex ESLint config to our own config is pretty much ready, but I'm going to make a couple of preparatory PRs to ease the review...

This is the first one to:

- Pin Poetry in the CI (there are breaking changes in [v2](https://github.com/python-poetry/poetry/releases))
- Prepare each project to lint its own JS/TS setup files (e.g. `packages/shared/rollup.utils`) instead of doing this from the root of the monorepo.