### PR TITLE
Fix support for enum/bool auxiliary signals in NX Line visualization

### DIFF
--- a/packages/app/src/providers/mock/mock-file.ts
+++ b/packages/app/src/providers/mock/mock-file.ts
@@ -284,11 +284,21 @@ export function makeMockFile(): GroupWithChildren {
           }),
           nxGroup('numeric-like', 'NXprocess', {
             children: [
-              nxData('bool', { signal: array('twoD_bool') }),
+              nxData('bool', {
+                signal: array('twoD_bool'),
+                auxiliary: { secondary_bool: array('secondary_bool') },
+                auxAttr: ['secondary_bool'],
+              }),
               nxData('enum', {
                 signal: array('twoD_enum', {
                   type: enumType(intType(false, 8), ENUM_MAPPING),
                 }),
+                auxiliary: {
+                  secondary_enum: array('secondary_enum', {
+                    type: enumType(intType(false, 8), ENUM_MAPPING),
+                  }),
+                },
+                auxAttr: ['secondary_enum'],
               }),
             ],
           }),

--- a/packages/app/src/vis-packs/core/hooks.ts
+++ b/packages/app/src/vis-packs/core/hooks.ts
@@ -4,6 +4,7 @@ import {
   type ArrayShape,
   type ArrayValue,
   type Dataset,
+  type NumericLikeType,
   type ScalarShape,
   type Value,
 } from '@h5web/shared/hdf5-models';
@@ -24,6 +25,12 @@ import {
 } from './utils';
 
 export const useToNumArray = createMemo(toNumArray);
