### PR TITLE
Upgrade react-slider

### DIFF
--- a/cypress/e2e/app.cy.ts
+++ b/cypress/e2e/app.cy.ts
@@ -199,7 +199,10 @@ describe('/mock', () => {
       .and('have.attr', 'aria-valuemax', 8);
 
     // Move slider up by three marks and check value
-    cy.get('@d1Slider').type('{upArrow}{upArrow}{upArrow}');
+    cy.get('@d1Slider').focus();
+    cy.press(Cypress.Keyboard.Keys.UP);
+    cy.press(Cypress.Keyboard.Keys.UP);
+    cy.press(Cypress.Keyboard.Keys.UP);
     cy.waitForStableDOM();
 
     cy.get('@d1Slider').should('have.attr', 'aria-valuenow', 3);
@@ -212,7 +215,8 @@ describe('/mock', () => {
     }
 
     // Move slider up by one mark to reach slice filled only with zeros
-    cy.get('@d1Slider').type('{upArrow}');
+    cy.get('@d1Slider').focus();
+    cy.press(Cypress.Keyboard.Keys.UP);
     cy.waitForStableDOM();
 
     cy.get('@d1Slider').should('have.attr', 'aria-valuenow', 4);

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -95,7 +95,7 @@
     "react-is": "^18.3.1",
     "react-keyed-flatten-children": "5.0.1",
     "react-measure": "2.5.2",
-    "react-slider": "2.0.4",
+    "react-slider": "2.0.6",
     "react-window": "2.2.1",
     "zustand": "5.0.8"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -477,8 +477,8 @@ importers:
         specifier: 2.5.2
         version: 2.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-slider:
-        specifier: 2.0.4
-        version: 2.0.4(react@18.3.1)
+        specifier: 2.0.6
+        version: 2.0.6(react@18.3.1)
       react-window:
         specifier: 2.2.1
         version: 2.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -4011,8 +4011,8 @@ packages:
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  react-slider@2.0.4:
-    resolution: {integrity: sha512-sWwQD01n6v+MbeLCYthJGZPc0kzOyhQHyd0bSo0edg+IAxTVQmj3Oy4SBK65eX6gNwS9meUn6Z5sIBUVmwAd9g==}
+  react-slider@2.0.6:
+    resolution: {integrity: sha512-gJxG1HwmuMTJ+oWIRCmVWvgwotNCbByTwRkFZC6U4MBsHqJBmxwbYRJUmxy4Tke1ef8r9jfXjgkmY/uHOCEvbA==}
     peerDependencies:
       react: ^16 || ^17 || ^18
 
@@ -8862,7 +8862,7 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  react-slider@2.0.4(react@18.3.1):
+  react-slider@2.0.6(react@18.3.1):
     dependencies:
       prop-types: 15.8.1
       react: 18.3.1


### PR DESCRIPTION
Another dependency upgrade unblocked thanks to Cypress 15. This time it's the new [`cy.press()`](https://docs.cypress.io/api/commands/press) command that saves the day. This command triggers real keyboard events, whereas the `cy.type` command triggers synthetic events, which `react-slider@2.0.6` had issues with.