### PR TITLE
Refactor mock dataset slicing to simplify typing of `applyMapping`

### DIFF
--- a/packages/app/src/providers/mock/utils.ts
+++ b/packages/app/src/providers/mock/utils.ts
@@ -14,9 +14,8 @@ import {
   type ScalarValue,
 } from '@h5web/shared/hdf5-models';
 import { getChildEntity } from '@h5web/shared/hdf5-utils';
+import { createArrayFromView } from '@h5web/shared/vis-utils';
 import ndarray from 'ndarray';
-
-import { applyMapping } from '../../vis-packs/core/utils';
 
 export const SLOW_TIMEOUT = 3000;
 
@@ -53,12 +52,12 @@ export function sliceValue<T extends DType>(
 ): ScalarValue<T>[] {
   const { shape } = dataset;
   const dataArray = ndarray(value as ScalarValue<typeof dataset.type>[], shape);
-  const mappedArray = applyMapping(
-    dataArray,
-    selection.split(',').map((s) => (s === ':' ? s : Number.parseInt(s))),
-  );
 
-  return mappedArray.data;
+  const slicingState = selection
+    .split(',')
+    .map((s) => (s === ':' ? null : Number.parseInt(s)));
+
+  return createArrayFromView(dataArray.pick(...slicingState)).data;
 }
 
 export function getChildrenPaths(

--- a/packages/app/src/vis-packs/core/utils.ts
+++ b/packages/app/src/vis-packs/core/utils.ts
@@ -9,11 +9,7 @@ import {
   DTypeClass,
   type NumericLikeType,
 } from '@h5web/shared/hdf5-models';
-import {
-  type Axis,
-  type Domain,
-  type NumArray,
-} from '@h5web/shared/vis-models';
+import { type Domain, type NumArray } from '@h5web/shared/vis-models';
 import { createArrayFromView } from '@h5web/shared/vis-utils';
 import ndarray, { type NdArray } from 'ndarray';
 
@@ -50,12 +46,12 @@ export function getBaseArray(
 
 export function applyMapping<T extends NdArray<ArrayValue> | undefined>(
   baseArray: T,
-  mapping: (number | Axis | ':')[],
+  mapping: DimensionMapping,
 ): T extends NdArray<ArrayValue> ? T : undefined;
 
 export function applyMapping(
   baseArray: NdArray<ArrayValue> | undefined,
-  mapping: (number | Axis | ':')[],
+  mapping: DimensionMapping,
 ): NdArray<ArrayValue> | undefined {
   if (!baseArray) {
     return undefined;


### PR DESCRIPTION
This is a very obscure change ahead of moving the dimension mapper into the lib.

The goal is for `applyMapping` to no longer rely on the low-level `Axis` type but only on the higher-level `DimensionMapping` type. Both types are going to move to the lib as well, but I'd like to avoid exposing `Axis` (and the `isAxis` utility), as this feels like an implementation detail.

Anyway, even if I end up exposing `Axis`, I think `sliceValue` should not use `applyMapping` anyway. It doesn't apply a dimension "mapping" but a "selection" string — most notably, it doesn't need to transpose the data array.