### PR TITLE
Document dimension mapper and improve props

### DIFF
--- a/apps/storybook/src/DimensionMapper.stories.tsx
+++ b/apps/storybook/src/DimensionMapper.stories.tsx
@@ -1,0 +1,102 @@
+import { DimensionMapper } from '@h5web/lib';
+import { type Meta, type StoryObj } from '@storybook/react';
+import { useState } from 'react';
+
+import FillHeight from './decorators/FillHeight';
+
+const meta = {
+  title: 'Building Blocks/DimensionMapper',
+  component: DimensionMapper,
+  decorators: [FillHeight],
+  parameters: { layout: 'fullscreen' },
+  args: {
+    dimMapping: [],
+    onChange: () => {},
+  },
+  argTypes: {
+    dimMapping: { control: false },
+  },
+} satisfies Meta<typeof DimensionMapper>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default = {
+  render: (args) => {
+    const { dimMapping: initialMapping, ...otherArgs } = args;
+    const [dimMapping, setDimMapping] = useState(initialMapping);
+
+    return (
+      <div style={{ display: 'flex' }}>
+        <DimensionMapper
+          {...otherArgs}
+          dimMapping={dimMapping}
+          onChange={setDimMapping}
+        />
+        <pre style={{ padding: '0 1rem', fontSize: '125%' }}>
+          {JSON.stringify(dimMapping)}
+        </pre>
+      </div>
+    );
+  },
+  args: {
+    dims: [5, 10, 15],
+    dimMapping: [2, 5, 'x'],
+  },
+} satisfies Story;
+
+export const DimensionHints = {
+  ...Default,
+  args: {
+    ...Default.args,
+    dimHints: [undefined, 'Threshold', 'Position (mm)'],
+  },
+} satisfies Story;
+
+export const FastSlicing = {
+  ...Default,
+  args: {
+    ...Default.args,
+    canSliceFast: () => true,
+  },
+} satisfies Story;
+
+export const TwoAxes = {
+  ...Default,
+  args: {
+    ...Default.args,
+    dimMapping: ['x', 5, 'y'],
+  },
+} satisfies Story;
+
+export const NoAxes = {
+  ...Default,
+  args: {
+    ...Default.args,
+    dimMapping: [0, 1, 2],
+  },
+} satisfies Story;
+
+export const SmallDimensions = {
+  ...Default,
+  args: {
+    dims: [1, 2, 3],
+    dimMapping: [0, 0, 0],
+  },
+} satisfies Story;
+
+export const LargeDimensions = {
+  ...Default,
+  args: {
+    dims: [10_000, 100_000],
+    dimMapping: [0, 99_999],
+  },
+} satisfies Story;
+
+export const ExtraDimensions = {
+  ...Default,
+  args: {
+    dims: [5, 10, 15, 20],
+    dimMapping: [0, 'x'],
+  },
+} satisfies Story;

