### PR TITLE
Change fallback message and add hint

### DIFF
--- a/packages/app/src/__tests__/Explorer.test.tsx
+++ b/packages/app/src/__tests__/Explorer.test.tsx
@@ -94,7 +94,7 @@ test('show spinner when group metadata is slow to fetch', async () => {
 
   // Wait for fetch of group metadata to succeed
   await expect(
-    screen.findByText(/No visualization available/, undefined, {
+    screen.findByText(/Nothing to display/, undefined, {
       timeout: SLOW_TIMEOUT,
     }),
   ).resolves.toBeVisible();

--- a/packages/app/src/__tests__/NexusPack.test.tsx
+++ b/packages/app/src/__tests__/NexusPack.test.tsx
@@ -179,9 +179,7 @@ test('show error/fallback for malformed NeXus entity', async () => {
 
   // No `signal` attribute
   await selectExplorerNode('no_signal');
-  expect(
-    screen.getByText('No visualization available for this entity.'),
-  ).toBeInTheDocument();
+  expect(screen.getByText(/Nothing to display/)).toBeInTheDocument();
   expect(errorSpy).not.toHaveBeenCalled();
   errorSpy.mockClear();
 
@@ -340,7 +338,7 @@ test('retry fetching automatically when re-selecting NxLine', async () => {
 
   // Switch to other entity with no visualization
   await selectExplorerNode('entities');
-  await expect(screen.findByText(/No visualization/)).resolves.toBeVisible();
+  await expect(screen.findByText(/Nothing to display/)).resolves.toBeVisible();
 
   // Select NXdata group again
   await selectExplorerNode('slow_nx_spectrum');

--- a/packages/app/src/__tests__/Visualizer.test.tsx
+++ b/packages/app/src/__tests__/Visualizer.test.tsx
@@ -7,7 +7,7 @@ import { Vis } from '../vis-packs/core/visualizations';
 
 test('show fallback message when no visualization is supported', async () => {
   await renderApp('/entities'); // simple group
-  expect(screen.getByText(/No visualization available/)).toBeVisible();
+  expect(screen.getByText(/Nothing to display/)).toBeVisible();
 });
 
 test('show loader while fetching dataset value', async () => {
@@ -31,7 +31,7 @@ test("show error when dataset value can't be fetched", async () => {
 
   // Make sure error boundary resets when selecting another entity
   await selectExplorerNode('entities');
-  expect(screen.getByText(/No visualization/)).toBeVisible();
+  expect(screen.getByText(/Nothing to display/)).toBeVisible();
 });
 
 test('cancel and retry slow fetch of dataset value', async () => {
@@ -103,7 +103,7 @@ test('retry fetching automatically when re-selecting dataset', async () => {
 
   // Switch to other entity with no visualization
   await selectExplorerNode('entities');
-  await expect(screen.findByText(/No visualization/)).resolves.toBeVisible();
+  await expect(screen.findByText(/Nothing to display/)).resolves.toBeVisible();
 
   // Select dataset again
   await selectExplorerNode('slow_value');

--- a/packages/app/src/visualizer/Visualizer.module.css
+++ b/packages/app/src/visualizer/Visualizer.module.css
@@ -27,6 +27,16 @@
   composes: fallback from global;
 }
 
+.fallback > p:first-child {
+  margin: 0;
+}
+
+.fallbackHint {
+  margin: 0.75em 0 0;
+  font-style: italic;
+  font-size: 90%;
+}
+
 .dimMapper {
   grid-area: dimMapper;
 }

--- a/packages/app/src/visualizer/Visualizer.tsx
+++ b/packages/app/src/visualizer/Visualizer.tsx
@@ -15,9 +15,12 @@ function Visualizer(props: Props) {
 
   if (!resolution) {
     return (
-      <p className={styles.fallback}>
-        No visualization available for this entity.
-      </p>
+      <div className={styles.fallback}>
+        <p>Nothing to display</p>
+        <p className={styles.fallbackHint}>
+          Please select another entity in the sidebar.
+        </p>
+      </div>
     );
   }
 


### PR DESCRIPTION
Initially we had only "Nothing to visualize", which could imply that there was nothing to visualize in the entire file. This problem was reported in #620 and we changed the message to "No visualization available for this entity" in #628. But @andygotz still thinks this is not very intuitive, which I tend to agree with.

So I'm going back to something shorter, "Nothing to display", but I'm also adding a hint (as suggested by @andygotz) to make it clear that there may still be things to visualize in the file: "Please select another entity in the sidebar."

- The use of the term sidebar explains how to use the interface (especially if the sidebar is hidden by default when users open the file).
- The term "entity" is generic yet still part of the HDF5 lingo.
- The hint is styled differently from the main message.
- The whole thing works regardless of what is selected (a group, an empty dataset, a datatype, etc.)


### BEFORE

<img width="949" height="270" alt="image" src="https://github.com/user-attachments/assets/9cc2a904-612e-4b28-8672-cb09b2280481" />

### AFTER

<img width="949" height="270" alt="image" src="https://github.com/user-attachments/assets/0692e3ef-ab4c-4365-a0be-7ba714d65fde" />


