### PR TITLE
Upgrade h5wasm and h5wasm-plugins and add support for bitgroom and bitround filters

### DIFF
--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -16,7 +16,7 @@
     "@h5web/app": "workspace:*",
     "@h5web/h5wasm": "workspace:*",
     "axios-hooks": "5.1.1",
-    "h5wasm-plugins": "0.2.0",
+    "h5wasm-plugins": "0.2.1",
     "normalize.css": "8.0.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/apps/demo/src/h5wasm/plugin-utils.ts
+++ b/apps/demo/src/h5wasm/plugin-utils.ts
@@ -1,6 +1,8 @@
 // Import compression plugins as static assets (i.e. as URLs)
 // cf. `vite.config.ts` and `src/vite-env.d.ts
 import { Plugin } from '@h5web/h5wasm';
+import bitgroom from 'h5wasm-plugins/plugins/libH5Zbitgroom.so';
+import bitround from 'h5wasm-plugins/plugins/libH5Zbitround.so';
 import blosc from 'h5wasm-plugins/plugins/libH5Zblosc.so';
 import blosc2 from 'h5wasm-plugins/plugins/libH5Zblosc2.so';
 import bshuf from 'h5wasm-plugins/plugins/libH5Zbshuf.so';
@@ -12,9 +14,11 @@ import zfp from 'h5wasm-plugins/plugins/libH5Zzfp.so';
 import zstd from 'h5wasm-plugins/plugins/libH5Zzstd.so';
 
 const PLUGINS: Record<Plugin, string> = {
+  [Plugin.Bitgroom]: bitgroom,
+  [Plugin.Bitround]: bitround,
+  [Plugin.Bitshuffle]: bshuf,
   [Plugin.Blosc]: blosc,
   [Plugin.Blosc2]: blosc2,
-  [Plugin.Bitshuffle]: bshuf,
   [Plugin.BZIP2]: bz2,
   [Plugin.JPEG]: jpeg,
   [Plugin.LZ4]: lz4,

--- a/packages/h5wasm/package.json
+++ b/packages/h5wasm/package.json
@@ -33,7 +33,7 @@
   "peerDependencies": {
     "@h5web/app": "workspace:*",
     "@types/react": "18.x",
-    "h5wasm-plugins": "0.2.0",
+    "h5wasm-plugins": "0.2.1",
     "react": "18.x",
     "typescript": ">=4.5"
   },
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "comlink": "4.4.2",
-    "h5wasm": "0.8.7",
+    "h5wasm": "0.8.8",
     "nanoid": "5.1.6"
   },
   "devDependencies": {

--- a/packages/h5wasm/src/models.ts
+++ b/packages/h5wasm/src/models.ts
@@ -7,6 +7,8 @@ export interface HDF5Diag {
 
 // https://github.com/h5wasm/h5wasm-plugins#included-plugins
 export enum Plugin {
+  Bitgroom = 'bitgroom',
+  Bitround = 'bitround',
   Bitshuffle = 'bshuf',
   Blosc = 'blosc',
   Blosc2 = 'blosc2',

--- a/packages/h5wasm/src/utils.ts
+++ b/packages/h5wasm/src/utils.ts
@@ -10,6 +10,8 @@ export const PLUGINS_BY_FILTER_ID: Record<number, Plugin> = {
   32_013: Plugin.ZFP,
   32_015: Plugin.Zstandard,
   32_019: Plugin.JPEG,
+  32_022: Plugin.Bitgroom,
+  32_023: Plugin.Bitround,
   32_026: Plugin.Blosc2,
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: 5.1.1
         version: 5.1.1(axios@1.13.2)(react@18.3.1)
       h5wasm-plugins:
-        specifier: 0.2.0
-        version: 0.2.0
+        specifier: 0.2.1
+        version: 0.2.1(h5wasm@0.8.8)
       normalize.css:
         specifier: 8.0.1
         version: 8.0.1
@@ -330,8 +330,8 @@ importers:
         specifier: 4.4.2
         version: 4.4.2
       h5wasm:
-        specifier: 0.8.7
-        version: 0.8.7
+        specifier: 0.8.8
+        version: 0.8.8
       nanoid:
         specifier: 5.1.6
         version: 5.1.6
@@ -3001,11 +3001,13 @@ packages:
   greenlet@1.1.0:
     resolution: {integrity: sha512-W/kKzq7ZSF/LFItIjaSaccw8L6js+9SMSS5buXZs/Td7qZAT91Kd0LTxuUjSWDwuyv4MPo/fhZdkRLV1zsuClg==}
 
-  h5wasm-plugins@0.2.0:
-    resolution: {integrity: sha512-bT3sW1OSvPBFDCqGYDMyjUIEbDRxx5/8k5AKRYEmog+kW6QIF0MHUhyGNFoeTOvjtjbLYlh6FKcgPiqEE4VLRw==}
-
-  h5wasm@0.8.7:
-    resolution: {integrity: sha512-7TJKTSXnZobVZYSywEsy3PnIqTDsyIX8i/WNmtnL6it+K/2OLcjZAg0Fpx+LUjyc9L/HqmWD8qYBd0Nf/dYwZA==}
+  h5wasm-plugins@0.2.1:
+    resolution: {integrity: sha512-79l7F9kuQEJrMPwX96Q7dJjVtOaxxbldujmFcBLYuMn2n28q1OBLlvtAthWckZ6U/opPIxy4/cNrS8kOTiSrNw==}
+    peerDependencies:
+      h5wasm: ^0.8.8
+    peerDependenciesMeta:
+      h5wasm:
+        optional: true
 
   h5wasm@0.8.8:
     resolution: {integrity: sha512-wgob0VuCgvVU6E2S4fwPkwf+SbsPfk1fuRgX5o392NDyPfJMjWlM+ZvVuRBTaoo/futq3Fd1iPcRA74s9wMC2w==}
@@ -7556,11 +7558,9 @@ snapshots:
 
   greenlet@1.1.0: {}
 
-  h5wasm-plugins@0.2.0:
-    dependencies:
+  h5wasm-plugins@0.2.1(h5wasm@0.8.8):
+    optionalDependencies:
       h5wasm: 0.8.8
-
-  h5wasm@0.8.7: {}
 
   h5wasm@0.8.8: {}
 


### PR DESCRIPTION
I've added the corresponding test files to silx.org and Bosquet:

- https://www.silx.org/pub/h5web/filters/bitgroom.h5
- https://www.silx.org/pub/h5web/filters/bitround.h5

---

### @h5web/h5wasm

- :tada: Support [**bitgroom**](https://h5web.panosc.eu/h5wasm?url=https%3A%2F%2Fwww.silx.org%2Fpub%2Fh5web%2Ffilters%2Fbitgroom.h5) and [**bitround**](https://h5web.panosc.eu/h5wasm?url=https%3A%2F%2Fwww.silx.org%2Fpub%2Fh5web%2Ffilters%2Fbitround.h5) filters
- :warning: **Breaking change:** Require `h5wasm-plugins@0.2.1`