### PR TITLE
Move relevant @types packages from dev to prod/peer dependencies

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -42,12 +42,20 @@
     "sync-version": "dot-json ../../package.json version | xargs dot-json package.json version"
   },
   "peerDependencies": {
+    "@types/react": "18.x",
+    "@types/react-dom": "18.x",
     "axios": ">=1",
     "react": ">=18",
     "react-dom": ">=18",
     "typescript": ">=4.5"
   },
   "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    },
+    "@types/react-dom": {
+      "optional": true
+    },
     "axios": {
       "optional": true
     },
@@ -56,6 +64,8 @@
     }
   },
   "dependencies": {
+    "@types/d3-format": "~3.0.4",
+    "@types/ndarray": "1.0.14",
     "@h5web/lib": "workspace:*",
     "@react-hookz/web": "25.1.1",
     "@react-three/fiber": "8.18.0",
@@ -76,8 +86,6 @@
     "@testing-library/jest-dom": "6.7.0",
     "@testing-library/react": "16.3.0",
     "@testing-library/user-event": "14.6.1",
-    "@types/d3-format": "~3.0.4",
-    "@types/ndarray": "1.0.14",
     "@types/node": "^22.17.2",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",

--- a/packages/h5wasm/package.json
+++ b/packages/h5wasm/package.json
@@ -37,10 +37,14 @@
   },
   "peerDependencies": {
     "@h5web/app": "workspace:*",
-    "react": ">=18",
+    "@types/react": "18.x",
+    "react": "18.x",
     "typescript": ">=4.5"
   },
   "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    },
     "typescript": {
       "optional": true
     }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -43,13 +43,25 @@
     "sync-version": "dot-json ../../package.json version | xargs dot-json package.json version"
   },
   "peerDependencies": {
-    "@react-three/fiber": ">=8",
-    "react": ">=18",
-    "react-dom": ">=18",
+    "@types/react": "18.x",
+    "@types/react-dom": "18.x",
+    "@types/three": ">=0.138",
+    "@react-three/fiber": "8.x",
+    "react": "18.x",
+    "react-dom": "18.x",
     "three": ">=0.138",
     "typescript": ">=4.5"
   },
   "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    },
+    "@types/react-dom": {
+      "optional": true
+    },
+    "@types/three": {
+      "optional": true
+    },
     "typescript": {
       "optional": true
     }
