### PR TITLE
Re-optimise switching between complex vis types

### DIFF
--- a/packages/app/src/vis-packs/core/heatmap/MappedHeatmapVis.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/MappedHeatmapVis.tsx
@@ -25,7 +25,7 @@ import visualizerStyles from '../../../visualizer/Visualizer.module.css';
 import {
   useExportEntries,
   useMappedArray,
-  useToNumArray,
+  usePhaseAmp,
   useToNumArrays,
 } from '../hooks';
 import {
@@ -75,24 +75,24 @@ function MappedHeatmapVis(props: Props) {
 
   const { shape: dims, type } = dataset;
   const isComplex = isComplexType(type);
-
-  // If complex dataset displayed as phase/amplitude: `numArray` = amplitude; `alphaArray` = phase
   const isPhaseAmp = complexVisType === ComplexVisType.PhaseAmplitude;
 
-  const numArray = useToNumArray(
-    value,
-    isPhaseAmp ? ComplexVisType.Amplitude : complexVisType,
-  );
-  const phaseArray = useToNumArray(
-    isComplex && isPhaseAmp ? value : undefined,
-    ComplexVisType.Phase,
-  );
-
+  const phaseAmp = usePhaseAmp(value);
   const numAxisArrays = useToNumArrays(axisValues);
 
   const [slicedDims, slicedMapping] = useSlicedDimsAndMapping(dims, dimMapping);
-  const dataArray = useMappedArray(numArray, slicedDims, slicedMapping);
-  const alphaArray = useMappedArray(phaseArray, slicedDims, slicedMapping);
+  const dataArray = useMappedArray(
+    isPhaseAmp
+      ? phaseAmp.amplitude
+      : phaseAmp[complexVisType] || phaseAmp.amplitude,
+    slicedDims,
+    slicedMapping,
+  );
+  const alphaArray = useMappedArray(
+    isPhaseAmp ? phaseAmp.phase : undefined,
+    slicedDims,
+    slicedMapping,
+  );
 
   const dataDomain =
     useDomain(dataArray, scaleType, undefined, ignoreValue) || DEFAULT_DOMAIN;

--- a/packages/app/src/vis-packs/core/hooks.ts
+++ b/packages/app/src/vis-packs/core/hooks.ts
@@ -9,8 +9,6 @@ import {
 } from '@h5web/shared/hdf5-models';
 import {
   type BuiltInExporter,
-  type ComplexLineVisType,
-  ComplexVisType,
   type ExportEntry,
   type ExportFormat,
   type IgnoreValue,
@@ -25,28 +23,31 @@ import {
   bigIntTypedArrayFromDType,
   typedArrayFromDType,
 } from '../../providers/utils';
-import { applyMapping, getBaseArray, toNumArray } from './utils';
+import { type PhaseAmp } from './models';
+import { applyMapping, getBaseArray, getPhaseAmp, toNumArray } from './utils';
 
 export const useToNumArray = createMemo(toNumArray);
 
 export function useToNumArrays(
-  arrays: ArrayValue<NumericLikeType | ComplexType>[],
-  complexVisType?: ComplexLineVisType,
+  arrays: ArrayValue<NumericLikeType>[],
 ): NumArray[];
 
 export function useToNumArrays(
-  arrays: (ArrayValue<NumericLikeType | ComplexType> | undefined)[],
-  complexVisType?: ComplexLineVisType,
+  arrays: (ArrayValue<NumericLikeType> | undefined)[],
 ): (NumArray | undefined)[];
 
 export function useToNumArrays(
-  arrays: (ArrayValue<NumericLikeType | ComplexType> | undefined)[],
-  complexVisType: ComplexLineVisType = ComplexVisType.Amplitude,
+  arrays: (ArrayValue<NumericLikeType> | undefined)[],
 ): (NumArray | undefined)[] {
-  return useMemo(
-    () => arrays.map((arr) => toNumArray(arr, complexVisType)),
-    [...arrays, complexVisType], // eslint-disable-line react-hooks/exhaustive-deps
-  );
+  return useMemo(() => arrays.map(toNumArray), arrays); // eslint-disable-line react-hooks/exhaustive-deps
+}
+
+export const usePhaseAmp = createMemo(getPhaseAmp);
+
+export function usePhaseAmps(
+  arrays: ArrayValue<NumericLikeType | ComplexType>[],
+): PhaseAmp[] {
+  return useMemo(() => arrays.map(getPhaseAmp), arrays); // eslint-disable-line react-hooks/exhaustive-deps
 }
 
 export function useBaseArray<T extends ArrayValue | undefined>(

--- a/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
+++ b/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
@@ -28,6 +28,8 @@ import {
   useExportEntries,
   useMappedArray,
   useMappedArrays,
+  usePhaseAmp,
+  usePhaseAmps,
   useToNumArray,
   useToNumArrays,
 } from '../hooks';
@@ -90,15 +92,22 @@ function MappedLineVis(props: Props) {
   const [slicedDims, slicedMapping] = useSlicedDimsAndMapping(dims, dimMapping);
   const hookArgs = [slicedDims, slicedMapping] as const;
 
-  const numArray = useToNumArray(value, complexVisType);
-  const numAuxArrays = useToNumArrays(auxValues, complexVisType);
+  const phaseAmp = usePhaseAmp(value);
+  const auxPhaseAmps = usePhaseAmps(auxValues);
+
   const numErrorsArray = useToNumArray(errors);
   const numAuxErrorsArrays = useToNumArrays(auxErrors);
   const numAxisArrays = useToNumArrays(axisValues);
 
-  const dataArray = useMappedArray(numArray, ...hookArgs);
+  const dataArray = useMappedArray(
+    phaseAmp[complexVisType] || phaseAmp.amplitude,
+    ...hookArgs,
+  );
+  const auxArrays = useMappedArrays(
+    auxPhaseAmps.map((pa) => pa[complexVisType] || phaseAmp.amplitude),
+    ...hookArgs,
+  );
   const errorsArray = useMappedArray(numErrorsArray, ...hookArgs);
-  const auxArrays = useMappedArrays(numAuxArrays, ...hookArgs);
   const auxErrorsArrays = useMappedArrays(numAuxErrorsArrays, ...hookArgs);
 
   const dataDomain = useDomain(

--- a/packages/app/src/vis-packs/core/models.ts
+++ b/packages/app/src/vis-packs/core/models.ts
@@ -1,0 +1,6 @@
+import { type NumArray } from '@h5web/shared/vis-models';
+
+export interface PhaseAmp {
+  amplitude: NumArray;
+  phase: NumArray | undefined; // `undefined` for numeric-like dataset
+}


### PR DESCRIPTION
I'm adjusting the implementation slightly from #1846 to re-optimise the switching between amplitude/phase(/both). I was hoping it would make `MappedHeatmapVis` a bit more readable but I'm not sure it does, and now `MappedLineVis` feels a bit less readable too...

The main downside of this implementation is that real datasets are now second-class citizens in the code, in the sense that the names of some variables and functions are more complex-oriented, and there is a step where I store them in a `PhaseAmp` object like this: `{ amplitude: numArray, phase: undefined }`.