### PR TITLE
Switch Alt to Opt on Mac in interaction help menu

### DIFF
--- a/packages/lib/src/toolbar/controls/InteractionHelp.tsx
+++ b/packages/lib/src/toolbar/controls/InteractionHelp.tsx
@@ -16,6 +16,9 @@ import Btn from './Btn';
 import { POPOVER_CLEARANCE, useFloatingDismiss } from './hooks';
 import styles from './InteractionHelp.module.css';
 
+// https://developer.mozilla.org/en-US/docs/Web/API/Navigator/platform
+const IS_MAC = navigator.platform.startsWith('Mac'); // eslint-disable-line @typescript-eslint/no-deprecated
+
 interface Props {
   interactions: InteractionInfo[];
 }
@@ -69,7 +72,9 @@ function InteractionHelp(props: Props) {
             {interactions.map(({ shortcut, description }) => (
               <li key={shortcut} className={styles.entry}>
                 <span>{description}</span>{' '}
-                <kbd className={styles.shortcut}>{shortcut}</kbd>
+                <kbd className={styles.shortcut}>
+                  {IS_MAC ? shortcut.replace('Alt', 'Opt') : shortcut}
+                </kbd>
               </li>
             ))}
           </ul>


### PR DESCRIPTION
Fix #1869

@NAThompson I've used <kbd>Opt</kbd> instead of <kbd>⌥</kbd> for readability and consistency with using the names of the keys rather than their symbols. Is it okay do you think?

<img width="308" height="352" alt="image" src="https://github.com/user-attachments/assets/04664b80-8b99-4fe4-b53f-30b699d0e890" />