### PR TITLE
Refactor `H5GroveApi` to simplify internals + handle errors on all endpoints

### DIFF
--- a/packages/app/src/providers/h5grove/h5grove-api.ts
+++ b/packages/app/src/providers/h5grove/h5grove-api.ts
@@ -23,7 +23,6 @@ import { type Fetcher, type ValuesStoreParams } from '../models';
 import { createAxiosFetcher, FetcherError, toJSON } from '../utils';
 import {
   type H5GroveAttrValuesResponse,
-  type H5GroveDataResponse,
   type H5GroveEntityResponse,
   type H5GrovePathsResponse,
 } from './models';
@@ -50,50 +49,101 @@ export class H5GroveApi extends DataProviderApi {
     this.fetcher = createAxiosFetcher(
       axios.create({
         adapter: 'fetch',
-        baseURL,
         ...axiosConfig,
       }),
     );
   }
 
   public override async getEntity(path: string): Promise<ProvidedEntity> {
-    const response = await this.fetchEntity(path);
-    return parseEntity(path, response);
+    try {
+      const buffer = await this.fetcher(`${this.baseURL}/meta/`, { path });
+      return parseEntity(path, toJSON(buffer) as H5GroveEntityResponse);
+    } catch (error) {
+      if (!(error instanceof FetcherError)) {
+        throw error;
+      }
+
+      const payload = toJSON(error.buffer);
+      if (!isH5GroveErrorResponse(payload)) {
+        throw error;
+      }
+
+      const { message } = payload;
+      if (message.includes('File not found')) {
+        throw new Error(`File not found: '${this.filepath}'`, { cause: error });
+      }
+      if (message.includes('Permission denied')) {
+        throw new Error(
+          `Cannot read file '${this.filepath}': Permission denied`,
+          { cause: error },
+        );
+      }
+      if (message.includes('not a valid path')) {
+        throw new Error(`No entity found at ${path}`, { cause: error });
+      }
+      if (message.includes('Cannot resolve')) {
+        throw new Error(`Could not resolve soft link at ${path}`, {
+          cause: error,
+        });
+      }
+
+      throw error;
+    }
   }
 
   public override async getValue(
-    params: ValuesStoreParams,
+    storeParams: ValuesStoreParams,
     abortSignal?: AbortSignal,
     onProgress?: OnProgress,
-  ): Promise<H5GroveDataResponse> {
-    const { dataset } = params;
+  ): Promise<unknown> {
+    const { dataset, selection } = storeParams;
+    const { path, type } = dataset;
 
-    if (dataset.type.class === DTypeClass.Opaque) {
-      return new Uint8Array(
-        await this.fetchBinaryData(params, abortSignal, onProgress),
-      );
+    const url = `${this.baseURL}/data/`;
+    const opts = { abortSignal, onProgress };
+    const baseParams = {
+      file: this.filepath,
+      path,
+      ...(selection && { selection }),
+    };
+
+    if (type.class === DTypeClass.Opaque) {
+      const params = { ...baseParams, format: 'bin' };
+      const buffer = await this.fetcher(url, params, opts);
+
+      return new Uint8Array(buffer);
     }
 
-    const DTypedArray = h5groveTypedArrayFromDType(dataset.type);
+    const DTypedArray = h5groveTypedArrayFromDType(type);
     if (DTypedArray) {
-      const buffer = await this.fetchBinaryData(
-        params,
-        abortSignal,
-        onProgress,
-        true,
-      );
+      const params = { ...baseParams, format: 'bin', dtype: 'safe' };
+      const buffer = await this.fetcher(url, params, opts);
+
       const array = new DTypedArray(buffer);
       return hasScalarShape(dataset) ? array[0] : array;
     }
 
-    return await this.fetchData(params, abortSignal, onProgress);
+    const params = { ...baseParams, flatten: 'true' };
+    const buffer = await this.fetcher(url, params, opts);
+
+    return toJSON(buffer);
   }
 
   public override async getAttrValues(
     entity: Entity,
   ): Promise<AttributeValues> {
     const { path, attributes } = entity;
-    return attributes.length > 0 ? this.fetchAttrValues(path) : {};
+
+    if (attributes.length === 0) {
+      return {};
+    }
+
+    const data = await this.fetcher(`${this.baseURL}/attr/`, {
+      file: this.filepath,
+      path,
+    });
+
+    return toJSON(data) as H5GroveAttrValuesResponse;
   }
 
   public override getExportURL(
@@ -136,91 +186,7 @@ export class H5GroveApi extends DataProviderApi {
   }
 
   public override async getSearchablePaths(path: string): Promise<string[]> {
-    const buffer = await this.fetcher(`/paths/`, { path });
+    const buffer = await this.fetcher(`${this.baseURL}/paths/`, { path });
     return toJSON(buffer) as H5GrovePathsResponse;
-  }
-
-  private async fetchEntity(path: string): Promise<H5GroveEntityResponse> {
-    try {
-      const buffer = await this.fetcher(`/meta/`, { path });
-      return toJSON(buffer) as H5GroveEntityResponse;
-    } catch (error) {
-      if (!(error instanceof FetcherError)) {
-        throw error;
-      }
-
-      const payload = toJSON(error.buffer);
-      if (!isH5GroveErrorResponse(payload)) {
-        throw error;
-      }
-
-      const { message } = payload;
-      if (message.includes('File not found')) {
-        throw new Error(`File not found: '${this.filepath}'`, { cause: error });
-      }
-      if (message.includes('Permission denied')) {
-        throw new Error(
-          `Cannot read file '${this.filepath}': Permission denied`,
-          { cause: error },
-        );
-      }
-      if (message.includes('not a valid path')) {
-        throw new Error(`No entity found at ${path}`, { cause: error });
-      }
-      if (message.includes('Cannot resolve')) {
-        throw new Error(`Could not resolve soft link at ${path}`, {
-          cause: error,
-        });
-      }
-
-      throw error;
-    }
-  }
-
-  private async fetchAttrValues(
-    path: string,
-  ): Promise<H5GroveAttrValuesResponse> {
-    const buffer = await this.fetcher(`/attr/`, { path });
-    return toJSON(buffer) as H5GroveAttrValuesResponse;
-  }
-
-  private async fetchData(
-    params: ValuesStoreParams,
-    abortSignal: AbortSignal | undefined,
-    onProgress: OnProgress | undefined,
-  ): Promise<H5GroveDataResponse> {
-    const { dataset, selection } = params;
-
-    const buffer = await this.fetcher(
-      '/data/',
-      {
-        path: dataset.path,
-        ...(selection && { selection }),
-        flatten: 'true',
-      },
-      { abortSignal, onProgress },
-    );
-
-    return toJSON(buffer);
-  }
-
-  private async fetchBinaryData(
-    params: ValuesStoreParams,
-    abortSignal: AbortSignal | undefined,
-    onProgress: OnProgress | undefined,
-    safe = false,
-  ): Promise<ArrayBuffer> {
-    const { dataset, selection } = params;
-
-    return this.fetcher(
-      '/data/',
-      {
-        path: dataset.path,
-        ...(selection && { selection }),
-        format: 'bin',
-        ...(safe && { dtype: 'safe' }),
-      },
-      { abortSignal, onProgress },
-    );
   }
 }

--- a/packages/app/src/providers/h5grove/models.ts
+++ b/packages/app/src/providers/h5grove/models.ts
@@ -1,7 +1,6 @@
 import { type AttributeValues, type Filter } from '@h5web/shared/hdf5-models';
 
 export type H5GroveEntityResponse = H5GroveEntity;
-export type H5GroveDataResponse = unknown;
 export type H5GroveAttrValuesResponse = AttributeValues;
 export type H5GrovePathsResponse = string[];
 


### PR DESCRIPTION
Two individual commits to finish cleaning up `H5GroveApi` before I extract the `fetcher`:

1. First, I remove the private `fetch*` methods (like `fetchEntity`, `fetchValue`, etc.), as I no longer think they make the code more readable anymore. The calls to the new `fetcher` are now inlined in the main provider methods (`getEntity`, `getValue`, etc.)

I kept being annoyed at having to go up and down the file to follow what is, in the end, fairly straightforward code. This refactoring also reduces duplication a bit in the `getValue` method: I can prepare a `baseParams` object (with the `file`, `path` and `selection` parameters) and spread it in all three `fetcher` calls.

2. Second, I extract the h5grove error handling logic into a private method and use it on every endpoint.

The h5grove errors that we handle ("File not found", "No entity found at <path>", etc.) can technically occur on every endpoint. While the H5Web viewer (`App`) is likely to trigger those errors only on the initial `getEntity('/')` call, it may not be the case when consumers implement their own viewers.