@@ -57,6 +69,16 @@
   "dependencies": {
     "@floating-ui/react": "0.27.15",
     "@react-hookz/web": "25.1.1",
+    "@types/d3-array": "~3.2.1",
+    "@types/d3-color": "~3.1.3",
+    "@types/d3-format": "~3.0.4",
+    "@types/d3-interpolate": "~3.0.4",
+    "@types/d3-scale": "~4.0.9",
+    "@types/d3-scale-chromatic": "~3.1.0",
+    "@types/ndarray": "~1.0.14",
+    "@types/react-measure": "~2.0.12",
+    "@types/react-slider": "~1.3.6",
+    "@types/react-window": "~1.8.8",
     "@visx/axis": "3.12.0",
     "@visx/drag": "3.12.0",
     "@visx/grid": "3.12.0",
@@ -84,19 +106,9 @@
     "@h5web/shared": "workspace:*",
     "@react-three/fiber": "8.18.0",
     "@rollup/plugin-alias": "5.1.1",
-    "@types/d3-array": "~3.2.1",
-    "@types/d3-color": "~3.1.3",
-    "@types/d3-format": "~3.0.4",
-    "@types/d3-interpolate": "~3.0.4",
-    "@types/d3-scale": "~4.0.9",
-    "@types/d3-scale-chromatic": "~3.1.0",
-    "@types/ndarray": "~1.0.14",
     "@types/node": "^22.17.2",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",
-    "@types/react-measure": "~2.0.12",
-    "@types/react-slider": "~1.3.6",
-    "@types/react-window": "~1.8.8",
     "@types/three": "0.179.0",
     "@vitejs/plugin-react-swc": "4.0.1",
     "concat": "1.0.3",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -29,14 +29,34 @@
     "lint:tsc": "tsc"
   },
   "peerDependencies": {
-    "d3-array": "3.2.4",
-    "d3-format": "3.1.0",
-    "ndarray": "1.0.19",
-    "ndarray-ops": "1.2.2",
-    "react": ">=18",
-    "zustand": "5.0.3"
+    "@types/d3-array": "*",
+    "@types/d3-format": "*",
+    "@types/ndarray": "*",
+    "@types/ndarray-ops": "*",
+    "@types/react": "*",
+    "d3-array": "*",
+    "d3-format": "*",
+    "ndarray": "*",
+    "ndarray-ops": "*",
+    "react": "*",
+    "zustand": "*"
   },
   "peerDependenciesMeta": {
+    "@types/d3-array": {
+      "optional": true
+    },
+    "@types/d3-format": {
+      "optional": true
+    },
+    "@types/ndarray": {
+      "optional": true
+    },
+    "@types/ndarray-ops": {
+      "optional": true
+    },
+    "@types/react": {
+      "optional": true
+    },
     "d3-array": {
       "optional": true
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,12 @@ importers:
       '@react-three/fiber':
         specifier: 8.18.0
         version: 8.18.0(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.179.1)
+      '@types/d3-format':
+        specifier: ~3.0.4
+        version: 3.0.4
+      '@types/ndarray':
+        specifier: 1.0.14
+        version: 1.0.14
       d3-format:
         specifier: 3.1.0
         version: 3.1.0
@@ -263,12 +269,6 @@ importers:
       '@testing-library/user-event':
         specifier: 14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
-      '@types/d3-format':
-        specifier: ~3.0.4
-        version: 3.0.4
-      '@types/ndarray':
-        specifier: 1.0.14
-        version: 1.0.14
       '@types/node':
         specifier: ^22.17.2
         version: 22.17.2
@@ -393,6 +393,36 @@ importers:
       '@react-hookz/web':
         specifier: 25.1.1
         version: 25.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/d3-array':
+        specifier: ~3.2.1
+        version: 3.2.1
+      '@types/d3-color':
+        specifier: ~3.1.3
+        version: 3.1.3
+      '@types/d3-format':
+        specifier: ~3.0.4
+        version: 3.0.4
+      '@types/d3-interpolate':
+        specifier: ~3.0.4
+        version: 3.0.4
+      '@types/d3-scale':
+        specifier: ~4.0.9
+        version: 4.0.9
+      '@types/d3-scale-chromatic':
+        specifier: ~3.1.0
+        version: 3.1.0
+      '@types/ndarray':
+        specifier: ~1.0.14
+        version: 1.0.14
+      '@types/react-measure':
+        specifier: ~2.0.12
+        version: 2.0.12
+      '@types/react-slider':
+        specifier: ~1.3.6
+        version: 1.3.6
+      '@types/react-window':
+        specifier: ~1.8.8
+        version: 1.8.8
       '@visx/axis':
         specifier: 3.12.0
         version: 3.12.0(react@18.3.1)
@@ -469,27 +499,6 @@ importers:
       '@rollup/plugin-alias':
         specifier: 5.1.1
         version: 5.1.1(rollup@4.46.4)
-      '@types/d3-array':
-        specifier: ~3.2.1
-        version: 3.2.1
-      '@types/d3-color':
-        specifier: ~3.1.3
-        version: 3.1.3
-      '@types/d3-format':
-        specifier: ~3.0.4
-        version: 3.0.4
-      '@types/d3-interpolate':
-        specifier: ~3.0.4
-        version: 3.0.4
-      '@types/d3-scale':
-        specifier: ~4.0.9
-        version: 4.0.9
-      '@types/d3-scale-chromatic':
-        specifier: ~3.1.0
-        version: 3.1.0
-      '@types/ndarray':
-        specifier: ~1.0.14
-        version: 1.0.14
       '@types/node':
         specifier: ^22.17.2
         version: 22.17.2
@@ -499,15 +508,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.7
         version: 18.3.7(@types/react@18.3.23)
-      '@types/react-measure':
-        specifier: ~2.0.12
-        version: 2.0.12
-      '@types/react-slider':
-        specifier: ~1.3.6
-        version: 1.3.6
-      '@types/react-window':
-        specifier: ~1.8.8
-        version: 1.8.8
       '@types/three':
         specifier: 0.179.0
         version: 0.179.0


### PR DESCRIPTION
When some of H5Web's APIs are used in a consumer project, the types that come from external dependencies like `ndarray` become `any`. The fix is to install the relevant `@types` packages in the consumer project. While most consumers should already have `@types/react` installed, they may not want to install `@types/ndarray` if they don't use the library directly.

In this PR, I move all the relevant `@types` packages (all except `@types/node` I think) from `devDependencies` to either `peerDependencies` (when the corresponding package is also a peer dependency—e.g. `@types/react`) or "production" `dependencies` (e.g. `@types/ndarray` in `@h5web/app`).

When I move an `@types` package to `peerDependencies`, I also mark it as optional via `peerDependenciesMeta` so that non-TypeScript users don't get a warning from their package manager.