### PR TITLE
Add ability to show/hide all auxiliaries at once in NX Line vis

### DIFF
--- a/packages/app/src/vis-packs/nexus/NxLineSignalPicker.module.css
+++ b/packages/app/src/vis-packs/nexus/NxLineSignalPicker.module.css
@@ -9,12 +9,10 @@
   padding: 0.25rem 0;
 }
 
-.auxHeading {
-  margin-top: 0.75rem;
-  margin-bottom: 0.25rem;
-  padding-left: 0.75rem;
+.allAuxOption {
   color: var(--h5w-selector-groupLabel--color, gray);
   text-transform: uppercase;
   font-size: 0.75em;
   font-weight: 600;
+  line-height: 1.6;
 }

--- a/packages/app/src/vis-packs/nexus/NxLineSignalPicker.tsx
+++ b/packages/app/src/vis-packs/nexus/NxLineSignalPicker.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Menu, Separator } from '@h5web/lib';
+import { Checkbox, Menu, MenuSeparator, Separator } from '@h5web/lib';
 import { createPortal } from 'react-dom';
 import { MdLineAxis } from 'react-icons/md';
 
@@ -29,6 +29,9 @@ function NxLineSignalPicker(props: Props) {
     return null;
   }
 
+  const someAuxChecked = auxChecked.some(Boolean);
+  const allAuxChecked = auxChecked.every(Boolean);
+
   return createPortal(
     <div className={styles.wrapper}>
       <Separator />
@@ -40,7 +43,17 @@ function NxLineSignalPicker(props: Props) {
           onChange={onSignalChange}
         />
 
-        <span className={styles.auxHeading}>Auxiliaries</span>
+        <MenuSeparator />
+        <Checkbox
+          className={styles.allAuxOption}
+          label="Auxiliary signals"
+          checked={allAuxChecked}
+          indeterminate={someAuxChecked && !allAuxChecked}
+          onChange={() => {
+            onAuxChange(auxChecked.map(() => !allAuxChecked));
+          }}
+        />
+
         {auxLabels.map((label, index) => {
           return (
             <Checkbox

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -18,6 +18,7 @@ export { default as ToggleGroup } from './toolbar/controls/ToggleGroup/ToggleGro
 export { default as RadioGroup } from './toolbar/controls/RadioGroup';
 export { default as Checkbox } from './toolbar/controls/Checkbox';
 export { default as Menu } from './toolbar/controls/Menu';
+export { default as MenuSeparator } from './toolbar/controls/MenuSeparator';
 export { default as DomainWidget } from './toolbar/controls/DomainWidget/DomainWidget';
 export { default as DomainSlider } from './toolbar/controls/DomainWidget/DomainSlider';
 export { default as DomainControls } from './toolbar/controls/DomainWidget/DomainControls';

--- a/packages/lib/src/toolbar/controls/Checkbox.tsx
+++ b/packages/lib/src/toolbar/controls/Checkbox.tsx
@@ -1,27 +1,44 @@
+import { isDefined } from '@h5web/shared/guards';
 import { useId } from 'react';
 
+import { type ClassStyleAttrs } from '../../vis/models';
 import styles from './Checkbox.module.css';
 
-interface Props {
+interface Props extends ClassStyleAttrs {
   label: string;
   disabled?: boolean;
   checked: boolean;
+  indeterminate?: boolean;
   onChange?: (checked: boolean) => void;
 }
 
 function Checkbox(props: Props) {
-  const { label, disabled, checked, onChange } = props;
+  const {
+    className,
+    style,
+    label,
+    disabled,
+    checked,
+    indeterminate,
+    onChange,
+  } = props;
   const labelId = useId();
   const inputId = useId();
 
   return (
     <label
       id={labelId}
-      className={styles.label}
+      className={`${styles.label} ${className}`}
+      style={style}
       htmlFor={inputId}
       aria-disabled={disabled}
     >
       <input
+        ref={
+          isDefined(indeterminate)
+            ? (el) => el && (el.indeterminate = indeterminate) // eslint-disable-line no-param-reassign
+            : undefined
+        }
         id={inputId}
         type="checkbox"
         checked={checked}

--- a/packages/lib/src/toolbar/controls/MenuSeparator.module.css
+++ b/packages/lib/src/toolbar/controls/MenuSeparator.module.css
@@ -1,0 +1,4 @@
+.sep {
+  margin: 0.375rem 0.75rem;
+  border-top: 1px solid var(--h5w-toolbar-separator--color, rgba(0, 0, 0, 0.2));
+}

--- a/packages/lib/src/toolbar/controls/MenuSeparator.tsx
+++ b/packages/lib/src/toolbar/controls/MenuSeparator.tsx
@@ -1,0 +1,9 @@
+import { type HTMLAttributes } from 'react';
+
+import styles from './MenuSeparator.module.css';
+
+function MenuSeparator(props: HTMLAttributes<HTMLSpanElement>) {
+  return <span className={styles.sep} {...props} />;
+}
+
+export default MenuSeparator;


### PR DESCRIPTION
I think this closes #1914 :tada: 

[Screencast from 2025-11-07 11-14-09.webm](https://github.com/user-attachments/assets/ca020e6c-fc12-4352-9ece-7b31d3a6d947)

---

- Add new component `MenuSeparator` to add a horizontal line between menu items