### PR TITLE
Make log ticks formatter selection logic more robust

### DIFF
--- a/packages/lib/src/vis/utils.ts
+++ b/packages/lib/src/vis/utils.ts
@@ -278,8 +278,15 @@ export function getTickFormatter(
   }
 
   // If available size allows for all log ticks to be rendered without overlap, use default formatter
-  const [min, max] = domain[0] > 0 ? domain : [-domain[1], -domain[0]];
   const threshold = adaptedLogTicksThreshold(availableSize);
+
+  /* In log scale, domain is either fully positive or fully negative
+   * (otherwise, it's `[NaN, NaN]` and it doesn't matter which formatter we use).
+   * If fully negative, convert to fully positive for threshold logic to work. */
+  const absDomain = domain.map(Math.abs) as Domain;
+  absDomain.sort((a, b) => a - b);
+
+  const [min, max] = absDomain;
   if (max / min < 10 ** threshold) {
     return formatTick;
   }


### PR DESCRIPTION
As explained in https://github.com/silx-kit/h5web/pull/1726#discussion_r1916192752, the log ticks formatter selection logic doesn't work when the domain array is in the wrong order (`[max, min]` instead of `[min, max]`). Ideally this shouldn't happen, and I'll investigate the idea of asserting `min < max` in `VisCanvas`.

Regardless, I'm not happy with the domain-flipping logic `const [min, max] = domain[0] > 0 ? domain : [-domain[1], -domain[0]];`. In this PR, I refactor it so it's more robust and explain why we need it at all in a comment. The new logic works with `[max, min]`, because why not:

| BEFORE | AFTER |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/72ecb8cd-ab71-46c0-a978-cfd08c185f4e) | ![image](https://github.com/user-attachments/assets/f2bb3352-a3a6-42fa-beb2-4b6f1873e87e) |
