### PR TITLE
Allow passing custom axis tick formatters to `VisCanvas`

### DIFF
--- a/apps/storybook/src/VisCanvas.stories.tsx
+++ b/apps/storybook/src/VisCanvas.stories.tsx
@@ -1,5 +1,6 @@
 import { ScaleType, VisCanvas } from '@h5web/lib';
 import { type Meta, type StoryFn, type StoryObj } from '@storybook/react';
+import { format } from 'd3-format';
 
 import FillHeight from './decorators/FillHeight';
 
@@ -31,6 +32,23 @@ export const NiceDomains = {
   args: {
     abscissaConfig: { visDomain: [-1.2, 2.8], showGrid: true, nice: true },
     ordinateConfig: { visDomain: [-1.2, 2.8], showGrid: true, nice: false },
+  },
+} satisfies Story;
+
+export const TickFormatters = {
+  args: {
+    abscissaConfig: {
+      visDomain: [-1.2, 2.8],
+      showGrid: true,
+      formatTick: (val) => {
+        return Math.round(val) === val ? val.toString() : val.toFixed(3);
+      },
+    },
+    ordinateConfig: {
+      visDomain: [50, 100],
+      showGrid: true,
+      formatTick: format('.2e'),
+    },
   },
 } satisfies Story;
 

--- a/packages/lib/src/vis/models.ts
+++ b/packages/lib/src/vis/models.ts
@@ -42,6 +42,7 @@ export interface AxisConfig {
   label?: string;
   flip?: boolean;
   nice?: boolean;
+  formatTick?: (val: number) => string;
 }
 
 export type VisScaleType = ColorScaleType | [ScaleType.Gamma, number];

--- a/packages/lib/src/vis/shared/Axis.tsx
+++ b/packages/lib/src/vis/shared/Axis.tsx
@@ -49,6 +49,7 @@ function Axis(props: Props) {
     showGrid,
     label,
     nice = false,
+    formatTick,
   } = config;
   // Restrain ticks scales to visible domains
   const scale = createScale(scaleType, {
@@ -76,7 +77,9 @@ function Axis(props: Props) {
         >
           <AxisComponent
             scale={scale}
-            tickFormat={getTickFormatter(domain, axisLength, scaleType)}
+            tickFormat={
+              formatTick || getTickFormatter(domain, axisLength, scaleType)
+            }
             label={label}
             labelOffset={offset - (isAbscissa ? 32 : 36)}
             hideAxisLine={showGrid}


### PR DESCRIPTION
Fix #1701

`VisCanvas`' internal tick formatter is meant as a good default:
- It uses D3 with format [`.3~g`](https://d3js.org/d3-format) to strongly limit the number of characters and prevent tick labels from overflowing.
- It tells D3 to force exponent notation for numbers such as `0.00000123` (for which D3 doesn't respect the precision in `g` mode).
- It skips rendering some tick labels in log scale when space is limited.

Unfortunately, this is far from perfect.

Finding the perfect tick formatting algorithm is just not possible, so the idea with this PR is to allow consumers of `VisCanvas` to implement one that works for their use case.

I think this opens the door to a lot of use cases. For instance, in the new `VisCanvas` story that demonstrates the use of `formatTick`, I pass a formatter that uses `toFixed` for decimal numbers, and `toString` for integers.

![image](https://github.com/user-attachments/assets/efa03005-23f9-478f-8a41-ebe676881550)

One could even imagine toggling between different tick formatters based on zoom level using a combination of `useCameraState` and an external store (since `useCameraState` can only be used inside `VisCanvas`).