### PR TITLE
Refactor `H5GroveApi` with `Fetcher` abstraction

### DIFF
--- a/packages/app/src/providers/h5grove/utils.ts
+++ b/packages/app/src/providers/h5grove/utils.ts
@@ -150,7 +150,7 @@ function parseAttributes(attrsMetadata: H5GroveAttribute[]): Attribute[] {
   }));
 }
 
-export function isH5GroveError(
+export function isH5GroveErrorResponse(
   payload: unknown,
 ): payload is H5GroveErrorResponse {
   return (

--- a/packages/app/src/providers/models.ts
+++ b/packages/app/src/providers/models.ts
@@ -6,7 +6,10 @@ import {
   type ProvidedEntity,
   type ScalarShape,
 } from '@h5web/shared/hdf5-models';
-import { type FetchStore } from '@h5web/shared/react-suspense-fetch';
+import {
+  type FetchStore,
+  type OnProgress,
+} from '@h5web/shared/react-suspense-fetch';
 
 import { type NxAttribute } from '../vis-packs/nexus/models';
 
@@ -26,3 +29,14 @@ export type ImageAttribute = 'CLASS' | 'IMAGE_SUBCLASS';
 export type AttrName = NxAttribute | ImageAttribute | '_FillValue';
 
 export type ProgressCallback = (prog: number[]) => void;
+
+export type Fetcher = (
+  url: string,
+  params: Record<string, string>,
+  opts?: FetcherOptions,
+) => Promise<ArrayBuffer>;
+
+export interface FetcherOptions {
+  abortSignal?: AbortSignal;
+  onProgress?: OnProgress;
+}


### PR DESCRIPTION
Part of #1800 

In order to remove `axios` from `H5GroveApi`, I first need to add a level of abstraction. In this PR, I introduce:

- a new `Fetcher` function type that accepts a URL and some params and returns an `ArrayBuffer`;
- a new  `FetcherError` class;
- a `createAxiosFetcher` utility to create a `Fetcher` function from an axios instance.

To keep the diff readable, I don't actually remove `axios` from `H5GroveApi` yet. For now, it's just an internal refactoring of `H5GroveApi`. The goal will of course be for consumers of `H5GroveProvider` to be able to pass their own `Fetcher` function.