### PR TITLE
Upgrade Node to 22

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,13 +26,21 @@
 
 ## Quick start
 
+Install [Node](https://nodejs.org/en) and [pnpm](https://pnpm.io/), following
+the version ranges declared in the `engines` field of the root `package.json`
+file.
+
+> If you work on multiple projects that require different versions of Node and
+> pnpm, we recommend installing them in an isolated environement (e.g. with
+> [Conda](https://docs.conda.io/projects/conda/en/stable/)) or with a
+> specialised tool like [Volta](https://docs.volta.sh/).
+
+Then, run:
+
 ```bash
 pnpm install
 pnpm start
 ```
-
-Once the development server has started, press `o` to open the development URL
-in your browser, or `h` to show all the available keyboard shortcuts.
 
 ## Development
 

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -26,7 +26,7 @@
     "wouter": "3.3.5"
   },
   "devDependencies": {
-    "@types/node": "^20.17.12",
+    "@types/node": "^22.12.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react-swc": "3.7.2",

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -38,7 +38,7 @@
     "@types/d3-array": "~3.2.1",
     "@types/d3-format": "~3.0.4",
     "@types/ndarray": "1.0.14",
-    "@types/node": "^20.17.12",
+    "@types/node": "^22.12.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@types/three": "0.172.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/silx-kit/h5web"
   },
   "engines": {
-    "node": "20.x",
+    "node": "22.x",
     "pnpm": "9.x"
   },
   "packageManager": "pnpm@9.15.4",
@@ -43,7 +43,7 @@
     "@simonsmith/cypress-image-snapshot": "9.1.0",
     "@stylistic/eslint-plugin-js": "2.13.0",
     "@testing-library/cypress": "10.0.2",
-    "@types/node": "^20.17.12",
+    "@types/node": "^22.12.0",
     "@vitest/eslint-plugin": "1.1.25",
     "confusing-browser-globals": "1.0.11",
     "cypress": "13.17.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -72,7 +72,7 @@
     "@testing-library/user-event": "14.6.0",
     "@types/d3-format": "~3.0.4",
     "@types/ndarray": "1.0.14",
-    "@types/node": "^20.17.12",
+    "@types/node": "^22.12.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@types/react-slider": "~1.3.6",

--- a/packages/h5wasm/package.json
+++ b/packages/h5wasm/package.json
@@ -54,7 +54,7 @@
     "@h5web/app": "workspace:*",
     "@h5web/shared": "workspace:*",
     "@rollup/plugin-alias": "5.1.0",
-    "@types/node": "^20.17.12",
+    "@types/node": "^22.12.0",
     "@types/react": "^18.3.3",
     "@vitejs/plugin-react-swc": "3.7.2",
     "dot-json": "1.3.0",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -85,7 +85,7 @@
     "@types/d3-scale": "~4.0.8",
     "@types/d3-scale-chromatic": "~3.1.0",
     "@types/ndarray": "~1.0.14",
-    "@types/node": "^20.17.12",
+    "@types/node": "^22.12.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@types/react-measure": "~2.0.12",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -58,7 +58,7 @@
     "@types/d3-format": "~3.0.4",
     "@types/ndarray": "~1.0.14",
     "@types/ndarray-ops": "~1.2.7",
-    "@types/node": "^20.17.12",
+    "@types/node": "^22.12.0",
     "@types/react": "^18.3.3",
     "d3-array": "3.2.4",
     "d3-format": "3.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,11 +18,11 @@ importers:
         specifier: 10.0.2
         version: 10.0.2(cypress@13.17.0)
       '@types/node':
-        specifier: ^20.17.12
-        version: 20.17.12
+        specifier: ^22.12.0
+        version: 22.12.0
       '@vitest/eslint-plugin':
         specifier: 1.1.25
-        version: 1.1.25(@typescript-eslint/utils@8.20.0(eslint@9.18.0)(typescript@5.7.3))(eslint@9.18.0)(typescript@5.7.3)(vitest@2.1.8(@types/node@20.17.12)(jsdom@26.0.0))
+        version: 1.1.25(@typescript-eslint/utils@8.20.0(eslint@9.18.0)(typescript@5.7.3))(eslint@9.18.0)(typescript@5.7.3)(vitest@2.1.8(@types/node@22.12.0)(jsdom@26.0.0))
       confusing-browser-globals:
         specifier: 1.0.11
         version: 1.0.11
@@ -82,10 +82,10 @@ importers:
         version: 8.20.0(eslint@9.18.0)(typescript@5.7.3)
       vitest:
         specifier: 2.1.8
-        version: 2.1.8(@types/node@20.17.12)(jsdom@26.0.0)
+        version: 2.1.8(@types/node@22.12.0)(jsdom@26.0.0)
       vitest-fail-on-console:
         specifier: 0.7.1
-        version: 0.7.1(vite@5.4.11(@types/node@20.17.12))(vitest@2.1.8(@types/node@20.17.12)(jsdom@26.0.0))
+        version: 0.7.1(vite@5.4.11(@types/node@22.12.0))(vitest@2.1.8(@types/node@22.12.0)(jsdom@26.0.0))
       wait-on:
         specifier: 8.0.2
         version: 8.0.2
@@ -127,8 +127,8 @@ importers:
         version: 3.3.5(react@18.3.1)
     devDependencies:
       '@types/node':
-        specifier: ^20.17.12
-        version: 20.17.12
+        specifier: ^22.12.0
+        version: 22.12.0
       '@types/react':
         specifier: ^18.3.3
         version: 18.3.3
@@ -137,7 +137,7 @@ importers:
         version: 18.3.0
       '@vitejs/plugin-react-swc':
         specifier: 3.7.2
-        version: 3.7.2(vite@5.4.11(@types/node@20.17.12))
+        version: 3.7.2(vite@5.4.11(@types/node@22.12.0))
       eslint:
         specifier: 9.18.0
         version: 9.18.0
@@ -146,16 +146,16 @@ importers:
         version: 5.7.3
       vite:
         specifier: 5.4.11
-        version: 5.4.11(@types/node@20.17.12)
+        version: 5.4.11(@types/node@22.12.0)
       vite-css-modules:
         specifier: 1.8.4
-        version: 1.8.4(postcss@8.5.1)(rollup@4.30.1)(vite@5.4.11(@types/node@20.17.12))
+        version: 1.8.4(postcss@8.5.1)(rollup@4.30.1)(vite@5.4.11(@types/node@22.12.0))
       vite-plugin-checker:
         specifier: 0.8.0
-        version: 0.8.0(eslint@9.18.0)(optionator@0.9.4)(typescript@5.7.3)(vite@5.4.11(@types/node@20.17.12))
+        version: 0.8.0(eslint@9.18.0)(optionator@0.9.4)(typescript@5.7.3)(vite@5.4.11(@types/node@22.12.0))
       vite-plugin-eslint:
         specifier: 1.8.1
-        version: 1.8.1(eslint@9.18.0)(vite@5.4.11(@types/node@20.17.12))
+        version: 1.8.1(eslint@9.18.0)(vite@5.4.11(@types/node@22.12.0))
 
   apps/storybook:
     dependencies:
@@ -222,7 +222,7 @@ importers:
         version: 8.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.5.0(prettier@3.4.2))(typescript@5.7.3)
       '@storybook/react-vite':
         specifier: 8.5.0
-        version: 8.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.30.1)(storybook@8.5.0(prettier@3.4.2))(typescript@5.7.3)(vite@5.4.11(@types/node@20.17.12))
+        version: 8.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.30.1)(storybook@8.5.0(prettier@3.4.2))(typescript@5.7.3)(vite@5.4.11(@types/node@22.12.0))
       '@types/d3-array':
         specifier: ~3.2.1
         version: 3.2.1
