### PR TITLE
Fix flickering of toolbar controls

### DIFF
--- a/packages/lib/src/toolbar/Toolbar.tsx
+++ b/packages/lib/src/toolbar/Toolbar.tsx
@@ -24,7 +24,7 @@ function Toolbar(props: PropsWithChildren<Props>) {
   const allChildren = flattenChildren(children).filter(isValidElementWithKey);
 
   const [containerSize, containerRef] = useMeasure<HTMLDivElement>();
-  const availableWidth = containerSize ? containerSize.width : 0;
+  const availableWidth = containerSize ? containerSize.width : Infinity; // render all controls in view until container is measured
 
   const childrenWidths = useMap<string, number>();
 


### PR DESCRIPTION
I finally managed to hunt down the cause of the toolbar controls flickering in some cases.

It was happening when the toolbar had enough space to fit all the controls _without_ the overflow menu menu present, but not enough to fit the last control _with_ the overflow menu button present. It was not happening consistently, though, which pointed to a race condition of sorts.

Here's what used to happen in details:

1. First render: the container and controls are not yet measure. We set the `availableWidth` to 0, and every control gets a size of 0. All the controls end up "in view" because their accumulated width is lower than **or equal** to the available width.
2. The container and all the controls are appended to the DOM and ready to be measured. The overflow menu is not rendered since it has no children.
3.  If the container is measured before the controls, all is well: the toolbar re-renders, all the controls still fit, the overflow menu is still empty and not rendered. There is no flickering.
4. If, however, **the controls are measured before the container**, the controls' accumulated widths become greater than the available width (which is still `0`) and they are **all moved out of view** into the overflow menu. The overflow menu button appears in the toolbar,, which reduces the width of the container.
5. From here, if the initial measurement of the container _without_ the overflow menu triggers a re-render of the toolbar before the measurement of the container _with_ the overflow menu, then the controls are all **moved back into view**, which hides the overflow menu.
6. The infinite rendering loop continues until the measurement somehow resynchronises with the visibility of the overflow menu.

From here, the fix is pretty clear: at step 4) we want the controls to remain in view regardless of their own measurement, until the container has had time to be properly measured. This can be achieved by letting `availableWidth` fall back to `Infinity` instead of `0` while the container is being measured.