### PR TITLE
Toggle exact notation in Line vis tooltip with wheel button

### DIFF
--- a/packages/app/src/vis-packs/core/complex/MappedComplexLineVis.tsx
+++ b/packages/app/src/vis-packs/core/complex/MappedComplexLineVis.tsx
@@ -56,8 +56,14 @@ function MappedComplexLineVis(props: Props) {
   } = props;
 
   const { visType } = config;
-  const { customDomain, yScaleType, xScaleType, curveType, showGrid } =
-    lineConfig;
+  const {
+    customDomain,
+    yScaleType,
+    xScaleType,
+    curveType,
+    showGrid,
+    exactNotation,
+  } = lineConfig;
 
   const numAxisArrays = useToNumArrays(axisValues);
   const [dataArray, ...auxArrays] = useMappedComplexArrays(
@@ -110,6 +116,7 @@ function MappedComplexLineVis(props: Props) {
           label: auxLabels[i],
           array,
         }))}
+        exactNotation={exactNotation}
         testid={dimMapping.toString()}
       />
     </>

--- a/packages/app/src/vis-packs/core/complex/MappedComplexVis.tsx
+++ b/packages/app/src/vis-packs/core/complex/MappedComplexVis.tsx
@@ -61,6 +61,7 @@ function MappedComplexVis(props: Props) {
     keepRatio,
     showGrid,
     invertColorMap,
+    exactNotation,
   } = heatmapConfig;
 
   const numAxisArrays = useToNumArrays(axisValues);
