### PR TITLE
Add linewidth parameter to DataCurve

### DIFF
--- a/apps/storybook/src/DataCurve.stories.tsx
+++ b/apps/storybook/src/DataCurve.stories.tsx
@@ -33,6 +33,7 @@ const meta = {
     curveType: CurveType.LineOnly,
     color: 'blue',
     visible: true,
+    lineWidth: 1,
   },
   argTypes: {
     abscissas: { control: false },

--- a/packages/lib/src/vis/line/DataCurve.tsx
+++ b/packages/lib/src/vis/line/DataCurve.tsx
@@ -14,6 +14,7 @@ interface Props {
   showErrors?: boolean;
   color: string;
   curveType?: CurveType;
+  lineWidth?: number;
   glyphType?: GlyphType;
   glyphSize?: number;
   visible?: boolean;
@@ -34,6 +35,7 @@ function DataCurve(props: Props) {
     showErrors,
     color,
     curveType = CurveType.LineOnly,
+    lineWidth = 1,
     glyphType = GlyphType.Cross,
     glyphSize = 6,
     visible = true,
@@ -52,6 +54,7 @@ function DataCurve(props: Props) {
         abscissas={abscissas}
         ordinates={ordinates}
         color={color}
+        lineWidth={lineWidth}
         ignoreValue={ignoreValue}
         visible={curveType !== CurveType.GlyphsOnly && visible}
         onClick={useEventHandler(onLineClick)}

--- a/packages/lib/src/vis/line/Line.tsx
+++ b/packages/lib/src/vis/line/Line.tsx
@@ -8,7 +8,6 @@ import { hasR3FEventHandlers } from '../utils';
 import LineGeometry from './lineGeometry';
 
 // Alias Three's `Line` to `Line_` to avoid conflict with SVG `line` in JSX
-// https://docs.pmnd.rs/react-three-fiber/tutorials/typescript#extending-threeelements
 class Line_ extends R3FLine {}
 extend({ Line_ });
 declare module '@react-three/fiber' {
@@ -21,6 +20,7 @@ interface Props extends Object3DNode<R3FLine, typeof R3FLine> {
   abscissas: NumArray;
   ordinates: NumArray;
   color: string;
+  lineWidth?: number;
   visible?: boolean;
   ignoreValue?: IgnoreValue;
 }
@@ -30,6 +30,7 @@ function Line(props: Props) {
     abscissas,
     ordinates,
     color,
+    lineWidth = 1,
     visible = true,
     ignoreValue,
     ...lineProps
@@ -55,7 +56,7 @@ function Line(props: Props) {
 
   return (
     <line_ geometry={geometry} visible={visible} {...lineProps}>
-      <lineBasicMaterial color={color} />
+      <lineBasicMaterial color={color} linewidth={lineWidth} />
     </line_>
   );
 }


### PR DESCRIPTION
This tries to add a linewidth parameter to the DataCurve.

It works for values of 1 to 6 inside of chrome, but does not work for larger values and firefox completely ignores it. Looking into the LineBasicMaterials [docs](https://threejs.org/docs/#api/en/materials/LineBasicMaterial), it is clear, that a reliable implementation would need to use [Line2](https://threejs.org/docs/index.html#examples/en/lines/Line2). 

However, this would be a large change.

I would be happy, with it at least working correctly in chrome.

What is your take on this?