### PR TITLE
Don't misuse render prop pattern

### DIFF
--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -26,7 +26,7 @@
     "wouter": "3.3.5"
   },
   "devDependencies": {
-    "@esrf/eslint-config": "1.0.3",
+    "@esrf/eslint-config": "1.0.4",
     "@types/node": "^22.12.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -28,7 +28,7 @@
     "three": "0.172.0"
   },
   "devDependencies": {
-    "@esrf/eslint-config": "1.0.3",
+    "@esrf/eslint-config": "1.0.4",
     "@storybook/addon-docs": "8.5.0",
     "@storybook/addon-essentials": "8.5.0",
     "@storybook/addon-links": "8.5.0",

--- a/apps/storybook/src/Toolbar.stories.tsx
+++ b/apps/storybook/src/Toolbar.stories.tsx
@@ -80,14 +80,14 @@ export const Default = {
 
           <ToggleBtn
             label="Grid"
-            icon={MdGridOn}
+            Icon={MdGridOn}
             value={showGrid}
             onToggle={toggleGrid}
           />
           <ToggleBtn
             label="Test"
             iconOnly
-            icon={FiTarget}
+            Icon={FiTarget}
             value={withTest}
             onToggle={toggleTest}
           />

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "postversion": "git push && git push --tags"
   },
   "devDependencies": {
-    "@esrf/eslint-config": "1.0.3",
+    "@esrf/eslint-config": "1.0.4",
     "@simonsmith/cypress-image-snapshot": "9.1.0",
     "@testing-library/cypress": "10.0.2",
     "@types/node": "^22.12.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -64,7 +64,7 @@
     "zustand": "5.0.3"
   },
   "devDependencies": {
-    "@esrf/eslint-config": "1.0.3",
+    "@esrf/eslint-config": "1.0.4",
     "@h5web/shared": "workspace:*",
     "@rollup/plugin-alias": "5.1.0",
     "@testing-library/dom": "10.4.0",

--- a/packages/app/src/breadcrumbs/BreadcrumbsBar.tsx
+++ b/packages/app/src/breadcrumbs/BreadcrumbsBar.tsx
@@ -43,7 +43,7 @@ function BreadcrumbsBar(props: Props) {
     <div className={styles.bar}>
       <ToggleBtn
         label="Toggle sidebar"
-        icon={FiSidebar}
+        Icon={FiSidebar}
         iconOnly
         value={isSidebarOpen}
         onToggle={onToggleSidebar}
@@ -71,7 +71,7 @@ function BreadcrumbsBar(props: Props) {
 
       {document.fullscreenEnabled && (
         <Btn
-          icon={isFullscreen ? FiMinimize : FiMaximize}
+          Icon={isFullscreen ? FiMinimize : FiMaximize}
           iconOnly
           label="Go full screen"
           onClick={() => {

--- a/packages/app/src/vis-packs/VisBoundary.tsx
+++ b/packages/app/src/vis-packs/VisBoundary.tsx
@@ -18,11 +18,10 @@ function VisBoundary(props: Props) {
 
   return (
     <ErrorBoundary
-      resetKeys={[resetKey]}
-      // eslint-disable-next-line react/no-unstable-nested-components
       fallbackRender={(args) => (
         <ErrorFallback className={visualizerStyles.vis} {...args} />
       )}
+      resetKeys={[resetKey]}
       onError={() => valuesStore.evictErrors()}
     >
       <Suspense fallback={<ValueLoader isSlice={isSlice} />}>

--- a/packages/app/src/vis-packs/core/complex/ComplexLineToolbar.tsx
+++ b/packages/app/src/vis-packs/core/complex/ComplexLineToolbar.tsx
@@ -73,7 +73,7 @@ function ComplexLineToolbar(props: Props) {
 
       <ToggleBtn
         label="Grid"
-        icon={MdGridOn}
+        Icon={MdGridOn}
         value={showGrid}
         onToggle={toggleGrid}
       />

--- a/packages/app/src/vis-packs/core/complex/ComplexToolbar.tsx
+++ b/packages/app/src/vis-packs/core/complex/ComplexToolbar.tsx
@@ -79,13 +79,13 @@ function ComplexToolbar(props: Props) {
 
       <ToggleBtn
         label="Keep ratio"
-        icon={MdAspectRatio}
+        Icon={MdAspectRatio}
         value={keepRatio}
         onToggle={toggleKeepRatio}
       />
       <ToggleBtn
         label="Grid"
-        icon={MdGridOn}
+        Icon={MdGridOn}
         value={showGrid}
         onToggle={toggleGrid}
       />

--- a/packages/app/src/vis-packs/core/heatmap/HeatmapToolbar.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/HeatmapToolbar.tsx
@@ -79,28 +79,28 @@ function HeatmapToolbar(props: Props) {
       <ToggleBtn
         label="X"
         aria-label="Flip X"
-        icon={MdSwapHoriz}
+        Icon={MdSwapHoriz}
         value={flipXAxis}
         onToggle={toggleXAxisFlip}
       />
       <ToggleBtn
         label="Y"
         aria-label="Flip Y"
-        icon={MdSwapVert}
+        Icon={MdSwapVert}
         value={flipYAxis}
         onToggle={toggleYAxisFlip}
       />
 
       <ToggleBtn
         label="Keep ratio"
-        icon={MdAspectRatio}
+        Icon={MdAspectRatio}
         value={keepRatio}
         onToggle={toggleKeepRatio}
       />
 
       <ToggleBtn
         label="Grid"
-        icon={MdGridOn}
+        Icon={MdGridOn}
         value={showGrid}
         onToggle={toggleGrid}
       />

--- a/packages/app/src/vis-packs/core/line/ErrorsIcon.tsx
+++ b/packages/app/src/vis-packs/core/line/ErrorsIcon.tsx
@@ -1,0 +1,14 @@
+import { type IconBaseProps } from 'react-icons';
+import { FiItalic } from 'react-icons/fi';
+
+function ErrorsIcon(props: IconBaseProps) {
+  return (
+    <FiItalic
+      transform="skewX(20)"
+      style={{ marginLeft: '-0.25em', marginRight: '0.0625rem' }}
+      {...props}
+    />
+  );
+}
+
+export default ErrorsIcon;

--- a/packages/app/src/vis-packs/core/line/LineToolbar.tsx
+++ b/packages/app/src/vis-packs/core/line/LineToolbar.tsx
@@ -10,11 +10,11 @@ import {
 } from '@h5web/lib';
 import { type Domain, type ExportEntry } from '@h5web/shared/vis-models';
 import { AXIS_SCALE_TYPES } from '@h5web/shared/vis-utils';
-import { FiItalic } from 'react-icons/fi';
 import { MdGridOn } from 'react-icons/md';
 
 import { INTERACTIONS_WITH_AXIAL_ZOOM } from '../utils';
 import { type LineConfig } from './config';
+import ErrorsIcon from './ErrorsIcon';
 
 interface Props {
   dataDomain: Domain;
@@ -69,14 +69,7 @@ function LineToolbar(props: Props) {
 
       <ToggleBtn
         label="Errors"
-        // eslint-disable-next-line react/no-unstable-nested-components
-        icon={(iconProps) => (
-          <FiItalic
-            transform="skewX(20)"
-            style={{ marginLeft: '-0.25em', marginRight: '0.0625rem' }}
-            {...iconProps}
-          />
-        )}
+        Icon={ErrorsIcon}
         value={!disableErrors && showErrors}
         onToggle={toggleErrors}
         disabled={disableErrors}
@@ -84,7 +77,7 @@ function LineToolbar(props: Props) {
 
       <ToggleBtn
         label="Grid"
-        icon={MdGridOn}
+        Icon={MdGridOn}
         value={showGrid}
         onToggle={toggleGrid}
       />

--- a/packages/app/src/vis-packs/core/matrix/MatrixToolbar.tsx
+++ b/packages/app/src/vis-packs/core/matrix/MatrixToolbar.tsx
@@ -43,7 +43,7 @@ function MatrixToolbar(props: Props) {
 
       <ToggleBtn
         label="Freeze indices"
-        icon={FiAnchor}
+        Icon={FiAnchor}
         value={sticky}
         onToggle={toggleSticky}
       />

--- a/packages/app/src/vis-packs/core/raw/RawToolbar.tsx
+++ b/packages/app/src/vis-packs/core/raw/RawToolbar.tsx
@@ -18,7 +18,7 @@ function RawToolbar(props: Props) {
     <Toolbar>
       <ToggleBtn
         label="Fit image"
-        icon={MdOutlineFitScreen}
+        Icon={MdOutlineFitScreen}
         value={fitImage}
         disabled={!isImage}
         onToggle={toggleFitImage}

--- a/packages/app/src/vis-packs/core/rgb/RgbToolbar.tsx
+++ b/packages/app/src/vis-packs/core/rgb/RgbToolbar.tsx
@@ -53,28 +53,28 @@ function RgbToolbar(props: Props) {
       <ToggleBtn
         label="X"
         aria-label="Flip X"
-        icon={MdSwapHoriz}
+        Icon={MdSwapHoriz}
         value={flipXAxis}
         onToggle={toggleXAxisFlip}
       />
       <ToggleBtn
         label="Y"
         aria-label="Flip Y"
-        icon={MdSwapVert}
+        Icon={MdSwapVert}
         value={flipYAxis}
         onToggle={toggleYAxisFlip}
       />
 
       <ToggleBtn
         label="Keep ratio"
-        icon={MdAspectRatio}
+        Icon={MdAspectRatio}
         value={keepRatio}
         onToggle={toggleKeepRatio}
       />
 
       <ToggleBtn
         label="Grid"
-        icon={MdGridOn}
+        Icon={MdGridOn}
         value={showGrid}
         onToggle={toggleGrid}
       />

--- a/packages/app/src/vis-packs/core/scatter/ScatterToolbar.tsx
+++ b/packages/app/src/vis-packs/core/scatter/ScatterToolbar.tsx
@@ -81,7 +81,7 @@ function ScatterToolbar(props: Props) {
 
       <ToggleBtn
         label="Grid"
-        icon={MdGridOn}
+        Icon={MdGridOn}
         value={showGrid}
         onToggle={toggleGrid}
       />

--- a/packages/h5wasm/package.json
+++ b/packages/h5wasm/package.json
@@ -51,7 +51,7 @@
     "nanoid": "5.0.9"
   },
   "devDependencies": {
-    "@esrf/eslint-config": "1.0.3",
+    "@esrf/eslint-config": "1.0.4",
     "@h5web/app": "workspace:*",
     "@h5web/shared": "workspace:*",
     "@rollup/plugin-alias": "5.1.0",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -75,7 +75,7 @@
     "zustand": "5.0.3"
   },
   "devDependencies": {
-    "@esrf/eslint-config": "1.0.3",
+    "@esrf/eslint-config": "1.0.4",
     "@h5web/shared": "workspace:*",
     "@react-three/fiber": "8.17.12",
     "@rollup/plugin-alias": "5.1.0",

--- a/packages/lib/src/toolbar/OverflowMenu.tsx
+++ b/packages/lib/src/toolbar/OverflowMenu.tsx
@@ -58,7 +58,7 @@ function OverflowMenu(props: PropsWithChildren<Props>) {
         ref={refs.setReference}
         id={referenceId}
         label="More controls"
-        icon={FiMenu}
+        Icon={FiMenu}
         iconOnly
         aria-haspopup="dialog"
         aria-expanded={isOpen}

--- a/packages/lib/src/toolbar/controls/Btn.tsx
+++ b/packages/lib/src/toolbar/controls/Btn.tsx
@@ -1,16 +1,11 @@
-import {
-  type ComponentType,
-  forwardRef,
-  type HTMLAttributes,
-  type SVGAttributes,
-} from 'react';
+import { type ComponentType, forwardRef, type HTMLAttributes } from 'react';
 import { MdArrowDropDown } from 'react-icons/md';
 
 import styles from '../Toolbar.module.css';
 
 interface Props extends HTMLAttributes<HTMLButtonElement> {
   label: string;
-  icon?: ComponentType<SVGAttributes<SVGElement>>;
+  Icon?: ComponentType<{ className: string }>;
   iconOnly?: boolean;
   small?: boolean;
   raised?: boolean;
@@ -21,7 +16,7 @@ interface Props extends HTMLAttributes<HTMLButtonElement> {
 const Btn = forwardRef<HTMLButtonElement, Props>((props, ref) => {
   const {
     label,
-    icon: Icon,
+    Icon,
     iconOnly,
     small,
     raised,

--- a/packages/lib/src/toolbar/controls/CellWidthInput.tsx
+++ b/packages/lib/src/toolbar/controls/CellWidthInput.tsx
@@ -63,7 +63,7 @@ function CellWidthInput(props: Props) {
 
       <Btn
         label="Reset"
-        icon={FiRotateCw}
+        Icon={FiRotateCw}
         iconOnly
         small
         disabled={!hasValue}

--- a/packages/lib/src/toolbar/controls/ColorMapSelector/ColorMapSelector.tsx
+++ b/packages/lib/src/toolbar/controls/ColorMapSelector/ColorMapSelector.tsx
@@ -34,7 +34,7 @@ function ColorMapSelector(props: Props) {
       <ToggleBtn
         small
         label="Invert"
-        icon={FiShuffle}
+        Icon={FiShuffle}
         value={invert}
         onToggle={onInversionChange}
       />

--- a/packages/lib/src/toolbar/controls/DomainWidget/DomainWidget.tsx
+++ b/packages/lib/src/toolbar/controls/DomainWidget/DomainWidget.tsx
@@ -99,7 +99,7 @@ function DomainWidget(props: Props) {
           label="Edit domain"
           aria-expanded={hovered || isEditing}
           aria-controls={POPUP_ID}
-          icon={FiEdit3}
+          Icon={FiEdit3}
           value={isEditing}
           disabled={disabled}
           onToggle={() => toggleEditing(!isEditing)}

--- a/packages/lib/src/toolbar/controls/ExportMenu.tsx
+++ b/packages/lib/src/toolbar/controls/ExportMenu.tsx
@@ -47,7 +47,7 @@ function ExportMenu(props: Props) {
         ref={refs.setReference}
         id={referenceId}
         label={`Export${isSlice ? ' slice' : ''}`}
-        icon={FiDownload}
+        Icon={FiDownload}
         withArrow
         disabled={entries.length === 0}
         aria-haspopup="menu"

--- a/packages/lib/src/toolbar/controls/InteractionHelp.tsx
+++ b/packages/lib/src/toolbar/controls/InteractionHelp.tsx
@@ -47,7 +47,7 @@ function InteractionHelp(props: Props) {
         ref={refs.setReference}
         id={referenceId}
         label="Show help"
-        icon={FiHelpCircle}
+        Icon={FiHelpCircle}
         iconOnly
         aria-haspopup="dialog"
         aria-expanded={isOpen}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -54,7 +54,7 @@
     }
   },
   "devDependencies": {
-    "@esrf/eslint-config": "1.0.3",
+    "@esrf/eslint-config": "1.0.4",
     "@types/d3-array": "~3.2.1",
     "@types/d3-format": "~3.0.4",
     "@types/ndarray": "~1.0.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@esrf/eslint-config':
-        specifier: 1.0.3
-        version: 1.0.3(@typescript-eslint/utils@8.28.0(eslint@9.23.0)(typescript@5.8.2))(eslint@9.23.0)(typescript@5.8.2)(vitest@2.1.8(@types/node@22.12.0)(jsdom@26.0.0))
+        specifier: 1.0.4
+        version: 1.0.4(@typescript-eslint/utils@8.28.0(eslint@9.23.0)(typescript@5.8.2))(eslint@9.23.0)(typescript@5.8.2)(vitest@2.1.8(@types/node@22.12.0)(jsdom@26.0.0))
       '@simonsmith/cypress-image-snapshot':
         specifier: 9.1.0
         version: 9.1.0(cypress@13.17.0)
@@ -82,8 +82,8 @@ importers:
         version: 3.3.5(react@18.3.1)
     devDependencies:
       '@esrf/eslint-config':
-        specifier: 1.0.3
-        version: 1.0.3(@typescript-eslint/utils@8.28.0(eslint@9.23.0)(typescript@5.8.2))(eslint@9.23.0)(typescript@5.8.2)(vitest@2.1.8(@types/node@22.12.0)(jsdom@26.0.0))
+        specifier: 1.0.4
+        version: 1.0.4(@typescript-eslint/utils@8.28.0(eslint@9.23.0)(typescript@5.8.2))(eslint@9.23.0)(typescript@5.8.2)(vitest@2.1.8(@types/node@22.12.0)(jsdom@26.0.0))
       '@types/node':
         specifier: ^22.12.0
         version: 22.12.0
@@ -161,8 +161,8 @@ importers:
         version: 0.172.0
     devDependencies:
       '@esrf/eslint-config':
-        specifier: 1.0.3
-        version: 1.0.3(@typescript-eslint/utils@8.28.0(eslint@9.23.0)(typescript@5.8.2))(eslint@9.23.0)(typescript@5.8.2)(vitest@2.1.8(@types/node@22.12.0)(jsdom@26.0.0))
+        specifier: 1.0.4
+        version: 1.0.4(@typescript-eslint/utils@8.28.0(eslint@9.23.0)(typescript@5.8.2))(eslint@9.23.0)(typescript@5.8.2)(vitest@2.1.8(@types/node@22.12.0)(jsdom@26.0.0))
       '@storybook/addon-docs':
         specifier: 8.5.0
         version: 8.5.0(@types/react@18.3.3)(storybook@8.5.0(prettier@3.4.2))
@@ -264,8 +264,8 @@ importers:
         version: 5.0.3(@types/react@18.3.3)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
     devDependencies:
       '@esrf/eslint-config':
-        specifier: 1.0.3
-        version: 1.0.3(@typescript-eslint/utils@8.28.0(eslint@9.23.0)(typescript@5.8.2))(eslint@9.23.0)(typescript@5.8.2)(vitest@2.1.8(@types/node@22.12.0)(jsdom@26.0.0))
+        specifier: 1.0.4
+        version: 1.0.4(@typescript-eslint/utils@8.28.0(eslint@9.23.0)(typescript@5.8.2))(eslint@9.23.0)(typescript@5.8.2)(vitest@2.1.8(@types/node@22.12.0)(jsdom@26.0.0))
       '@h5web/shared':
         specifier: workspace:*
         version: link:../shared
@@ -358,8 +358,8 @@ importers:
         version: 5.0.9
     devDependencies:
       '@esrf/eslint-config':
-        specifier: 1.0.3
-        version: 1.0.3(@typescript-eslint/utils@8.28.0(eslint@9.23.0)(typescript@5.8.2))(eslint@9.23.0)(typescript@5.8.2)(vitest@2.1.8(@types/node@22.12.0)(jsdom@26.0.0))
+        specifier: 1.0.4
+        version: 1.0.4(@typescript-eslint/utils@8.28.0(eslint@9.23.0)(typescript@5.8.2))(eslint@9.23.0)(typescript@5.8.2)(vitest@2.1.8(@types/node@22.12.0)(jsdom@26.0.0))
       '@h5web/app':
         specifier: workspace:*
         version: link:../app
@@ -476,8 +476,8 @@ importers:
         version: 5.0.3(@types/react@18.3.3)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
     devDependencies:
       '@esrf/eslint-config':
-        specifier: 1.0.3
-        version: 1.0.3(@typescript-eslint/utils@8.28.0(eslint@9.23.0)(typescript@5.8.2))(eslint@9.23.0)(typescript@5.8.2)(vitest@2.1.8(@types/node@22.12.0)(jsdom@26.0.0))
+        specifier: 1.0.4
+        version: 1.0.4(@typescript-eslint/utils@8.28.0(eslint@9.23.0)(typescript@5.8.2))(eslint@9.23.0)(typescript@5.8.2)(vitest@2.1.8(@types/node@22.12.0)(jsdom@26.0.0))
       '@h5web/shared':
         specifier: workspace:*
         version: link:../shared
@@ -575,8 +575,8 @@ importers:
   packages/shared:
     devDependencies:
       '@esrf/eslint-config':
-        specifier: 1.0.3
-        version: 1.0.3(@typescript-eslint/utils@8.28.0(eslint@9.23.0)(typescript@5.8.2))(eslint@9.23.0)(typescript@5.8.2)(vitest@2.1.8(@types/node@22.12.0)(jsdom@26.0.0))
+        specifier: 1.0.4
+        version: 1.0.4(@typescript-eslint/utils@8.28.0(eslint@9.23.0)(typescript@5.8.2))(eslint@9.23.0)(typescript@5.8.2)(vitest@2.1.8(@types/node@22.12.0)(jsdom@26.0.0))
       '@types/d3-array':
         specifier: ~3.2.1
         version: 3.2.1
@@ -1093,8 +1093,8 @@ packages:
     resolution: {integrity: sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@esrf/eslint-config@1.0.3':
-    resolution: {integrity: sha512-NIP240c69ph9H6p7LixAu+qFWxXUKzeOKoLnsVCR673knmvz9xOsKhoyYjt59/+eo+o8RF8WexZ9fJpo+tDamQ==}
+  '@esrf/eslint-config@1.0.4':
+    resolution: {integrity: sha512-rcRRC/IiZZCkMfWIJdrv+Qu72sn/2Elr/gWys5qyJ8uo8Nh3Vde5C/+ulecXgIwOtqrYCIMRYQely5S6qm5fYA==}
     peerDependencies:
       eslint: 9.23.x
       typescript: '>=5'
@@ -1938,10 +1938,6 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
-  '@typescript-eslint/scope-manager@8.20.0':
-    resolution: {integrity: sha512-J7+VkpeGzhOt3FeG1+SzhiMj9NzGD/M6KoGn9f4dbz3YzK9hvbhVTmLj/HiTp9DazIzJ8B4XcM80LrR9Dm1rJw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@typescript-eslint/scope-manager@8.28.0':
     resolution: {integrity: sha512-u2oITX3BJwzWCapoZ/pXw6BCOl8rJP4Ij/3wPoGvY8XwvXflOzd1kLrDUUUAIEdJSFh+ASwdTHqtan9xSg8buw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1953,19 +1949,9 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
-  '@typescript-eslint/types@8.20.0':
-    resolution: {integrity: sha512-cqaMiY72CkP+2xZRrFt3ExRBu0WmVitN/rYPZErA80mHjHx/Svgp8yfbzkJmDoQ/whcytOPO9/IZXnOc+wigRA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@typescript-eslint/types@8.28.0':
     resolution: {integrity: sha512-bn4WS1bkKEjx7HqiwG2JNB3YJdC1q6Ue7GyGlwPHyt0TnVq6TtD/hiOdTZt71sq0s7UzqBFXD8t8o2e63tXgwA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.20.0':
-    resolution: {integrity: sha512-Y7ncuy78bJqHI35NwzWol8E0X7XkRVS4K4P4TCyzWkOJih5NDvtoRDW4Ba9YJJoB2igm9yXDdYI/+fkiiAxPzA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <5.8.0'
 
   '@typescript-eslint/typescript-estree@8.28.0':
     resolution: {integrity: sha512-H74nHEeBGeklctAVUvmDkxB1mk+PAZ9FiOMPFncdqeRBXxk1lWSYraHw8V12b7aa6Sg9HOBNbGdSHobBPuQSuA==}
@@ -1973,23 +1959,12 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <5.9.0'
 
-  '@typescript-eslint/utils@8.20.0':
-    resolution: {integrity: sha512-dq70RUw6UK9ei7vxc4KQtBRk7qkHZv447OUZ6RPQMQl71I3NZxQJX/f32Smr+iqWrB02pHKn2yAdHBb0KNrRMA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <5.8.0'
-
   '@typescript-eslint/utils@8.28.0':
     resolution: {integrity: sha512-OELa9hbTYciYITqgurT1u/SzpQVtDLmQMFzy/N8pQE+tefOyCWT79jHsav294aTqV1q1u+VzqDGbuujvRYaeSQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
-
-  '@typescript-eslint/visitor-keys@8.20.0':
-    resolution: {integrity: sha512-v/BpkeeYAsPkKCkR8BDwcno0llhzWVqPOamQrAEMdpZav2Y9OVjd9dwJyBLJWwf335B5DmlifECIkZRJCaGaHA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/visitor-keys@8.28.0':
     resolution: {integrity: sha512-hbn8SZ8w4u2pRwgQ1GlUrPKE+t2XvcCW5tTRF7j6SMYIuYG37XuzIW44JCZPa36evi0Oy2SnM664BlIaAuQcvg==}
@@ -4734,12 +4709,6 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
-  ts-api-utils@2.0.0:
-    resolution: {integrity: sha512-xCt/TOAc+EOHS1XPnijD3/yzpH6qg2xppZO1YDqGoVsNXfQfzHpOdNuXwrwOU8u4ITXJyDCTyt8w5g1sZv9ynQ==}
-    engines: {node: '>=18.12'}
-    peerDependencies:
-      typescript: '>=4.8.4'
-
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
     engines: {node: '>=18.12'}
@@ -5592,7 +5561,7 @@ snapshots:
       '@eslint/core': 0.12.0
       levn: 0.4.1
 
-  '@esrf/eslint-config@1.0.3(@typescript-eslint/utils@8.28.0(eslint@9.23.0)(typescript@5.8.2))(eslint@9.23.0)(typescript@5.8.2)(vitest@2.1.8(@types/node@22.12.0)(jsdom@26.0.0))':
+  '@esrf/eslint-config@1.0.4(@typescript-eslint/utils@8.28.0(eslint@9.23.0)(typescript@5.8.2))(eslint@9.23.0)(typescript@5.8.2)(vitest@2.1.8(@types/node@22.12.0)(jsdom@26.0.0))':
     dependencies:
       '@stylistic/eslint-plugin-js': 4.2.0(eslint@9.23.0)
       '@vitest/eslint-plugin': 1.1.38(@typescript-eslint/utils@8.28.0(eslint@9.23.0)(typescript@5.8.2))(eslint@9.23.0)(typescript@5.8.2)(vitest@2.1.8(@types/node@22.12.0)(jsdom@26.0.0))
@@ -6484,11 +6453,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.20.0':
-    dependencies:
-      '@typescript-eslint/types': 8.20.0
-      '@typescript-eslint/visitor-keys': 8.20.0
-
   '@typescript-eslint/scope-manager@8.28.0':
     dependencies:
       '@typescript-eslint/types': 8.28.0
@@ -6505,23 +6469,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.20.0': {}
-
   '@typescript-eslint/types@8.28.0': {}
-
-  '@typescript-eslint/typescript-estree@8.20.0(typescript@5.8.2)':
-    dependencies:
-      '@typescript-eslint/types': 8.20.0
-      '@typescript-eslint/visitor-keys': 8.20.0
-      debug: 4.4.0(supports-color@8.1.1)
-      fast-glob: 3.3.3
-      is-glob: 4.0.3
-      minimatch: 9.0.5
-      semver: 7.6.3
-      ts-api-utils: 2.0.0(typescript@5.8.2)
-      typescript: 5.8.2
-    transitivePeerDependencies:
-      - supports-color
 
   '@typescript-eslint/typescript-estree@8.28.0(typescript@5.8.2)':
     dependencies:
@@ -6531,26 +6479,15 @@ snapshots:
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
-      semver: 7.6.3
+      semver: 7.7.1
       ts-api-utils: 2.1.0(typescript@5.8.2)
-      typescript: 5.8.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.20.0(eslint@9.23.0)(typescript@5.8.2)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.23.0)
-      '@typescript-eslint/scope-manager': 8.20.0
-      '@typescript-eslint/types': 8.20.0
-      '@typescript-eslint/typescript-estree': 8.20.0(typescript@5.8.2)
-      eslint: 9.23.0
       typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/utils@8.28.0(eslint@9.23.0)(typescript@5.8.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.23.0)
+      '@eslint-community/eslint-utils': 4.5.1(eslint@9.23.0)
       '@typescript-eslint/scope-manager': 8.28.0
       '@typescript-eslint/types': 8.28.0
       '@typescript-eslint/typescript-estree': 8.28.0(typescript@5.8.2)
@@ -6558,11 +6495,6 @@ snapshots:
       typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
-
-  '@typescript-eslint/visitor-keys@8.20.0':
-    dependencies:
-      '@typescript-eslint/types': 8.20.0
-      eslint-visitor-keys: 4.2.0
 
   '@typescript-eslint/visitor-keys@8.28.0':
     dependencies:
@@ -7648,7 +7580,7 @@ snapshots:
 
   eslint-plugin-promise@7.2.1(eslint@9.23.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.23.0)
+      '@eslint-community/eslint-utils': 4.5.1(eslint@9.23.0)
       eslint: 9.23.0
 
   eslint-plugin-react-hooks@5.2.0(eslint@9.23.0):
@@ -7679,7 +7611,7 @@ snapshots:
 
   eslint-plugin-regexp@2.7.0(eslint@9.23.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.23.0)
+      '@eslint-community/eslint-utils': 4.5.1(eslint@9.23.0)
       '@eslint-community/regexpp': 4.12.1
       comment-parser: 1.4.1
       eslint: 9.23.0
@@ -7695,7 +7627,7 @@ snapshots:
   eslint-plugin-storybook@0.11.6(eslint@9.23.0)(typescript@5.8.2):
     dependencies:
       '@storybook/csf': 0.1.12
-      '@typescript-eslint/utils': 8.20.0(eslint@9.23.0)(typescript@5.8.2)
+      '@typescript-eslint/utils': 8.28.0(eslint@9.23.0)(typescript@5.8.2)
       eslint: 9.23.0
       ts-dedent: 2.2.0
     transitivePeerDependencies:
@@ -7704,8 +7636,8 @@ snapshots:
 
   eslint-plugin-testing-library@7.1.1(eslint@9.23.0)(typescript@5.8.2):
     dependencies:
-      '@typescript-eslint/scope-manager': 8.20.0
-      '@typescript-eslint/utils': 8.20.0(eslint@9.23.0)(typescript@5.8.2)
+      '@typescript-eslint/scope-manager': 8.28.0
+      '@typescript-eslint/utils': 8.28.0(eslint@9.23.0)(typescript@5.8.2)
       eslint: 9.23.0
     transitivePeerDependencies:
       - supports-color
@@ -9850,10 +9782,6 @@ snapshots:
   troika-worker-utils@0.52.0: {}
 
   trough@2.2.0: {}
-
-  ts-api-utils@2.0.0(typescript@5.8.2):
-    dependencies:
-      typescript: 5.8.2
 
   ts-api-utils@2.1.0(typescript@5.8.2):
     dependencies:


### PR DESCRIPTION
I've relaxed the rule [`react/no-unstable-nested-components`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unstable-nested-components.md) to allow the render prop pattern:

```tsx
<ErrorBoundary
  fallbackRender={(args) => (
    <ErrorFallback className={visualizerStyles.vis} {...args} />
  )}
/>
```

The code above is okay (and unavoidable) as long as `fallbackRender` is used as a function inside `ErrorBoundary` - e.g. `{fallbackRender(...args)}`.

It's not okay when the render prop is used as a component. An example of this was the `icon` prop of the `Btn` component:

```tsx
// Btn.tsx
const { icon: Icon } = props;
return <>{Icon && <Icon className={styles.icon} />}</>

<Btn
  // render prop but used as component
  icon={(iconProps) => (
    <FiItalic
      transform="skewX(20)"
      style={{ marginLeft: '-0.25em', marginRight: '0.0625rem' }}
      {...iconProps}
    />
  )}
/>
```

Unfortunately, `react/no-unstable-nested-components` cannot detect these two cases, which leads to false positives. Since the render prop pattern is legitimate and unavoidable in many cases, the rule could lead to worse solutions. So I've decided to turn on the rule's `allowAsProp` option, which allows passing "nested" components as props.

I'm also fixing the `icon` prop by turning it into a component prop:

```tsx
// Btn.tsx
const { Icon } = props;
return <>{Icon && <Icon className={styles.icon} />}</>

<Btn
  // good component prop (icon is extracted into its own component)
  Icon={ErrorsIcon}
/>
```