### PR TITLE
Strip comas in column headers when exporting to CSV

### DIFF
--- a/packages/app/src/vis-packs/core/compound/utils.ts
+++ b/packages/app/src/vis-packs/core/compound/utils.ts
@@ -9,7 +9,7 @@ export function generateCsv(
   compoundArray: NdArray<ScalarValue<PrintableType>[]>,
   formatters: ((val: ScalarValue<PrintableType>) => string)[],
 ): string {
-  let csv = names.join(','); // column headers
+  let csv = names.map((n) => n.replaceAll(',', '')).join(','); // column headers
   const [dim1, dim2] = compoundArray.shape;
 
   for (let i = 0; i < dim1; i += 1) {

--- a/packages/app/src/vis-packs/core/line/utils.ts
+++ b/packages/app/src/vis-packs/core/line/utils.ts
@@ -13,15 +13,16 @@ export function generateCsv(
 
   // Column headers
   if (name) {
-    csv += name;
-    csv += abscissaParams.value
-      ? `,${abscissaParams.label || 'abscissas'}`
-      : '';
+    const abscissaLabel = abscissaParams.label?.replaceAll(',', '');
+
+    csv += name.replaceAll(',', '');
+    csv += abscissaParams.value ? `,${abscissaLabel || 'abscissas'}` : '';
     csv += errorsArray ? `,errors` : '';
 
     for (const aux of auxiliaries) {
-      csv += `,${aux.label}`;
-      csv += aux.errors ? `,${aux.label}_errors` : '';
+      const auxLabel = aux.label.replaceAll(',', '');
+      csv += `,${auxLabel}`;
+      csv += aux.errors ? `,${auxLabel}_errors` : '';
     }
   }
 


### PR DESCRIPTION
We get column headers when exporting to CSV from the _NX Line_ and _Compound_ visualizations. In #1763, I overlooked the fact that dataset labels and compound field names can contain comas, which could potentially break CSV files.