### PR TITLE
Throw custom `AbortError` when aborting a fetch

### DIFF
--- a/packages/app/src/ErrorFallback.tsx
+++ b/packages/app/src/ErrorFallback.tsx
@@ -1,7 +1,7 @@
 import { type FallbackProps } from 'react-error-boundary';
 
 import styles from './App.module.css';
-import { CANCELLED_ERROR_MSG } from './providers/utils';
+import { CANCELLED_BY_USER } from './providers/utils';
 
 interface Props extends FallbackProps {
   className?: string;
@@ -11,10 +11,10 @@ interface Props extends FallbackProps {
 function ErrorFallback(props: Props) {
   const { className = '', error, resetErrorBoundary } = props;
 
-  if (error instanceof Error && error.message === CANCELLED_ERROR_MSG) {
+  if (error instanceof Error && error.message === CANCELLED_BY_USER) {
     return (
       <p className={`${styles.error} ${className}`}>
-        {CANCELLED_ERROR_MSG}
+        Request cancelled
         <span>–</span>
         <button
           className={styles.retryBtn}

--- a/packages/app/src/ErrorFallback.tsx
+++ b/packages/app/src/ErrorFallback.tsx
@@ -1,7 +1,7 @@
 import { type FallbackProps } from 'react-error-boundary';
 
 import styles from './App.module.css';
-import { AbortError, CANCELLED_BY_USER } from './providers/utils';
+import { AbortError } from './providers/utils';
 
 interface Props extends FallbackProps {
   className?: string;
@@ -11,7 +11,7 @@ interface Props extends FallbackProps {
 function ErrorFallback(props: Props) {
   const { className = '', error, resetErrorBoundary } = props;
 
-  if (error instanceof AbortError && error.message === CANCELLED_BY_USER) {
+  if (error instanceof AbortError) {
     return (
       <p className={`${styles.error} ${className}`}>
         Request cancelled

--- a/packages/app/src/ErrorFallback.tsx
+++ b/packages/app/src/ErrorFallback.tsx
@@ -1,7 +1,7 @@
 import { type FallbackProps } from 'react-error-boundary';
 
 import styles from './App.module.css';
-import { CANCELLED_BY_USER } from './providers/utils';
+import { AbortError, CANCELLED_BY_USER } from './providers/utils';
 
 interface Props extends FallbackProps {
   className?: string;
@@ -11,7 +11,7 @@ interface Props extends FallbackProps {
 function ErrorFallback(props: Props) {
   const { className = '', error, resetErrorBoundary } = props;
 
-  if (error instanceof Error && error.message === CANCELLED_BY_USER) {
+  if (error instanceof AbortError && error.message === CANCELLED_BY_USER) {
     return (
       <p className={`${styles.error} ${className}`}>
         Request cancelled

--- a/packages/app/src/providers/api.ts
+++ b/packages/app/src/providers/api.ts
@@ -20,7 +20,7 @@ export abstract class DataProviderApi {
 
   public abstract getValue(
     params: ValuesStoreParams,
-    signal?: AbortSignal,
+    abortSignal?: AbortSignal,
     onProgress?: OnProgress,
   ): Promise<unknown>;
 

--- a/packages/app/src/providers/h5grove/h5grove-api.ts
+++ b/packages/app/src/providers/h5grove/h5grove-api.ts
@@ -24,7 +24,7 @@ import axios, {
 
 import { DataProviderApi } from '../api';
 import { type ValuesStoreParams } from '../models';
-import { createAxiosProgressHandler } from '../utils';
+import { AbortError, createAxiosProgressHandler } from '../utils';
 import {
   type H5GroveAttrValuesResponse,
   type H5GroveDataResponse,
@@ -92,14 +92,7 @@ export class H5GroveApi extends DataProviderApi {
       return await this.fetchData(params, abortSignal, onProgress);
     } catch (error) {
       if (error instanceof AxiosError && axios.isCancel(error)) {
-        // Throw abort reason instead of axios `CancelError`
-        // https://github.com/axios/axios/issues/5758
-        throw new Error(
-          typeof abortSignal?.reason === 'string'
-            ? abortSignal.reason
-            : 'cancelled',
-          { cause: error },
-        );
+        throw new AbortError(abortSignal, error);
       }
 
       throw error;

--- a/packages/app/src/providers/hsds/hsds-api.ts
+++ b/packages/app/src/providers/hsds/hsds-api.ts
@@ -26,7 +26,7 @@ import axios, { AxiosError, type AxiosInstance } from 'axios';
 
 import { DataProviderApi } from '../api';
 import { type ValuesStoreParams } from '../models';
-import { createAxiosProgressHandler } from '../utils';
+import { AbortError, createAxiosProgressHandler } from '../utils';
 import {
   type BaseHsdsEntity,
   type HsdsAttribute,
@@ -270,14 +270,7 @@ export class HsdsApi extends DataProviderApi {
       return data.value;
     } catch (error) {
       if (error instanceof AxiosError && axios.isCancel(error)) {
-        // Throw abort reason instead of axios `CancelError`
-        // https://github.com/axios/axios/issues/5758
-        throw new Error(
-          typeof abortSignal?.reason === 'string'
-            ? abortSignal.reason
-            : 'cancelled',
-          { cause: error },
-        );
+        throw new AbortError(abortSignal, error);
       }
 
       throw error;

--- a/packages/app/src/providers/hsds/hsds-api.ts
+++ b/packages/app/src/providers/hsds/hsds-api.ts
@@ -137,13 +137,18 @@ export class HsdsApi extends DataProviderApi {
 
   public override async getValue(
     params: ValuesStoreParams,
-    signal?: AbortSignal,
+    abortSignal?: AbortSignal,
     onProgress?: OnProgress,
   ): Promise<unknown> {
     const { dataset } = params;
     assertHsdsDataset(dataset);
 
-    const value = await this.fetchValue(dataset.id, params, signal, onProgress);
+    const value = await this.fetchValue(
+      dataset.id,
+      params,
+      abortSignal,
+      onProgress,
+    );
 
     /* HSDS doesn't reduce the number of dimensions when selecting indices,
      * so the flattening must be done on all dimensions regardless of the selection.
@@ -247,7 +252,7 @@ export class HsdsApi extends DataProviderApi {
   private async fetchValue(
     entityId: HsdsId,
     params: ValuesStoreParams,
-    signal?: AbortSignal,
+    abortSignal?: AbortSignal,
     onProgress?: OnProgress,
   ): Promise<unknown> {
     const { selection } = params;
@@ -257,7 +262,7 @@ export class HsdsApi extends DataProviderApi {
         `/datasets/${entityId}/value`,
         {
           params: { select: selection ? `[${selection}]` : undefined },
-          signal,
+          signal: abortSignal,
           onDownloadProgress: createAxiosProgressHandler(onProgress),
         },
       );
@@ -268,7 +273,9 @@ export class HsdsApi extends DataProviderApi {
         // Throw abort reason instead of axios `CancelError`
         // https://github.com/axios/axios/issues/5758
         throw new Error(
-          typeof signal?.reason === 'string' ? signal.reason : 'cancelled',
+          typeof abortSignal?.reason === 'string'
+            ? abortSignal.reason
+            : 'cancelled',
           { cause: error },
         );
       }

--- a/packages/app/src/providers/mock/mock-api.ts
+++ b/packages/app/src/providers/mock/mock-api.ts
@@ -54,7 +54,7 @@ export class MockApi extends DataProviderApi {
 
   public override async getValue(
     params: ValuesStoreParams,
-    signal?: AbortSignal,
+    abortSignal?: AbortSignal,
   ): Promise<unknown> {
     const { dataset, selection } = params;
     assertMockDataset(dataset);
@@ -68,7 +68,7 @@ export class MockApi extends DataProviderApi {
     }
 
     if (dataset.name.startsWith('slow')) {
-      await cancellableDelay(signal);
+      await cancellableDelay(abortSignal);
     }
 
     const { value } = dataset;

--- a/packages/app/src/providers/mock/utils.ts
+++ b/packages/app/src/providers/mock/utils.ts
@@ -17,6 +17,7 @@ import { getChildEntity } from '@h5web/shared/hdf5-utils';
 import ndarray from 'ndarray';
 
 import { applyMapping } from '../../vis-packs/core/utils';
+import { AbortError } from '../utils';
 
 export const SLOW_TIMEOUT = 3000;
 
@@ -92,13 +93,7 @@ export async function cancellableDelay(
     function handleAbort() {
       clearTimeout(timeout);
       abortSignal?.removeEventListener('abort', handleAbort);
-      reject(
-        new Error(
-          typeof abortSignal?.reason === 'string'
-            ? abortSignal.reason
-            : 'cancelled',
-        ),
-      );
+      reject(new AbortError(abortSignal));
     }
 
     abortSignal?.addEventListener('abort', handleAbort);

--- a/packages/app/src/providers/mock/utils.ts
+++ b/packages/app/src/providers/mock/utils.ts
@@ -80,23 +80,27 @@ export function getChildrenPaths(
   );
 }
 
-export async function cancellableDelay(signal?: AbortSignal): Promise<void> {
+export async function cancellableDelay(
+  abortSignal?: AbortSignal,
+): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     const timeout = setTimeout(() => {
-      signal?.removeEventListener('abort', handleAbort);
+      abortSignal?.removeEventListener('abort', handleAbort);
       resolve();
     }, SLOW_TIMEOUT);
 
     function handleAbort() {
       clearTimeout(timeout);
-      signal?.removeEventListener('abort', handleAbort);
+      abortSignal?.removeEventListener('abort', handleAbort);
       reject(
         new Error(
-          typeof signal?.reason === 'string' ? signal.reason : 'cancelled',
+          typeof abortSignal?.reason === 'string'
+            ? abortSignal.reason
+            : 'cancelled',
         ),
       );
     }
 
-    signal?.addEventListener('abort', handleAbort);
+    abortSignal?.addEventListener('abort', handleAbort);
   });
 }

--- a/packages/app/src/providers/utils.ts
+++ b/packages/app/src/providers/utils.ts
@@ -19,8 +19,6 @@ import { type AxiosProgressEvent, isAxiosError } from 'axios';
 
 import { type DataProviderApi } from './api';
 
-export const CANCELLED_BY_USER = 'Cancelled by user';
-
 export function typedArrayFromDType(
   dtype: DType,
 ): TypedArrayConstructor | undefined {

--- a/packages/app/src/providers/utils.ts
+++ b/packages/app/src/providers/utils.ts
@@ -102,3 +102,13 @@ export function createAxiosProgressHandler(
     })
   );
 }
+
+export class AbortError extends Error {
+  public constructor(abortSignal?: AbortSignal, cause?: unknown) {
+    const message =
+      typeof abortSignal?.reason === 'string' ? abortSignal.reason : undefined;
+
+    super(message, { cause });
+    this.name = 'AbortError';
+  }
+}

--- a/packages/app/src/providers/utils.ts
+++ b/packages/app/src/providers/utils.ts
@@ -19,7 +19,7 @@ import { type AxiosProgressEvent, isAxiosError } from 'axios';
 
 import { type DataProviderApi } from './api';
 
-export const CANCELLED_ERROR_MSG = 'Request cancelled';
+export const CANCELLED_BY_USER = 'Cancelled by user';
 
 export function typedArrayFromDType(
   dtype: DType,

--- a/packages/app/src/vis-packs/ValueLoader.tsx
+++ b/packages/app/src/vis-packs/ValueLoader.tsx
@@ -2,7 +2,6 @@ import { useTimeoutEffect, useToggle } from '@react-hookz/web';
 import { useStore } from 'zustand';
 
 import { useDataContext } from '../providers/DataProvider';
-import { CANCELLED_BY_USER } from '../providers/utils';
 import styles from './ValueLoader.module.css';
 
 const MAX_PROGRESS_BARS = 3;
@@ -53,7 +52,7 @@ function ValueLoader(props: Props) {
             <button
               className={styles.cancelBtn}
               type="button"
-              onClick={() => valuesStore.abortAll(CANCELLED_BY_USER)}
+              onClick={() => valuesStore.abortAll('cancelled by user')}
             >
               Cancel?
             </button>

--- a/packages/app/src/vis-packs/ValueLoader.tsx
+++ b/packages/app/src/vis-packs/ValueLoader.tsx
@@ -2,7 +2,7 @@ import { useTimeoutEffect, useToggle } from '@react-hookz/web';
 import { useStore } from 'zustand';
 
 import { useDataContext } from '../providers/DataProvider';
-import { CANCELLED_ERROR_MSG } from '../providers/utils';
+import { CANCELLED_BY_USER } from '../providers/utils';
 import styles from './ValueLoader.module.css';
 
 const MAX_PROGRESS_BARS = 3;
@@ -53,7 +53,7 @@ function ValueLoader(props: Props) {
             <button
               className={styles.cancelBtn}
               type="button"
-              onClick={() => valuesStore.abortAll(CANCELLED_ERROR_MSG)}
+              onClick={() => valuesStore.abortAll(CANCELLED_BY_USER)}
             >
               Cancel?
             </button>

--- a/packages/shared/src/react-suspense-fetch.ts
+++ b/packages/shared/src/react-suspense-fetch.ts
@@ -2,7 +2,7 @@ import { createStore, type StoreApi } from 'zustand/vanilla';
 
 type FetchFunc<Input, Result> = (
   input: Input,
-  signal: AbortSignal,
+  abortSignal: AbortSignal,
   onProgress: OnProgress,
 ) => Promise<Result>;
 


### PR DESCRIPTION
I've got a working solution for removing `axios` from the providers (#1800), but it's going to take a few PRs...

This PR focuses on cleaning up the code related to aborting requests. I won't reexplain how this all works — the important bit is that, in order to show an informative error message with a "retry" button, we have to know when a request is aborted and why (e.g. manually by the user, or automatically when switching dataset).

![image](https://github.com/user-attachments/assets/616c7ab2-a791-4bab-aa93-e1ba3bb1b8ae)

To do this, we catch the error that axios (and the underlying `fetch` call) throws when a request is aborted via its [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController/signal). We then rethrow our own error so that we have a very simple check to do in the generic `ErrorFallback` component (we definitely don't want to check if an error is an axios `CanceledError` in this component...)

In this PR, I simply introduce a new `AbortError` to make this logic even more robust and especially to remove some duplicated logic related to forwarding the "abort reason". See individual commits for more info.