@@ -233,8 +233,8 @@ importers:
         specifier: 1.0.14
         version: 1.0.14
       '@types/node':
-        specifier: ^20.17.12
-        version: 20.17.12
+        specifier: ^22.12.0
+        version: 22.12.0
       '@types/react':
         specifier: ^18.3.3
         version: 18.3.3
@@ -258,7 +258,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: 5.4.11
-        version: 5.4.11(@types/node@20.17.12)
+        version: 5.4.11(@types/node@22.12.0)
 
   packages/app:
     dependencies:
@@ -327,8 +327,8 @@ importers:
         specifier: 1.0.14
         version: 1.0.14
       '@types/node':
-        specifier: ^20.17.12
-        version: 20.17.12
+        specifier: ^22.12.0
+        version: 22.12.0
       '@types/react':
         specifier: ^18.3.3
         version: 18.3.3
@@ -340,7 +340,7 @@ importers:
         version: 1.3.6
       '@vitejs/plugin-react-swc':
         specifier: 3.7.2
-        version: 3.7.2(vite@5.4.11(@types/node@20.17.12))
+        version: 3.7.2(vite@5.4.11(@types/node@22.12.0))
       concat:
         specifier: 1.0.3
         version: 1.0.3
@@ -373,13 +373,13 @@ importers:
         version: 5.7.3
       vite:
         specifier: 5.4.11
