### PR TITLE
Decouple axios from `HsdsProvider`

### DIFF
--- a/apps/demo/src/HsdsApp.tsx
+++ b/apps/demo/src/HsdsApp.tsx
@@ -1,4 +1,11 @@
-import { App, assertEnvVar, HsdsProvider } from '@h5web/app';
+import {
+  App,
+  assertEnvVar,
+  createAxiosFetcher,
+  HsdsProvider,
+} from '@h5web/app';
+import axios from 'axios';
+import { useMemo } from 'react';
 import { useSearchParams } from 'wouter';
 
 import { getFeedbackURL } from './utils';
@@ -19,13 +26,17 @@ function HsdsApp() {
   const [searchParams] = useSearchParams();
   const filepath = `${SUBDOMAIN}${searchParams.get('file') || FILEPATH}`;
 
+  const fetcher = useMemo(() => {
+    return createAxiosFetcher(
+      axios.create({
+        adapter: 'fetch',
+        auth: { username: USERNAME, password: PASSWORD },
+      }),
+    );
+  }, []);
+
   return (
-    <HsdsProvider
-      url={URL}
-      username={USERNAME}
-      password={PASSWORD}
-      filepath={filepath}
-    >
+    <HsdsProvider url={URL} filepath={filepath} fetcher={fetcher}>
       <App
         sidebarOpen={!searchParams.has('wide')}
         getFeedbackURL={getFeedbackURL}

--- a/packages/app/src/providers/hsds/HsdsProvider.tsx
+++ b/packages/app/src/providers/hsds/HsdsProvider.tsx
@@ -2,31 +2,30 @@ import { type PropsWithChildren, useMemo } from 'react';
 
 import { type DataProviderApi } from '../api';
 import DataProvider from '../DataProvider';
+import { type Fetcher } from '../models';
 import { HsdsApi } from './hsds-api';
 
 interface Props {
   url: string;
-  username: string;
-  password: string;
   filepath: string;
   resetKeys?: unknown[];
+  fetcher: Fetcher;
   getExportURL?: DataProviderApi['getExportURL'];
 }
 
 function HsdsProvider(props: PropsWithChildren<Props>) {
   const {
     url,
-    username,
-    password,
     filepath,
     resetKeys = [],
+    fetcher,
     getExportURL,
     children,
   } = props;
 
   const api = useMemo(
-    () => new HsdsApi(url, username, password, filepath, getExportURL),
-    [filepath, password, url, username, ...resetKeys, getExportURL], // eslint-disable-line react-hooks/exhaustive-deps
+    () => new HsdsApi(url, filepath, fetcher, getExportURL),
+    [url, filepath, ...resetKeys, fetcher, getExportURL], // eslint-disable-line react-hooks/exhaustive-deps
   );
 
   return <DataProvider api={api}>{children}</DataProvider>;

--- a/packages/app/src/providers/hsds/hsds-api.ts
+++ b/packages/app/src/providers/hsds/hsds-api.ts
@@ -186,47 +186,67 @@ export class HsdsApi extends DataProviderApi {
   }
 
   private async fetchDataset(id: HsdsId): Promise<HsdsDatasetResponse> {
-    const buffer = await this.fetcher(`${this.baseURL}/datasets/${id}`, {
-      domain: this.filepath,
-    });
+    try {
+      const buffer = await this.fetcher(`${this.baseURL}/datasets/${id}`, {
+        domain: this.filepath,
+      });
 
-    return toJSON(buffer) as HsdsDatasetResponse;
+      return toJSON(buffer) as HsdsDatasetResponse;
+    } catch (error) {
+      throw this.wrapHsdsError(error) || error;
+    }
   }
 
   private async fetchDatatype(id: HsdsId): Promise<HsdsDatatypeResponse> {
-    const buffer = await this.fetcher(`${this.baseURL}/datatypes/${id}`, {
-      domain: this.filepath,
-    });
+    try {
+      const buffer = await this.fetcher(`${this.baseURL}/datatypes/${id}`, {
+        domain: this.filepath,
+      });
 
-    return toJSON(buffer) as HsdsDatatypeResponse;
+      return toJSON(buffer) as HsdsDatatypeResponse;
+    } catch (error) {
+      throw this.wrapHsdsError(error) || error;
+    }
   }
 
   private async fetchGroup(id: HsdsId): Promise<HsdsGroupResponse> {
-    const buffer = await this.fetcher(`${this.baseURL}/groups/${id}`, {
-      domain: this.filepath,
-    });
+    try {
+      const buffer = await this.fetcher(`${this.baseURL}/groups/${id}`, {
+        domain: this.filepath,
+      });
 
-    return toJSON(buffer) as HsdsGroupResponse;
+      return toJSON(buffer) as HsdsGroupResponse;
+    } catch (error) {
+      throw this.wrapHsdsError(error) || error;
+    }
   }
 
   private async fetchLinks(id: HsdsId): Promise<HsdsLink[]> {
-    const buffer = await this.fetcher(`${this.baseURL}/groups/${id}/links`, {
-      domain: this.filepath,
-    });
+    try {
+      const buffer = await this.fetcher(`${this.baseURL}/groups/${id}/links`, {
+        domain: this.filepath,
+      });
 
-    return (toJSON(buffer) as HsdsLinksResponse).links;
+      return (toJSON(buffer) as HsdsLinksResponse).links;
+    } catch (error) {
+      throw this.wrapHsdsError(error) || error;
+    }
   }
 
   private async fetchAttributes(
     entityCollection: HsdsCollection,
     entityId: HsdsId,
   ): Promise<HsdsAttribute[]> {
-    const buffer = await this.fetcher(
-      `${this.baseURL}/${entityCollection}/${entityId}/attributes`,
-      { domain: this.filepath },
-    );
+    try {
+      const buffer = await this.fetcher(
+        `${this.baseURL}/${entityCollection}/${entityId}/attributes`,
+        { domain: this.filepath },
+      );
 
-    return (toJSON(buffer) as HsdsAttributesResponse).attributes;
+      return (toJSON(buffer) as HsdsAttributesResponse).attributes;
+    } catch (error) {
+      throw this.wrapHsdsError(error) || error;
+    }
   }
 
   private async fetchValue(
@@ -235,16 +255,20 @@ export class HsdsApi extends DataProviderApi {
     abortSignal?: AbortSignal,
     onProgress?: OnProgress,
   ): Promise<unknown> {
-    const buffer = await this.fetcher(
-      `${this.baseURL}/datasets/${entityId}/value`,
-      {
-        domain: this.filepath,
-        ...(selection && { select: `[${selection}]` }),
-      },
-      { abortSignal, onProgress },
-    );
+    try {
+      const buffer = await this.fetcher(
+        `${this.baseURL}/datasets/${entityId}/value`,
+        {
+          domain: this.filepath,
+          ...(selection && { select: `[${selection}]` }),
+        },
+        { abortSignal, onProgress },
+      );
 
-    return (toExtendedJSON(buffer) as HsdsValueResponse).value;
+      return (toExtendedJSON(buffer) as HsdsValueResponse).value;
+    } catch (error) {
+      throw this.wrapHsdsError(error) || error;
+    }
   }
 
   private async fetchAttributeWithValue(
@@ -252,12 +276,16 @@ export class HsdsApi extends DataProviderApi {
     entityId: HsdsId,
     attributeName: string,
   ): Promise<HsdsAttributeWithValueResponse> {
-    const buffer = await this.fetcher(
-      `${this.baseURL}/${entityCollection}/${entityId}/attributes/${attributeName}`,
-      { domain: this.filepath },
-    );
+    try {
+      const buffer = await this.fetcher(
+        `${this.baseURL}/${entityCollection}/${entityId}/attributes/${attributeName}`,
+        { domain: this.filepath },
+      );
 
-    return toExtendedJSON(buffer) as HsdsAttributeWithValueResponse;
+      return toExtendedJSON(buffer) as HsdsAttributeWithValueResponse;
+    } catch (error) {
+      throw this.wrapHsdsError(error) || error;
+    }
   }
 
   private async resolveLink(

--- a/packages/app/src/providers/hsds/utils.ts
+++ b/packages/app/src/providers/hsds/utils.ts
@@ -172,3 +172,15 @@ export function flattenValue(
   const dims = slicedDims || dataset.shape;
   return value.flat(dims.length - 1);
 }
+
+export function toExtendedJSON(buffer: ArrayBuffer): unknown {
+  const str = new TextDecoder().decode(buffer);
+
+  try {
+    return JSON.parse(str);
+  } catch {
+    // Convert Infinity/NaN to JSON strings and try again
+    // https://github.com/HDFGroup/hsds/issues/87
+    return JSON.parse(str.replaceAll(/-?Infinity|NaN/gu, '"$&"'));
+  }
+}

--- a/packages/app/src/providers/hsds/utils.ts
+++ b/packages/app/src/providers/hsds/utils.ts
@@ -179,8 +179,15 @@ export function toExtendedJSON(buffer: ArrayBuffer): unknown {
   try {
     return JSON.parse(str);
   } catch {
-    // Convert Infinity/NaN to JSON strings and try again
-    // https://github.com/HDFGroup/hsds/issues/87
-    return JSON.parse(str.replaceAll(/-?Infinity|NaN/gu, '"$&"'));
+    try {
+      // Convert Infinity/NaN to JSON strings and try again
+      // https://github.com/HDFGroup/hsds/issues/87
+      return JSON.parse(str.replaceAll(/-?Infinity|NaN/gu, '"$&"'));
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        throw new TypeError('Expected valid JSON', { cause: error });
+      }
+      throw error;
+    }
   }
 }

--- a/packages/app/src/providers/utils.ts
+++ b/packages/app/src/providers/utils.ts
@@ -90,7 +90,14 @@ export async function getValueOrError(
 }
 
 export function toJSON(buffer: ArrayBuffer): unknown {
-  return JSON.parse(new TextDecoder().decode(buffer));
+  try {
+    return JSON.parse(new TextDecoder().decode(buffer));
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new TypeError('Expected valid JSON', { cause: error });
+    }
+    throw error;
+  }
 }
 
 export function createBasicFetcher(): Fetcher {

--- a/packages/app/src/providers/utils.ts
+++ b/packages/app/src/providers/utils.ts
@@ -11,17 +11,11 @@ import {
   type DType,
   type ScalarShape,
 } from '@h5web/shared/hdf5-models';
-import { type OnProgress } from '@h5web/shared/react-suspense-fetch';
 import {
   type BigIntTypedArrayConstructor,
   type TypedArrayConstructor,
 } from '@h5web/shared/vis-models';
-import {
-  type AxiosInstance,
-  type AxiosProgressEvent,
-  isAxiosError,
-  isCancel,
-} from 'axios';
+import { type AxiosInstance, isAxiosError, isCancel } from 'axios';
 
 import { type DataProviderApi } from './api';
 import { type Fetcher, type FetcherOptions } from './models';
@@ -99,19 +93,6 @@ export function toJSON(buffer: ArrayBuffer): unknown {
   return JSON.parse(new TextDecoder().decode(buffer));
 }
 
-export function createAxiosProgressHandler(
-  onProgress: OnProgress | undefined,
-): ((evt: AxiosProgressEvent) => void) | undefined {
-  return (
-    onProgress &&
-    ((evt: AxiosProgressEvent) => {
-      if (evt.total !== undefined && evt.total > 0) {
-        onProgress(evt.loaded / evt.total);
-      }
-    })
-  );
-}
-
 export function createBasicFetcher(): Fetcher {
   return async (
     url: string,
@@ -155,7 +136,13 @@ export function createAxiosFetcher(axiosInstance: AxiosInstance): Fetcher {
         responseType: 'arraybuffer',
         params: { ...axiosInstance.defaults.params, ...params },
         signal: abortSignal,
-        onDownloadProgress: createAxiosProgressHandler(onProgress),
+        onDownloadProgress:
+          onProgress &&
+          ((evt) => {
+            if (evt.total !== undefined && evt.total > 0) {
+              onProgress(evt.loaded / evt.total);
+            }
+          }),
       });
       return data;
     } catch (error) {

--- a/packages/app/src/test-utils.tsx
+++ b/packages/app/src/test-utils.tsx
@@ -147,7 +147,7 @@ export async function assertListeningAt(
 ) {
   try {
     await fetch(url);
-  } catch {
-    throw new Error(message);
+  } catch (error) {
+    throw new Error(message, { cause: error });
   }
 }


### PR DESCRIPTION
To follow up on #1800, I now decouple axios from `HsdsApi` like I did in `H5GroveApi`.

I worked on improving error handling in a separate commit. Every internal `fetch` method now handles HSDS' "file not found" errors, and when HSDS doesn't return valid JSON (e.g. when a compression is not supported), I no longer silence the JSON parsing error:

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/569a3650-fa8e-4bc1-ae44-3fabc17bc15c) | ![image](https://github.com/user-attachments/assets/ae72173c-d322-43a4-bbfc-d39ba925a8a2) |