### PR TITLE
Extract and test dim mapping state initialisation

### DIFF
--- a/packages/app/src/dimension-mapper/store.tsx
+++ b/packages/app/src/dimension-mapper/store.tsx
@@ -10,6 +10,7 @@ import { createStore, type StoreApi, useStore } from 'zustand';
 
 import { areSameDims } from '../vis-packs/nexus/utils';
 import { type DimensionMapping } from './models';
+import { initDimMapping } from './utils';
 
 interface DimMappingState {
   dims: ArrayShape;
@@ -23,7 +24,7 @@ interface DimMappingState {
   ) => void;
 }
 
-function createLineConfigStore() {
+function createDimMappingStore() {
   return createStore<DimMappingState>((set) => ({
     dims: [],
     axesCount: 0,
@@ -41,7 +42,7 @@ interface Props {}
 export function DimMappingProvider(props: PropsWithChildren<Props>) {
   const { children } = props;
 
-  const [store] = useState(createLineConfigStore);
+  const [store] = useState(createDimMappingStore);
 
   return (
     <StoreContext.Provider value={store}>{children}</StoreContext.Provider>
@@ -59,14 +60,7 @@ export function useDimMappingState(
   const isStale =
     axesCount !== state.axesCount || !areSameDims(dims, state.dims);
 
-  const mapping = isStale
-    ? [
-        ...Array.from({ length: dims.length - axesCount }, () => 0),
-        ...(dims.length > 0
-          ? ['y' as const, 'x' as const].slice(-axesCount)
-          : []),
-      ]
-    : state.mapping;
+  const mapping = isStale ? initDimMapping(dims, axesCount) : state.mapping;
 
   useEffect(() => {
     state.reset(dims, axesCount, mapping);

--- a/packages/app/src/dimension-mapper/utils.test.ts
+++ b/packages/app/src/dimension-mapper/utils.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { initDimMapping } from './utils';
+
+describe('initDimMapping', () => {
+  it('should map axes to dimensions', () => {
+    expect(initDimMapping([], 0)).toStrictEqual([]);
+    expect(initDimMapping([1], 1)).toStrictEqual(['x']);
+    expect(initDimMapping([1, 1], 2)).toStrictEqual(['y', 'x']);
+  });
+
+  it('should slice extra dimensions', () => {
+    expect(initDimMapping([1], 0)).toStrictEqual([0]);
+    expect(initDimMapping([1, 1], 1)).toStrictEqual([0, 'x']);
+    expect(initDimMapping([1, 1, 1], 1)).toStrictEqual([0, 0, 'x']);
+    expect(initDimMapping([1, 1, 1], 2)).toStrictEqual([0, 'y', 'x']);
+    expect(initDimMapping([1, 1, 1, 1], 2)).toStrictEqual([0, 0, 'y', 'x']);
+  });
+
+  it('should cap number of axes to number of dimensions', () => {
+    expect(initDimMapping([], 1)).toStrictEqual([]);
+    expect(initDimMapping([], 2)).toStrictEqual([]);
+    expect(initDimMapping([1], 2)).toStrictEqual(['x']);
+  });
+
+  it('should throw when number of axes not supported', () => {
+    expect(() => initDimMapping([1], -1)).toThrow(RangeError);
+    expect(() => initDimMapping([1, 1, 1], 3)).toThrow(RangeError);
+  });
+});

--- a/packages/app/src/dimension-mapper/utils.ts
+++ b/packages/app/src/dimension-mapper/utils.ts
@@ -2,8 +2,29 @@ import { type Axis } from '@h5web/shared/vis-models';
 import { useSyncedRef, useUnmountEffect } from '@react-hookz/web';
 import { type DependencyList, useEffect, useMemo, useRef } from 'react';
 
+import { type DimensionMapping } from './models';
+
 export function isAxis(elem: number | Axis): elem is Axis {
   return typeof elem !== 'number';
+}
+
+export function initDimMapping(
+  dims: number[],
+  axesCount: number,
+): DimensionMapping {
+  if (axesCount < 0 || axesCount > 2) {
+    throw new RangeError('Expected 0, 1 or 2 axes');
+  }
+
+  // Cap number of axes to number of dimensions
+  const safeAxesCount = Math.min(axesCount, dims.length);
+
+  return [
+    ...Array.from({ length: dims.length - safeAxesCount }, () => 0),
+    ...(safeAxesCount > 0
+      ? ['y' as const, 'x' as const].slice(-safeAxesCount)
+      : []),
+  ];
 }
 
 // Debounced callback with a delay that can be adjusted on every invocation


### PR DESCRIPTION
I'm planning to move the dimension mapper and related utilities/styles/models to the library, because I'd like to use them in Braggy. As a first step, I extract the dim mapping state intialisation into a dedicated utility function.

While I'm at it, I add support for initialising a dim mapping state with 0 axes (for slicing scalar values, cf. my attempt in https://github.com/silx-kit/h5web/pull/1768/files#diff-123aa107dfdd1a6159a9a847361690b69a161a6551acf1c537ad0239eaa6699f). It's not needed yet, but it actually  makes the new `initDimMapping` function more robust, IMO. I also add some unit tests to cover all edge cases.