### PR TITLE
Document and test dimension mapping utilities

### DIFF
--- a/apps/storybook/src/Utilities.mdx
+++ b/apps/storybook/src/Utilities.mdx
@@ -221,6 +221,55 @@ createIndex(length: number, maxValue: number): BufferAttribute
 createIndex(100 * 2 * 3, 100); // 2 triangles per vertex; 3 indices per triangle
 ```
 
+#### initDimMapping
+
+Initialise a dimension mapping array from the given dimensions, for a visualization with the given number of axes.
+
+This function assumes that the last dimension should be mapped to the `x` axis, that the second last dimension
+should be mapped to the `y` axis`, and that the user should be able to slice through the remaining dimensions
+(starting at index `0`) with the `DimensionMapper`.
+
+```tsx
+initDimMapping(dims: number[], axesCount: number): DimensionMapping
+
+initDimMapping([5], 1); // ['x']
+initDimMapping([5, 10], 2); // ['y', 'x']
+initDimMapping([5, 10, 15, 20], 2); // [0, 0, 'y', 'x']
+
+const [dimMapping, setDimMapping] = useState(initDimMapping(dims, 1))
+<DimensionMapper value={dimMapping} onChange={setDimMapping} />
+```
+
+#### getSliceSelection
+
+Convert a dimension mapping array to a selection string that can be passed to the data provider
+to retrieve a specific dataset slice (cf. `DataProvider#getValue`). If the dimension mapping array
+has no sliceable dimension (i.e. only `'x'` and/or `'y'`), the returned selection is `undefined`,
+which instructs the provider to retrieve the entire dataset.
+
+```ts
+getSliceSelection(dimMapping?: DimensionMapping): string | undefined
+
+getSliceSelection(['x']); // undefined
+getSliceSelection(['y', 'x']); // undefined
+
+getSliceSelection([10, 'x']); // '10,:'
+getSliceSelection([0, 5, 'y', 'x']); // '0,5,:,:'
+getSliceSelection(['x', 10, 20, 30]); // ':,10,20,30'
+```
+
+#### getSlicedDimsAndMapping
+
+Use after retrieving a dataset slice to compute the remaining dimensions and axis mapping of the slice.
+
+```ts
+getSlicedDimsAndMapping(dims: number[], dimMapping: DimensionMapping): [number[], DimensionMapping]
+
+getSlicedDimsAndMapping([10, 20], ['y', 'x']); // [[10, 20], ['y', 'x']] (i.e. no slicing performed)
+getSlicedDimsAndMapping([10, 20, 30], [0, 'x', 0]); // [[2], ['x']]
+getSlicedDimsAndMapping([10, 20, 30], ['x', 10, 'y']); // [[10, 30], ['x', 'y']]
+```
+
 ---
 
 ### Hooks
@@ -230,9 +279,10 @@ createIndex(100 * 2 * 3, 100); // 2 triangles per vertex; 3 indices per triangle
 - **`useCombinedDomain(...args): Domain | undefined`** - Memoised version of `getCombinedDomain`.
 - **`useVisDomain(...args): Domain`** - Memoised version of `getVisDomain`.
 - **`useSafeDomain(...args): [Domain, DomainErrors]`** - Memoised version of `getSafeDomain`.
-- **`useAxisValues(..args): number[]`** - Memoised version of `getAxisValues`.
-- **`useAxisDomain(..args): Domain | undefined`** - Memoised version of `getAxisDomain`.
-- **`useValueToIndexScale(..args): ScaleThreshold<number, number>`** - Memoised version of `getValueToIndexScale`.
+- **`useAxisValues(...args): number[]`** - Memoised version of `getAxisValues`.
+- **`useAxisDomain(...args): Domain | undefined`** - Memoised version of `getAxisDomain`.
+- **`useValueToIndexScale(...args): ScaleThreshold<number, number>`** - Memoised version of `getValueToIndexScale`.
+- **`useSlicedDimsAndMapping(...args): [number[], DimensionMapping]`** - Memoised version of `getSlicedDimsAndMapping`.
 
 #### useCanvasEvent
 

--- a/packages/lib/src/dimension-mapper/AxisMapper.tsx
+++ b/packages/lib/src/dimension-mapper/AxisMapper.tsx
@@ -1,9 +1,8 @@
 import { ToggleGroup } from '@h5web/lib';
 import { type AxisMapping } from '@h5web/shared/nexus-models';