-        version: 5.4.11(@types/node@20.17.12)
+        version: 5.4.11(@types/node@22.12.0)
       vite-css-modules:
         specifier: 1.8.4
-        version: 1.8.4(postcss@8.5.1)(rollup@4.30.1)(vite@5.4.11(@types/node@20.17.12))
+        version: 1.8.4(postcss@8.5.1)(rollup@4.30.1)(vite@5.4.11(@types/node@22.12.0))
       vitest:
         specifier: 2.1.8
-        version: 2.1.8(@types/node@20.17.12)(jsdom@26.0.0)
+        version: 2.1.8(@types/node@22.12.0)(jsdom@26.0.0)
 
   packages/h5wasm:
     dependencies:
@@ -403,14 +403,14 @@ importers:
         specifier: 5.1.0
         version: 5.1.0(rollup@4.30.1)
       '@types/node':
-        specifier: ^20.17.12
-        version: 20.17.12
+        specifier: ^22.12.0
+        version: 22.12.0
       '@types/react':
         specifier: ^18.3.3
         version: 18.3.3
       '@vitejs/plugin-react-swc':
         specifier: 3.7.2
-        version: 3.7.2(vite@5.4.11(@types/node@20.17.12))
+        version: 3.7.2(vite@5.4.11(@types/node@22.12.0))
       dot-json:
         specifier: 1.3.0
         version: 1.3.0
@@ -434,10 +434,10 @@ importers:
         version: 5.7.3
       vite:
         specifier: 5.4.11
-        version: 5.4.11(@types/node@20.17.12)
+        version: 5.4.11(@types/node@22.12.0)
       vitest:
         specifier: 2.1.8
-        version: 2.1.8(@types/node@20.17.12)(jsdom@26.0.0)
+        version: 2.1.8(@types/node@22.12.0)(jsdom@26.0.0)
 
   packages/lib:
     dependencies:
@@ -539,8 +539,8 @@ importers:
         specifier: ~1.0.14
         version: 1.0.14
       '@types/node':
-        specifier: ^20.17.12
-        version: 20.17.12
+        specifier: ^22.12.0
+        version: 22.12.0
       '@types/react':
         specifier: ^18.3.3
         version: 18.3.3
@@ -561,7 +561,7 @@ importers:
         version: 0.172.0
       '@vitejs/plugin-react-swc':
         specifier: 3.7.2
-        version: 3.7.2(vite@5.4.11(@types/node@20.17.12))
+        version: 3.7.2(vite@5.4.11(@types/node@22.12.0))
       concat:
         specifier: 1.0.3
         version: 1.0.3
@@ -594,13 +594,13 @@ importers:
         version: 5.7.3
       vite:
         specifier: 5.4.11
-        version: 5.4.11(@types/node@20.17.12)
+        version: 5.4.11(@types/node@22.12.0)
       vite-css-modules:
         specifier: 1.8.4
-        version: 1.8.4(postcss@8.5.1)(rollup@4.30.1)(vite@5.4.11(@types/node@20.17.12))
+        version: 1.8.4(postcss@8.5.1)(rollup@4.30.1)(vite@5.4.11(@types/node@22.12.0))
       vitest:
         specifier: 2.1.8
-        version: 2.1.8(@types/node@20.17.12)(jsdom@26.0.0)
+        version: 2.1.8(@types/node@22.12.0)(jsdom@26.0.0)
 
   packages/shared:
     devDependencies:
@@ -617,8 +617,8 @@ importers:
         specifier: ~1.2.7
         version: 1.2.7
       '@types/node':
-        specifier: ^20.17.12
-        version: 20.17.12
+        specifier: ^22.12.0
+        version: 22.12.0
       '@types/react':
         specifier: ^18.3.3
         version: 18.3.3
