### PR TITLE
Fix abort error handling

### DIFF
--- a/packages/app/src/ErrorFallback.tsx
+++ b/packages/app/src/ErrorFallback.tsx
@@ -1,7 +1,7 @@
+import { AbortError } from '@h5web/shared/react-suspense-fetch';
 import { type FallbackProps } from 'react-error-boundary';
 
 import styles from './App.module.css';
-import { AbortError } from './providers/utils';
 
 interface Props extends FallbackProps {
   className?: string;

--- a/packages/app/src/providers/mock/mock-api.ts
+++ b/packages/app/src/providers/mock/mock-api.ts
@@ -67,7 +67,7 @@ export class MockApi extends DataProviderApi {
       throw new Error('error');
     }
 
-    if (dataset.name.startsWith('slow')) {
+    if (dataset.name.startsWith('slow') && abortSignal) {
       await cancellableDelay(abortSignal);
     }
 

--- a/packages/app/src/providers/mock/utils.ts
+++ b/packages/app/src/providers/mock/utils.ts
@@ -17,7 +17,6 @@ import { getChildEntity } from '@h5web/shared/hdf5-utils';
 import ndarray from 'ndarray';
 
 import { applyMapping } from '../../vis-packs/core/utils';
-import { AbortError } from '../utils';
 
 export const SLOW_TIMEOUT = 3000;
 
@@ -82,20 +81,20 @@ export function getChildrenPaths(
 }
 
 export async function cancellableDelay(
-  abortSignal?: AbortSignal,
+  abortSignal: AbortSignal,
 ): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     const timeout = setTimeout(() => {
-      abortSignal?.removeEventListener('abort', handleAbort);
+      abortSignal.removeEventListener('abort', handleAbort);
       resolve();
     }, SLOW_TIMEOUT);
 
     function handleAbort() {
       clearTimeout(timeout);
-      abortSignal?.removeEventListener('abort', handleAbort);
-      reject(new AbortError(abortSignal));
+      abortSignal.removeEventListener('abort', handleAbort);
+      reject(abortSignal.reason); // eslint-disable-line @typescript-eslint/prefer-promise-reject-errors
     }
 
-    abortSignal?.addEventListener('abort', handleAbort);
+    abortSignal.addEventListener('abort', handleAbort);
   });
 }

--- a/packages/shared/src/react-suspense-fetch.ts
+++ b/packages/shared/src/react-suspense-fetch.ts
@@ -176,7 +176,14 @@ function createInstance<Input, Result>(
     },
     isError: () => error !== undefined,
     abort: (reason?: string) => {
-      controller.abort(reason);
+      controller.abort(new AbortError(reason));
     },
   };
+}
+
+export class AbortError extends Error {
+  public constructor(reason?: string) {
+    super(reason);
+    this.name = 'AbortError';
+  }
 }


### PR DESCRIPTION
This fixes an issue with the basic fetcher when requests are aborted (via `abortSignal.abort(<reason>)`).

In the h5grove demo, where the basic fetcher is configured without any headers, the browser throws a `DOMException`. But in the HSDS demo, where we pass an `Authentication` header for basic auth, the browser throws the abort reason as is (i.e. the reason string itself). Our current error handling logic expects a `DOMException`, so in the HSDS demo, we just see "Unknown error".

Both Firefox and Chrome behave the same way, so there must be an explanation but I could not find it. :disappointed: 

The fix is to simply look at the `abortSignal.aborted` flag in the `catch` block... It's basically what axios does as well (though in a much more convoluted way).

Additionally, I realised that `abortSignal.abort()` is meant to be called with an `Error`, not a `string`. So I now pass `AbortError` directly, and then I simply rethrow it from the fetcher with `throw abortSignal.reason`.

All in all, it cleans things up very nicely.