### PR TITLE
Propagage unknown h5grove errors

### DIFF
--- a/packages/app/src/providers/h5grove/h5grove-api.ts
+++ b/packages/app/src/providers/h5grove/h5grove-api.ts
@@ -201,6 +201,6 @@ export class H5GroveApi extends DataProviderApi {
       });
     }
 
-    return undefined;
+    return new Error(error.message, { cause: error });
   }
 }


### PR DESCRIPTION
If the h5grove instance (or an authorization proxy for instance) returns a custom error, we need to propagate it.