### PR TITLE
Allow changing texture mag/min filter of Heatmap vis

### DIFF
--- a/apps/storybook/src/HeatmapMesh.stories.tsx
+++ b/apps/storybook/src/HeatmapMesh.stories.tsx
@@ -40,6 +40,7 @@ const meta = {
   args: {
     invertColorMap: false,
     magFilter: NearestFilter,
+    minFilter: NearestFilter,
   },
   argTypes: {
     scaleType: {
@@ -47,6 +48,13 @@ const meta = {
       options: COLOR_SCALE_TYPES,
     },
     magFilter: {
+      control: {
+        type: 'inline-radio',
+        labels: { [NearestFilter]: 'nearest', [LinearFilter]: 'linear' },
+      },
+      options: [NearestFilter, LinearFilter],
+    },
+    minFilter: {
       control: {
         type: 'inline-radio',
         labels: { [NearestFilter]: 'nearest', [LinearFilter]: 'linear' },

--- a/apps/storybook/src/HeatmapVis.stories.tsx
+++ b/apps/storybook/src/HeatmapVis.stories.tsx
@@ -9,6 +9,7 @@ import { assertDefined } from '@h5web/shared/guards';
 import { COLOR_SCALE_TYPES, toTypedNdArray } from '@h5web/shared/vis-utils';
 import { type Meta, type StoryObj } from '@storybook/react';
 import ndarray from 'ndarray';
+import { LinearFilter, NearestFilter } from 'three';
 
 import FillHeight from './decorators/FillHeight';
 
@@ -37,6 +38,8 @@ const meta = {
     scaleType: ScaleType.Linear,
     aspect: 'equal',
     showGrid: true,
+    magFilter: NearestFilter,
+    minFilter: NearestFilter,
   },
   argTypes: {
     dataArray: { control: false },
@@ -51,6 +54,20 @@ const meta = {
     aspect: {
       control: { type: 'inline-radio' },
       options: ['auto', 'equal', 0.25],
+    },
+    magFilter: {
+      control: {
+        type: 'inline-radio',
+        labels: { [NearestFilter]: 'nearest', [LinearFilter]: 'linear' },
+      },
+      options: [NearestFilter, LinearFilter], // https://threejs.org/docs/#api/en/constants/Textures
+    },
+    minFilter: {
+      control: {
+        type: 'inline-radio',
+        labels: { [NearestFilter]: 'nearest', [LinearFilter]: 'linear' },
+      },
+      options: [NearestFilter, LinearFilter], // ... and more https://threejs.org/docs/#api/en/constants/Textures
     },
   },
 } satisfies Meta<typeof HeatmapVis>;

--- a/packages/lib/src/vis/heatmap/HeatmapMaterial.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapMaterial.tsx
@@ -6,6 +6,7 @@ import {
   DataTexture,
   DoubleSide,
   type MagnificationTextureFilter,
+  type MinificationTextureFilter,
   RGBAFormat,
   UnsignedByteType,
   Vector4,
@@ -24,10 +25,11 @@ interface Props extends VisMeshProps {
   scaleType: VisScaleType;
   colorMap: ColorMap;
   invertColorMap?: boolean;
-  magFilter?: MagnificationTextureFilter;
   alphaValues?: NdArray<TextureSafeTypedArray | Uint16Array>; // uint16 values are treated as half floats
   alphaDomain?: Domain;
   badColor?: RGBColor | string;
+  magFilter?: MagnificationTextureFilter;
+  minFilter?: MinificationTextureFilter;
   mask?: NdArray<Uint8Array>;
 }
 
@@ -53,14 +55,15 @@ function HeatmapMaterial(props: Props) {
     scaleType: visScaleType,
     colorMap,
     invertColorMap = false,
-    magFilter,
     alphaValues,
     alphaDomain = DEFAULT_DOMAIN,
     badColor = DEFAULT_BAD_COLOR,
+    magFilter,
+    minFilter,
     mask,
   } = props;
 
-  const dataTexture = useDataTexture(values, magFilter);
+  const dataTexture = useDataTexture(values, magFilter, minFilter);
   const alphaTexture = useDataTexture(alphaValues);
   const maskTexture = useDataTexture(mask);
 

--- a/packages/lib/src/vis/heatmap/HeatmapMesh.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapMesh.tsx
@@ -1,7 +1,10 @@
 import { type Domain } from '@h5web/shared/vis-models';
 import { type RGBColor } from 'd3-color';
 import { type NdArray } from 'ndarray';
-import { type MagnificationTextureFilter } from 'three';
+import {
+  type MagnificationTextureFilter,
+  type MinificationTextureFilter,
+} from 'three';
 
 import { type VisScaleType } from '../models';
 import VisMesh, { type VisMeshProps } from '../shared/VisMesh';
@@ -14,10 +17,11 @@ interface Props extends VisMeshProps {
   scaleType: VisScaleType;
   colorMap: ColorMap;
   invertColorMap?: boolean;
-  magFilter?: MagnificationTextureFilter;
   alphaValues?: NdArray<TextureSafeTypedArray | Uint16Array>; // uint16 values are treated as half floats
   alphaDomain?: Domain;
   badColor?: RGBColor | string;
+  magFilter?: MagnificationTextureFilter;
+  minFilter?: MinificationTextureFilter;
   mask?: NdArray<Uint8Array>;
 }
 
@@ -28,10 +32,11 @@ function HeatmapMesh(props: Props) {
     scaleType,
     colorMap,
     invertColorMap,
-    magFilter,
     alphaValues,
     alphaDomain,
     badColor,
+    magFilter,
+    minFilter,
     mask,
     ...visMeshProps
   } = props;
@@ -44,10 +49,11 @@ function HeatmapMesh(props: Props) {
         scaleType={scaleType}
         colorMap={colorMap}
         invertColorMap={invertColorMap}
-        magFilter={magFilter}
         alphaValues={alphaValues}
         alphaDomain={alphaDomain}
         badColor={badColor}
+        magFilter={magFilter}
+        minFilter={minFilter}
         mask={mask}
       />
     </VisMesh>

--- a/packages/lib/src/vis/heatmap/HeatmapVis.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapVis.tsx
@@ -8,6 +8,10 @@ import {
 import { formatTooltipVal, getDims } from '@h5web/shared/vis-utils';
 import { type NdArray } from 'ndarray';
 import { type ReactElement, type ReactNode } from 'react';
+import {
+  type MagnificationTextureFilter,
+  type MinificationTextureFilter,
+} from 'three';
 
 import DefaultInteractions, {
   type DefaultInteractionsConfig,
@@ -42,6 +46,8 @@ interface Props extends ClassStyleAttrs {
   abscissaParams?: AxisParams;
   ordinateParams?: AxisParams;
   alpha?: { array: NdArray<NumArray>; domain: Domain };
+  magFilter?: MagnificationTextureFilter;
+  minFilter?: MinificationTextureFilter;
   flipXAxis?: boolean;
   flipYAxis?: boolean;
   renderTooltip?: (data: TooltipData) => ReactElement;
@@ -64,6 +70,8 @@ function HeatmapVis(props: Props) {
     abscissaParams = {},
     ordinateParams = {},
     alpha,
+    magFilter,
+    minFilter,
     flipXAxis,
     flipYAxis,
     renderTooltip,
@@ -155,6 +163,8 @@ function HeatmapVis(props: Props) {
           alphaValues={safeAlphaArray}
           alphaDomain={alpha?.domain}
           scale={[flipXAxis ? -1 : 1, flipYAxis ? -1 : 1, 1]}
+          magFilter={magFilter}
+          minFilter={minFilter}
           mask={maskArray}
         />
 

--- a/packages/lib/src/vis/heatmap/utils.ts
+++ b/packages/lib/src/vis/heatmap/utils.ts
@@ -13,6 +13,7 @@ import {
   FloatType,
   HalfFloatType,
   type MagnificationTextureFilter,
+  type MinificationTextureFilter,
   NearestFilter,
   RedFormat,
   UnsignedByteType,
@@ -184,18 +185,22 @@ export function toTextureSafeNdArray(
 export function getDataTexture(
   values: NdArray<TextureSafeTypedArray | Uint16Array>,
   magFilter?: MagnificationTextureFilter,
+  minFilter?: MinificationTextureFilter,
 ): DataTexture;
 export function getDataTexture(
   values: undefined,
   magFilter?: MagnificationTextureFilter,
+  minFilter?: MinificationTextureFilter,
 ): undefined;
 export function getDataTexture(
   values: NdArray<TextureSafeTypedArray | Uint16Array> | undefined,
   magFilter?: MagnificationTextureFilter,
+  minFilter?: MinificationTextureFilter,
 ): DataTexture | undefined;
 export function getDataTexture(
   values: NdArray<TextureSafeTypedArray | Uint16Array> | undefined,
   magFilter: MagnificationTextureFilter = NearestFilter,
+  minFilter: MinificationTextureFilter = NearestFilter,
 ): DataTexture | undefined {
   if (!values) {
     return undefined;
@@ -212,6 +217,7 @@ export function getDataTexture(
     ClampToEdgeWrapping,
     ClampToEdgeWrapping,
     magFilter,
+    minFilter,
   );
   texture.needsUpdate = true;
 


### PR DESCRIPTION
Fix #1721

`[HeatmapVis, HeatmapMesh]` Add props `magFilter` and `minFilter` to allow changing the heatmap texture's [magnification and minification filters](https://threejs.org/docs/#api/en/constants/Textures) (`NearestFilter` by default)