@@ -645,7 +645,7 @@ importers:
         version: 5.7.3
       vitest:
         specifier: 2.1.8
-        version: 2.1.8(@types/node@20.17.12)(jsdom@26.0.0)
+        version: 2.1.8(@types/node@22.12.0)(jsdom@26.0.0)
       zustand:
         specifier: 5.0.3
         version: 5.0.3(@types/react@18.3.3)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
@@ -1869,8 +1869,8 @@ packages:
   '@types/ndarray@1.0.14':
     resolution: {integrity: sha512-oANmFZMnFQvb219SSBIhI1Ih/r4CvHDOzkWyJS/XRqkMrGH5/kaPSA1hQhdIBzouaE+5KpE/f5ylI9cujmckQg==}
 
-  '@types/node@20.17.12':
-    resolution: {integrity: sha512-vo/wmBgMIiEA23A/knMfn/cf37VnuF52nZh5ZoW0GWt4e4sxNquibrMRJ7UQsA06+MBx9r/H1jsI9grYjQCQlw==}
+  '@types/node@22.12.0':
+    resolution: {integrity: sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -5121,8 +5121,8 @@ packages:
   underscore@1.13.6:
     resolution: {integrity: sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==}
 
-  undici-types@6.19.8:
-    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+  undici-types@6.20.0:
+    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
   unified@11.0.4:
     resolution: {integrity: sha512-apMPnyLjAX+ty4OrNap7yumyVAMlKx5IWU2wlzzUdYJO9A8f1p9m/gywF/GM2ZDFcjQPrx59Mc90KwmxsoklxQ==}
@@ -5964,15 +5964,15 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.17.12
+      '@types/node': 22.12.0
       '@types/yargs': 17.0.32
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.4.2(typescript@5.7.3)(vite@5.4.11(@types/node@20.17.12))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.4.2(typescript@5.7.3)(vite@5.4.11(@types/node@22.12.0))':
     dependencies:
       magic-string: 0.27.0
       react-docgen-typescript: 2.2.2(typescript@5.7.3)
-      vite: 5.4.11(@types/node@20.17.12)
+      vite: 5.4.11(@types/node@22.12.0)
     optionalDependencies:
       typescript: 5.7.3
 
@@ -6320,13 +6320,13 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/builder-vite@8.5.0(storybook@8.5.0(prettier@3.4.2))(vite@5.4.11(@types/node@20.17.12))':
+  '@storybook/builder-vite@8.5.0(storybook@8.5.0(prettier@3.4.2))(vite@5.4.11(@types/node@22.12.0))':
     dependencies:
       '@storybook/csf-plugin': 8.5.0(storybook@8.5.0(prettier@3.4.2))
       browser-assert: 1.2.1
       storybook: 8.5.0(prettier@3.4.2)
       ts-dedent: 2.2.0
-      vite: 5.4.11(@types/node@20.17.12)
+      vite: 5.4.11(@types/node@22.12.0)
 
   '@storybook/components@8.5.0(storybook@8.5.0(prettier@3.4.2))':
     dependencies:
@@ -6386,11 +6386,11 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.5.0(prettier@3.4.2)
 
-  '@storybook/react-vite@8.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.30.1)(storybook@8.5.0(prettier@3.4.2))(typescript@5.7.3)(vite@5.4.11(@types/node@20.17.12))':
+  '@storybook/react-vite@8.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.30.1)(storybook@8.5.0(prettier@3.4.2))(typescript@5.7.3)(vite@5.4.11(@types/node@22.12.0))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.4.2(typescript@5.7.3)(vite@5.4.11(@types/node@20.17.12))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.4.2(typescript@5.7.3)(vite@5.4.11(@types/node@22.12.0))
       '@rollup/pluginutils': 5.1.4(rollup@4.30.1)
-      '@storybook/builder-vite': 8.5.0(storybook@8.5.0(prettier@3.4.2))(vite@5.4.11(@types/node@20.17.12))
+      '@storybook/builder-vite': 8.5.0(storybook@8.5.0(prettier@3.4.2))(vite@5.4.11(@types/node@22.12.0))
       '@storybook/react': 8.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.5.0(prettier@3.4.2))(typescript@5.7.3)
       find-up: 5.0.0
       magic-string: 0.30.17
