### PR TITLE
Allow customising selector selection

### DIFF
--- a/packages/lib/src/toolbar/controls/Selector/Selector.tsx
+++ b/packages/lib/src/toolbar/controls/Selector/Selector.tsx
@@ -15,15 +15,24 @@ import styles from './Selector.module.css';
 
 interface Props<T> {
   label?: string;
-  value: T;
-  disabled?: boolean;
-  onChange: (value: T) => void;
   options: Record<string, T[]> | T[];
+  disabled?: boolean;
+  value: T;
+  onChange: (value: T) => void;
   renderOption: (option: T) => ReactNode;
+  renderSelection?: (option: T) => ReactNode;
 }
 
 function Selector<T extends string>(props: Props<T>) {
-  const { label, value, disabled, onChange, options, renderOption } = props;
+  const {
+    label,
+    options,
+    disabled,
+    value,
+    onChange,
+    renderOption,
+    renderSelection = renderOption,
+  } = props;
 
   const { context, refs, floatingStyles } = useFloatingMenu();
   const { open: isOpen, floatingId, onOpenChange: toggle } = context;
@@ -80,7 +89,7 @@ function Selector<T extends string>(props: Props<T>) {
         {...getReferenceProps()}
       >
         <span id={currentOptionId} className={toolbarStyles.btnLike}>
-          {renderOption(value)}
+          {renderSelection(value)}
           <MdArrowDropDown className={toolbarStyles.arrowIcon} />
         </span>
       </button>


### PR DESCRIPTION
During the migration  of the `Selector` component to Floating UI, I [removed](https://github.com/silx-kit/h5web/pull/1647/files#diff-8acf415080b833542b9e59be4a91bf52c9792e4227c56e1b992f671f95c6f55a) the ability to customise the rendering of the trigger button aka the "selected option" (which I now call simply "selection" to avoid confusion with the options rendered inside the drop-down menu.)

In the viewer, we never customise the trigger button, but turns out that we do in Braggy (the button doesn't contain the label of the current selection; only the color preview):

![image](https://github.com/user-attachments/assets/3ca1d3dc-778f-443c-bfd7-c65e13822bb7)

So I re-add this ability with a dedicated prop called `renderSelection`. If the prop is not provided, it defaults to `renderOption`. I think it's better to add a prop to `Selector` than to add an argument to `renderSelection` (as it was done before via `OptionComponent`).