### PR TITLE
Allow passing request options to `createBasicFetcher`

### DIFF
--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -6,7 +6,11 @@ export { default as MockProvider } from './providers/mock/MockProvider';
 export { default as HsdsProvider } from './providers/hsds/HsdsProvider';
 export { default as H5GroveProvider } from './providers/h5grove/H5GroveProvider';
 
-export { createBasicFetcher, createAxiosFetcher } from './providers/utils';
+export {
+  createBasicFetcher,
+  createAxiosFetcher,
+  buildBasicAuthHeader,
+} from './providers/utils';
 
 export { enableBigIntSerialization } from './utils';
 export { getFeedbackMailto } from './breadcrumbs/utils';

--- a/packages/app/src/providers/utils.ts
+++ b/packages/app/src/providers/utils.ts
@@ -100,7 +100,9 @@ export function toJSON(buffer: ArrayBuffer): unknown {
   }
 }
 
-export function createBasicFetcher(): Fetcher {
+export function createBasicFetcher(
+  fetchOpts: Omit<RequestInit, 'signal'> = {},
+): Fetcher {
   return async (
     url: string,
     params: Record<string, string>,
@@ -111,6 +113,7 @@ export function createBasicFetcher(): Fetcher {
 
     try {
       const response = await fetch(`${url}?${queryParams.toString()}`, {
+        ...fetchOpts,
         signal: abortSignal,
       });
 
@@ -165,6 +168,13 @@ export function createAxiosFetcher(axiosInstance: AxiosInstance): Fetcher {
       throw error;
     }
   };
+}
+
+export function buildBasicAuthHeader(
+  username: string,
+  password: string,
+): Record<string, string> {
+  return { Authorization: `Basic ${btoa(`${username}:${password}`)}` };
 }
 
 export class AbortError extends Error {


### PR DESCRIPTION
- Document the new `fetcher` prop of `HsdsProvider`
- Provide a way to initialialise a basic fetcher for `HsdsProvider` using basic HTTP authentication (just for convenience and so we can document a simple way to get started):

```ts
const fetcher = createBasicFetcher({
  headers: buildBasicAuthHeader(USERNAME, PASSWORD),
});
```