### PR TITLE
Fix race condition when evicting aborted requests from cache

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -41,8 +41,7 @@ function App(props: Props) {
   const { valuesStore } = useDataContext();
   function onSelectPath(path: string) {
     setSelectedPath(path);
-    valuesStore.abortAll('entity changed');
-    valuesStore.evictErrors();
+    valuesStore.abortAll('entity changed', true);
   }
 
   return (

--- a/packages/app/src/visualizer/VisManager.tsx
+++ b/packages/app/src/visualizer/VisManager.tsx
@@ -31,8 +31,7 @@ function VisManager(props: Props) {
   const { valuesStore } = useDataContext();
   function onVisChange(index: number) {
     setActiveVis(index);
-    valuesStore.abortAll('visualization changed');
-    valuesStore.evictErrors();
+    valuesStore.abortAll('visualization changed', true);
   }
 
   return (

--- a/packages/shared/src/react-suspense-fetch.ts
+++ b/packages/shared/src/react-suspense-fetch.ts
@@ -22,8 +22,8 @@ export interface FetchStore<Input, Result> {
   preset: (input: Input, result: Result) => void;
   evict: (input: Input) => void;
   evictErrors: () => void;
-  abort: (input: Input, reason?: string) => void;
-  abortAll: (reason?: string) => void;
+  abort: (input: Input, reason?: string, evict?: boolean) => void;
+  abortAll: (reason?: string, evict?: boolean) => void;
   get progressStore(): StoreApi<ProgressState<Input>>;
 }
 
@@ -83,12 +83,20 @@ export function createFetchStore<Input, Result>(
         }
       });
     },
-    abort: (input: Input, reason?: string): void => {
+    abort: (input: Input, reason?: string, evict?: boolean): void => {
       cache.get(input)?.abort(reason);
+
+      if (evict) {
+        cache.delete(input);
+      }
     },
-    abortAll: (reason?: string): void => {
-      cache.values().forEach((instance) => {
+    abortAll: (reason?: string, evict?: boolean): void => {
+      cache.entries().forEach(([input, instance]) => {
         instance.abort(reason);
+
+        if (evict) {
+          cache.delete(input);
+        }
       });
     },
     get progressStore() {


### PR DESCRIPTION
### Before

An abort error shows up when switching between two visualisation and the dimension mapping/slicing state is maintained. (Before, #1801, the abort reason "visualization changed" was displayed.)

This was due to a race condition:

```ts
  function onVisChange(index: number) {
    setActiveVis(index);
    valuesStore.abortAll('visualization changed'); # aborts the fetch request, which is asynchronous
    valuesStore.evictErrors(); # tries to evict error from store cache before it's actually been caught
  }
```

[Screencast from 2025-05-16 09-30-11.webm](https://github.com/user-attachments/assets/b63ec505-d039-4733-b30a-c502dfa2b239)

### After

The fix is to evict from cache as part of the `abortAll` call.

[Screencast from 2025-05-16 09-30-54.webm](https://github.com/user-attachments/assets/a58d2e39-566b-45a6-8d31-3bd8d0733287)