### PR TITLE
Replace Line/Points and Piecewise toggle buttons by a dropdown

### DIFF
--- a/packages/app/src/vis-packs/core/line/LineToolbar.tsx
+++ b/packages/app/src/vis-packs/core/line/LineToolbar.tsx
@@ -1,13 +1,11 @@
 import {
   ComplexVisTypeSelector,
-  CurveType,
   DomainWidget,
   ExportMenu,
-  Interpolation,
+  LineAspectSelector,
   ScaleSelector,
   Separator,
   ToggleBtn,
-  ToggleGroup,
   Toolbar,
 } from '@h5web/lib';
 import {
@@ -16,7 +14,6 @@ import {
   type ExportEntry,
 } from '@h5web/shared/vis-models';
 import { AXIS_SCALE_TYPES } from '@h5web/shared/vis-utils';
-import { FiGitPullRequest } from 'react-icons/fi';
 import { MdGridOn } from 'react-icons/md';
 
 import { INTERACTIONS_WITH_AXIAL_ZOOM } from '../utils';
@@ -114,33 +111,12 @@ function LineToolbar(props: Props) {
         onToggle={toggleGrid}
       />
 
-      <ToggleBtn
-        label="PiecewiseConstant"
-        Icon={FiGitPullRequest}
-        value={interpolation === Interpolation.Constant}
-        onToggle={() => {
-          if (interpolation === Interpolation.Constant) {
-            setInterpolation(Interpolation.Linear);
-            return;
-          }
-          setInterpolation(Interpolation.Constant);
-        }}
+      <LineAspectSelector
+        curveType={curveType}
+        onCurveTypeChanged={setCurveType}
+        interpolation={interpolation}
+        onInterpolationChanged={setInterpolation}
       />
-
-      <Separator />
-
-      <ToggleGroup
-        role="radiogroup"
-        ariaLabel="Curve type"
-        value={curveType}
-        onChange={(val) => {
-          setCurveType(val as CurveType);
-        }}
-      >
-        <ToggleGroup.Btn label="Line" value={CurveType.LineOnly} />
-        <ToggleGroup.Btn label="Points" value={CurveType.GlyphsOnly} />
-        <ToggleGroup.Btn label="Both" value={CurveType.LineAndGlyphs} />
-      </ToggleGroup>
 
       {exportEntries && exportEntries.length > 0 && (
         <>

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -28,6 +28,7 @@ export { default as FloatingControl } from './toolbar/floating/FloatingControl';
 export { default as ResetZoomButton } from './toolbar/floating/ResetZoomButton';
 export { default as NotationToggleGroup } from './toolbar/controls/NotationToggleGroup';
 export { default as Histogram } from './toolbar/controls/Histogram/Histogram';
+export { default as LineAspectSelector } from './toolbar/controls/LineAspectSelector/LineAspectSelector';
 export type { ToolbarProps } from './toolbar/Toolbar';
 export type { DomainWidgetProps } from './toolbar/controls/DomainWidget/DomainWidget';
 export type { DomainSliderProps } from './toolbar/controls/DomainWidget/DomainSlider';

--- a/packages/lib/src/toolbar/controls/LineAspectSelector/LineAspectSelector.tsx
+++ b/packages/lib/src/toolbar/controls/LineAspectSelector/LineAspectSelector.tsx
@@ -1,0 +1,91 @@
+import { useClick, useInteractions } from '@floating-ui/react';
+import { useId } from 'react';
+import { MdArrowDropDown, MdAutoGraph } from 'react-icons/md';
+
+import { CurveType, Interpolation } from '../../../vis/line/models';
+import toolbarStyles from '../../Toolbar.module.css';
+import { useFloatingDismiss, useFloatingMenu } from '../hooks';
+import RadioGroup from './RadioGroup';
+
+const CURVE_TYPE_LABELS: Record<CurveType, string> = {
+  [CurveType.LineOnly]: 'Line',
+  [CurveType.GlyphsOnly]: 'Points',
+  [CurveType.LineAndGlyphs]: 'Both',
+};
+
+interface Props {
+  curveType: CurveType;
+  onCurveTypeChanged: (curveType: CurveType) => void;
+  interpolation: Interpolation;
+  onInterpolationChanged: (interpolation: Interpolation) => void;
+}
+
+function LineAspectSelector(props: Props) {
+  const {
+    curveType,
+    onCurveTypeChanged,
+    interpolation,
+    onInterpolationChanged,
+  } = props;
+
+  const { context, refs, floatingStyles } = useFloatingMenu();
+  const { open: isOpen, floatingId } = context;
+
+  const referenceId = useId();
+
+  const { getReferenceProps, getFloatingProps } = useInteractions([
+    useClick(context),
+    useFloatingDismiss(context),
+  ]);
+
+  return (
+    <>
+      <button
+        ref={refs.setReference}
+        id={referenceId}
+        className={toolbarStyles.btn}
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        aria-controls={(isOpen && floatingId) || undefined}
+        {...getReferenceProps()}
+      >
+        <span className={toolbarStyles.btnLike}>
+          <MdAutoGraph className={toolbarStyles.icon} />
+          Aspect
+          <MdArrowDropDown className={toolbarStyles.arrowIcon} />
+        </span>
+      </button>
+
+      {isOpen && (
+        <div
+          ref={refs.setFloating}
+          id={floatingId}
+          className={toolbarStyles.menu}
+          style={floatingStyles}
+          role="menu"
+          aria-labelledby={referenceId}
+          {...getFloatingProps()}
+        >
+          <RadioGroup
+            name="curvetype"
+            value={curveType}
+            options={Object.values(CurveType)}
+            optionsLabels={CURVE_TYPE_LABELS}
+            onValueChanged={onCurveTypeChanged}
+          />
+          <RadioGroup
+            name="interpolation"
+            value={interpolation}
+            options={Object.values(Interpolation)}
+            label="Interpolation"
+            onValueChanged={onInterpolationChanged}
+            disabled={curveType === CurveType.GlyphsOnly}
+          />
+        </div>
+      )}
+    </>
+  );
+}
+
+export default LineAspectSelector;

--- a/packages/lib/src/toolbar/controls/LineAspectSelector/RadioGroup.module.css
+++ b/packages/lib/src/toolbar/controls/LineAspectSelector/RadioGroup.module.css
@@ -1,0 +1,26 @@
+.groupLabel {
+  margin-bottom: 0.25rem;
+  margin-top: 0.5rem;
+  padding-left: 0.75rem;
+  color: var(--h5w-selector-groupLabel--color, gray);
+  text-transform: uppercase;
+  font-size: 0.75em;
+  font-weight: 600;
+}
+
+.group {
+  display: flex;
+  flex-direction: column;
+}
+
+.option {
+  composes: btnClean from global;
+  display: flex;
+  align-items: center;
+  padding: 0.375rem 0.75rem;
+  white-space: nowrap;
+}
+
+.optionText {
+  margin-left: 0.375rem;
+}

--- a/packages/lib/src/toolbar/controls/LineAspectSelector/RadioGroup.tsx
+++ b/packages/lib/src/toolbar/controls/LineAspectSelector/RadioGroup.tsx
@@ -1,0 +1,54 @@
+import styles from './RadioGroup.module.css';
+
+interface Props<T extends string> {
+  value: T;
+  onValueChanged: (value: T) => void;
+  name: string;
+  options: T[];
+  optionsLabels?: Record<T, string>;
+  label?: string;
+  disabled?: boolean;
+}
+
+function RadioGroup<T extends string>(props: Props<T>) {
+  const {
+    value,
+    onValueChanged,
+    name,
+    options,
+    optionsLabels,
+    label,
+    disabled,
+  } = props;
+
+  return (
+    <div className={styles.group} role="radiogroup">
+      {label && <span className={styles.groupLabel}>{label}</span>}
+      {options.map((option) => {
+        return (
+          <label
+            id={`${option}-label`}
+            key={option}
+            className={styles.option}
+            htmlFor={option}
+            aria-disabled={disabled}
+          >
+            <input
+              id={option}
+              name={name}
+              type="radio"
+              checked={option === value}
+              onChange={() => onValueChanged(option)}
+              aria-labelledby={`${option}-label`}
+            />
+            <span className={styles.optionText}>
+              {optionsLabels ? optionsLabels[option] : option}
+            </span>
+          </label>
+        );
+      })}
+    </div>
+  );
+}
+
+export default RadioGroup;


### PR DESCRIPTION
Fix #1875 

[Screencast from 2025-09-25 13-48-01.webm](https://github.com/user-attachments/assets/a7488aa2-da4e-40b8-a740-d6cf5ca753cc)

Side boon: interpolation is disabled when displaying only points (since it is not relevant).
