### PR TITLE
Fix aux colors in dark mode

### DIFF
--- a/packages/app/src/App.module.css
+++ b/packages/app/src/App.module.css
@@ -61,9 +61,6 @@
   --h5w-slicingSlider-track--color: var(--secondary-dark);
   --h5w-slicingSlider-thumb--borderColor: var(--secondary);
   --h5w-slicingSlider-thumb--bgColor: var(--primary-bg);
-
-  --h5w-line--color: darkblue;
-  --h5w-line--colorAux: orangered, forestgreen, red, mediumorchid, olive;
 }
 
 .root *,
@@ -96,7 +93,7 @@
 
     /* Change line colors for better contrast once inverted */
     --h5w-line--color: deepskyblue;
-    --h5w-custom--line-colorAux: orange, lightgreen, red, violet, gold;
+    --h5w-line--colorAux: orange, lightgreen, red, violet, gold;
   }
 
   .root[data-allow-dark-mode] [data-keep-colors],


### PR DESCRIPTION
We had chosen custom, brighter colors for auxiliary lines in dark mode but they were no longer applied due to an outdated CSS variable name.

### BEFORE

<img width="966" height="629" alt="image" src="https://github.com/user-attachments/assets/93f31329-ee66-4568-bb29-41df49146940" />

### AFTER

<img width="966" height="629" alt="image" src="https://github.com/user-attachments/assets/c1cfddc0-4312-4993-901e-73554d19a249" />
