### PR TITLE
Hide "Errors" toggle in Line toolbar instead of disabling it

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -83,7 +83,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.local
-          key: poetry-4 # increment to reset cache
+          key: poetry-5 # increment to reset cache
 
       - name: Install Poetry 📜
         if: steps.poetry.outputs.cache-hit != 'true'
@@ -96,7 +96,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pypoetry/virtualenvs
-          key: poetry-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-7 # increment to reset cache
+          key: poetry-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-8 # increment to reset cache
 
       - name: Create Poetry environments 📜
         if: steps.poetry-venvs.outputs.cache-hit != 'true'

--- a/apps/storybook/src/DataCurve.stories.tsx
+++ b/apps/storybook/src/DataCurve.stories.tsx
@@ -30,7 +30,6 @@ const meta = {
   args: {
     abscissas: range(oneD.size),
     ordinates: oneD.data,
-    errors: oneD.data.map(() => 10),
     curveType: CurveType.LineOnly,
     color: 'blue',
     materialProps: {},
@@ -53,13 +52,13 @@ type Story = StoryObj<typeof meta>;
 
 export const Default = {
   render: (args) => {
-    const { abscissas, ordinates, errors, showErrors, ignoreValue } = args;
+    const { abscissas, ordinates, errors, ignoreValue } = args;
 
     const abscissaDomain = useDomain(abscissas);
     const ordinateDomain = useDomain(
       ordinates,
       ScaleType.Linear,
-      showErrors ? errors : undefined,
+      errors,
       ignoreValue,
     );
 
@@ -117,7 +116,7 @@ export const Glyphs = {
 export const WithErrors = {
   ...Default,
   args: {
-    showErrors: true,
+    errors: oneD.data.map(() => 10),
   },
 } satisfies Story;
 

--- a/packages/app/src/vis-packs/core/line/LineToolbar.tsx
+++ b/packages/app/src/vis-packs/core/line/LineToolbar.tsx
@@ -27,20 +27,14 @@ interface Props {
   dataDomain: Domain;
   isSlice?: boolean;
   isComplex?: boolean;
-  disableErrors?: boolean;
+  withErrors?: boolean;
   config: LineConfig;
   exportEntries?: ExportEntry[];
 }
 
 function LineToolbar(props: Props) {
-  const {
-    dataDomain,
-    isSlice,
-    isComplex,
-    disableErrors,
-    config,
-    exportEntries,
-  } = props;
+  const { dataDomain, isSlice, isComplex, withErrors, config, exportEntries } =
+    props;
 
   const {
     customDomain,
@@ -97,13 +91,12 @@ function LineToolbar(props: Props) {
 
       <Separator />
 
-      {!isComplex && (
+      {withErrors && (
         <ToggleBtn
           label="Errors"
           Icon={ErrorsIcon}
-          value={!disableErrors && showErrors}
+          value={showErrors}
           onToggle={toggleErrors}
-          disabled={disableErrors}
         />
       )}
 

--- a/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
+++ b/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
@@ -154,7 +154,7 @@ function MappedLineVis(props: Props) {
           <LineToolbar
             dataDomain={combinedDomain}
             isSlice={selection !== undefined}
-            disableErrors={!errors}
+            withErrors={!!errors}
             config={config}
             exportEntries={exportEntries}
           />,

--- a/packages/lib/src/vis/line/DataCurve.tsx
+++ b/packages/lib/src/vis/line/DataCurve.tsx
@@ -35,7 +35,7 @@ function DataCurve(props: Props) {
     abscissas,
     ordinates,
     errors,
-    showErrors,
+    showErrors = true,
     color,
     width,
     interpolation,

--- a/packages/lib/src/vis/line/LineVis.tsx
+++ b/packages/lib/src/vis/line/LineVis.tsx
@@ -62,7 +62,7 @@ function LineVis(props: Props) {
     title,
     dtype,
     errorsArray,
-    showErrors = false,
+    showErrors = true,
     auxiliaries = [],
     renderTooltip,
     children,


### PR DESCRIPTION
Extracted from #1868

- `< NX Line >` Hide "Errors" toggle completely in toolbar (instead of disabling it) when there aren't any error values
- `< Line >` Never show "Errors" toggle at all, since there can never be error values anyway
- `[LineVis, DataCurve]` If prop `showErrors` is not specified, default to `true` so that error bars are shown by default if error values are provided