### PR TITLE
Allow consumers of `H5GroveProvider` to pass their own fetcher

### DIFF
--- a/apps/demo/src/H5GroveApp.tsx
+++ b/apps/demo/src/H5GroveApp.tsx
@@ -22,7 +22,7 @@ function H5GroveApp() {
   const filepath = searchParams.get('file') || FILEPATH;
 
   return (
-    <H5GroveProvider baseUrl={URL} filepath={filepath} fetcher={fetcher}>
+    <H5GroveProvider url={URL} filepath={filepath} fetcher={fetcher}>
       <App
         sidebarOpen={!searchParams.has('wide')}
         getFeedbackURL={getFeedbackURL}

--- a/apps/demo/src/H5GroveApp.tsx
+++ b/apps/demo/src/H5GroveApp.tsx
@@ -1,11 +1,18 @@
-import { App, assertEnvVar, H5GroveProvider } from '@h5web/app';
-import { useMemo } from 'react';
+import {
+  App,
+  assertEnvVar,
+  createAxiosFetcher,
+  H5GroveProvider,
+} from '@h5web/app';
+import axios from 'axios';
 import { useSearchParams } from 'wouter';
 
 import { getFeedbackURL } from './utils';
 
 const URL = import.meta.env.VITE_H5GROVE_URL;
 const FILEPATH = import.meta.env.VITE_H5GROVE_FALLBACK_FILEPATH;
+
+const fetcher = createAxiosFetcher(axios.create({ adapter: 'fetch' }));
 
 function H5GroveApp() {
   assertEnvVar(URL, 'VITE_H5GROVE_URL');
@@ -15,11 +22,7 @@ function H5GroveApp() {
   const filepath = searchParams.get('file') || FILEPATH;
 
   return (
-    <H5GroveProvider
-      url={URL}
-      filepath={filepath}
-      axiosConfig={useMemo(() => ({ params: { file: filepath } }), [filepath])}
-    >
+    <H5GroveProvider baseUrl={URL} filepath={filepath} fetcher={fetcher}>
       <App
         sidebarOpen={!searchParams.has('wide')}
         getFeedbackURL={getFeedbackURL}

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -6,6 +6,8 @@ export { default as MockProvider } from './providers/mock/MockProvider';
 export { default as HsdsProvider } from './providers/hsds/HsdsProvider';
 export { default as H5GroveProvider } from './providers/h5grove/H5GroveProvider';
 
+export { createBasicFetcher, createAxiosFetcher } from './providers/utils';
+
 export { enableBigIntSerialization } from './utils';
 export { getFeedbackMailto } from './breadcrumbs/utils';
 export type { FeedbackContext } from './breadcrumbs/models';

--- a/packages/app/src/providers/h5grove/H5GroveProvider.tsx
+++ b/packages/app/src/providers/h5grove/H5GroveProvider.tsx
@@ -6,7 +6,7 @@ import { type Fetcher } from '../models';
 import { H5GroveApi } from './h5grove-api';
 
 interface Props {
-  baseUrl: string;
+  url: string;
   filepath: string;
   resetKeys?: unknown[];
   fetcher?: Fetcher;
@@ -15,7 +15,7 @@ interface Props {
 
 function H5GroveProvider(props: PropsWithChildren<Props>) {
   const {
-    baseUrl,
+    url,
     filepath,
     resetKeys = [],
     fetcher,
@@ -24,8 +24,8 @@ function H5GroveProvider(props: PropsWithChildren<Props>) {
   } = props;
 
   const api = useMemo(
-    () => new H5GroveApi(baseUrl, filepath, fetcher, getExportURL),
-    [filepath, baseUrl, ...resetKeys, fetcher, getExportURL], // eslint-disable-line react-hooks/exhaustive-deps
+    () => new H5GroveApi(url, filepath, fetcher, getExportURL),
+    [filepath, url, ...resetKeys, fetcher, getExportURL], // eslint-disable-line react-hooks/exhaustive-deps
   );
 
   return <DataProvider api={api}>{children}</DataProvider>;

--- a/packages/app/src/providers/h5grove/H5GroveProvider.tsx
+++ b/packages/app/src/providers/h5grove/H5GroveProvider.tsx
@@ -1,31 +1,31 @@
-import { type AxiosRequestConfig } from 'axios';
 import { type PropsWithChildren, useMemo } from 'react';
 
 import { type DataProviderApi } from '../api';
 import DataProvider from '../DataProvider';
+import { type Fetcher } from '../models';
 import { H5GroveApi } from './h5grove-api';
 
 interface Props {
-  url: string;
+  baseUrl: string;
   filepath: string;
-  axiosConfig?: AxiosRequestConfig;
   resetKeys?: unknown[];
+  fetcher?: Fetcher;
   getExportURL?: DataProviderApi['getExportURL'];
 }
 
 function H5GroveProvider(props: PropsWithChildren<Props>) {
   const {
-    url,
+    baseUrl,
     filepath,
-    axiosConfig,
     resetKeys = [],
+    fetcher,
     getExportURL,
     children,
   } = props;
 
   const api = useMemo(
-    () => new H5GroveApi(url, filepath, axiosConfig, getExportURL),
-    [filepath, url, axiosConfig, ...resetKeys, getExportURL], // eslint-disable-line react-hooks/exhaustive-deps
+    () => new H5GroveApi(baseUrl, filepath, fetcher, getExportURL),
+    [filepath, baseUrl, ...resetKeys, fetcher, getExportURL], // eslint-disable-line react-hooks/exhaustive-deps
   );
 
   return <DataProvider api={api}>{children}</DataProvider>;

--- a/packages/app/src/providers/h5grove/h5grove-api.test.ts
+++ b/packages/app/src/providers/h5grove/h5grove-api.test.ts
@@ -22,9 +22,7 @@ beforeAll(async () => {
 });
 
 test.skipIf(SKIP)('test file matches snapshot', async () => {
-  const api = new H5GroveApi(H5GROVE_URL, TEST_FILE, {
-    params: { file: TEST_FILE },
-  });
+  const api = new H5GroveApi(H5GROVE_URL, TEST_FILE);
 
   const root = await api.getEntity('/');
   assertGroup(root);

--- a/packages/app/src/vis-packs/ValueLoader.module.css
+++ b/packages/app/src/vis-packs/ValueLoader.module.css
@@ -24,6 +24,18 @@
   border: none;
   border-radius: 0.75rem;
   overflow: hidden;
+  appearance: none;
+
+  --indeterminate-bg: linear-gradient(
+    -45deg,
+    rgba(255, 255, 255, 0.15) 25%,
+    transparent 25%,
+    transparent 50%,
+    rgba(255, 255, 255, 0.15) 50%,
+    rgba(255, 255, 255, 0.15) 75%,
+    transparent 75%,
+    transparent
+  );
 }
 
 .progress::-webkit-progress-value {
@@ -32,6 +44,25 @@
 
 .progress::-moz-progress-bar {
   background-color: var(--primary);
+}
+
+.progress:indeterminate::-webkit-progress-value {
+  width: 100% !important;
+  background-image: var(--indeterminate-bg);
+  background-size: 3rem 3rem;
+  animation: stripes 1s linear infinite;
+}
+
+.progress:indeterminate::-moz-progress-bar {
+  background-image: var(--indeterminate-bg);
+  background-size: 3rem 3rem;
+  animation: stripes 1s linear infinite;
+}
+
+@keyframes stripes {
+  to {
+    background-position: 3rem 0;
+  }
 }
 
 .loader > p {

--- a/packages/shared/src/react-suspense-fetch.ts
+++ b/packages/shared/src/react-suspense-fetch.ts
@@ -28,8 +28,8 @@ export interface FetchStore<Input, Result> {
 }
 
 interface ProgressState<Input> {
-  ongoing: Map<Input, number>;
-  setProgress: (input: Input, value: number) => void;
+  ongoing: Map<Input, number | undefined>;
+  setProgress: (input: Input, value?: number) => void;
   clearProgress: (input: Input) => void;
 }
 
@@ -152,7 +152,7 @@ function createInstance<Input, Result>(
 
   promise = (async () => {
     try {
-      progressStore.getState().setProgress(input, 0);
+      progressStore.getState().setProgress(input);
       result = await fetchFunc(input, controller.signal, (value) => {
         progressStore.getState().setProgress(input, value);
       });


### PR DESCRIPTION
It's finally coming together. Closes #1800.

Consumers can now provide their own fetcher and therefore their own axios instance (with custom headers, interceptors, etc.) As documented, some config options of the axios instance are ignored, like `baseURL`, `responseType`, etc.

Now that the `fetcher` is exposed through a prop on `H5GroveProvider` comes the question of whether to make it required or not. I chose to make it **optional** and to provide a basic fetcher implementation internally based on the Fetch API. My reasoning is that I don't want consumers to have to think about this `fetcher` business when they first install `@h5web/app` and try to use `H5GroveProvider` for the first time.

Technically, the only thing that the basic fetcher doesn't do that axios does is to track the progress of the requests. It's mind boggling to me how complicated it is to achieve this: https://github.com/axios/axios/blob/v1.x/lib/helpers/trackStream.js ... so I decided it wasn't worth it. What this means for users is that they see a progress bar that doesn't actually progress — e.g. with network throttling enabled to emphasize the problem:

[Screencast from 2025-05-19 11-46-36.webm](https://github.com/user-attachments/assets/a0e8297f-008f-46f7-bbd2-d53eae4c93eb)

To fix this, I now start the progress state with no value (`undefined`) and show an "indeterminate" progress bar:

[Screencast from 2025-05-19 14-09-52.webm](https://github.com/user-attachments/assets/26ff5e9c-4e83-43ba-942c-183475b4aca8)

This new behaviour is actually also useful with the axios fetcher, as the indeterminate progress bar now shows up while the connection is being established, before the first packets are received:

[Screencast from 2025-05-19 14-16-21.webm](https://github.com/user-attachments/assets/9a6f3814-5ec3-416a-8c9c-cb6053501728)

---

Next up, I'll tweak the implementation of `createAxiosFetcher` slightly so it doesn't rely on axios at all (`isAxiosError`, `isCancel`). Then, I'll implement the `fetcher` API in `HsdsProvider` and remove axios from `@h5web/app` entirely.