### PR TITLE
Split `VLenType` out of `ArrayType`

### DIFF
--- a/packages/app/src/providers/h5grove/utils.test.ts
+++ b/packages/app/src/providers/h5grove/utils.test.ts
@@ -13,6 +13,7 @@ import {
   strType,
   timeType,
   unknownType,
+  vlenType,
 } from '@h5web/shared/hdf5-utils';
 import { describe, expect, it } from 'vitest';
 
@@ -94,15 +95,17 @@ describe('parseDType', () => {
     ).toStrictEqual(boolType(intType(true, 8)));
   });
 
-  it('should convert array types', () => {
+  it('should convert vlen type', () => {
     expect(
       parseDType({
         class: 9,
         size: 1,
         base: { class: 1, size: 4, order: 0 },
       }),
-    ).toStrictEqual(arrayType(floatType()));
+    ).toStrictEqual(vlenType(floatType()));
+  });
 
+  it('should convert array type', () => {
     expect(
       parseDType({
         class: 10,

--- a/packages/app/src/providers/h5grove/utils.ts
+++ b/packages/app/src/providers/h5grove/utils.ts
@@ -22,6 +22,7 @@ import {
   strType,
   timeType,
   unknownType,
+  vlenType,
 } from '@h5web/shared/hdf5-utils';
 import {
   type BigIntTypedArrayConstructor,
@@ -214,7 +215,7 @@ export function parseDType(type: H5GroveType): DType {
   }
 
   if (h5tClass === H5T_CLASS.VLEN) {
-    return arrayType(parseDType(type.base));
+    return vlenType(parseDType(type.base));
   }
 
   // `H5GroveType` doesn't allow for any other `h5tClass` value at this point,

--- a/packages/app/src/providers/hsds/models.ts
+++ b/packages/app/src/providers/hsds/models.ts
@@ -94,6 +94,7 @@ export interface HsdsShape {
 export type HsdsType =
   | HsdsNumericType
   | HsdsStringType
+  | HsdsVLenType
   | HsdsArrayType
   | HsdsCompoundType
   | HsdsEnumType;
@@ -110,10 +111,15 @@ export interface HsdsStringType {
   length: number | 'H5T_VARIABLE';
 }
 
-export interface HsdsArrayType {
-  class: 'H5T_ARRAY' | 'H5T_VLEN';
+export interface HsdsVLenType {
+  class: 'H5T_VLEN';
   base: HsdsType;
-  dims?: number[];
+}
+
+export interface HsdsArrayType {
+  class: 'H5T_ARRAY';
+  base: HsdsType;
+  dims: number[];
 }
 
 export interface HsdsCompoundType {

--- a/packages/app/src/providers/hsds/utils.test.ts
+++ b/packages/app/src/providers/hsds/utils.test.ts
@@ -9,6 +9,7 @@ import {
   intType,
   strType,
   unknownType,
+  vlenType,
 } from '@h5web/shared/hdf5-utils';
 import { describe, expect, it } from 'vitest';
 
@@ -18,6 +19,7 @@ import {
   type HsdsEnumType,
   type HsdsStringType,
   type HsdsType,
+  type HsdsVLenType,
 } from './models';
 import { convertHsdsType } from './utils';
 
@@ -83,6 +85,15 @@ describe('convertHsdsType', () => {
     expect(convertHsdsType(beFloat.hsds)).toStrictEqual(beFloat.hdf5);
   });
 
+  it('should convert the base of VLen type', () => {
+    const vlen: HsdsVLenType = {
+      class: 'H5T_VLEN',
+      base: leInt.hsds,
+    };
+
+    expect(convertHsdsType(vlen)).toStrictEqual(vlenType(leInt.hdf5));
+  });
+
   it('should convert the base of Array type', () => {
     const arr: HsdsArrayType = {
       class: 'H5T_ARRAY',
@@ -93,20 +104,8 @@ describe('convertHsdsType', () => {
     expect(convertHsdsType(arr)).toStrictEqual(arrayType(leInt.hdf5, [4, 5]));
   });
 
-  it('should convert the base of VLen type', () => {
-    const vlen: HsdsArrayType = {
-      class: 'H5T_VLEN',
-      base: leInt.hsds,
-    };
-
-    expect(convertHsdsType(vlen)).toStrictEqual(arrayType(leInt.hdf5));
-  });
-
   it('should convert the field types of Compound type', () => {
-    const vlen: HsdsArrayType = {
-      class: 'H5T_VLEN',
-      base: leInt.hsds,
-    };
+    const vlen: HsdsVLenType = { class: 'H5T_VLEN', base: leInt.hsds };
     const compound: HsdsCompoundType = {
       class: 'H5T_COMPOUND',
       fields: [
@@ -117,7 +116,7 @@ describe('convertHsdsType', () => {
     expect(convertHsdsType(compound)).toStrictEqual(
       compoundType({
         f1: beFloat.hdf5,
-        f2: arrayType(leInt.hdf5),
+        f2: vlenType(leInt.hdf5),
       }),
     );
   });

--- a/packages/app/src/providers/hsds/utils.ts
+++ b/packages/app/src/providers/hsds/utils.ts
@@ -8,7 +8,6 @@ import {
   type CompoundType,
   type Dataset,
   type DType,
-  DTypeClass,
   type Entity,
   type EnumType,
   type Group,
@@ -17,6 +16,7 @@ import {
   type Shape,
 } from '@h5web/shared/hdf5-models';
 import {
+  arrayType,
   compoundType,
   cplxType,
   enumOrBoolType,
@@ -24,6 +24,7 @@ import {
   intType,
   strType,
   unknownType,
+  vlenType,
 } from '@h5web/shared/hdf5-utils';
 
 import {
@@ -139,14 +140,11 @@ export function convertHsdsType(hsdsType: HsdsType): DType {
       );
     }
 
-    case 'H5T_ARRAY':
     case 'H5T_VLEN':
-      return {
-        class:
-          hsdsType.class === 'H5T_ARRAY' ? DTypeClass.Array : DTypeClass.VLen,
-        base: convertHsdsType(hsdsType.base),
-        ...(hsdsType.dims && { dims: hsdsType.dims }),
-      };
+      return vlenType(convertHsdsType(hsdsType.base));
+
+    case 'H5T_ARRAY':
+      return arrayType(convertHsdsType(hsdsType.base), hsdsType.dims);
 
     case 'H5T_ENUM':
       return convertHsdsEnumType(hsdsType);

--- a/packages/app/src/providers/mock/mock-file.ts
+++ b/packages/app/src/providers/mock/mock-file.ts
@@ -13,6 +13,7 @@ import {
   printableCompoundType,
   strType,
   unknownType,
+  vlenType,
 } from '@h5web/shared/hdf5-utils';
 import {
   array,
@@ -87,9 +88,9 @@ export function makeMockFile(): GroupWithChildren {
           ],
         }),
         scalar('scalar_vlen', [1, 2, 3], {
-          type: arrayType(intType()),
+          type: vlenType(intType()),
           attributes: [
-            scalarAttr('attr', [1, 2, 3], { type: arrayType(intType()) }),
+            scalarAttr('attr', [1, 2, 3], { type: vlenType(intType()) }),
           ],
         }),
         scalar('scalar_enum', 2, {

--- a/packages/h5wasm/src/worker-utils.ts
+++ b/packages/h5wasm/src/worker-utils.ts
@@ -27,6 +27,7 @@ import {
   strType,
   timeType,
   unknownType,
+  vlenType,
 } from '@h5web/shared/hdf5-utils';
 import {
   type Dataset as H5WasmDataset,
@@ -279,7 +280,7 @@ function parseDType(metadata: Metadata): DType {
   if (h5tClass === H5T_CLASS.VLEN) {
     const { vlen_type } = metadata;
     assertDefined(vlen_type);
-    return arrayType(parseDType(vlen_type));
+    return vlenType(parseDType(vlen_type));
   }
 
   if (h5tClass === H5T_CLASS.ARRAY) {

--- a/packages/shared/src/hdf5-models.ts
+++ b/packages/shared/src/hdf5-models.ts
@@ -128,6 +128,7 @@ export type DType =
   | PrintableType
   | CompoundType
   | ArrayType
+  | VLenType
   | TimeType
   | BitfieldType
   | OpaqueType
@@ -166,9 +167,14 @@ export interface CompoundType<T extends DType = DType> {
 }
 
 export interface ArrayType<T extends DType = DType> {
-  class: DTypeClass.Array | DTypeClass.VLen;
+  class: DTypeClass.Array;
   base: T;
-  dims?: number[];
+  dims: number[];
+}
+
+export interface VLenType<T extends DType = DType> {
+  class: DTypeClass.VLen;
+  base: T;
 }
 
 export interface BooleanType {

--- a/packages/shared/src/hdf5-utils.ts
+++ b/packages/shared/src/hdf5-utils.ts
@@ -28,6 +28,7 @@ import {
   type StringType,
   type TimeType,
   type UnknownType,
+  type VLenType,
 } from './hdf5-models';
 
 export function getChildEntity(
@@ -114,15 +115,15 @@ export function compoundOrCplxType<T extends DType>(
   return compoundType(fields);
 }
 
+export function vlenType<T extends DType>(baseType: T): VLenType<T> {
+  return { class: DTypeClass.VLen, base: baseType };
+}
+
 export function arrayType<T extends DType>(
   baseType: T,
-  dims?: number[],
+  dims: number[],
 ): ArrayType<T> {
-  return {
-    class: dims ? DTypeClass.Array : DTypeClass.VLen,
-    base: baseType,
-    ...(dims && { dims }),
-  };
+  return { class: DTypeClass.Array, base: baseType, dims };
 }
 
 export function boolType(baseType: NumericType): BooleanType {


### PR DESCRIPTION
Following the split of `NumericType` into `IntegerType` and `FloatType` in #1736, I'm doing the same with  `ArrayType`, which was covering two [`H5T_class_t`](https://support.hdfgroup.org/documentation/hdf5/latest/_h5_tpublic_8h.html#a071841985f647f69516dbe77d93167f2) values: `H5T_ARRAY` and `H5T_VLEN`.

Turns out this was making things more complicated than they needed to be... So now we have two separate dtypes: `VLenType` and `ArrayType`.

Note that nothing changes in the UI or in the provider snapshots, since the enum value `DTypeClass.VLen` doesn't change: it remains "Array (variable-length)".