### PR TITLE
Fix metadata viewer layout with overflow

### DIFF
--- a/apps/demo/src/h5wasm/DropZone.module.css
+++ b/apps/demo/src/h5wasm/DropZone.module.css
@@ -38,6 +38,7 @@
 .h5web {
   flex: 1;
   display: flex;
+  min-width: 0;
   height: 100vh;
   z-index: 0; /* STACKING CONTEXT */
 }

--- a/packages/app/src/metadata-viewer/MetadataViewer.module.css
+++ b/packages/app/src/metadata-viewer/MetadataViewer.module.css
@@ -48,6 +48,7 @@
 }
 
 .metadataViewer {
+  flex: 1;
   overflow-y: scroll;
   scrollbar-width: thin;
 }


### PR DESCRIPTION
Fix #1740 

# Before

[Screencast from 2025-01-24 15-31-48.webm](https://github.com/user-attachments/assets/e9cf09f7-be52-461d-a92b-62e455301e22)

# After `min-width: 0` in demo, but before `flex: 1` in metadata viewer

[Screencast from 2025-01-24 15-33-21.webm](https://github.com/user-attachments/assets/123745d8-16b5-4b1e-b5ce-00f0fbd9f944)

# After both fixes

[Screencast from 2025-01-24 15-33-35.webm](https://github.com/user-attachments/assets/2f232009-4f51-4fa7-baca-9e5d18f3486b)