### PR TITLE
Go ESM only

### DIFF
--- a/apps/storybook/src/GettingStarted.mdx
+++ b/apps/storybook/src/GettingStarted.mdx
@@ -109,7 +109,7 @@ import { Meta } from '@storybook/addon-docs/blocks';
 1. Import the library's styles before any other import:
 
    ```ts
-   import '@h5web/lib/styles.css'; // or '@h5web/lib/dist/styles.css' with older bundlers
+   import '@h5web/lib/styles.css';
 
    import { HeatmapVis, getDomain } from '@h5web/lib';
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -15,20 +15,13 @@
   ],
   "exports": {
     "./global-styles.css": "./src/global-styles.css",
+    "./styles.css": "./dist/styles.css",
     ".": "./src/index.ts"
   },
   "publishConfig": {
-    "main": "dist/index.js",
-    "module": "dist/index.mjs",
-    "types": "dist/index.d.ts",
     "exports": {
-      "./dist/styles.css": "./dist/styles.css",
       "./styles.css": "./dist/styles.css",
-      ".": {
-        "types": "./dist/index.d.ts",
-        "import": "./dist/index.mjs",
-        "default": "./dist/index.js"
-      }
+      ".": "./dist/index.js"
     }
   },
   "scripts": {

--- a/packages/app/src/styles.ts
+++ b/packages/app/src/styles.ts
@@ -3,4 +3,4 @@
    Output is later concatenated with local app styles. */
 
 import 'react-reflex/styles.css';
-import '@h5web/lib/dist/styles.css'; // distributed lib styles
+import '@h5web/lib/styles.css'; // distributed lib styles

--- a/packages/app/vite.config.js
+++ b/packages/app/vite.config.js
@@ -22,8 +22,9 @@ export default defineProject({
   build: {
     lib: {
       entry: path.resolve('src/index.ts'),
-      formats: ['es', 'cjs'],
-      fileName: (format) => `index.${format === 'es' ? 'mjs' : 'js'}`,
+      formats: ['es'],
+      fileName: 'index',
+      cssFileName: 'app',
     },
     rollupOptions: {
       external: [...externals].map((dep) => new RegExp(`^${dep}($|\\/)`, 'u')), // e.g. externalize `react-icons/fi`

--- a/packages/h5wasm/README.md
+++ b/packages/h5wasm/README.md
@@ -46,7 +46,7 @@ npm install @h5web/app @h5web/h5wasm
 ```
 
 ```tsx
-import '@h5web/app/dist/styles.css';
+import '@h5web/app/styles.css';
 
 import { useState } from 'react';
 import { App } from '@h5web/app';

--- a/packages/h5wasm/package.json
+++ b/packages/h5wasm/package.json
@@ -13,17 +13,12 @@
   "files": [
     "dist"
   ],
-  "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "publishConfig": {
-    "main": "dist/index.js",
-    "module": "dist/index.mjs",
-    "types": "dist/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./dist/index.d.ts",
-        "import": "./dist/index.mjs",
-        "default": "./dist/index.js"
-      }
+      ".": "./dist/index.js"
     }
   },
   "scripts": {

--- a/packages/h5wasm/vite.config.js
+++ b/packages/h5wasm/vite.config.js
@@ -21,8 +21,8 @@ export default defineProject({
   build: {
     lib: {
       entry: path.resolve('src/index.ts'),
-      formats: ['es', 'cjs'],
-      fileName: (format) => `index.${format === 'es' ? 'mjs' : 'js'}`,
+      formats: ['es'],
+      fileName: 'index',
     },
     rollupOptions: {
       external: [...externals].map((dep) => new RegExp(`^${dep}($|\\/)`, 'u')), // e.g. externalize `react-icons/fi`

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -15,21 +15,13 @@
   ],
   "exports": {
     "./global-styles.css": "./src/global-styles.css",
-    "./dist/styles.css": "./dist/styles.css",
+    "./styles.css": "./dist/styles.css",
     ".": "./src/index.ts"
   },
   "publishConfig": {
-    "main": "dist/index.js",
-    "module": "dist/index.mjs",
-    "types": "dist/index.d.ts",
     "exports": {
-      "./dist/styles.css": "./dist/styles.css",
       "./styles.css": "./dist/styles.css",
-      ".": {
-        "types": "./dist/index.d.ts",
-        "import": "./dist/index.mjs",
-        "default": "./dist/index.js"
-      }
+      ".": "./dist/index.js"
     }
   },
   "scripts": {

--- a/packages/lib/src/global-styles.css
+++ b/packages/lib/src/global-styles.css
@@ -1,2 +1,2 @@
-/* Global lib styles for demo (via packages/app/src/styles.css) and Storybook */
+/* Global lib styles for demo (via packages/app/src/global-styles.css) and Storybook */
 @import '@h5web/shared/styles.css'; /* global shared styles */

--- a/packages/lib/vite.config.js
+++ b/packages/lib/vite.config.js
@@ -20,8 +20,9 @@ export default defineProject({
   build: {
     lib: {
       entry: path.resolve('src/index.ts'),
-      formats: ['es', 'cjs'],
-      fileName: (format) => `index.${format === 'es' ? 'mjs' : 'js'}`,
+      formats: ['es'],
+      fileName: 'index',
+      cssFileName: 'lib',
     },
     rollupOptions: {
       external: [...externals].map((dep) => new RegExp(`^${dep}($|\\/)`, 'u')), // e.g. externalize `react-icons/fi`


### PR DESCRIPTION
Thanks to Node 24 (and now 22)'s ability to `require()` ESM modules from CommonJS modules, the ecosystem is finally ready to move on to [ESM-only publishing](https://antfu.me/posts/move-on-to-esm-only). More info here: https://2ality.com/2025/02/typescript-esm-packages.html

I'll do plenty of beta testing once merged, of course.

Note also the following change, which is also long overdue:

- :warning: Remove deprecated imports `@h5web/lib/dist/styles.css` and `@h5web/app/dist/styles.css` — please use `@h5web/lib/styles.css` and `@h5web/app/styles.css` respectively instead.