+
+export function useToNumArrays(
+  arrays: ArrayValue<NumericLikeType>[],
+): NumArray[] {
+  return useMemo(() => arrays.map(toNumArray), arrays); // eslint-disable-line react-hooks/exhaustive-deps
+}
 
 export function useValuesInCache(
   ...datasets: (Dataset<ScalarShape | ArrayShape> | undefined)[]
@@ -129,23 +136,23 @@ export function useMappedArray(
   return useMemo(() => applyMapping(baseArray, mapping), [baseArray, mapping]);
 }
 
-export function useMappedArrays(
-  values: NumArray[],
+export function useMappedArrays<T extends ArrayValue>(
+  values: T[],
   dims: number[],
   mapping: DimensionMapping,
-): NdArray<NumArray>[];
+): NdArray<T>[];
+
+export function useMappedArrays<T extends ArrayValue>(
+  values: (T | undefined)[],
+  dims: number[],
+  mapping: DimensionMapping,
+): (NdArray<T> | undefined)[];
 
 export function useMappedArrays(
-  values: (NumArray | undefined)[],
+  values: (ArrayValue | undefined)[],
   dims: number[],
   mapping: DimensionMapping,
-): (NdArray<NumArray> | undefined)[];
-
-export function useMappedArrays(
-  values: (NumArray | undefined)[],
-  dims: number[],
-  mapping: DimensionMapping,
-): (NdArray<NumArray> | undefined)[] {
+): (NdArray<ArrayValue> | undefined)[] {
   const baseArrays = useMemo(
     () => values.map((arr) => getBaseArray(arr, dims)),
     [dims, ...values], // eslint-disable-line react-hooks/exhaustive-deps

--- a/packages/app/src/vis-packs/nexus/NxSignalPicker.tsx
+++ b/packages/app/src/vis-packs/nexus/NxSignalPicker.tsx
@@ -1,14 +1,19 @@
-import { type ComplexType, type NumericType } from '@h5web/shared/hdf5-models';
+import {
+  type ComplexType,
+  type NumericLikeType,
+} from '@h5web/shared/hdf5-models';
 
 import { type DatasetDef } from './models';
 import styles from './NxSignalPicker.module.css';
 
-interface Props<T extends NumericType | ComplexType> {
+interface Props<T extends NumericLikeType | ComplexType> {
   definitions: DatasetDef<T>[];
   onChange: (def: DatasetDef<T>) => void;
 }
 
-function NxSignalPicker<T extends NumericType | ComplexType>(props: Props<T>) {
+function NxSignalPicker<T extends NumericLikeType | ComplexType>(
+  props: Props<T>,
+) {
   const { definitions, onChange } = props;
 
   return (

--- a/packages/app/src/vis-packs/nexus/NxValuesFetcher.tsx
+++ b/packages/app/src/vis-packs/nexus/NxValuesFetcher.tsx
@@ -1,4 +1,7 @@
-import { type ComplexType, type NumericType } from '@h5web/shared/hdf5-models';
+import {
+  type ComplexType,
+  type NumericLikeType,
+} from '@h5web/shared/hdf5-models';
 import { type ReactNode } from 'react';
 
 import {
@@ -8,13 +11,15 @@ import {
 } from '../core/hooks';
 import { type NxData, type NxValues } from './models';
 
-interface Props<T extends NumericType | ComplexType> {
+interface Props<T extends NumericLikeType | ComplexType> {
   nxData: NxData<T>;
   selection?: string; // for slice-by-slice fetching
   render: (val: NxValues<T>) => ReactNode;
 }
 
-function NxValuesFetcher<T extends NumericType | ComplexType>(props: Props<T>) {
+function NxValuesFetcher<T extends NumericLikeType | ComplexType>(
+  props: Props<T>,
+) {
   const { nxData, selection, render } = props;
   const { signalDef, axisDefs, auxDefs, titleDataset } = nxData;
 

--- a/packages/app/src/vis-packs/nexus/guards.ts
+++ b/packages/app/src/vis-packs/nexus/guards.ts
@@ -2,27 +2,52 @@ import {
   assertComplexType,
   assertNumericLikeType,
   assertNumericType,
+  isDefined,
 } from '@h5web/shared/guards';
-import { type ComplexType, type NumericType } from '@h5web/shared/hdf5-models';
+import {
+  type ComplexType,
+  type NumericLikeType,
+  type NumericType,
+} from '@h5web/shared/hdf5-models';
 
 import { type NxData } from './models';
 
 export function assertNumericLikeNxData(
   nxData: NxData,
-): asserts nxData is NxData<NumericType> {
-  const { signalDef, auxDefs } = nxData;
+): asserts nxData is NxData<NumericLikeType> {
+  const { signalDef, auxDefs, axisDefs } = nxData;
+
   assertNumericLikeType(signalDef.dataset);
+
   auxDefs.forEach((def) => {
     assertNumericLikeType(def.dataset);
+  });
+
+  if (signalDef.errorDataset) {
+    assertNumericType(signalDef.errorDataset);
+  }
+
+  axisDefs.filter(isDefined).forEach((def) => {
+    assertNumericType(def.dataset);
   });
 }
 
 export function assertNumericNxData(
   nxData: NxData,
 ): asserts nxData is NxData<NumericType> {
-  const { signalDef, auxDefs } = nxData;
+  const { signalDef, auxDefs, axisDefs } = nxData;
+
   assertNumericType(signalDef.dataset);
+
   auxDefs.forEach((def) => {
+    assertNumericType(def.dataset);
+  });
+
+  if (signalDef.errorDataset) {
+    assertNumericType(signalDef.errorDataset);
+  }
+
+  axisDefs.filter(isDefined).forEach((def) => {
     assertNumericType(def.dataset);
   });
 }
@@ -30,9 +55,19 @@ export function assertNumericNxData(
 export function assertComplexNxData(
   nxData: NxData,
 ): asserts nxData is NxData<ComplexType> {
-  const { signalDef, auxDefs } = nxData;
+  const { signalDef, auxDefs, axisDefs } = nxData;
+
   assertComplexType(signalDef.dataset);
+
   auxDefs.forEach((def) => {
     assertComplexType(def.dataset);
+  });
+
+  if (signalDef.errorDataset) {
+    assertNumericType(signalDef.errorDataset);
+  }
+
+  axisDefs.filter(isDefined).forEach((def) => {
+    assertNumericType(def.dataset);
   });
 }

--- a/packages/app/src/vis-packs/nexus/hooks.ts
+++ b/packages/app/src/vis-packs/nexus/hooks.ts
@@ -1,7 +1,7 @@
 import {
   type ComplexType,
   type GroupWithChildren,
-  type NumericType,
+  type NumericLikeType,
 } from '@h5web/shared/hdf5-models';
 
 import { type DimensionMapping } from '../../dimension-mapper/models';
@@ -48,7 +48,7 @@ export function useNxData(group: GroupWithChildren): NxData {
   };
 }
 
-export function useNxImageDataToFetch<T extends NumericType | ComplexType>(
+export function useNxImageDataToFetch<T extends NumericLikeType | ComplexType>(
   nxData: NxData<T>,
   selectedDef: DatasetDef<T>,
 ): NxData<T> {

--- a/packages/app/src/vis-packs/nexus/models.ts
+++ b/packages/app/src/vis-packs/nexus/models.ts
@@ -56,7 +56,7 @@ export interface NxData<
   silxStyle: SilxStyle;
 }
 
-export interface NxValues<T extends NumericType | ComplexType> {
+export interface NxValues<T extends NumericLikeType | ComplexType> {
   title: string;
   signal: ArrayValue<T>;
   errors?: NumArray;

--- a/packages/shared/src/mock-values.ts
+++ b/packages/shared/src/mock-values.ts
@@ -266,6 +266,24 @@ export const mockValues = {
       ].flat(1),
       [2, 2],
     ),
+  secondary_bool: () => {
+    const { data: dataOneDBool } = oneD_bool();
+    return ndarray(
+      dataOneDBool.flatMap((rowBool) =>
+        dataOneDBool.map((colBool) => (rowBool ? !colBool : colBool)),
+      ),
+      [10, 10],
+    );
+  },
+  secondary_enum: () => {
+    const { data: dataOneDEnum } = oneD_enum();
+    return ndarray(
+      dataOneDEnum.flatMap((rowEnum) =>
+        dataOneDEnum.map((colEnum, j) => (j % 2 === 0 ? colEnum : rowEnum)),
+      ),
+      [10, 10],
+    );
+  },
   tertiary: () =>
     ndarray(
       twoD().data.map((v) => v / 2),


### PR DESCRIPTION
`assertNumericLikeNxData` was asserting for `NxData<NumericType>` instead of `NxData<NumericLikeType>` ... but was correctly calling `assertNumericLikeType` internally! So `MappedLineVis` thought it could only receive numeric (nd)arrays (`number[] | TypedArray`) when in fact, at runtime, it could receive `boolean[]`.

No errors were thrown at runtime because JS automatically coerces booleans to numbers in all mathematical operations (e.g. `Math.min(false, 2) => 0`). This typing bug would have been more problematic with `bigint[]`, though.

I say "Fix support", because the fix still has invisible runtime implications: I now convert boolean auxiliary arrays to number arrays in `MappedLineVis` with a new hook called `useToNumArrays`, which avoids type coercion further down the line (e.g. in `useDomains`).