@@ -111,6 +112,7 @@ function MappedComplexVis(props: Props) {
         scaleType={scaleType}
         aspect={keepRatio ? 'equal' : 'auto'}
         showGrid={showGrid}
+        exactNotation={exactNotation}
         invertColorMap={invertColorMap}
         abscissaParams={{
           label: axisLabels[xDimIndex],

--- a/packages/app/src/vis-packs/core/heatmap/HeatmapToolbar.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/HeatmapToolbar.tsx
@@ -14,6 +14,7 @@ import { COLOR_SCALE_TYPES } from '@h5web/shared/vis-utils';
 import {
   MdAspectRatio,
   MdGridOn,
+  MdQueryStats,
   MdSwapHoriz,
   MdSwapVert,
 } from 'react-icons/md';
@@ -39,6 +40,7 @@ function HeatmapToolbar(props: Props) {
     invertColorMap,
     flipXAxis,
     flipYAxis,
+    exactNotation,
     setCustomDomain,
     setColorMap,
     setScaleType,
@@ -47,6 +49,7 @@ function HeatmapToolbar(props: Props) {
     toggleColorMapInversion,
     toggleXAxisFlip,
     toggleYAxisFlip,
+    toggleExactNotation,
   } = config;
 
   return (
@@ -103,6 +106,13 @@ function HeatmapToolbar(props: Props) {
         Icon={MdGridOn}
         value={showGrid}
         onToggle={toggleGrid}
+      />
+
+      <ToggleBtn
+        label="Exact"
+        Icon={MdQueryStats}
+        value={exactNotation}
+        onToggle={toggleExactNotation}
       />
 
       <Separator />

--- a/packages/app/src/vis-packs/core/heatmap/MappedHeatmapVis.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/MappedHeatmapVis.tsx
@@ -62,6 +62,7 @@ function MappedHeatmapVis(props: Props) {
     invertColorMap,
     flipXAxis,
     flipYAxis,
+    exactNotation,
   } = config;
 
   const numArray = useToNumArray(value);
@@ -116,6 +117,7 @@ function MappedHeatmapVis(props: Props) {
         }}
         flipXAxis={flipXAxis}
         flipYAxis={flipYAxis}
+        exactNotation={exactNotation}
         ignoreValue={ignoreValue}
       />
     </>

--- a/packages/app/src/vis-packs/core/heatmap/config.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/config.tsx
@@ -33,6 +33,9 @@ export interface HeatmapConfig {
 
   flipYAxis: boolean;
   toggleYAxisFlip: () => void;
+
+  exactNotation: boolean;
+  toggleExactNotation: () => void;
 }
 
 function createHeatmapConfigStore() {
@@ -69,6 +72,10 @@ function createHeatmapConfigStore() {
         flipXAxis: false,
         toggleXAxisFlip: () =>
           set((state) => ({ flipXAxis: !state.flipXAxis })),
+
+        exactNotation: false,
+        toggleExactNotation: () =>
+          set((state) => ({ exactNotation: !state.exactNotation })),
       }),
       {
         name: 'h5web:heatmap',

--- a/packages/app/src/vis-packs/core/line/LineToolbar.tsx
+++ b/packages/app/src/vis-packs/core/line/LineToolbar.tsx
@@ -10,7 +10,7 @@ import {
 } from '@h5web/lib';
 import { type Domain, type ExportEntry } from '@h5web/shared/vis-models';
 import { AXIS_SCALE_TYPES } from '@h5web/shared/vis-utils';
-import { MdGridOn } from 'react-icons/md';
+import { MdGridOn, MdQueryStats } from 'react-icons/md';
 
 import { INTERACTIONS_WITH_AXIAL_ZOOM } from '../utils';
 import { type LineConfig } from './config';
@@ -34,12 +34,14 @@ function LineToolbar(props: Props) {
     xScaleType,
     yScaleType,
     showErrors,
+    exactNotation,
     setCustomDomain,
     setCurveType,
     toggleGrid,
     setXScaleType,
     setYScaleType,
     toggleErrors,
+    toggleExactNotation,
   } = config;
 
   return (
@@ -80,6 +82,13 @@ function LineToolbar(props: Props) {
         Icon={MdGridOn}
         value={showGrid}
         onToggle={toggleGrid}
+      />
+
+      <ToggleBtn
+        label="Exact"
+        Icon={MdQueryStats}
+        value={exactNotation}
+        onToggle={toggleExactNotation}
       />
 
       <Separator />

--- a/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
+++ b/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
@@ -75,6 +75,7 @@ function MappedLineVis(props: Props) {
     curveType,
     showGrid,
     showErrors,
+    exactNotation,
   } = config;
 
   const { shape: dims } = dataset;
@@ -160,6 +161,7 @@ function MappedLineVis(props: Props) {
         errorsArray={errorsArray}
         showErrors={showErrors}
         auxiliaries={auxiliaries}
+        exactNotation={exactNotation}
         testid={dimMapping.toString()}
         ignoreValue={ignoreValue}
       />

--- a/packages/app/src/vis-packs/core/line/config.tsx
+++ b/packages/app/src/vis-packs/core/line/config.tsx
@@ -25,6 +25,9 @@ export interface LineConfig {
 
   showErrors: boolean;
   toggleErrors: () => void;
+
+  exactNotation: boolean;
+  toggleExactNotation: () => void;
 }
 
 function createLineConfigStore() {
@@ -47,6 +50,10 @@ function createLineConfigStore() {
 
         showErrors: true,
         toggleErrors: () => set((state) => ({ showErrors: !state.showErrors })),
+
+        exactNotation: false,
+        toggleExactNotation: () =>
+          set((state) => ({ exactNotation: !state.exactNotation })),
       }),
       {
         name: 'h5web:line',

--- a/packages/lib/src/vis/heatmap/HeatmapVis.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapVis.tsx
@@ -50,6 +50,7 @@ interface Props extends ClassStyleAttrs {
   minFilter?: MinificationTextureFilter;
   flipXAxis?: boolean;
   flipYAxis?: boolean;
+  exactNotation?: boolean;
   renderTooltip?: (data: TooltipData) => ReactElement;
   children?: ReactNode;
   interactions?: DefaultInteractionsConfig;
@@ -74,6 +75,7 @@ function HeatmapVis(props: Props) {
     minFilter,
     flipXAxis,
     flipYAxis,
+    exactNotation,
     renderTooltip,
     children,
     interactions,
@@ -81,6 +83,7 @@ function HeatmapVis(props: Props) {
     className = '',
     style,
   } = props;
+
   const { label: abscissaLabel, value: abscissaValue } = abscissaParams;
   const { label: ordinateLabel, value: ordinateValue } = ordinateParams;
   const { rows, cols } = getDims(dataArray);
@@ -142,12 +145,17 @@ function HeatmapVis(props: Props) {
 
             return (
               <>
-                {`${abscissaLabel ?? 'x'}=${formatTooltipVal(abscissa)}, `}
-                {`${ordinateLabel ?? 'y'}=${formatTooltipVal(ordinate)}`}
+                {`${abscissaLabel ?? 'x'}=${exactNotation ? abscissa : formatTooltipVal(abscissa)}, `}
+                {`${ordinateLabel ?? 'y'}=${exactNotation ? ordinate : formatTooltipVal(ordinate)}`}
                 <div className={styles.tooltipValue}>
-                  <strong>{formatTooltipVal(dataArray.get(yi, xi))}</strong>
+                  <strong>
+                    {exactNotation
+                      ? dataArray.get(yi, xi)
+                      : formatTooltipVal(dataArray.get(yi, xi))}
+                  </strong>
                   {dtype && <em>{` (${dtype})`}</em>}
-                  {alpha && ` (${formatTooltipVal(alpha.array.get(yi, xi))})`}
+                  {alpha &&
+                    ` (${exactNotation ? alpha.array.get(yi, xi) : formatTooltipVal(alpha.array.get(yi, xi))})`}
                 </div>
               </>
             );

--- a/packages/lib/src/vis/line/LineVis.tsx
+++ b/packages/lib/src/vis/line/LineVis.tsx
@@ -37,6 +37,7 @@ interface Props extends ClassStyleAttrs {
   errorsArray?: NdArray<NumArray>;
   showErrors?: boolean;
   auxiliaries?: AuxiliaryParams[];
+  exactNotation?: boolean;
   renderTooltip?: (data: TooltipData) => ReactElement;
   children?: ReactNode;
   interactions?: DefaultInteractionsConfig;
@@ -58,6 +59,7 @@ function LineVis(props: Props) {
     errorsArray,
     showErrors = false,
     auxiliaries = [],
+    exactNotation,
     renderTooltip,
     children,
     interactions,
@@ -124,7 +126,7 @@ function LineVis(props: Props) {
 
         <TooltipMesh
           guides="vertical"
-          renderTooltip={(x, _, exact) => {
+          renderTooltip={(x) => {
             const xi = abscissaToIndex(x);
             const abscissa = abscissas[xi];
 
@@ -137,7 +139,7 @@ function LineVis(props: Props) {
 
             return (
               <>
-                {`${abscissaLabel ?? 'x'} = ${exact ? abscissa : formatTooltipVal(abscissa)}`}
+                {`${abscissaLabel ?? 'x'} = ${exactNotation ? abscissa : formatTooltipVal(abscissa)}`}
 
                 <div className={styles.tooltipValue}>
                   {auxiliaries.length > 0 && (
@@ -148,9 +150,11 @@ function LineVis(props: Props) {
                     />
                   )}
                   <span>
-                    <strong>{exact ? value : formatTooltipVal(value)}</strong>
+                    <strong>
+                      {exactNotation ? value : formatTooltipVal(value)}
+                    </strong>
                     {error !== undefined &&
-                      ` ±${exact ? error : formatTooltipErr(error)}`}
+                      ` ±${exactNotation ? error : formatTooltipErr(error)}`}
                     {dtype && <em>{` (${dtype})`}</em>}
                   </span>
                 </div>
@@ -163,9 +167,11 @@ function LineVis(props: Props) {
                       style={{ color: auxColors[index % auxColors.length] }}
                     />
                     {label ? `${label} = ` : ''}
-                    {exact ? array.get(xi) : formatTooltipVal(array.get(xi))}
+                    {exactNotation
+                      ? array.get(xi)
+                      : formatTooltipVal(array.get(xi))}
                     {errors &&
-                      ` ±${exact ? errors.get(xi) : formatTooltipErr(errors.get(xi))}`}
+                      ` ±${exactNotation ? errors.get(xi) : formatTooltipErr(errors.get(xi))}`}
                   </div>
                 ))}
               </>

--- a/packages/lib/src/vis/line/LineVis.tsx
+++ b/packages/lib/src/vis/line/LineVis.tsx
@@ -124,7 +124,7 @@ function LineVis(props: Props) {
 
         <TooltipMesh
           guides="vertical"
-          renderTooltip={(x) => {
+          renderTooltip={(x, _, exact) => {
             const xi = abscissaToIndex(x);
             const abscissa = abscissas[xi];
 
@@ -137,7 +137,7 @@ function LineVis(props: Props) {
 
             return (
               <>
-                {`${abscissaLabel ?? 'x'} = ${formatTooltipVal(abscissa)}`}
+                {`${abscissaLabel ?? 'x'} = ${exact ? abscissa : formatTooltipVal(abscissa)}`}
 
                 <div className={styles.tooltipValue}>
                   {auxiliaries.length > 0 && (
@@ -148,8 +148,9 @@ function LineVis(props: Props) {
                     />
                   )}
                   <span>
-                    <strong>{formatTooltipVal(value)}</strong>
-                    {error !== undefined && ` ±${formatTooltipErr(error)}`}
+                    <strong>{exact ? value : formatTooltipVal(value)}</strong>
+                    {error !== undefined &&
+                      ` ±${exact ? error : formatTooltipErr(error)}`}
                     {dtype && <em>{` (${dtype})`}</em>}
                   </span>
                 </div>
@@ -162,8 +163,9 @@ function LineVis(props: Props) {
                       style={{ color: auxColors[index % auxColors.length] }}
                     />
                     {label ? `${label} = ` : ''}
-                    {formatTooltipVal(array.get(xi))}
-                    {errors && ` ±${formatTooltipErr(errors.get(xi))}`}
+                    {exact ? array.get(xi) : formatTooltipVal(array.get(xi))}
+                    {errors &&
+                      ` ±${exact ? errors.get(xi) : formatTooltipErr(errors.get(xi))}`}
                   </div>
                 ))}
               </>

--- a/packages/lib/src/vis/shared/TooltipMesh.tsx
+++ b/packages/lib/src/vis/shared/TooltipMesh.tsx
@@ -1,3 +1,4 @@
+import { useToggle } from '@react-hookz/web';
 import { type ThreeEvent } from '@react-three/fiber';
 import { useTooltip } from '@visx/tooltip';
 import { type ReactElement, useCallback } from 'react';
@@ -10,7 +11,11 @@ import VisMesh from './VisMesh';
 interface Props {
   size?: Size;
   guides?: 'horizontal' | 'vertical' | 'both';
-  renderTooltip: (x: number, y: number) => ReactElement | undefined;
+  renderTooltip: (
+    x: number,
+    y: number,
+    exact: boolean,
+  ) => ReactElement | undefined;
 }
 
 function TooltipMesh(props: Props) {
@@ -26,6 +31,8 @@ function TooltipMesh(props: Props) {
     showTooltip,
     hideTooltip,
   } = useTooltip<Coords>();
+
+  const [isExact, toggleExact] = useToggle();
 
   // Show and/or update tooltip when pointer moves except when dragging
   const onPointerMove = useCallback(
@@ -57,7 +64,16 @@ function TooltipMesh(props: Props) {
   }, [hideTooltip, tooltipOpen]);
 
   // Hide tooltip when user starts panning
-  const onPointerDown = useCallback(() => hideTooltip(), [hideTooltip]);
+  const onPointerDown = useCallback(
+    (evt: ThreeEvent<PointerEvent>) => {
+      if (evt.button === 1) {
+        toggleExact();
+      } else {
+        hideTooltip();
+      }
+    },
+    [hideTooltip, toggleExact],
+  );
 
   // Show tooltip after dragging, if pointer is released inside the vis viewport
   const onPointerUp = useCallback(
@@ -71,7 +87,7 @@ function TooltipMesh(props: Props) {
     [height, onPointerMove, width],
   );
 
-  const content = tooltipData && renderTooltip(...tooltipData);
+  const content = tooltipData && renderTooltip(...tooltipData, isExact);
 
   return (
     <>

--- a/packages/lib/src/vis/shared/TooltipMesh.tsx
+++ b/packages/lib/src/vis/shared/TooltipMesh.tsx
@@ -1,4 +1,3 @@
-import { useToggle } from '@react-hookz/web';
 import { type ThreeEvent } from '@react-three/fiber';
 import { useTooltip } from '@visx/tooltip';
 import { type ReactElement, useCallback } from 'react';
@@ -11,15 +10,11 @@ import VisMesh from './VisMesh';
 interface Props {
   size?: Size;
   guides?: 'horizontal' | 'vertical' | 'both';
-  renderTooltip: (
-    x: number,
-    y: number,
-    exact: boolean,
-  ) => ReactElement | undefined;
+  renderTooltip: (x: number, y: number) => ReactElement | undefined;
 }
 
 function TooltipMesh(props: Props) {
-  const { guides, renderTooltip, size } = props;
+  const { size, guides, renderTooltip } = props;
   const { canvasSize, worldToData } = useVisCanvasContext();
   const { width, height } = canvasSize;
 
@@ -31,8 +26,6 @@ function TooltipMesh(props: Props) {
     showTooltip,
     hideTooltip,
   } = useTooltip<Coords>();
-
-  const [isExact, toggleExact] = useToggle();
 
   // Show and/or update tooltip when pointer moves except when dragging
   const onPointerMove = useCallback(
@@ -64,16 +57,7 @@ function TooltipMesh(props: Props) {
   }, [hideTooltip, tooltipOpen]);
 
   // Hide tooltip when user starts panning
-  const onPointerDown = useCallback(
-    (evt: ThreeEvent<PointerEvent>) => {
-      if (evt.button === 1) {
-        toggleExact();
-      } else {
-        hideTooltip();
-      }
-    },
-    [hideTooltip, toggleExact],
-  );
+  const onPointerDown = useCallback(() => hideTooltip(), [hideTooltip]);
 
   // Show tooltip after dragging, if pointer is released inside the vis viewport
   const onPointerUp = useCallback(
@@ -87,7 +71,7 @@ function TooltipMesh(props: Props) {
     [height, onPointerMove, width],
   );
 
-  const content = tooltipData && renderTooltip(...tooltipData, isExact);
+  const content = tooltipData && renderTooltip(...tooltipData);
 
   return (
     <>


### PR DESCRIPTION
Proof of concept for #1646.

While the new _Exact_ notation introduced in #1753 makes sense for the _Matrix_ vis (especially since the _Auto_ notation remains the default), the tooltips of the WebGL-based visualizations are another matter. Showing exact values can quickly add clutter:

![image](https://github.com/user-attachments/assets/13d73b8b-7049-4728-8b8e-10ec5a3b565e)

There's no easy way to know what precision the user expects to see. Finding the smallest difference between two values is of course not an option, so we're basically left with... providing a good default behaviour and letting the user opt in to see more precise values.

In this spirit, here's my attempt at an interaction that consists in clicking the wheel button to toggle "exact" precision on or off for the tooltip:

[Screencast from 2025-02-05 14-40-53.webm](https://github.com/user-attachments/assets/cd6ce54e-02e5-4fa2-9f31-7769c1309dcd)

This is just a draft to request feedback on the interaction — please ignore the implementation for now.