-import { type Axis } from '@h5web/shared/vis-models';
+import { type Axis, type DimensionMapping } from '@h5web/shared/vis-models';
 
 import styles from './DimensionMapper.module.css';
-import { type DimensionMapping } from './models';
 
 interface Props {
   axis: Axis;

--- a/packages/lib/src/dimension-mapper/DimensionMapper.tsx
+++ b/packages/lib/src/dimension-mapper/DimensionMapper.tsx
@@ -1,14 +1,13 @@
-import { type AxisMapping } from '@h5web/shared/nexus-models';
+import { type DimensionMapping } from '@h5web/shared/vis-models';
 import { type HTMLAttributes } from 'react';
 
 import AxisMapper from './AxisMapper';
 import styles from './DimensionMapper.module.css';
-import { type DimensionMapping } from './models';
 import SlicingSlider from './SlicingSlider';
 
 interface Props extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
   dims: number[];
-  dimHints?: AxisMapping<string>;
+  dimHints?: (string | undefined)[];
   dimMapping: DimensionMapping;
   canSliceFast?: (nextMapping: DimensionMapping) => boolean;
   onChange: (d: DimensionMapping) => void;

--- a/packages/lib/src/dimension-mapper/hooks.ts
+++ b/packages/lib/src/dimension-mapper/hooks.ts
@@ -1,21 +1,10 @@
+import { createMemo } from '@h5web/shared/createMemo';
 import { useSyncedRef, useUnmountEffect } from '@react-hookz/web';
 import { type DependencyList, useEffect, useMemo, useRef } from 'react';
 
-import { type DimensionMapping } from './models';
-import { isAxis } from './utils';
+import { getSlicedDimsAndMapping } from './utils';
 
-export function useSlicedDimsAndMapping(
-  dims: number[],
-  dimMapping: DimensionMapping,
-): [number[], DimensionMapping] {
-  return useMemo(
-    () => [
-      dims.filter((_, i) => isAxis(dimMapping[i])),
-      dimMapping.filter(isAxis),
-    ],
-    [dimMapping, dims],
-  );
-}
+export const useSlicedDimsAndMapping = createMemo(getSlicedDimsAndMapping);
 
 // Debounced callback with a delay that can be adjusted on every invocation
 export function useDynamicDebouncedCallback<

--- a/packages/lib/src/dimension-mapper/models.ts
+++ b/packages/lib/src/dimension-mapper/models.ts
@@ -1,3 +1,0 @@
-import { type Axis } from '@h5web/shared/vis-models';
-
-export type DimensionMapping = (number | Axis)[];

--- a/packages/lib/src/dimension-mapper/utils.test.ts
+++ b/packages/lib/src/dimension-mapper/utils.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { initDimMapping } from './utils';
+import {
+  getSlicedDimsAndMapping,
+  getSliceSelection,
+  initDimMapping,
+} from './utils';
 
 describe('initDimMapping', () => {
   it('should map axes to dimensions', () => {
@@ -26,5 +30,57 @@ describe('initDimMapping', () => {
   it('should throw when number of axes not supported', () => {
     expect(() => initDimMapping([1], -1)).toThrow(RangeError);
     expect(() => initDimMapping([1, 1, 1], 3)).toThrow(RangeError);
+  });
+});
+
+describe('getSliceSelection', () => {
+  it('should convert dimension mapping with sliceable dimensions', () => {
+    expect(getSliceSelection([0])).toBe('0');
+    expect(getSliceSelection([0, 0])).toBe('0,0');
+    expect(getSliceSelection([0, 'x'])).toBe('0,:');
+    expect(getSliceSelection(['x', 5])).toBe(':,5');
+    expect(getSliceSelection([0, 0, 'y', 'x'])).toBe('0,0,:,:');
+    expect(getSliceSelection([5, 'y', 20, 'x', 10])).toBe('5,:,20,:,10');
+  });
+
+  it('should return `undefined` when dimension mapping has no sliceable dimension', () => {
+    expect(getSliceSelection()).toBeUndefined();
+    expect(getSliceSelection([])).toBeUndefined();
+    expect(getSliceSelection(['x'])).toBeUndefined();
+    expect(getSliceSelection(['y', 'x'])).toBeUndefined();
+  });
+});
+
+describe('getSlicedDimsAndMapping', () => {
+  it('should compute remaining dimensions and axis mapping after slicing', () => {
+    expect(getSlicedDimsAndMapping([10], [2])).toStrictEqual([[], []]);
+    expect(getSlicedDimsAndMapping([10, 20], [0, 1])).toStrictEqual([[], []]);
+    expect(getSlicedDimsAndMapping([10, 20], ['x', 0])).toStrictEqual([
+      [10],
+      ['x'],
+    ]);
+    expect(getSlicedDimsAndMapping([10, 20], [0, 'x'])).toStrictEqual([
+      [20],
+      ['x'],
+    ]);
+    expect(
+      getSlicedDimsAndMapping([10, 20, 30, 40], [0, 'y', 0, 'x']),
+    ).toStrictEqual([
+      [20, 40],
+      ['y', 'x'],
+    ]);
+  });
+
+  it('should leave dimensions and mapping unchanged when mapping has no sliceable dimension', () => {
+    expect(getSlicedDimsAndMapping([], [])).toStrictEqual([[], []]);
+    expect(getSlicedDimsAndMapping([10], ['x'])).toStrictEqual([[10], ['x']]);
+    expect(getSlicedDimsAndMapping([10, 20], ['y', 'x'])).toStrictEqual([
+      [10, 20],
+      ['y', 'x'],
+    ]);
+    expect(getSlicedDimsAndMapping([10, 20], ['x', 'y'])).toStrictEqual([
+      [10, 20],
+      ['x', 'y'],
+    ]);
   });
 });

--- a/packages/lib/src/dimension-mapper/utils.ts
+++ b/packages/lib/src/dimension-mapper/utils.ts
@@ -1,6 +1,4 @@
-import { type Axis } from '@h5web/shared/vis-models';
-
-import { type DimensionMapping } from './models';
+import { type Axis, type DimensionMapping } from '@h5web/shared/vis-models';
 
 export function initDimMapping(
   dims: number[],
@@ -35,4 +33,14 @@ export function getSliceSelection(
 
 export function isAxis(elem: number | Axis): elem is Axis {
   return typeof elem !== 'number';
+}
+
+export function getSlicedDimsAndMapping(
+  dims: number[],
+  dimMapping: DimensionMapping,
+): [number[], DimensionMapping] {
+  return [
+    dims.filter((_, i) => isAxis(dimMapping[i])),
+    dimMapping.filter(isAxis),
+  ];
 }

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -37,10 +37,6 @@ export type { HistogramProps } from './toolbar/controls/Histogram/Histogram';
 
 // Dimension mapper
 export { default as DimensionMapper } from './dimension-mapper/DimensionMapper';
-export { initDimMapping, getSliceSelection } from './dimension-mapper/utils';
-export { useSlicedDimsAndMapping } from './dimension-mapper/hooks';
-export { type DimensionMapping } from './dimension-mapper/models';
-export { type AxisMapping } from '@h5web/shared/nexus-models';
 
 // Building blocks
 export { default as VisCanvas } from './vis/shared/VisCanvas';
@@ -145,6 +141,13 @@ export {
 } from './interactions/hooks';
 export { default as Box } from './interactions/box';
 
+export {
+  initDimMapping,
+  getSliceSelection,
+  getSlicedDimsAndMapping,
+} from './dimension-mapper/utils';
+export { useSlicedDimsAndMapping } from './dimension-mapper/hooks';
+
 // Geometries
 export { default as H5WebGeometry } from './vis/shared/h5webGeometry';
 export { default as LineGeometry } from './vis/line/lineGeometry';
@@ -170,6 +173,7 @@ export type {
   VisibleDomains,
   Dims,
   Axis,
+  DimensionMapping,
   ColorScaleType,
   AxisScaleType,
   IgnoreValue,

--- a/packages/shared/src/vis-models.ts
+++ b/packages/shared/src/vis-models.ts
@@ -28,6 +28,7 @@ export type BigIntTypedArrayConstructor =
 
 export type Domain = [min: number, max: number];
 export type Axis = 'x' | 'y';
+export type DimensionMapping = (number | Axis)[];
 
 export interface VisibleDomains {
   xVisibleDomain: Domain;


### PR DESCRIPTION
Final PR about moving the dimension mapper and related utilities to the lib.

- Extract and expose a non-memoised utility from `useSlicedDimsAndMapping`: `getSlicedDimsAndMapping`.
- Document `initDimMapping`, `getSliceSelection`, `getSlicedDimsAndMapping` (and `useSlicedDimsAndMapping`)
- Unit test `getSliceSelection` and `getSlicedDimsAndMapping` (I already wrote tests for `initDimMapping` in a previous PR)