### PR TITLE
add materialProps as properties for Line and DataCurve

### DIFF
--- a/apps/storybook/src/DataCurve.stories.tsx
+++ b/apps/storybook/src/DataCurve.stories.tsx
@@ -32,6 +32,7 @@ const meta = {
     errors: oneD.data.map(() => 10),
     curveType: CurveType.LineOnly,
     color: 'blue',
+    materialProps: {},
     visible: true,
   },
   argTypes: {
@@ -39,6 +40,10 @@ const meta = {
     ordinates: { control: false },
     errors: { control: false },
     color: { control: { type: 'color' } },
+    materialProps: {
+      control: 'object',
+      description: 'Properties passed to the underlying Three.js material.',
+    },
   },
 } satisfies Meta<typeof DataCurve>;
 

--- a/packages/lib/src/vis/line/DataCurve.tsx
+++ b/packages/lib/src/vis/line/DataCurve.tsx
@@ -1,5 +1,8 @@
 import { type IgnoreValue, type NumArray } from '@h5web/shared/vis-models';
-import { type ThreeEvent } from '@react-three/fiber';
+import {
+  type LineBasicMaterialProps,
+  type ThreeEvent,
+} from '@react-three/fiber';
 
 import ErrorBars from './ErrorBars';
 import Glyphs from './Glyphs';
@@ -16,6 +19,7 @@ interface Props {
   curveType?: CurveType;
   glyphType?: GlyphType;
   glyphSize?: number;
+  materialProps?: LineBasicMaterialProps;
   visible?: boolean;
   onLineClick?: (index: number, event: ThreeEvent<MouseEvent>) => void;
   onLineEnter?: (index: number, event: ThreeEvent<PointerEvent>) => void;
@@ -36,6 +40,7 @@ function DataCurve(props: Props) {
     curveType = CurveType.LineOnly,
     glyphType = GlyphType.Cross,
     glyphSize = 6,
+    materialProps = {},
     visible = true,
     onLineClick,
     onLineEnter,
@@ -53,6 +58,7 @@ function DataCurve(props: Props) {
         ordinates={ordinates}
         color={color}
         ignoreValue={ignoreValue}
+        materialProps={materialProps}
         visible={curveType !== CurveType.GlyphsOnly && visible}
         onClick={useEventHandler(onLineClick)}
         onPointerEnter={useEventHandler(onLineEnter)}

--- a/packages/lib/src/vis/line/Line.tsx
+++ b/packages/lib/src/vis/line/Line.tsx
@@ -1,5 +1,9 @@
 import { type IgnoreValue, type NumArray } from '@h5web/shared/vis-models';
-import { extend, type Object3DNode } from '@react-three/fiber';
+import {
+  extend,
+  type LineBasicMaterialProps,
+  type Object3DNode,
+} from '@react-three/fiber';
 import { Line as R3FLine } from 'three';
 
 import { useGeometry } from '../hooks';
@@ -21,6 +25,7 @@ interface Props extends Object3DNode<R3FLine, typeof R3FLine> {
   abscissas: NumArray;
   ordinates: NumArray;
   color: string;
+  materialProps?: LineBasicMaterialProps;
   visible?: boolean;
   ignoreValue?: IgnoreValue;
 }
@@ -30,6 +35,7 @@ function Line(props: Props) {
     abscissas,
     ordinates,
     color,
+    materialProps = {},
     visible = true,
     ignoreValue,
     ...lineProps
@@ -55,7 +61,7 @@ function Line(props: Props) {
 
   return (
     <line_ geometry={geometry} visible={visible} {...lineProps}>
-      <lineBasicMaterial color={color} />
+      <lineBasicMaterial color={color} {...materialProps} />
     </line_>
   );
 }


### PR DESCRIPTION
adds materialsProps to Line and DataCurve

this allows to pass extra information like linewidth or opacity to the line creation process.

e.g. 

materialsProbs = { linewidth: 3}

This PR is result of discussion in #1815 