### PR TITLE
Open local files in SWMR read mode with h5wasm

### DIFF
--- a/packages/h5wasm/src/worker.ts
+++ b/packages/h5wasm/src/worker.ts
@@ -37,7 +37,11 @@ async function openLocalFile(file: File): Promise<bigint> {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
   WORKERFS.createNode(rootNode, fileName, WORKERFS.FILE_MODE, 0, file);
 
-  return h5wasm.open(`${WORKERFS_FOLDER}/${fileName}`, undefined, undefined); // https://github.com/emscripten-core/emscripten/issues/22389
+  return h5wasm.open(
+    `${WORKERFS_FOLDER}/${fileName}`,
+    h5wasm.H5F_ACC_SWMR_READ, // in case file is opened for writing in a concurrent process
+    undefined, // https://github.com/emscripten-core/emscripten/issues/22389
+  );
 }
 
 async function closeFile(fileId: bigint): Promise<number> {


### PR DESCRIPTION
Fix #1835 

My very naïve repro seems to confirm that it works:

```py
import h5py, numpy, time

with h5py.File("../swmr.h5", "w", libver="latest") as file:
    arr = numpy.array([1, 2, 3, 4])
    dset = file.create_dataset("data", data=arr)
    file.swmr_mode = True
    time.sleep(3600)
```

It's definitely simpler to just open all files in SWMR mode (rather than to first open without, catch the error and try again with SWMR). Do you know if there's any issue with that @woutdenolf @loichuder?