### PR TITLE
Export and document context access hooks

### DIFF
--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -481,7 +481,8 @@ function MyApp() {
 ```
 
 For convenience, the following hooks are available to access data through the
-data context: `useEntity`, `useDatasetValue`.
+data context: `useEntity`, `useDatasetValue`, `useDatasetsValues`,
+`usePrefetchValues`.
 
 We also provide a large number of type guards and assertion functions to narrow
 down the kind/shape/type of HDF5 entities returned by `useEntity`, as well as a
@@ -507,4 +508,30 @@ function MyApp() {
     />
   );
 }
+```
+
+When accessing the values of multiple datasets with multiple consecutive calls
+to `useDatasetValue` (and/or `useDatasetsValues`), invoke `usePrefetchValues`
+first to ensure that the values are requested in parallel rather than
+sequentially:
+
+```tsx
+const axesDatasets = [abscissasDataset, ordinatesDataset];
+usePrefetchValues([valuesDataset, ...axesDatasets]);
+
+const values = useDatasetValue(valuesDataset);
+const [abscissas, ordinates] = useDatasetsValues(axesDatasets);
+```
+
+All three hooks accept a `selection` parameter to request specific slices from
+n-dimensional datasets:
+
+```tsx
+const selection = '0,:,:';
+usePrefetchValues([valuesDataset], selection); // prefetch the first 2D slice
+usePrefetchValues([abscissasDataset, ordinatesDataset]); // pretech in full (i.e. no selection)
+
+const values = useDatasetValue(valuesDataset, selection);
+const abscissas = useDatasetValue(abscissasDataset);
+const ordinates = useDatasetValue(ordinatesDataset);
 ```

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -479,3 +479,32 @@ function MyApp() {
   return <pre>{JSON.stringify(group, null, 2)}</pre>;
 }
 ```
+
+For convenience, the following hooks are available to access data through the
+data context: `useEntity`, `useDatasetValue`.
+
+We also provide a large number of type guards and assertion functions to narrow
+down the kind/shape/type of HDF5 entities returned by `useEntity`, as well as a
+memoised hook called `useNdArray` to create ndarrays that can be passed to the
+visualization components (available in `@h5web/lib`).
+
+```tsx
+function MyApp() {
+  const entity = useEntity('/nD_datasets/twoD'); // ProvidedEntity
+  assertDataset(entity); // Dataset
+  assertArrayShape(entity); // Dataset<ArrayShape>
+  assertFloatType(entity); // Dataset<ArrayShape, FloatType>
+
+  const value = useDatasetValue(entity); // number[] | TypedArray
+  const dataArray = useNdArray(value, entity.shape);
+  const domain = useDomain(dataArray);
+
+  return (
+    <HeatmapVis
+      style={{ width: '100vw', height: '100vh' }}
+      dataArray={dataArray}
+      domain={domain}
+    />
+  );
+}
+```

--- a/packages/app/src/dimension-mapper/hooks.ts
+++ b/packages/app/src/dimension-mapper/hooks.ts
@@ -1,0 +1,21 @@
+import {
+  type ArrayShape,
+  type Dataset,
+  type ScalarShape,
+} from '@h5web/shared/hdf5-models';
+
+import { useDataContext } from '../providers/DataProvider';
+import { getSliceSelection } from '../vis-packs/core/utils';
+import { type DimensionMapping } from './models';
+
+export function useValuesInCache(
+  ...datasets: (Dataset<ScalarShape | ArrayShape> | undefined)[]
+): (dimMapping: DimensionMapping) => boolean {
+  const { valuesStore } = useDataContext();
+  return (dimMapping) => {
+    const selection = getSliceSelection(dimMapping);
+    return datasets.every(
+      (dataset) => !dataset || valuesStore.has({ dataset, selection }),
+    );
+  };
+}

--- a/packages/app/src/explorer/EntityList.tsx
+++ b/packages/app/src/explorer/EntityList.tsx
@@ -1,7 +1,7 @@
 import { assertGroup } from '@h5web/shared/guards';
 import { buildEntityPath } from '@h5web/shared/hdf5-utils';
 
-import { useDataContext } from '../providers/DataProvider';
+import { useEntity } from '../hooks';
 import EntityItem from './EntityItem';
 import styles from './Explorer.module.css';
 
@@ -15,8 +15,7 @@ interface Props {
 function EntityList(props: Props) {
   const { level, parentPath, selectedPath, onSelect } = props;
 
-  const { entitiesStore } = useDataContext();
-  const group = entitiesStore.get(parentPath);
+  const group = useEntity(parentPath);
   assertGroup(group);
 
   if (group.children.length === 0) {

--- a/packages/app/src/hooks.ts
+++ b/packages/app/src/hooks.ts
@@ -51,17 +51,17 @@ export function useDatasetValue<D extends Dataset<ArrayShape | ScalarShape>>(
   return value;
 }
 
-export function useDatasetValues<D extends Dataset<ArrayShape | ScalarShape>>(
+export function useDatasetsValues<D extends Dataset<ArrayShape | ScalarShape>>(
   datasets: D[],
   selection?: string,
 ): Value<D>[];
 
-export function useDatasetValues<D extends Dataset<ArrayShape | ScalarShape>>(
+export function useDatasetsValues<D extends Dataset<ArrayShape | ScalarShape>>(
   datasets: (D | undefined)[],
   selection?: string,
 ): (Value<D> | undefined)[];
 
-export function useDatasetValues<D extends Dataset<ArrayShape | ScalarShape>>(
+export function useDatasetsValues<D extends Dataset<ArrayShape | ScalarShape>>(
   datasets: (D | undefined)[],
   selection?: string,
 ): (Value<D> | undefined)[] {

--- a/packages/app/src/hooks.ts
+++ b/packages/app/src/hooks.ts
@@ -1,0 +1,79 @@
+import { assertDatasetValue, isDefined } from '@h5web/shared/guards';
+import {
+  type ArrayShape,
+  type Dataset,
+  type ProvidedEntity,
+  type ScalarShape,
+  type Value,
+} from '@h5web/shared/hdf5-models';
+
+import { useDataContext } from './providers/DataProvider';
+
+export function useEntity(path: string): ProvidedEntity {
+  const { entitiesStore } = useDataContext();
+  return entitiesStore.get(path);
+}
+
+export function usePrefetchValues(
+  datasets: (Dataset<ScalarShape | ArrayShape> | undefined)[],
+  selection?: string,
+): void {
+  const { valuesStore } = useDataContext();
+  datasets.filter(isDefined).forEach((dataset) => {
+    valuesStore.prefetch({ dataset, selection });
+  });
+}
+
+export function useDatasetValue<D extends Dataset<ArrayShape | ScalarShape>>(
+  dataset: D,
+  selection?: string,
+): Value<D>;
+
+export function useDatasetValue<D extends Dataset<ArrayShape | ScalarShape>>(
+  dataset: D | undefined,
+  selection?: string,
+): Value<D> | undefined;
+
+export function useDatasetValue<D extends Dataset<ArrayShape | ScalarShape>>(
+  dataset: D | undefined,
+  selection?: string,
+): Value<D> | undefined {
+  const { valuesStore } = useDataContext();
+
+  if (!dataset) {
+    return undefined;
+  }
+
+  // If `selection` is undefined, the entire dataset will be fetched
+  const value = valuesStore.get({ dataset, selection });
+
+  assertDatasetValue(value, dataset);
+  return value;
+}
+
+export function useDatasetValues<D extends Dataset<ArrayShape | ScalarShape>>(
+  datasets: D[],
+  selection?: string,
+): Value<D>[];
+
+export function useDatasetValues<D extends Dataset<ArrayShape | ScalarShape>>(
+  datasets: (D | undefined)[],
+  selection?: string,
+): (Value<D> | undefined)[];
+
+export function useDatasetValues<D extends Dataset<ArrayShape | ScalarShape>>(
+  datasets: (D | undefined)[],
+  selection?: string,
+): (Value<D> | undefined)[] {
+  const { valuesStore } = useDataContext();
+
+  return datasets.map((dataset) => {
+    if (!dataset) {
+      return undefined;
+    }
+
+    const value = valuesStore.get({ dataset, selection });
+    assertDatasetValue(value, dataset);
+    return value;
+  });
+}

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -23,7 +23,12 @@ export type {
 } from './providers/models';
 
 // Hooks
-export { useEntity, useDatasetValue } from './hooks';
+export {
+  useEntity,
+  useDatasetValue,
+  useDatasetsValues,
+  usePrefetchValues,
+} from './hooks';
 export { useBaseArray as useNdArray } from './vis-packs/core/hooks';
 
 // Models

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -15,14 +15,18 @@ export type GetExportURL = NonNullable<DataProviderApi['getExportURL']>;
 // Context
 export { useDataContext } from './providers/DataProvider';
 export type { DataContextValue } from './providers/DataProvider';
+export type {
+  EntitiesStore,
+  ValuesStore,
+  ValuesStoreParams,
+  AttrValuesStore,
+} from './providers/models';
 
-// Undocumented (for @h5web/h5wasm)
-export { default as DataProvider } from './providers/DataProvider';
-export { DataProviderApi } from './providers/api';
-export type { ValuesStoreParams } from './providers/models';
-export { getValueOrError } from './providers/utils';
+// Hooks
+export { useEntity, useDatasetValue } from './hooks';
+export { useBaseArray as useNdArray } from './vis-packs/core/hooks';
 
-// Undocumented models
+// Models
 export { EntityKind } from '@h5web/shared/hdf5-models';
 
 export type {
@@ -66,13 +70,14 @@ export type {
   UnknownType,
 
   // Value
+  Value,
   ScalarValue,
   ArrayValue,
   AttributeValues,
   H5WebComplex,
 } from '@h5web/shared/hdf5-models';
 
-// Undocumented guards and assertions
+// Type guards and assertions
 export {
   isDefined,
   isNonNull,
@@ -117,6 +122,8 @@ export {
   isPrintableType,
   isCompoundType,
   hasStringType,
+  hasIntegerType,
+  hasFloatType,
   hasNumericType,
   hasBoolType,
   hasEnumType,
@@ -125,7 +132,11 @@ export {
   hasPrintableType,
   hasCompoundType,
   assertStringType,
+  assertIntegerType,
+  assertFloatType,
   assertNumericType,
+  assertBoolType,
+  assertEnumType,
   assertNumericLikeType,
   assertComplexType,
   assertPrintableType,
@@ -133,3 +144,8 @@ export {
   assertScalarValue,
   assertDatasetValue,
 } from '@h5web/shared/guards';
+
+// Undocumented (for @h5web/h5wasm)
+export { default as DataProvider } from './providers/DataProvider';
+export { DataProviderApi } from './providers/api';
+export { getValueOrError } from './providers/utils';

--- a/packages/app/src/metadata-viewer/MetadataViewer.tsx
+++ b/packages/app/src/metadata-viewer/MetadataViewer.tsx
@@ -4,7 +4,7 @@ import { buildEntityPath } from '@h5web/shared/hdf5-utils';
 import { memo, Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
-import { useDataContext } from '../providers/DataProvider';
+import { useEntity } from '../hooks';
 import AttrErrorFallback from './AttrErrorFallback';
 import AttributesInfo from './AttributesInfo';
 import AttrValueLoader from './AttrValueLoader';
@@ -21,9 +21,7 @@ interface Props {
 function MetadataViewer(props: Props) {
   const { path, onSelectPath } = props;
 
-  const { entitiesStore } = useDataContext();
-  const entity = entitiesStore.get(path);
-
+  const entity = useEntity(path);
   const { kind, attributes } = entity;
   const title = kind === EntityKind.Unresolved ? 'Entity' : kind;
 

--- a/packages/app/src/vis-packs/core/ValueFetcher.tsx
+++ b/packages/app/src/vis-packs/core/ValueFetcher.tsx
@@ -6,7 +6,7 @@ import {
 } from '@h5web/shared/hdf5-models';
 import { type ReactNode } from 'react';
 
-import { useDatasetValue } from './hooks';
+import { useDatasetValue } from '../../hooks';
 
 interface Props<D extends Dataset> {
   dataset: D;

--- a/packages/app/src/vis-packs/core/complex/ComplexLineVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/complex/ComplexLineVisContainer.tsx
@@ -5,10 +5,10 @@ import {
 } from '@h5web/shared/guards';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
+import { useValuesInCache } from '../../../dimension-mapper/hooks';
 import { useDimMappingState } from '../../../dimension-mapper/store';
 import { type VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
-import { useValuesInCache } from '../hooks';
 import { useLineConfig } from '../line/config';
 import { getSliceSelection } from '../utils';
 import ValueFetcher from '../ValueFetcher';

--- a/packages/app/src/vis-packs/core/complex/ComplexVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/complex/ComplexVisContainer.tsx
@@ -6,11 +6,11 @@ import {
 } from '@h5web/shared/guards';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
+import { useValuesInCache } from '../../../dimension-mapper/hooks';
 import { useDimMappingState } from '../../../dimension-mapper/store';
 import { type VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
 import { useHeatmapConfig } from '../heatmap/config';
-import { useValuesInCache } from '../hooks';
 import { getSliceSelection } from '../utils';
 import ValueFetcher from '../ValueFetcher';
 import { useComplexConfig } from './config';

--- a/packages/app/src/vis-packs/core/compound/CompoundVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/compound/CompoundVisContainer.tsx
@@ -6,10 +6,10 @@ import {
 } from '@h5web/shared/guards';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
+import { useValuesInCache } from '../../../dimension-mapper/hooks';
 import { useDimMappingState } from '../../../dimension-mapper/store';
 import { type VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
-import { useValuesInCache } from '../hooks';
 import { useMatrixConfig } from '../matrix/config';
 import { getSliceSelection } from '../utils';
 import ValueFetcher from '../ValueFetcher';

--- a/packages/app/src/vis-packs/core/heatmap/HeatmapVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/HeatmapVisContainer.tsx
@@ -6,10 +6,11 @@ import {
 } from '@h5web/shared/guards';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
+import { useValuesInCache } from '../../../dimension-mapper/hooks';
 import { useDimMappingState } from '../../../dimension-mapper/store';
 import { type VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
-import { useIgnoreFillValue, useValuesInCache } from '../hooks';
+import { useIgnoreFillValue } from '../hooks';
 import { getSliceSelection } from '../utils';
 import ValueFetcher from '../ValueFetcher';
 import { useHeatmapConfig } from './config';

--- a/packages/app/src/vis-packs/core/hooks.ts
+++ b/packages/app/src/vis-packs/core/hooks.ts
@@ -1,12 +1,8 @@
 import { createMemo } from '@h5web/shared/createMemo';
-import { assertDatasetValue, isDefined } from '@h5web/shared/guards';
 import {
-  type ArrayShape,
   type ArrayValue,
   type Dataset,
   type NumericLikeType,
-  type ScalarShape,
-  type Value,
 } from '@h5web/shared/hdf5-models';
 import { type IgnoreValue, type NumArray } from '@h5web/shared/vis-models';
 import { castArray } from '@h5web/shared/vis-utils';
@@ -20,12 +16,7 @@ import {
   bigIntTypedArrayFromDType,
   typedArrayFromDType,
 } from '../../providers/utils';
-import {
-  applyMapping,
-  getBaseArray,
-  getSliceSelection,
-  toNumArray,
-} from './utils';
+import { applyMapping, getBaseArray, toNumArray } from './utils';
 
 export const useToNumArray = createMemo(toNumArray);
 
@@ -41,82 +32,6 @@ export function useToNumArrays(
   arrays: (ArrayValue<NumericLikeType> | undefined)[],
 ): (NumArray | undefined)[] {
   return useMemo(() => arrays.map(toNumArray), arrays); // eslint-disable-line react-hooks/exhaustive-deps
-}
-
-export function useValuesInCache(
-  ...datasets: (Dataset<ScalarShape | ArrayShape> | undefined)[]
-): (dimMapping: DimensionMapping) => boolean {
-  const { valuesStore } = useDataContext();
-  return (dimMapping) => {
-    const selection = getSliceSelection(dimMapping);
-    return datasets.every(
-      (dataset) => !dataset || valuesStore.has({ dataset, selection }),
-    );
-  };
-}
-
-export function usePrefetchValues(
-  datasets: (Dataset<ScalarShape | ArrayShape> | undefined)[],
-  selection?: string,
-): void {
-  const { valuesStore } = useDataContext();
-  datasets.filter(isDefined).forEach((dataset) => {
-    valuesStore.prefetch({ dataset, selection });
-  });
-}
-
-export function useDatasetValue<D extends Dataset<ArrayShape | ScalarShape>>(
-  dataset: D,
-  selection?: string,
-): Value<D>;
-
-export function useDatasetValue<D extends Dataset<ArrayShape | ScalarShape>>(
-  dataset: D | undefined,
-  selection?: string,
-): Value<D> | undefined;
-
-export function useDatasetValue<D extends Dataset<ArrayShape | ScalarShape>>(
-  dataset: D | undefined,
-  selection?: string,
-): Value<D> | undefined {
-  const { valuesStore } = useDataContext();
-
-  if (!dataset) {
-    return undefined;
-  }
-
-  // If `selection` is undefined, the entire dataset will be fetched
-  const value = valuesStore.get({ dataset, selection });
-
-  assertDatasetValue(value, dataset);
-  return value;
-}
-
-export function useDatasetValues<D extends Dataset<ArrayShape | ScalarShape>>(
-  datasets: D[],
-  selection?: string,
-): Value<D>[];
-
-export function useDatasetValues<D extends Dataset<ArrayShape | ScalarShape>>(
-  datasets: (D | undefined)[],
-  selection?: string,
-): (Value<D> | undefined)[];
-
-export function useDatasetValues<D extends Dataset<ArrayShape | ScalarShape>>(
-  datasets: (D | undefined)[],
-  selection?: string,
-): (Value<D> | undefined)[] {
-  const { valuesStore } = useDataContext();
-
-  return datasets.map((dataset) => {
-    if (!dataset) {
-      return undefined;
-    }
-
-    const value = valuesStore.get({ dataset, selection });
-    assertDatasetValue(value, dataset);
-    return value;
-  });
 }
 
 export function useBaseArray<T extends ArrayValue | undefined>(

--- a/packages/app/src/vis-packs/core/line/LineVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/line/LineVisContainer.tsx
@@ -5,10 +5,11 @@ import {
 } from '@h5web/shared/guards';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
+import { useValuesInCache } from '../../../dimension-mapper/hooks';
 import { useDimMappingState } from '../../../dimension-mapper/store';
 import { type VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
-import { useIgnoreFillValue, useValuesInCache } from '../hooks';
+import { useIgnoreFillValue } from '../hooks';
 import { getSliceSelection } from '../utils';
 import ValueFetcher from '../ValueFetcher';
 import { useLineConfig } from './config';

--- a/packages/app/src/vis-packs/core/matrix/MatrixVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/matrix/MatrixVisContainer.tsx
@@ -5,10 +5,10 @@ import {
 } from '@h5web/shared/guards';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
+import { useValuesInCache } from '../../../dimension-mapper/hooks';
 import { useDimMappingState } from '../../../dimension-mapper/store';
 import { type VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
-import { useValuesInCache } from '../hooks';
 import { getSliceSelection } from '../utils';
 import ValueFetcher from '../ValueFetcher';
 import { useMatrixConfig } from './config';

--- a/packages/app/src/vis-packs/core/rgb/RgbVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/rgb/RgbVisContainer.tsx
@@ -6,11 +6,11 @@ import {
 } from '@h5web/shared/guards';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
+import { useValuesInCache } from '../../../dimension-mapper/hooks';
 import { useDimMappingState } from '../../../dimension-mapper/store';
 import { useDataContext } from '../../../providers/DataProvider';
 import { type VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
-import { useValuesInCache } from '../hooks';
 import { getSliceSelection } from '../utils';
 import ValueFetcher from '../ValueFetcher';
 import { useRgbConfig } from './config';

--- a/packages/app/src/vis-packs/core/surface/SurfaceVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/surface/SurfaceVisContainer.tsx
@@ -6,10 +6,10 @@ import {
 } from '@h5web/shared/guards';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
+import { useValuesInCache } from '../../../dimension-mapper/hooks';
 import { useDimMappingState } from '../../../dimension-mapper/store';
 import { type VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
-import { useValuesInCache } from '../hooks';
 import { getSliceSelection } from '../utils';
 import ValueFetcher from '../ValueFetcher';
 import { useSurfaceConfig } from './config';

--- a/packages/app/src/vis-packs/nexus/NxNoteFetcher.tsx
+++ b/packages/app/src/vis-packs/nexus/NxNoteFetcher.tsx
@@ -5,7 +5,7 @@ import {
 } from '@h5web/shared/hdf5-models';
 import { type ReactNode } from 'react';
 
-import { useDatasetValues, usePrefetchValues } from '../core/hooks';
+import { useDatasetValues, usePrefetchValues } from '../../hooks';
 
 interface Props {
   dataDataset: Dataset<ScalarShape, StringType>;

--- a/packages/app/src/vis-packs/nexus/NxNoteFetcher.tsx
+++ b/packages/app/src/vis-packs/nexus/NxNoteFetcher.tsx
@@ -5,7 +5,7 @@ import {
 } from '@h5web/shared/hdf5-models';
 import { type ReactNode } from 'react';
 
-import { useDatasetValues, usePrefetchValues } from '../../hooks';
+import { useDatasetsValues, usePrefetchValues } from '../../hooks';
 
 interface Props {
   dataDataset: Dataset<ScalarShape, StringType>;
@@ -17,7 +17,7 @@ function NxNoteFetcher(props: Props) {
   const { dataDataset, typeDataset, render } = props;
 
   usePrefetchValues([dataDataset, typeDataset]);
-  const [value, mimeType] = useDatasetValues([dataDataset, typeDataset]);
+  const [value, mimeType] = useDatasetsValues([dataDataset, typeDataset]);
 
   return <>{render(value, mimeType)}</>;
 }

--- a/packages/app/src/vis-packs/nexus/NxValuesFetcher.tsx
+++ b/packages/app/src/vis-packs/nexus/NxValuesFetcher.tsx
@@ -5,8 +5,8 @@ import {
 import { type ReactNode } from 'react';
 
 import {
+  useDatasetsValues,
   useDatasetValue,
-  useDatasetValues,
   usePrefetchValues,
 } from '../../hooks';
 import { type NxData, type NxValues } from './models';
@@ -41,9 +41,9 @@ function NxValuesFetcher<T extends NumericLikeType | ComplexType>(
   const title = useDatasetValue(titleDataset) || signalDef.label;
   const signal = useDatasetValue(signalDef.dataset, selection);
   const errors = useDatasetValue(signalDef.errorDataset, selection);
-  const auxValues = useDatasetValues(auxDatasets, selection);
-  const auxErrors = useDatasetValues(auxErrorDatasets, selection);
-  const axisValues = useDatasetValues(axisDatasets);
+  const auxValues = useDatasetsValues(auxDatasets, selection);
+  const auxErrors = useDatasetsValues(auxErrorDatasets, selection);
+  const axisValues = useDatasetsValues(axisDatasets);
 
   return render({ title, signal, errors, auxValues, auxErrors, axisValues });
 }

--- a/packages/app/src/vis-packs/nexus/NxValuesFetcher.tsx
+++ b/packages/app/src/vis-packs/nexus/NxValuesFetcher.tsx
@@ -8,7 +8,7 @@ import {
   useDatasetValue,
   useDatasetValues,
   usePrefetchValues,
-} from '../core/hooks';
+} from '../../hooks';
 import { type NxData, type NxValues } from './models';
 
 interface Props<T extends NumericLikeType | ComplexType> {

--- a/packages/app/src/vis-packs/nexus/hooks.ts
+++ b/packages/app/src/vis-packs/nexus/hooks.ts
@@ -4,9 +4,9 @@ import {
   type NumericLikeType,
 } from '@h5web/shared/hdf5-models';
 
+import { useValuesInCache } from '../../dimension-mapper/hooks';
 import { type DimensionMapping } from '../../dimension-mapper/models';
 import { useDataContext } from '../../providers/DataProvider';
-import { useValuesInCache } from '../core/hooks';
 import { type DatasetDef, type NxData } from './models';
 import {
   assertNxDataGroup,

--- a/packages/shared/src/guards.ts
+++ b/packages/shared/src/guards.ts
@@ -332,10 +332,40 @@ export function isNumericType(type: DType): type is NumericType {
   return isIntegerType(type) || isFloatType(type);
 }
 
+export function hasIntegerType<S extends Shape>(
+  dataset: Dataset<S>,
+): dataset is Dataset<S, IntegerType> {
+  return isIntegerType(dataset.type);
+}
+
+export function hasFloatType<S extends Shape>(
+  dataset: Dataset<S>,
+): dataset is Dataset<S, FloatType> {
+  return isFloatType(dataset.type);
+}
+
 export function hasNumericType<S extends Shape>(
   dataset: Dataset<S>,
 ): dataset is Dataset<S, NumericType> {
   return isNumericType(dataset.type);
+}
+
+export function assertIntegerType<S extends Shape>(
+  dataset: Dataset<S>,
+  message = 'Expected dataset to have integer type',
+): asserts dataset is Dataset<S, IntegerType> {
+  if (!hasIntegerType(dataset)) {
+    throw new Error(message);
+  }
+}
+
+export function assertFloatType<S extends Shape>(
+  dataset: Dataset<S>,
+  message = 'Expected dataset to have float type',
+): asserts dataset is Dataset<S, FloatType> {
+  if (!hasFloatType(dataset)) {
+    throw new Error(message);
+  }
 }
 
 export function assertNumericType<S extends Shape>(
@@ -351,14 +381,18 @@ export function isBoolType(type: DType): type is BooleanType {
   return type.class === DTypeClass.Bool;
 }
 
+export function isEnumType(type: DType): type is EnumType {
+  return type.class === DTypeClass.Enum;
+}
+
+export function isNumericLikeType(type: DType): type is NumericLikeType {
+  return isNumericType(type) || isBoolType(type) || isEnumType(type);
+}
+
 export function hasBoolType<S extends Shape>(
   dataset: Dataset<S>,
 ): dataset is Dataset<S, BooleanType> {
   return isBoolType(dataset.type);
-}
-
-export function isEnumType(type: DType): type is EnumType {
-  return type.class === DTypeClass.Enum;
 }
 
 export function hasEnumType<S extends Shape>(
@@ -367,14 +401,28 @@ export function hasEnumType<S extends Shape>(
   return isEnumType(dataset.type);
 }
 
-export function isNumericLikeType(type: DType): type is NumericLikeType {
-  return isNumericType(type) || isBoolType(type) || isEnumType(type);
-}
-
 export function hasNumericLikeType<S extends Shape>(
   dataset: Dataset<S>,
 ): dataset is Dataset<S, NumericLikeType> {
   return isNumericLikeType(dataset.type);
+}
+
+export function assertBoolType<S extends Shape>(
+  dataset: Dataset<S>,
+  message = 'Expected dataset to have boolean type',
+): asserts dataset is Dataset<S, BooleanType> {
+  if (!hasBoolType(dataset)) {
+    throw new Error(message);
+  }
+}
+
+export function assertEnumType<S extends Shape>(
+  dataset: Dataset<S>,
+  message = 'Expected dataset to have enum type',
+): asserts dataset is Dataset<S, EnumType> {
+  if (!hasEnumType(dataset)) {
+    throw new Error(message);
+  }
 }
 
 export function assertNumericLikeType<S extends Shape>(


### PR DESCRIPTION
Following #1759, I'm exporting a few more hooks and guards, still with the goal of making it easier to build a custom visualization that accesses data from one of `@h5web/app`'s providers, like [in the data portal](https://gitlab.esrf.fr/icat/data-portal/-/blob/main/packages/h5/src/h5/ImageVisForMXData.tsx).

Most notably, I'm exporting the following five hooks:

- **`useEntity`** (new) to get the metadata of an entity  at a given path from the entities store
- **`useDatasetValue`** to get a dataset's value from the values store
- **`useDatasetsValues`**  (previously named `useDatasetValues`) to get multiple datasets' values from the values store (notably when the list of datasets to access is dynamic)
- **`usePrefetchValues`** to prepare getting multiple datasets' values so they are eventually retrieved in parallel rather than sequentially
- **`useNdArray`** (internally `useBaseArray`) to wrap an array or typed array in an ndarray that can be passed down to `@h5web/lib`'s visualizations

I'm also exporting and/or adding the following guards and assertions:

- `hasIntegerType`
- `hasFloatType`
- `assertIntegerType`
- `assertFloatType`
- `assertBoolType`
- `assertEnumType`

Finally, I'm somewhat documenting the newly exported hooks and guards in `@h5web/app`'s README. The goal is to have a place to link to with a minimal example. Long term, this should be part of a fully fledged documentation site.