### PR TITLE
Normalise prop types of mapped components with `ArrayValue`

### DIFF
--- a/packages/app/src/providers/mock/mock-api.ts
+++ b/packages/app/src/providers/mock/mock-api.ts
@@ -5,11 +5,12 @@ import {
 } from '@h5web/shared/guards';
 import {
   type ArrayShape,
+  type ArrayValue,
   type AttributeValues,
   type Dataset,
   type Entity,
   type GroupWithChildren,
-  type NumArrayDataset,
+  type NumericType,
   type ProvidedEntity,
   type Value,
 } from '@h5web/shared/hdf5-models';
@@ -123,7 +124,7 @@ export class MockApi extends DataProviderApi {
     ) {
       return async () => {
         let csv = '';
-        (value as Value<NumArrayDataset>).forEach((val) => {
+        (value as ArrayValue<NumericType>).forEach((val) => {
           csv += `${val.toString()}\n`;
         });
 

--- a/packages/app/src/providers/mock/utils.ts
+++ b/packages/app/src/providers/mock/utils.ts
@@ -9,9 +9,9 @@ import {
   type Dataset,
   type DType,
   type GroupWithChildren,
-  type Primitive,
   type ProvidedEntity,
   type ScalarShape,
+  type ScalarValue,
 } from '@h5web/shared/hdf5-models';
 import { getChildEntity } from '@h5web/shared/hdf5-utils';
 import ndarray from 'ndarray';
@@ -50,9 +50,9 @@ export function sliceValue<T extends DType>(
   value: unknown,
   dataset: Dataset<ArrayShape | ScalarShape, T>,
   selection: string,
-): Primitive<T>[] {
+): ScalarValue<T>[] {
   const { shape } = dataset;
-  const dataArray = ndarray(value as Primitive<typeof dataset.type>[], shape);
+  const dataArray = ndarray(value as ScalarValue<typeof dataset.type>[], shape);
   const mappedArray = applyMapping(
     dataArray,
     selection.split(',').map((s) => (s === ':' ? s : Number.parseInt(s))),

--- a/packages/app/src/vis-packs/core/complex/MappedComplexLineVis.tsx
+++ b/packages/app/src/vis-packs/core/complex/MappedComplexLineVis.tsx
@@ -6,9 +6,12 @@ import {
   useSafeDomain,
   useVisDomain,
 } from '@h5web/lib';
-import { type ArrayValue, type ComplexType } from '@h5web/shared/hdf5-models';
+import {
+  type ArrayValue,
+  type ComplexType,
+  type NumericType,
+} from '@h5web/shared/hdf5-models';
 import { type AxisMapping } from '@h5web/shared/nexus-models';
-import { type NumArray } from '@h5web/shared/vis-models';
 import { createPortal } from 'react-dom';
 
 import { type DimensionMapping } from '../../../dimension-mapper/models';
@@ -28,7 +31,7 @@ interface Props {
   dims: number[];
   dimMapping: DimensionMapping;
   axisLabels?: AxisMapping<string>;
-  axisValues?: AxisMapping<NumArray>;
+  axisValues?: AxisMapping<ArrayValue<NumericType>>;
   title: string;
   toolbarContainer: HTMLDivElement | undefined;
   config: ComplexLineConfig;

--- a/packages/app/src/vis-packs/core/complex/MappedComplexVis.tsx
+++ b/packages/app/src/vis-packs/core/complex/MappedComplexVis.tsx
@@ -4,9 +4,13 @@ import {
   useValidDomainForScale,
   useVisDomain,
 } from '@h5web/lib';
-import { type H5WebComplex } from '@h5web/shared/hdf5-models';
+import {
+  type ArrayValue,
+  type ComplexType,
+  type NumericType,
+} from '@h5web/shared/hdf5-models';
 import { type AxisMapping } from '@h5web/shared/nexus-models';
-import { ComplexVisType, type NumArray } from '@h5web/shared/vis-models';
+import { ComplexVisType } from '@h5web/shared/vis-models';
 import { useMemo } from 'react';
 import { createPortal } from 'react-dom';
 
@@ -24,11 +28,11 @@ import { type ComplexConfig } from './config';
 import { COMPLEX_VIS_TYPE_LABELS, getPhaseAmplitudeValues } from './utils';
 
 interface Props {
-  value: H5WebComplex[];
+  value: ArrayValue<ComplexType>;
   dims: number[];
   dimMapping: DimensionMapping;
   axisLabels?: AxisMapping<string>;
-  axisValues?: AxisMapping<NumArray>;
+  axisValues?: AxisMapping<ArrayValue<NumericType>>;
   title: string;
   toolbarContainer: HTMLDivElement | undefined;
   config: ComplexConfig;

--- a/packages/app/src/vis-packs/core/compound/MappedCompoundVis.tsx
+++ b/packages/app/src/vis-packs/core/compound/MappedCompoundVis.tsx
@@ -1,11 +1,12 @@
 import { MatrixVis } from '@h5web/lib';
 import {
   type ArrayShape,
+  type ArrayValue,
   type CompoundType,
   type Dataset,
   type PrintableType,
   type ScalarShape,
-  type Value,
+  type ScalarValue,
 } from '@h5web/shared/hdf5-models';
 import { createPortal } from 'react-dom';
 
@@ -20,7 +21,9 @@ import { getSliceSelection } from '../utils';
 
 interface Props {
   dataset: Dataset<ScalarShape | ArrayShape, CompoundType<PrintableType>>;
-  value: Value<Props['dataset']>;
+  value:
+    | ScalarValue<CompoundType<PrintableType>>
+    | ArrayValue<CompoundType<PrintableType>>;
   dimMapping: DimensionMapping;
   toolbarContainer: HTMLDivElement | undefined;
   config: MatrixVisConfig;

--- a/packages/app/src/vis-packs/core/heatmap/MappedHeatmapVis.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/MappedHeatmapVis.tsx
@@ -4,9 +4,9 @@ import {
   type ArrayValue,
   type Dataset,
   type NumericLikeType,
+  type NumericType,
 } from '@h5web/shared/hdf5-models';
 import { type AxisMapping } from '@h5web/shared/nexus-models';
-import { type NumArray } from '@h5web/shared/vis-models';
 import { createPortal } from 'react-dom';
 
 import { type DimensionMapping } from '../../../dimension-mapper/models';
@@ -25,7 +25,7 @@ interface Props {
   dataset: Dataset<ArrayShape, NumericLikeType>;
   value: ArrayValue<NumericLikeType>;
   axisLabels?: AxisMapping<string>;
-  axisValues?: AxisMapping<NumArray>;
+  axisValues?: AxisMapping<ArrayValue<NumericType>>;
   dimMapping: DimensionMapping;
   title: string;
   toolbarContainer: HTMLDivElement | undefined;

--- a/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
+++ b/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
@@ -8,12 +8,12 @@ import {
 } from '@h5web/lib';
 import {
   type ArrayShape,
+  type ArrayValue,
   type Dataset,
   type NumericLikeType,
-  type Value,
+  type NumericType,
 } from '@h5web/shared/hdf5-models';
 import { type AxisMapping } from '@h5web/shared/nexus-models';
-import { type NumArray } from '@h5web/shared/vis-models';
 import { createPortal } from 'react-dom';
 
 import { type DimensionMapping } from '../../../dimension-mapper/models';
@@ -32,16 +32,16 @@ import LineToolbar from './LineToolbar';
 
 interface Props {
   dataset: Dataset<ArrayShape, NumericLikeType>;
-  value: Value<Props['dataset']>;
+  value: ArrayValue<NumericLikeType>;
   valueLabel?: string;
-  errors?: NumArray;
+  errors?: ArrayValue<NumericType>;
   auxLabels?: string[];
-  auxValues?: Value<Props['dataset']>[];
-  auxErrors?: (NumArray | undefined)[];
+  auxValues?: ArrayValue<NumericLikeType>[];
+  auxErrors?: (ArrayValue<NumericType> | undefined)[];
   dims: number[];
   dimMapping: DimensionMapping;
   axisLabels?: AxisMapping<string>;
-  axisValues?: AxisMapping<NumArray>;
+  axisValues?: AxisMapping<ArrayValue<NumericType>>;
   title: string;
   toolbarContainer?: HTMLDivElement | undefined;
   config: LineConfig;

--- a/packages/app/src/vis-packs/core/matrix/MappedMatrixVis.tsx
+++ b/packages/app/src/vis-packs/core/matrix/MappedMatrixVis.tsx
@@ -1,9 +1,9 @@
 import { MatrixVis } from '@h5web/lib';
 import {
   type ArrayShape,
+  type ArrayValue,
   type Dataset,
   type PrintableType,
-  type Value,
 } from '@h5web/shared/hdf5-models';
 import { createPortal } from 'react-dom';
 
@@ -18,7 +18,7 @@ import { getCellWidth, getFormatter } from './utils';
 
 interface Props {
   dataset: Dataset<ArrayShape, PrintableType>;
-  value: Value<Props['dataset']>;
+  value: ArrayValue<PrintableType>;
   dimMapping: DimensionMapping;
   toolbarContainer: HTMLDivElement | undefined;
   config: MatrixVisConfig;

--- a/packages/app/src/vis-packs/core/rgb/MappedRgbVis.tsx
+++ b/packages/app/src/vis-packs/core/rgb/MappedRgbVis.tsx
@@ -1,8 +1,11 @@
 import { RgbVis } from '@h5web/lib';
-import { type NumArrayDataset } from '@h5web/shared/hdf5-models';
+import {
+  type ArrayShape,
+  type ArrayValue,
+  type Dataset,
+  type NumericType,
+} from '@h5web/shared/hdf5-models';
 import { type AxisMapping } from '@h5web/shared/nexus-models';
-import { type NumArray } from '@h5web/shared/vis-models';
-import { type TypedArray } from 'ndarray';
 import { createPortal } from 'react-dom';
 
 import { type DimensionMapping } from '../../../dimension-mapper/models';
@@ -12,10 +15,10 @@ import { type RgbVisConfig } from './config';
 import RgbToolbar from './RgbToolbar';
 
 interface Props {
-  dataset: NumArrayDataset;
-  value: number[] | TypedArray;
+  dataset: Dataset<ArrayShape, NumericType>;
+  value: ArrayValue<NumericType>;
   axisLabels?: AxisMapping<string>;
-  axisValues?: AxisMapping<NumArray>;
+  axisValues?: AxisMapping<ArrayValue<NumericType>>;
   dimMapping: DimensionMapping;
   title: string;
   toolbarContainer: HTMLDivElement | undefined;

--- a/packages/app/src/vis-packs/core/scatter/MappedScatterVis.tsx
+++ b/packages/app/src/vis-packs/core/scatter/MappedScatterVis.tsx
@@ -1,7 +1,7 @@
 import { ScatterVis, useDomain, useSafeDomain, useVisDomain } from '@h5web/lib';
 import { assertDefined } from '@h5web/shared/guards';
+import { type ArrayValue, type NumericType } from '@h5web/shared/hdf5-models';
 import { type AxisMapping } from '@h5web/shared/nexus-models';
-import { type NumArray } from '@h5web/shared/vis-models';
 import { createPortal } from 'react-dom';
 
 import visualizerStyles from '../../../visualizer/Visualizer.module.css';
@@ -11,9 +11,9 @@ import { type ScatterConfig } from './config';
 import ScatterToolbar from './ScatterToolbar';
 
 interface Props {
-  value: NumArray;
+  value: ArrayValue<NumericType>;
   axisLabels: AxisMapping<string>;
-  axisValues: AxisMapping<NumArray>;
+  axisValues: AxisMapping<ArrayValue<NumericType>>;
   title: string;
   toolbarContainer: HTMLDivElement | undefined;
   config: ScatterConfig;

--- a/packages/app/src/vis-packs/core/surface/MappedSurfaceVis.tsx
+++ b/packages/app/src/vis-packs/core/surface/MappedSurfaceVis.tsx
@@ -1,6 +1,10 @@
 import { SurfaceVis, useDomain, useSafeDomain, useVisDomain } from '@h5web/lib';
-import { type NumArrayDataset } from '@h5web/shared/hdf5-models';
-import { type TypedArray } from 'ndarray';
+import {
+  type ArrayShape,
+  type ArrayValue,
+  type Dataset,
+  type NumericType,
+} from '@h5web/shared/hdf5-models';
 import { createPortal } from 'react-dom';
 
 import { type DimensionMapping } from '../../../dimension-mapper/models';
@@ -11,8 +15,8 @@ import { type SurfaceConfig } from './config';
 import SurfaceToolbar from './SurfaceToolbar';
 
 interface Props {
-  dataset: NumArrayDataset;
-  value: number[] | TypedArray;
+  dataset: Dataset<ArrayShape, NumericType>;
+  value: ArrayValue<NumericType>;
   dimMapping: DimensionMapping;
   toolbarContainer: HTMLDivElement | undefined;
   config: SurfaceConfig;

--- a/packages/app/src/vis-packs/nexus/models.ts
+++ b/packages/app/src/vis-packs/nexus/models.ts
@@ -4,7 +4,6 @@ import {
   type ArrayValue,
   type ComplexType,
   type Dataset,
-  type NumArrayDataset,
   type NumericLikeType,
   type NumericType,
   type ScalarShape,
@@ -36,7 +35,7 @@ export interface DatasetDef<
 }
 
 type WithError<T extends DatasetDef> = T & {
-  errorDataset?: NumArrayDataset;
+  errorDataset?: Dataset<ArrayShape, NumericType>;
 };
 
 export type AxisDef = DatasetDef<NumericType>;

--- a/packages/app/src/vis-packs/nexus/utils.ts
+++ b/packages/app/src/vis-packs/nexus/utils.ts
@@ -18,8 +18,8 @@ import {
   type Dataset,
   type Group,
   type GroupWithChildren,
-  type NumArrayDataset,
   type NumericLikeType,
+  type NumericType,
   type ScalarShape,
   type StringType,
 } from '@h5web/shared/hdf5-models';
@@ -93,7 +93,7 @@ export function findSignalDataset(
 export function findErrorDataset(
   group: GroupWithChildren,
   signalName: string,
-): NumArrayDataset | undefined {
+): Dataset<ArrayShape, NumericType> | undefined {
   const dataset =
     getChildEntity(group, `${signalName}_errors`) ||
     getChildEntity(group, 'errors');
@@ -111,7 +111,7 @@ export function findErrorDataset(
 export function findAuxErrorDataset(
   group: GroupWithChildren,
   auxSignalName: string,
-): NumArrayDataset | undefined {
+): Dataset<ArrayShape, NumericType> | undefined {
   const dataset = getChildEntity(group, `${auxSignalName}_errors`);
 
   if (!dataset) {
@@ -172,7 +172,7 @@ function findOldStyleAxesDatasets(
   group: GroupWithChildren,
   signal: Dataset,
   attrValuesStore: AttrValuesStore,
-): NumArrayDataset[] {
+): Dataset<ArrayShape, NumericType>[] {
   const axesList = attrValuesStore.getSingle(signal, 'axes');
   const axesNames = parseAxesList(axesList);
 
@@ -190,7 +190,7 @@ export function findAxesDatasets(
   group: GroupWithChildren,
   signal: Dataset,
   attrValuesStore: AttrValuesStore,
-): (NumArrayDataset | undefined)[] {
+): (Dataset<ArrayShape, NumericType> | undefined)[] {
   if (!hasAttribute(group, 'axes')) {
     return findOldStyleAxesDatasets(group, signal, attrValuesStore);
   }

--- a/packages/shared/src/guards.ts
+++ b/packages/shared/src/guards.ts
@@ -20,9 +20,9 @@ import {
   type IntegerType,
   type NumericLikeType,
   type NumericType,
-  type Primitive,
   type PrintableType,
   type ScalarShape,
+  type ScalarValue,
   type Shape,
   type StringType,
   type Value,
@@ -423,7 +423,7 @@ export function isComplexValue(
 function assertPrimitiveValue(
   type: DType,
   value: unknown,
-): asserts value is Primitive {
+): asserts value is ScalarValue {
   if (isNumericType(type)) {
     assertNum(value);
   } else if (isStringType(type)) {

--- a/packages/shared/src/hdf5-models.ts
+++ b/packages/shared/src/hdf5-models.ts
@@ -87,8 +87,6 @@ export interface VirtualSource {
   path: string;
 }
 
-export type NumArrayDataset = Dataset<ArrayShape, NumericType>;
-
 /* ----------------- */
 /* ----- SHAPE ----- */
 
@@ -207,24 +205,24 @@ export interface UnknownType {
 /* ----------------- */
 /* ----- VALUE ----- */
 
-export type Primitive<T extends DType = DType> = T extends NumericLikeType
+export type ScalarValue<T extends DType = DType> = T extends NumericLikeType
   ? number | (T extends BooleanType ? boolean : never) // let providers choose how to return booleans
   : T extends StringType
     ? string
     : T extends ComplexType
       ? H5WebComplex
       : T extends CompoundType<infer TFields>
-        ? Primitive<TFields>[]
+        ? ScalarValue<TFields>[]
         : unknown;
 
 export type ArrayValue<T extends DType = DType> = T extends NumericLikeType
-  ? TypedArray | number[] | (T extends BooleanType ? boolean[] : never) // don't use `Primitive` to avoid `(number | boolean)[]`
-  : Primitive<T>[];
+  ? TypedArray | number[] | (T extends BooleanType ? boolean[] : never) // don't use `ScalarValue` to avoid `(number | boolean)[]`
+  : ScalarValue<T>[];
 
 export type Value<D extends Dataset> =
   D extends Dataset<infer S, infer T>
     ? S extends ScalarShape
-      ? Primitive<T>
+      ? ScalarValue<T>
       : S extends ArrayShape
         ? ArrayValue<T>
         : never

--- a/packages/shared/src/vis-models.ts
+++ b/packages/shared/src/vis-models.ts
@@ -1,6 +1,6 @@
 import { type NdArray, type TypedArray } from 'ndarray';
 
-import { type DType, type Primitive } from './hdf5-models';
+import { type DType, type ScalarValue } from './hdf5-models';
 
 export type NumArray = TypedArray | number[];
 export type AnyNumArray = NdArray<NumArray> | NumArray;
@@ -63,4 +63,4 @@ export type MappedTuple<T extends unknown[], U = T[number]> = {
   [index in keyof T]: U;
 };
 
-export type ValueFormatter<T extends DType> = (val: Primitive<T>) => string;
+export type ValueFormatter<T extends DType> = (val: ScalarValue<T>) => string;

--- a/packages/shared/src/vis-utils.ts
+++ b/packages/shared/src/vis-utils.ts
@@ -8,7 +8,7 @@ import {
   type BooleanType,
   type ComplexType,
   type EnumType,
-  type Primitive,
+  type ScalarValue,
 } from './hdf5-models';
 import {
   type AnyNumArray,
@@ -59,7 +59,7 @@ export function formatTick(val: number | { valueOf: () => number }): string {
   return str;
 }
 
-export function formatBool(value: Primitive<BooleanType>): string {
+export function formatBool(value: ScalarValue<BooleanType>): string {
   return (typeof value === 'number' ? !!value : value).toString();
 }
 


### PR DESCRIPTION
From https://github.com/silx-kit/h5web/pull/1738#discussion_r1924836346

The `value`, `auxValues`, `errors`, `auxErrors` and `axisValues` props of mapped components (`MappedLineVis`, `MappedRgbVis`, etc.) were typed in a few different, inconsistent ways:

 - with `NumArray` (= `number[] | TypedArray`)
 - with `ArrayValue<DType>` (where `DType` matches the one of the `dataset` prop — e.g. `Dataset<ArrayShape, NumericType>` => `ArrayValue<NumericType>`, but it works with any other dtype or dtype union like `NumericLikeType`)
 - with `Value<Props['dataset']>` to avoid duplicating the dtype.

While the third way is the most robust and DRY, it's not the most readable since it adds an extra level of misdirection. And while the first way is the most explicit, it becomes less readable and/or more error-prone with other dtypes, like `NumericLikeType`, `PrintableType` or `ComplexType` (especially once we start supporting big ints).

So I'm going for the middle ground with `ArrayValue`.

---

While I'm at it:

- I remove `NumArrayDataset` completely, which was an alias for `Dataset<ArrayShape, NumericType>`; it adds a couple of imports in a few files, but it's less confusing, especially since we don't have aliases for datasets with other dtypes, like `Dataset<ArrayShape, NumericLikeType>`.
- I rename `Primitive` to `ScalarValue`. This makes it clearer that `ScalarValue` is the value of datasets with `ScalarShape`.