@@ -6400,7 +6400,7 @@ snapshots:
       resolve: 1.22.10
       storybook: 8.5.0(prettier@3.4.2)
       tsconfig-paths: 4.2.0
-      vite: 5.4.11(@types/node@20.17.12)
+      vite: 5.4.11(@types/node@22.12.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -6658,9 +6658,9 @@ snapshots:
 
   '@types/ndarray@1.0.14': {}
 
-  '@types/node@20.17.12':
+  '@types/node@22.12.0':
     dependencies:
-      undici-types: 6.19.8
+      undici-types: 6.20.0
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -6668,7 +6668,7 @@ snapshots:
 
   '@types/pixelmatch@5.2.6':
     dependencies:
-      '@types/node': 20.17.12
+      '@types/node': 22.12.0
 
   '@types/prop-types@15.7.12': {}
 
@@ -6734,7 +6734,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 20.17.12
+      '@types/node': 22.12.0
     optional: true
 
   '@typescript-eslint/eslint-plugin@8.20.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0)(typescript@5.7.3))(eslint@9.18.0)(typescript@5.7.3)':
@@ -6979,20 +6979,20 @@ snapshots:
       d3-time-format: 4.1.0
       internmap: 2.0.3
 
-  '@vitejs/plugin-react-swc@3.7.2(vite@5.4.11(@types/node@20.17.12))':
+  '@vitejs/plugin-react-swc@3.7.2(vite@5.4.11(@types/node@22.12.0))':
     dependencies:
       '@swc/core': 1.10.7
-      vite: 5.4.11(@types/node@20.17.12)
+      vite: 5.4.11(@types/node@22.12.0)
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitest/eslint-plugin@1.1.25(@typescript-eslint/utils@8.20.0(eslint@9.18.0)(typescript@5.7.3))(eslint@9.18.0)(typescript@5.7.3)(vitest@2.1.8(@types/node@20.17.12)(jsdom@26.0.0))':
+  '@vitest/eslint-plugin@1.1.25(@typescript-eslint/utils@8.20.0(eslint@9.18.0)(typescript@5.7.3))(eslint@9.18.0)(typescript@5.7.3)(vitest@2.1.8(@types/node@22.12.0)(jsdom@26.0.0))':
     dependencies:
       '@typescript-eslint/utils': 8.20.0(eslint@9.18.0)(typescript@5.7.3)
       eslint: 9.18.0
     optionalDependencies:
       typescript: 5.7.3
-      vitest: 2.1.8(@types/node@20.17.12)(jsdom@26.0.0)
+      vitest: 2.1.8(@types/node@22.12.0)(jsdom@26.0.0)
 
   '@vitest/expect@2.1.8':
     dependencies:
@@ -7001,13 +7001,13 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.8(vite@5.4.11(@types/node@20.17.12))':
+  '@vitest/mocker@2.1.8(vite@5.4.11(@types/node@22.12.0))':
     dependencies:
       '@vitest/spy': 2.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 5.4.11(@types/node@20.17.12)
+      vite: 5.4.11(@types/node@22.12.0)
 
   '@vitest/pretty-format@2.1.8':
     dependencies:
@@ -8982,7 +8982,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.17.12
+      '@types/node': 22.12.0
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -10710,7 +10710,7 @@ snapshots:
 
   underscore@1.13.6: {}
 
-  undici-types@6.19.8: {}
+  undici-types@6.20.0: {}
 
   unified@11.0.4:
     dependencies:
@@ -10810,7 +10810,7 @@ snapshots:
       unist-util-stringify-position: 4.0.0
       vfile-message: 4.0.2
 
-  vite-css-modules@1.8.4(postcss@8.5.1)(rollup@4.30.1)(vite@5.4.11(@types/node@20.17.12)):
+  vite-css-modules@1.8.4(postcss@8.5.1)(rollup@4.30.1)(vite@5.4.11(@types/node@22.12.0)):
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@rollup/pluginutils': 5.1.4(rollup@4.30.1)
@@ -10822,17 +10822,17 @@ snapshots:
       postcss-modules-local-by-default: 4.2.0(postcss@8.5.1)
       postcss-modules-scope: 3.2.1(postcss@8.5.1)
       postcss-modules-values: 4.0.0(postcss@8.5.1)
-      vite: 5.4.11(@types/node@20.17.12)
+      vite: 5.4.11(@types/node@22.12.0)
     transitivePeerDependencies:
       - rollup
 
-  vite-node@2.1.8(@types/node@20.17.12):
+  vite-node@2.1.8(@types/node@22.12.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0(supports-color@8.1.1)
       es-module-lexer: 1.6.0
       pathe: 1.1.2
-      vite: 5.4.11(@types/node@20.17.12)
+      vite: 5.4.11(@types/node@22.12.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -10844,7 +10844,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-checker@0.8.0(eslint@9.18.0)(optionator@0.9.4)(typescript@5.7.3)(vite@5.4.11(@types/node@20.17.12)):
+  vite-plugin-checker@0.8.0(eslint@9.18.0)(optionator@0.9.4)(typescript@5.7.3)(vite@5.4.11(@types/node@22.12.0)):
     dependencies:
       '@babel/code-frame': 7.26.2
       ansi-escapes: 4.3.2
@@ -10856,7 +10856,7 @@ snapshots:
       npm-run-path: 4.0.1
       strip-ansi: 6.0.1
       tiny-invariant: 1.3.3
-      vite: 5.4.11(@types/node@20.17.12)
+      vite: 5.4.11(@types/node@22.12.0)
       vscode-languageclient: 7.0.0
       vscode-languageserver: 7.0.0
       vscode-languageserver-textdocument: 1.0.12
@@ -10866,33 +10866,33 @@ snapshots:
       optionator: 0.9.4
       typescript: 5.7.3
 
-  vite-plugin-eslint@1.8.1(eslint@9.18.0)(vite@5.4.11(@types/node@20.17.12)):
+  vite-plugin-eslint@1.8.1(eslint@9.18.0)(vite@5.4.11(@types/node@22.12.0)):
     dependencies:
       '@rollup/pluginutils': 4.2.1
       '@types/eslint': 8.56.5
       eslint: 9.18.0
       rollup: 2.79.1
-      vite: 5.4.11(@types/node@20.17.12)
+      vite: 5.4.11(@types/node@22.12.0)
 
-  vite@5.4.11(@types/node@20.17.12):
+  vite@5.4.11(@types/node@22.12.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.1
       rollup: 4.30.1
     optionalDependencies:
-      '@types/node': 20.17.12
+      '@types/node': 22.12.0
       fsevents: 2.3.3
 
-  vitest-fail-on-console@0.7.1(vite@5.4.11(@types/node@20.17.12))(vitest@2.1.8(@types/node@20.17.12)(jsdom@26.0.0)):
+  vitest-fail-on-console@0.7.1(vite@5.4.11(@types/node@22.12.0))(vitest@2.1.8(@types/node@22.12.0)(jsdom@26.0.0)):
     dependencies:
       chalk: 5.3.0
-      vite: 5.4.11(@types/node@20.17.12)
-      vitest: 2.1.8(@types/node@20.17.12)(jsdom@26.0.0)
+      vite: 5.4.11(@types/node@22.12.0)
+      vitest: 2.1.8(@types/node@22.12.0)(jsdom@26.0.0)
 
-  vitest@2.1.8(@types/node@20.17.12)(jsdom@26.0.0):
+  vitest@2.1.8(@types/node@22.12.0)(jsdom@26.0.0):
     dependencies:
       '@vitest/expect': 2.1.8
-      '@vitest/mocker': 2.1.8(vite@5.4.11(@types/node@20.17.12))
+      '@vitest/mocker': 2.1.8(vite@5.4.11(@types/node@22.12.0))
       '@vitest/pretty-format': 2.1.8
       '@vitest/runner': 2.1.8
       '@vitest/snapshot': 2.1.8
@@ -10908,11 +10908,11 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 1.2.0
-      vite: 5.4.11(@types/node@20.17.12)
-      vite-node: 2.1.8(@types/node@20.17.12)
+      vite: 5.4.11(@types/node@22.12.0)
+      vite-node: 2.1.8(@types/node@22.12.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 20.17.12
+      '@types/node': 22.12.0
       jsdom: 26.0.0
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
Upgrade Node to v22, which is the current LTS version, and fix #1717 by mentioning the prerequisite of installing Node and pnpm in the _Getting started_ section of the CONTRIBUTING guide.