--- a/packages/app/src/hooks.ts
+++ b/packages/app/src/hooks.ts
@@ -83,8 +83,8 @@ export function useValuesInCache(
   ...datasets: (Dataset<ScalarShape | ArrayShape> | undefined)[]
 ): (dimMapping: DimensionMapping) => boolean {
   const { valuesStore } = useDataContext();
-  return (dimMapping) => {
-    const selection = getSliceSelection(dimMapping);
+  return (nextMapping) => {
+    const selection = getSliceSelection(nextMapping);
     return datasets.every(
       (dataset) => !dataset || valuesStore.has({ dataset, selection }),
     );

--- a/packages/app/src/vis-packs/core/complex/ComplexLineVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/complex/ComplexLineVisContainer.tsx
@@ -34,7 +34,7 @@ function ComplexLineVisContainer(props: VisContainerProps) {
         className={visualizerStyles.dimMapper}
         dims={dims}
         dimMapping={dimMapping}
-        isCached={useValuesInCache(entity)}
+        canSliceFast={useValuesInCache(entity)}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping} isSlice={selection !== undefined}>

--- a/packages/app/src/vis-packs/core/complex/ComplexVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/complex/ComplexVisContainer.tsx
@@ -36,7 +36,7 @@ function ComplexVisContainer(props: VisContainerProps) {
         className={visualizerStyles.dimMapper}
         dims={dims}
         dimMapping={dimMapping}
-        isCached={useValuesInCache(entity)}
+        canSliceFast={useValuesInCache(entity)}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping} isSlice={selection !== undefined}>

--- a/packages/app/src/vis-packs/core/compound/CompoundVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/compound/CompoundVisContainer.tsx
@@ -34,7 +34,7 @@ function CompoundVisContainer(props: VisContainerProps) {
         className={visualizerStyles.dimMapper}
         dims={dims}
         dimMapping={dimMapping}
-        isCached={useValuesInCache(entity)}
+        canSliceFast={useValuesInCache(entity)}
         onChange={setDimMapping}
       />
       <VisBoundary isSlice={selection !== undefined}>

--- a/packages/app/src/vis-packs/core/heatmap/HeatmapVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/HeatmapVisContainer.tsx
@@ -37,7 +37,7 @@ function HeatmapVisContainer(props: VisContainerProps) {
         className={visualizerStyles.dimMapper}
         dims={dims}
         dimMapping={dimMapping}
-        isCached={useValuesInCache(entity)}
+        canSliceFast={useValuesInCache(entity)}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping} isSlice={selection !== undefined}>

--- a/packages/app/src/vis-packs/core/line/LineVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/line/LineVisContainer.tsx
@@ -34,7 +34,7 @@ function LineVisContainer(props: VisContainerProps) {
         className={visualizerStyles.dimMapper}
         dims={dims}
         dimMapping={dimMapping}
-        isCached={useValuesInCache(entity)}
+        canSliceFast={useValuesInCache(entity)}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping} isSlice={selection !== undefined}>

--- a/packages/app/src/vis-packs/core/matrix/MatrixVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/matrix/MatrixVisContainer.tsx
@@ -33,7 +33,7 @@ function MatrixVisContainer(props: VisContainerProps) {
         className={visualizerStyles.dimMapper}
         dims={dims}
         dimMapping={dimMapping}
-        isCached={useValuesInCache(entity)}
+        canSliceFast={useValuesInCache(entity)}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping} isSlice={selection !== undefined}>

--- a/packages/app/src/vis-packs/core/rgb/RgbVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/rgb/RgbVisContainer.tsx
@@ -46,7 +46,7 @@ function RgbVisContainer(props: VisContainerProps) {
         className={visualizerStyles.dimMapper}
         dims={dims}
         dimMapping={dimMapping}
-        isCached={useValuesInCache(entity)}
+        canSliceFast={useValuesInCache(entity)}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping} isSlice={selection !== undefined}>

--- a/packages/app/src/vis-packs/core/surface/SurfaceVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/surface/SurfaceVisContainer.tsx
@@ -34,7 +34,7 @@ function SurfaceVisContainer(props: VisContainerProps) {
         className={visualizerStyles.dimMapper}
         dims={dims}
         dimMapping={dimMapping}
-        isCached={useValuesInCache(entity)}
+        canSliceFast={useValuesInCache(entity)}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping} isSlice={selection !== undefined}>

--- a/packages/app/src/vis-packs/nexus/containers/NxComplexImageContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxComplexImageContainer.tsx
@@ -52,7 +52,7 @@ function NxComplexImageContainer(props: VisContainerProps) {
       <DimensionMapper
         className={visualizerStyles.dimMapper}
         dims={dims}
-        axisLabels={axisLabels}
+        dimHints={axisLabels}
         dimMapping={dimMapping}
         canSliceFast={useNxValuesCached(nxData)}
         onChange={setDimMapping}

--- a/packages/app/src/vis-packs/nexus/containers/NxComplexImageContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxComplexImageContainer.tsx
@@ -54,7 +54,7 @@ function NxComplexImageContainer(props: VisContainerProps) {
         dims={dims}
         axisLabels={axisLabels}
         dimMapping={dimMapping}
-        isCached={useNxValuesCached(nxData)}
+        canSliceFast={useNxValuesCached(nxData)}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping}>

--- a/packages/app/src/vis-packs/nexus/containers/NxComplexSpectrumContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxComplexSpectrumContainer.tsx
@@ -42,7 +42,7 @@ function NxComplexSpectrumContainer(props: VisContainerProps) {
         dims={signalDims}
         axisLabels={axisLabels}
         dimMapping={dimMapping}
-        isCached={useNxValuesCached(nxData)}
+        canSliceFast={useNxValuesCached(nxData)}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping}>

--- a/packages/app/src/vis-packs/nexus/containers/NxComplexSpectrumContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxComplexSpectrumContainer.tsx
@@ -40,7 +40,7 @@ function NxComplexSpectrumContainer(props: VisContainerProps) {
       <DimensionMapper
         className={visualizerStyles.dimMapper}
         dims={signalDims}
-        axisLabels={axisLabels}
+        dimHints={axisLabels}
         dimMapping={dimMapping}
         canSliceFast={useNxValuesCached(nxData)}
         onChange={setDimMapping}

--- a/packages/app/src/vis-packs/nexus/containers/NxImageContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxImageContainer.tsx
@@ -52,7 +52,7 @@ function NxImageContainer(props: VisContainerProps) {
         dims={dims}
         axisLabels={axisLabels}
         dimMapping={dimMapping}
-        isCached={useNxValuesCached(nxData)}
+        canSliceFast={useNxValuesCached(nxData)}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping}>

--- a/packages/app/src/vis-packs/nexus/containers/NxImageContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxImageContainer.tsx
@@ -50,7 +50,7 @@ function NxImageContainer(props: VisContainerProps) {
       <DimensionMapper
         className={visualizerStyles.dimMapper}
         dims={dims}
-        axisLabels={axisLabels}
+        dimHints={axisLabels}
         dimMapping={dimMapping}
         canSliceFast={useNxValuesCached(nxData)}
         onChange={setDimMapping}

--- a/packages/app/src/vis-packs/nexus/containers/NxRgbContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxRgbContainer.tsx
@@ -37,7 +37,7 @@ function NxRgbContainer(props: VisContainerProps) {
       <DimensionMapper
         className={visualizerStyles.dimMapper}
         dims={dims}
-        axisLabels={axisLabels}
+        dimHints={axisLabels}
         dimMapping={dimMapping}
         canSliceFast={useNxValuesCached(nxData)}
         onChange={setDimMapping}

--- a/packages/app/src/vis-packs/nexus/containers/NxRgbContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxRgbContainer.tsx
@@ -39,7 +39,7 @@ function NxRgbContainer(props: VisContainerProps) {
         dims={dims}
         axisLabels={axisLabels}
         dimMapping={dimMapping}
-        isCached={useNxValuesCached(nxData)}
+        canSliceFast={useNxValuesCached(nxData)}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping}>

--- a/packages/app/src/vis-packs/nexus/containers/NxSpectrumContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxSpectrumContainer.tsx
@@ -47,7 +47,7 @@ function NxSpectrumContainer(props: VisContainerProps) {
         dims={signalDims}
         axisLabels={axisLabels}
         dimMapping={dimMapping}
-        isCached={useNxValuesCached(nxData)}
+        canSliceFast={useNxValuesCached(nxData)}
         onChange={setDimMapping}
       />
       <VisBoundary resetKey={dimMapping}>

--- a/packages/app/src/vis-packs/nexus/containers/NxSpectrumContainer.tsx
+++ b/packages/app/src/vis-packs/nexus/containers/NxSpectrumContainer.tsx
@@ -45,7 +45,7 @@ function NxSpectrumContainer(props: VisContainerProps) {
       <DimensionMapper
         className={visualizerStyles.dimMapper}
         dims={signalDims}
-        axisLabels={axisLabels}
+        dimHints={axisLabels}
         dimMapping={dimMapping}
         canSliceFast={useNxValuesCached(nxData)}
         onChange={setDimMapping}

--- a/packages/lib/src/dimension-mapper/AxisMapper.tsx
+++ b/packages/lib/src/dimension-mapper/AxisMapper.tsx
@@ -7,13 +7,13 @@ import { type DimensionMapping } from './models';
 
 interface Props {
   axis: Axis;
-  axisLabels: AxisMapping<string> | undefined;
+  dimHints: AxisMapping<string> | undefined;
   dimMapping: DimensionMapping;
   onChange: (mapperState: DimensionMapping) => void;
 }
 
 function AxisMapper(props: Props) {
-  const { axis, axisLabels, dimMapping, onChange } = props;
+  const { axis, dimHints, dimMapping, onChange } = props;
   const selectedDim = dimMapping.indexOf(axis);
 
   if (selectedDim === -1) {
@@ -46,7 +46,7 @@ function AxisMapper(props: Props) {
             key={i} // eslint-disable-line react/no-array-index-key
             label={`D${i}`}
             value={i.toString()}
-            hint={axisLabels?.[i]}
+            hint={dimHints?.[i]}
           />
         ))}
       </ToggleGroup>

--- a/packages/lib/src/dimension-mapper/DimensionMapper.tsx
+++ b/packages/lib/src/dimension-mapper/DimensionMapper.tsx
@@ -8,7 +8,7 @@ import SlicingSlider from './SlicingSlider';
 
 interface Props extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
   dims: number[];
-  axisLabels?: AxisMapping<string>;
+  dimHints?: AxisMapping<string>;
   dimMapping: DimensionMapping;
   canSliceFast?: (nextMapping: DimensionMapping) => boolean;
   onChange: (d: DimensionMapping) => void;
@@ -18,7 +18,7 @@ function DimensionMapper(props: Props) {
   const {
     className,
     dims,
-    axisLabels,
+    dimHints,
     dimMapping,
     canSliceFast,
     onChange,
@@ -47,13 +47,13 @@ function DimensionMapper(props: Props) {
         </div>
         <AxisMapper
           axis="x"
-          axisLabels={axisLabels}
+          dimHints={dimHints}
           dimMapping={dimMapping}
           onChange={onChange}
         />
         <AxisMapper
           axis="y"
-          axisLabels={axisLabels}
+          dimHints={dimHints}
           dimMapping={dimMapping}
           onChange={onChange}
         />

--- a/packages/lib/src/dimension-mapper/DimensionMapper.tsx
+++ b/packages/lib/src/dimension-mapper/DimensionMapper.tsx
@@ -10,12 +10,13 @@ interface Props {
   dims: number[];
   axisLabels?: AxisMapping<string>;
   dimMapping: DimensionMapping;
-  isCached?: (dimMapping: DimensionMapping) => boolean;
+  canSliceFast?: (nextMapping: DimensionMapping) => boolean;
   onChange: (d: DimensionMapping) => void;
 }
 
 function DimensionMapper(props: Props) {
-  const { className, dims, axisLabels, dimMapping, isCached, onChange } = props;
+  const { className, dims, axisLabels, dimMapping, canSliceFast, onChange } =
+    props;
   const mappableDims = dims.slice(0, dimMapping.length);
 
   if (dimMapping.length === 0) {
@@ -59,11 +60,11 @@ function DimensionMapper(props: Props) {
               length={dims[index]}
               initialValue={val}
               isFastSlice={
-                isCached &&
+                canSliceFast &&
                 ((newVal) => {
                   const newMapping = [...dimMapping];
                   newMapping[index] = newVal;
-                  return isCached(newMapping);
+                  return canSliceFast(newMapping);
                 })
               }
               onChange={(newVal) => {

--- a/packages/lib/src/dimension-mapper/DimensionMapper.tsx
+++ b/packages/lib/src/dimension-mapper/DimensionMapper.tsx
@@ -1,12 +1,12 @@
 import { type AxisMapping } from '@h5web/shared/nexus-models';
+import { type HTMLAttributes } from 'react';
 
 import AxisMapper from './AxisMapper';
 import styles from './DimensionMapper.module.css';
 import { type DimensionMapping } from './models';
 import SlicingSlider from './SlicingSlider';
 
-interface Props {
-  className: string;
+interface Props extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
   dims: number[];
   axisLabels?: AxisMapping<string>;
   dimMapping: DimensionMapping;
@@ -15,8 +15,15 @@ interface Props {
 }
 
 function DimensionMapper(props: Props) {
-  const { className, dims, axisLabels, dimMapping, canSliceFast, onChange } =
-    props;
+  const {
+    className,
+    dims,
+    axisLabels,
+    dimMapping,
+    canSliceFast,
+    onChange,
+    ...htmlProps
+  } = props;
   const mappableDims = dims.slice(0, dimMapping.length);
 
   if (dimMapping.length === 0) {
@@ -24,7 +31,7 @@ function DimensionMapper(props: Props) {
   }
 
   return (
-    <div className={`${styles.mapper} ${className}`}>
+    <div className={`${styles.mapper} ${className}`} {...htmlProps}>
       <div className={styles.axisMapperWrapper}>
         <div className={styles.dims}>
           <span className={styles.dimsLabel}>

--- a/packages/lib/src/dimension-mapper/SlicingSlider.module.css
+++ b/packages/lib/src/dimension-mapper/SlicingSlider.module.css
@@ -30,9 +30,8 @@
 .track {
   flex: 1;
   margin: calc(var(--thumb-height) / 2) 0;
-  width: 2px;
-  background-color: var(--secondary-dark);
-  border-radius: 1px;
+  border-left: 2px solid var(--secondary-dark);
+  border-radius: 2px;
 }
 
 .thumb {

--- a/packages/lib/src/dimension-mapper/SlicingSlider.tsx
+++ b/packages/lib/src/dimension-mapper/SlicingSlider.tsx
@@ -21,6 +21,10 @@ interface Props {
 function SlicingSlider(props: Props) {
   const { dimension, length, initialValue, isFastSlice, onChange } = props;
 
+  if (length <= 0) {
+    throw new Error('Expected non-empty dimension');
+  }
+
   const [value, setValue] = useState(initialValue);
   const onDebouncedChange = useDynamicDebouncedCallback(
     onChange,

--- a/packages/lib/src/toolbar/controls/ToggleGroup/ToggleGroup.module.css
+++ b/packages/lib/src/toolbar/controls/ToggleGroup/ToggleGroup.module.css
@@ -5,7 +5,7 @@
 
 .btn {
   composes: btn from '../../utils.module.css';
-  padding: 0;
+  padding: 0 !important; /* style ordering issue in Storybook */
 }
 
 .btnLike {


### PR DESCRIPTION
I've made separate commits but I think the global diff is clear enough with some comments. The goal here is to improve the public API of `DimensionMapper` and to document it in Storybook:

![Screenshot 2025-06-18 at 15-23-15 building-blocks-dimensionmapper--docs](https://github.com/user-attachments/assets/109f23c6-e2ff-45f4-887b-7d553bbae72d)

Remaining work:
- allow customising appearance through CSS variables, and
- document utilities and hooks.