### PR TITLE
Refactor mapped complex components to improve memoisation

### DIFF
--- a/packages/app/src/vis-packs/core/complex/utils.ts
+++ b/packages/app/src/vis-packs/core/complex/utils.ts
@@ -1,13 +1,5 @@
 import { type H5WebComplex } from '@h5web/shared/hdf5-models';
-import { type Bounds, ComplexVisType } from '@h5web/shared/vis-models';
-import { getNewBounds } from '@h5web/shared/vis-utils';
-
-const INITIAL_BOUNDS: Bounds = {
-  min: Infinity,
-  max: -Infinity,
-  positiveMin: Infinity,
-  strictPositiveMin: Infinity,
-};
+import { ComplexVisType } from '@h5web/shared/vis-models';
 
 export const COMPLEX_VIS_TYPE_LABELS = {
   [ComplexVisType.Amplitude]: 'Amplitude',
@@ -15,32 +7,17 @@ export const COMPLEX_VIS_TYPE_LABELS = {
   [ComplexVisType.PhaseAmplitude]: 'Phase & Amplitude',
 };
 
-export function getPhaseAmplitudeValues(mappedValues: H5WebComplex[]): {
-  phaseValues: number[];
-  phaseBounds: Bounds;
-  amplitudeValues: number[];
-  amplitudeBounds: Bounds;
+export function getPhaseAmplitude(values: H5WebComplex[]): {
+  phase: number[];
+  amplitude: number[];
 } {
-  const phaseValues: number[] = [];
-  const amplitudeValues: number[] = [];
+  const phase: number[] = Array.from({ length: values.length });
+  const amplitude: number[] = Array.from({ length: values.length });
 
-  const [phaseBounds, amplitudeBounds] = mappedValues.reduce(
-    (acc, [real, imag]) => {
-      const phase = Math.atan2(imag, real);
-      phaseValues.push(phase);
+  values.forEach(([real, imag], i) => {
+    phase[i] = Math.atan2(imag, real);
+    amplitude[i] = Math.hypot(real, imag);
+  });
 
-      const amplitude = Math.hypot(real, imag);
-      amplitudeValues.push(amplitude);
-
-      return [getNewBounds(acc[0], phase), getNewBounds(acc[1], amplitude)];
-    },
-    [INITIAL_BOUNDS, INITIAL_BOUNDS],
-  );
-
-  return {
-    phaseValues,
-    phaseBounds,
-    amplitudeValues,
-    amplitudeBounds,
-  };
+  return { phase, amplitude };
 }

--- a/packages/app/src/vis-packs/core/heatmap/MappedHeatmapVis.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/MappedHeatmapVis.tsx
@@ -69,8 +69,8 @@ function MappedHeatmapVis(props: Props) {
   const numAxisArrays = useToNumArrays(axisValues);
 
   const { shape: dims } = dataset;
-  const [slicedDims, slicedMapping] = useSlicedDimsAndMapping(dims, dimMapping);
-  const dataArray = useMappedArray(numArray, slicedDims, slicedMapping);
+  const mappingArgs = useSlicedDimsAndMapping(dims, dimMapping);
+  const dataArray = useMappedArray(numArray, ...mappingArgs);
 
   const dataDomain =
     useDomain(dataArray, scaleType, undefined, ignoreValue) || DEFAULT_DOMAIN;

--- a/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
+++ b/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
@@ -82,8 +82,7 @@ function MappedLineVis(props: Props) {
   } = config;
 
   const { shape: dims } = dataset;
-  const [slicedDims, slicedMapping] = useSlicedDimsAndMapping(dims, dimMapping);
-  const hookArgs = [slicedDims, slicedMapping] as const;
+  const mappingArgs = useSlicedDimsAndMapping(dims, dimMapping);
 
   const numArray = useToNumArray(value);
   const numAuxArrays = useMemo(
@@ -102,10 +101,10 @@ function MappedLineVis(props: Props) {
   const numAuxErrorsArrays = useToNumArrays(auxErrors);
   const numAxisArrays = useToNumArrays(axisValues);
 
-  const dataArray = useMappedArray(numArray, ...hookArgs);
-  const errorsArray = useMappedArray(numErrorsArray, ...hookArgs);
-  const auxArrays = useMappedArrays(numAuxArrays, ...hookArgs);
-  const auxErrorsArrays = useMappedArrays(numAuxErrorsArrays, ...hookArgs);
+  const dataArray = useMappedArray(numArray, ...mappingArgs);
+  const errorsArray = useMappedArray(numErrorsArray, ...mappingArgs);
+  const auxArrays = useMappedArrays(numAuxArrays, ...mappingArgs);
+  const auxErrorsArrays = useMappedArrays(numAuxErrorsArrays, ...mappingArgs);
 
   const dataDomain = useDomain(
     dataArray,

--- a/packages/app/src/vis-packs/core/matrix/MappedMatrixVis.tsx
+++ b/packages/app/src/vis-packs/core/matrix/MappedMatrixVis.tsx
@@ -36,8 +36,8 @@ function MappedMatrixVis(props: Props) {
   const { sticky, customCellWidth, notation } = config;
 
   const { shape: dims, type } = dataset;
-  const [slicedDims, slicedMapping] = useSlicedDimsAndMapping(dims, dimMapping);
-  const mappedArray = useMappedArray(value, slicedDims, slicedMapping);
+  const mappingArgs = useSlicedDimsAndMapping(dims, dimMapping);
+  const mappedArray = useMappedArray(value, ...mappingArgs);
 
   const formatter = getFormatter(type, notation);
   const cellWidth = getCellWidth(type);

--- a/packages/app/src/vis-packs/core/rgb/MappedRgbVis.tsx
+++ b/packages/app/src/vis-packs/core/rgb/MappedRgbVis.tsx
@@ -41,14 +41,13 @@ function MappedRgbVis(props: Props) {
   } = props;
 
   const { showGrid, keepRatio, imageType, flipXAxis, flipYAxis } = config;
-  const { shape: dims } = dataset;
-
-  const numAxisArrays = useToNumArrays(axisValues);
-
-  const [slicedDims, slicedMapping] = useSlicedDimsAndMapping(dims, dimMapping);
 
   const numArray = useToNumArray(value);
-  const dataArray = useMappedArray(numArray, slicedDims, slicedMapping);
+  const numAxisArrays = useToNumArrays(axisValues);
+
+  const { shape: dims } = dataset;
+  const mappingArgs = useSlicedDimsAndMapping(dims, dimMapping);
+  const dataArray = useMappedArray(numArray, ...mappingArgs);
 
   const xDimIndex = dimMapping.indexOf('x');
   const yDimIndex = dimMapping.indexOf('y');

--- a/packages/app/src/vis-packs/core/surface/MappedSurfaceVis.tsx
+++ b/packages/app/src/vis-packs/core/surface/MappedSurfaceVis.tsx
@@ -30,14 +30,13 @@ interface Props {
 
 function MappedSurfaceVis(props: Props) {
   const { dataset, value, dimMapping, toolbarContainer, config } = props;
-
   const { customDomain, colorMap, scaleType, invertColorMap } = config;
 
-  const { shape: dims } = dataset;
-  const [slicedDims, slicedMapping] = useSlicedDimsAndMapping(dims, dimMapping);
-
   const numArray = useToNumArray(value);
-  const dataArray = useMappedArray(numArray, slicedDims, slicedMapping);
+
+  const { shape: dims } = dataset;
+  const mappingArgs = useSlicedDimsAndMapping(dims, dimMapping);
+  const dataArray = useMappedArray(numArray, ...mappingArgs);
 
   const dataDomain = useDomain(dataArray, scaleType) || DEFAULT_DOMAIN;
   const visDomain = useVisDomain(customDomain, dataDomain);


### PR DESCRIPTION
Memoisation was not quite right in the mapped complex vis components, especially in `MappedComplexLineVis`. The choice between using the phase or amplitude arrays and domains based on `complexVisType` has to be the last step—we have to compute and memoise them separately all the way otherwise we end up recomputing them or even re-transposing the arrays when the user interacts with the dimension mapper or the toolbar...

This neatens things up quite nicely, actually! :raised_hands:  We used to call the low-level utilities `getValidDomainForScale` and `getBaseArray` from the mapped complex vis components instead of the higher-level `useDomain` and `useMappedArray`. Now it's all consistent with the non-complex mapped vis components. :tada: 