### PR TITLE
Move viewer CSS out of dimension mapper

### DIFF
--- a/packages/app/src/dimension-mapper/DimensionMapper.module.css
+++ b/packages/app/src/dimension-mapper/DimensionMapper.module.css
@@ -1,5 +1,4 @@
 .mapper {
-  grid-area: dimMapper;
   display: flex;
   flex-direction: column;
   padding: 1rem 0.375rem 1rem 0.375rem;

--- a/packages/app/src/dimension-mapper/DimensionMapper.tsx
+++ b/packages/app/src/dimension-mapper/DimensionMapper.tsx
@@ -6,6 +6,7 @@ import { type DimensionMapping } from './models';
 import SlicingSlider from './SlicingSlider';
 
 interface Props {
+  className: string;
   dims: number[];
   axisLabels?: AxisMapping<string>;
   dimMapping: DimensionMapping;
@@ -14,7 +15,7 @@ interface Props {
 }
 
 function DimensionMapper(props: Props) {
-  const { dims, axisLabels, dimMapping, isCached, onChange } = props;
+  const { className, dims, axisLabels, dimMapping, isCached, onChange } = props;
   const mappableDims = dims.slice(0, dimMapping.length);
 
   if (dimMapping.length === 0) {
@@ -22,7 +23,7 @@ function DimensionMapper(props: Props) {
   }
 
   return (
-    <div className={styles.mapper}>
+    <div className={`${styles.mapper} ${className}`}>
       <div className={styles.axisMapperWrapper}>
         <div className={styles.dims}>
           <span className={styles.dimsLabel}>

--- a/packages/app/src/vis-packs/core/complex/ComplexLineVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/complex/ComplexLineVisContainer.tsx
@@ -7,6 +7,7 @@ import {
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useValuesInCache } from '../../../dimension-mapper/hooks';
 import { useDimMappingState } from '../../../dimension-mapper/store';
+import visualizerStyles from '../../../visualizer/Visualizer.module.css';
 import { type VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
 import { useLineConfig } from '../line/config';
@@ -31,6 +32,7 @@ function ComplexLineVisContainer(props: VisContainerProps) {
   return (
     <>
       <DimensionMapper
+        className={visualizerStyles.dimMapper}
         dims={dims}
         dimMapping={dimMapping}
         isCached={useValuesInCache(entity)}

--- a/packages/app/src/vis-packs/core/complex/ComplexVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/complex/ComplexVisContainer.tsx
@@ -8,6 +8,7 @@ import {
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useValuesInCache } from '../../../dimension-mapper/hooks';
 import { useDimMappingState } from '../../../dimension-mapper/store';
+import visualizerStyles from '../../../visualizer/Visualizer.module.css';
 import { type VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
 import { useHeatmapConfig } from '../heatmap/config';
@@ -33,6 +34,7 @@ function ComplexVisContainer(props: VisContainerProps) {
   return (
     <>
       <DimensionMapper
+        className={visualizerStyles.dimMapper}
         dims={dims}
         dimMapping={dimMapping}
         isCached={useValuesInCache(entity)}

--- a/packages/app/src/vis-packs/core/compound/CompoundVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/compound/CompoundVisContainer.tsx
@@ -8,6 +8,7 @@ import {
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useValuesInCache } from '../../../dimension-mapper/hooks';
 import { useDimMappingState } from '../../../dimension-mapper/store';
+import visualizerStyles from '../../../visualizer/Visualizer.module.css';
 import { type VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
 import { useMatrixConfig } from '../matrix/config';
@@ -31,6 +32,7 @@ function CompoundVisContainer(props: VisContainerProps) {
   return (
     <>
       <DimensionMapper
+        className={visualizerStyles.dimMapper}
         dims={dims}
         dimMapping={dimMapping}
         isCached={useValuesInCache(entity)}

--- a/packages/app/src/vis-packs/core/heatmap/HeatmapVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/HeatmapVisContainer.tsx
@@ -8,6 +8,7 @@ import {
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useValuesInCache } from '../../../dimension-mapper/hooks';
 import { useDimMappingState } from '../../../dimension-mapper/store';
+import visualizerStyles from '../../../visualizer/Visualizer.module.css';
 import { type VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
 import { useIgnoreFillValue } from '../hooks';
@@ -34,6 +35,7 @@ function HeatmapVisContainer(props: VisContainerProps) {
   return (
     <>
       <DimensionMapper
+        className={visualizerStyles.dimMapper}
         dims={dims}
         dimMapping={dimMapping}
         isCached={useValuesInCache(entity)}

--- a/packages/app/src/vis-packs/core/line/LineVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/line/LineVisContainer.tsx
@@ -7,6 +7,7 @@ import {
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useValuesInCache } from '../../../dimension-mapper/hooks';
 import { useDimMappingState } from '../../../dimension-mapper/store';
+import visualizerStyles from '../../../visualizer/Visualizer.module.css';
 import { type VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
 import { useIgnoreFillValue } from '../hooks';
@@ -31,6 +32,7 @@ function LineVisContainer(props: VisContainerProps) {
   return (
     <>
       <DimensionMapper
+        className={visualizerStyles.dimMapper}
         dims={dims}
         dimMapping={dimMapping}
         isCached={useValuesInCache(entity)}

--- a/packages/app/src/vis-packs/core/matrix/MatrixVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/matrix/MatrixVisContainer.tsx
@@ -7,6 +7,7 @@ import {
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useValuesInCache } from '../../../dimension-mapper/hooks';
 import { useDimMappingState } from '../../../dimension-mapper/store';
+import visualizerStyles from '../../../visualizer/Visualizer.module.css';
 import { type VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
 import { getSliceSelection } from '../utils';
@@ -30,6 +31,7 @@ function MatrixVisContainer(props: VisContainerProps) {
   return (
     <>
       <DimensionMapper
+        className={visualizerStyles.dimMapper}
         dims={dims}
         dimMapping={dimMapping}
         isCached={useValuesInCache(entity)}

--- a/packages/app/src/vis-packs/core/rgb/RgbVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/rgb/RgbVisContainer.tsx
@@ -9,6 +9,7 @@ import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useValuesInCache } from '../../../dimension-mapper/hooks';
 import { useDimMappingState } from '../../../dimension-mapper/store';
 import { useDataContext } from '../../../providers/DataProvider';
+import visualizerStyles from '../../../visualizer/Visualizer.module.css';
 import { type VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
 import { getSliceSelection } from '../utils';
@@ -43,6 +44,7 @@ function RgbVisContainer(props: VisContainerProps) {
   return (
     <>
       <DimensionMapper
+        className={visualizerStyles.dimMapper}
         dims={dims}
         dimMapping={dimMapping}
         isCached={useValuesInCache(entity)}

--- a/packages/app/src/vis-packs/core/surface/SurfaceVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/surface/SurfaceVisContainer.tsx
@@ -8,6 +8,7 @@ import {
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useValuesInCache } from '../../../dimension-mapper/hooks';
 import { useDimMappingState } from '../../../dimension-mapper/store';
+import visualizerStyles from '../../../visualizer/Visualizer.module.css';
 import { type VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
 import { getSliceSelection } from '../utils';
@@ -31,6 +32,7 @@ function SurfaceVisContainer(props: VisContainerProps) {
   return (
     <>
       <DimensionMapper
+        className={visualizerStyles.dimMapper}
         dims={dims}
         dimMapping={dimMapping}
         isCached={useValuesInCache(entity)}

--- a/packages/app/src/vis-packs/nexus/containers/NxComplexImageContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxComplexImageContainer.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useDimMappingState } from '../../../dimension-mapper/store';
+import visualizerStyles from '../../../visualizer/Visualizer.module.css';
 import { useComplexConfig } from '../../core/complex/config';
 import MappedComplexVis from '../../core/complex/MappedComplexVis';
 import { useHeatmapConfig } from '../../core/heatmap/config';
@@ -50,6 +51,7 @@ function NxComplexImageContainer(props: VisContainerProps) {
         />
       )}
       <DimensionMapper
+        className={visualizerStyles.dimMapper}
         dims={dims}
         axisLabels={axisLabels}
         dimMapping={dimMapping}

--- a/packages/app/src/vis-packs/nexus/containers/NxComplexSpectrumContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxComplexSpectrumContainer.tsx
@@ -3,6 +3,7 @@ import { assertGroup, isAxisScaleType } from '@h5web/shared/guards';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useDimMappingState } from '../../../dimension-mapper/store';
+import visualizerStyles from '../../../visualizer/Visualizer.module.css';
 import { useComplexLineConfig } from '../../core/complex/lineConfig';
 import MappedComplexLineVis from '../../core/complex/MappedComplexLineVis';
 import { useLineConfig } from '../../core/line/config';
@@ -39,6 +40,7 @@ function NxComplexSpectrumContainer(props: VisContainerProps) {
   return (
     <>
       <DimensionMapper
+        className={visualizerStyles.dimMapper}
         dims={signalDims}
         axisLabels={axisLabels}
         dimMapping={dimMapping}

--- a/packages/app/src/vis-packs/nexus/containers/NxImageContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxImageContainer.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useDimMappingState } from '../../../dimension-mapper/store';
+import visualizerStyles from '../../../visualizer/Visualizer.module.css';
 import { useHeatmapConfig } from '../../core/heatmap/config';
 import MappedHeatmapVis from '../../core/heatmap/MappedHeatmapVis';
 import { getSliceSelection } from '../../core/utils';
@@ -48,6 +49,7 @@ function NxImageContainer(props: VisContainerProps) {
         />
       )}
       <DimensionMapper
+        className={visualizerStyles.dimMapper}
         dims={dims}
         axisLabels={axisLabels}
         dimMapping={dimMapping}

--- a/packages/app/src/vis-packs/nexus/containers/NxRgbContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxRgbContainer.tsx
@@ -2,6 +2,7 @@ import { assertGroup, assertMinDims } from '@h5web/shared/guards';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useDimMappingState } from '../../../dimension-mapper/store';
+import visualizerStyles from '../../../visualizer/Visualizer.module.css';
 import { useRgbConfig } from '../../core/rgb/config';
 import MappedRgbVis from '../../core/rgb/MappedRgbVis';
 import { getSliceSelection } from '../../core/utils';
@@ -35,6 +36,7 @@ function NxRgbContainer(props: VisContainerProps) {
   return (
     <>
       <DimensionMapper
+        className={visualizerStyles.dimMapper}
         dims={dims}
         axisLabels={axisLabels}
         dimMapping={dimMapping}

--- a/packages/app/src/vis-packs/nexus/containers/NxSpectrumContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxSpectrumContainer.tsx
@@ -3,6 +3,7 @@ import { assertGroup, isAxisScaleType } from '@h5web/shared/guards';
 
 import DimensionMapper from '../../../dimension-mapper/DimensionMapper';
 import { useDimMappingState } from '../../../dimension-mapper/store';
+import visualizerStyles from '../../../visualizer/Visualizer.module.css';
 import { useLineConfig } from '../../core/line/config';
 import MappedLineVis from '../../core/line/MappedLineVis';
 import { getSliceSelection } from '../../core/utils';
@@ -44,6 +45,7 @@ function NxSpectrumContainer(props: VisContainerProps) {
   return (
     <>
       <DimensionMapper
+        className={visualizerStyles.dimMapper}
         dims={signalDims}
         axisLabels={axisLabels}
         dimMapping={dimMapping}

--- a/packages/app/src/visualizer/Visualizer.module.css
+++ b/packages/app/src/visualizer/Visualizer.module.css
@@ -28,6 +28,10 @@
   composes: fallback from global;
 }
 
+.dimMapper {
+  grid-area: dimMapper;
+}
+
 .vis {
   grid-area: vis;
 }


### PR DESCRIPTION
I'm just moving the `grid-area` property, which positions the dimension mapper on the vis area, out of `DimensionMapper.module.css` and into `Visualizer.module.css`.

I'll have to deal with the CSS variables at the same time as I move the mapper to the lib. I don't think it's possible to do this in a dedicated PR. I'll do separate commits, though.