### PR TITLE
Make axios a peer/dev dep in app package

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -42,11 +42,15 @@
     "sync-version": "dot-json ../../package.json version | xargs dot-json package.json version"
   },
   "peerDependencies": {
+    "axios": ">=1",
     "react": ">=18",
     "react-dom": ">=18",
     "typescript": ">=4.5"
   },
   "peerDependenciesMeta": {
+    "axios": {
+      "optional": true
+    },
     "typescript": {
       "optional": true
     }
@@ -55,7 +59,6 @@
     "@h5web/lib": "workspace:*",
     "@react-hookz/web": "25.0.1",
     "@react-three/fiber": "8.17.12",
-    "axios": "1.8.4",
     "d3-format": "3.1.0",
     "ndarray": "1.0.19",
     "ndarray-ops": "1.2.2",
@@ -81,6 +84,7 @@
     "@types/react-dom": "^18.3.5",
     "@types/react-slider": "~1.3.6",
     "@vitejs/plugin-react-swc": "3.8.1",
+    "axios": "1.8.4",
     "concat": "1.0.3",
     "dot-json": "1.3.0",
     "eslint": "9.23.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,9 +232,6 @@ importers:
       '@react-three/fiber':
         specifier: 8.17.12
         version: 8.17.12(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.172.0)
-      axios:
-        specifier: 1.8.4
-        version: 1.8.4
       d3-format:
         specifier: 3.1.0
         version: 3.1.0
@@ -305,6 +302,9 @@ importers:
       '@vitejs/plugin-react-swc':
         specifier: 3.8.1
         version: 3.8.1(vite@6.2.4(@types/node@22.13.16))
+      axios:
+        specifier: 1.8.4
+        version: 1.8.4
       concat:
         specifier: 1.0.3
         version: 1.0.3


### PR DESCRIPTION
I was planning on removing axios from the app package completely, but we need to keep it if we want `createAxiosFetcher` to be properly typed and type-checked.

So in the end, I turn it into a dev dependency and add it as an optional peer dependency. And to make sure this doesn't cause issues in consumer packages that don't install axios, I remove the two remaining non-type imports of `axios` from the app package (`isAxiosError` and `isCancel`).