### PR TITLE
Make N+1 bin optional in histogram

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -93,7 +93,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pypoetry/virtualenvs
-          key: poetry-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-6 # increment to reset cache
+          key: poetry-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-7 # increment to reset cache
 
       - name: Create Poetry environments 📜
         if: steps.poetry-venvs.outputs.cache-hit != 'true'

--- a/apps/storybook/src/Histogram.stories.tsx
+++ b/apps/storybook/src/Histogram.stories.tsx
@@ -43,7 +43,7 @@ export const Default = {
     dataDomain: [4, 400],
     value: [10, 100],
     values: [130, 92, 76, 68, 60, 52, 50, 26],
-    bins: [4, 53.5, 103, 152.5, 202, 251.5, 301, 350.5, 400],
+    bins: [4, 53.5, 103, 152.5, 202, 251.5, 301, 350.5],
     scaleType: ScaleType.Linear,
   },
 } satisfies Story;
@@ -70,7 +70,7 @@ export const TypedValues = {
   args: {
     ...Default.args,
     values: new Int32Array([26, 50, 52, 60, 68, 76, 92, 130]),
-    bins: new Float32Array([4, 53.5, 103, 152.5, 202, 251.5, 301, 350.5, 400]),
+    bins: new Float32Array([4, 53.5, 103, 152.5, 202, 251.5, 301, 350.5]),
   },
 } satisfies Story;
 

--- a/packages/lib/src/toolbar/controls/Histogram/Histogram.tsx
+++ b/packages/lib/src/toolbar/controls/Histogram/Histogram.tsx
@@ -4,7 +4,7 @@ import { AxisBottom, AxisLeft } from '@visx/axis';
 import { scaleLinear } from '@visx/scale';
 import { type ReactNode } from 'react';
 
-import { useSafeDomain } from '../../../vis/heatmap/hooks';
+import { usePixelEdgeValues, useSafeDomain } from '../../../vis/heatmap/hooks';
 import { useCombinedDomain, useDomain } from '../../../vis/hooks';
 import { type HistogramParams } from '../../../vis/models';
 import Tick from '../../../vis/shared/Tick';
@@ -31,7 +31,7 @@ interface Props extends HistogramParams {
 function Histogram(props: Props) {
   const {
     values,
-    bins,
+    bins: rawBins,
     scaleType,
     value,
     dataDomain,
@@ -41,6 +41,7 @@ function Histogram(props: Props) {
   } = props;
   const { colorMap, invertColorMap } = props;
 
+  const bins = usePixelEdgeValues(rawBins, values.length);
   const binDomain = useDomain(bins, scaleType) || DEFAULT_DOMAIN;
   const [safeValue] = useSafeDomain(value, dataDomain, scaleType);
   const xDomain = useCombinedDomain([binDomain, safeValue, dataDomain]);


### PR DESCRIPTION
It's the same issue we had with the heatmap vis: the x axis needs to go up to the right-hand edge of the last bin; otherwise we can't compute the width of the last bar and we get a `NaN` width warning in the browser console.

This PR makes the extra value in the `bins` array optional. If it's not present, we assume we want the same step value as between the last and second last bins.