### PR TITLE
Increase test coverage of explorer and search

### DIFF
--- a/packages/app/src/__tests__/Explorer.test.tsx
+++ b/packages/app/src/__tests__/Explorer.test.tsx
@@ -1,8 +1,8 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { expect, test } from 'vitest';
 
 import { SLOW_TIMEOUT } from '../providers/mock/utils';
-import { renderApp } from '../test-utils';
+import { getExplorerItem, renderApp } from '../test-utils';
 
 test('select root group by default', async () => {
   await renderApp();
@@ -10,7 +10,7 @@ test('select root group by default', async () => {
   const title = screen.getByRole('heading', { name: 'source.h5' });
   expect(title).toBeVisible();
 
-  const fileBtn = screen.getByRole('treeitem', { name: 'source.h5' });
+  const fileBtn = getExplorerItem('source.h5');
   expect(fileBtn).toBeVisible();
   expect(fileBtn).toHaveAttribute('aria-selected', 'true');
 });
@@ -18,7 +18,7 @@ test('select root group by default', async () => {
 test('toggle sidebar', async () => {
   const { user } = await renderApp();
 
-  const fileBtn = screen.getByRole('treeitem', { name: 'source.h5' });
+  const fileBtn = getExplorerItem('source.h5');
   const sidebarBtn = screen.getByRole('button', {
     name: 'Toggle sidebar',
   });
@@ -38,7 +38,7 @@ test('toggle sidebar', async () => {
 test('navigate groups in explorer', async () => {
   const { selectExplorerNode } = await renderApp();
 
-  const groupBtn = screen.getByRole('treeitem', { name: 'entities' });
+  const groupBtn = getExplorerItem('entities');
   expect(groupBtn).toHaveAttribute('aria-selected', 'false');
   expect(groupBtn).toHaveAttribute('aria-expanded', 'false');
 
@@ -47,7 +47,7 @@ test('navigate groups in explorer', async () => {
   expect(groupBtn).toHaveAttribute('aria-selected', 'true');
   expect(groupBtn).toHaveAttribute('aria-expanded', 'true');
 
-  const childGroupBtn = screen.getByRole('treeitem', { name: 'empty_group' });
+  const childGroupBtn = getExplorerItem('empty_group');
   expect(childGroupBtn).toHaveAttribute('aria-selected', 'false');
   expect(childGroupBtn).toHaveAttribute('aria-expanded', 'false');
 
@@ -76,6 +76,122 @@ test('navigate groups in explorer', async () => {
   ).not.toBeInTheDocument();
   expect(groupBtn).toHaveAttribute('aria-selected', 'true');
   expect(groupBtn).toHaveAttribute('aria-expanded', 'false');
+
+  // Reselect root group
+  await selectExplorerNode('source.h5');
+  expect(getExplorerItem('source.h5')).toHaveAttribute('aria-selected', 'true');
+});
+
+test('navigate with arrow keys', async () => {
+  const { user } = await renderApp();
+
+  const rootItem = getExplorerItem('source.h5');
+  expect(rootItem).toHaveFocus();
+
+  // Up/down arrows to move focus
+  await user.keyboard('{ArrowDown}{ArrowDown}');
+  expect(getExplorerItem('nD_datasets')).toHaveFocus();
+
+  await user.keyboard('{ArrowUp}{ArrowUp}');
+  expect(rootItem).toHaveFocus();
+
+  // Arrow right to give focus to first child
+  await user.keyboard('{ArrowRight}');
+  const entitiesItem = getExplorerItem('entities');
+  expect(entitiesItem).toHaveFocus();
+  expect(entitiesItem).toHaveAttribute('aria-expanded', 'false'); // still collapsed
+
+  // Arrow right again to expand group
+  await user.keyboard('{ArrowRight}');
+  expect(entitiesItem).toHaveFocus(); // still focused
+  expect(entitiesItem).toHaveAttribute('aria-expanded', 'true'); // now expanded
+
+  await user.keyboard('{ArrowRight}{ArrowRight}');
+  const emptyGroupItem = getExplorerItem('empty_group');
+  await waitFor(() => {
+    expect(emptyGroupItem).toHaveFocus();
+  });
+  expect(emptyGroupItem).toHaveAttribute('aria-expanded', 'true');
+
+  // Arrow right does nothing when group is empty or focused item is not a group
+  await user.keyboard('{ArrowRight}');
+  expect(emptyGroupItem).toHaveFocus();
+  expect(emptyGroupItem).toHaveAttribute('aria-expanded', 'true');
+
+  await user.keyboard('{ArrowDown}{ArrowRight}');
+  expect(getExplorerItem('empty_dataset')).toHaveFocus();
+
+  // Arrow left to give focus to parent group
+  await user.keyboard('{ArrowLeft}');
+  expect(entitiesItem).toHaveFocus();
+  expect(entitiesItem).toHaveAttribute('aria-expanded', 'true'); // still expanded
+
+  // Arrow left again to collapse group
+  await user.keyboard('{ArrowLeft}');
+  expect(entitiesItem).toHaveFocus();
+  expect(entitiesItem).toHaveAttribute('aria-expanded', 'false');
+
+  // Arrow left again to go give focus back to root group
+  await user.keyboard('{ArrowLeft}');
+  expect(rootItem).toHaveFocus();
+});
+
+test('select explorer items with enter key', async () => {
+  const { user } = await renderApp();
+
+  await user.keyboard('{ArrowDown}');
+  const entitiesItem = getExplorerItem('entities');
+  expect(entitiesItem).toHaveFocus();
+
+  // Enter to select and expand
+  await user.keyboard('{Enter}');
+  expect(entitiesItem).toHaveAttribute('aria-selected', 'true');
+  expect(entitiesItem).toHaveAttribute('aria-expanded', 'true');
+
+  await user.keyboard('{ArrowDown}{ArrowDown}');
+
+  // Enter to select dataset
+  await user.keyboard('{Enter}');
+  await waitFor(() => {
+    expect(getExplorerItem('empty_dataset')).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+  });
+
+  await user.keyboard('{ArrowUp}{ArrowUp}');
+
+  // Enter to re-select expanded group
+  await user.keyboard('{Enter}');
+  expect(entitiesItem).toHaveAttribute('aria-selected', 'true');
+  expect(entitiesItem).toHaveAttribute('aria-expanded', 'true'); // still expanded
+
+  // Enter again to collapse
+  await user.keyboard('{Enter}');
+  expect(entitiesItem).toHaveAttribute('aria-expanded', 'false'); // now collapsed
+});
+
+test('navigate with home and end keys', async () => {
+  const { user } = await renderApp();
+
+  const root = getExplorerItem('source.h5');
+  const lastItem = getExplorerItem('resilience');
+
+  // From root to last item
+  await user.keyboard('{End}');
+  expect(lastItem).toHaveFocus();
+
+  // From last item to root
+  await user.keyboard('{Home}');
+  expect(root).toHaveFocus();
+
+  // From any item to last item
+  await user.keyboard('{ArrowDown}{End}');
+  expect(lastItem).toHaveFocus();
+
+  // From any item to to root
+  await user.keyboard('{ArrowUp}{Home}');
+  expect(root).toHaveFocus();
 });
 
 test('show spinner when group metadata is slow to fetch', async () => {

--- a/packages/app/src/__tests__/Search.test.tsx
+++ b/packages/app/src/__tests__/Search.test.tsx
@@ -1,0 +1,32 @@
+import { screen } from '@testing-library/react';
+import { expect, test } from 'vitest';
+
+import { renderApp } from '../test-utils';
+
+test('search for entities', async () => {
+  const { user } = await renderApp();
+
+  // Select "Search" tab
+  await user.click(screen.getByRole('tab', { name: 'Search' }));
+  expect(screen.queryByRole('treeitem')).toBeNull(); // no results yet
+
+  // Type search text
+  await user.type(screen.getByLabelText('Path to search'), 'empty');
+  expect(screen.getAllByRole('treeitem')).toHaveLength(2); // two results
+
+  // Select a result
+  const itemToSelect = screen.getByRole('treeitem', {
+    name: '/entities/empty_group',
+  });
+  await user.click(itemToSelect);
+  expect(itemToSelect).toHaveAttribute('aria-selected', 'true');
+
+  // Switch back to explorer and make sure result is still selected and visible
+  await user.click(screen.getByRole('tab', { name: 'Explorer' }));
+
+  const selectedItem = await screen.findByRole('treeitem', {
+    name: 'empty_group',
+  });
+  expect(selectedItem).toHaveAttribute('aria-selected', 'true');
+  expect(selectedItem).toBeVisible();
+});

--- a/packages/app/src/explorer/EntityItem.tsx
+++ b/packages/app/src/explorer/EntityItem.tsx
@@ -61,30 +61,30 @@ function EntityItem(props: Props) {
   }, [btnRef, isSelected]);
 
   const handleKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLButtonElement>) => {
-      switch (e.key) {
+    (evt: KeyboardEvent<HTMLButtonElement>) => {
+      switch (evt.key) {
         case 'Home':
-          focusFirst(e);
+          focusFirst(evt);
           return;
 
         case 'End':
-          focusLast(e);
+          focusLast(evt);
           return;
 
         case 'ArrowDown':
-          focusNext(e);
+          focusNext(evt);
           return;
 
         case 'ArrowUp':
-          focusPrevious(e);
+          focusPrevious(evt);
           return;
 
         case 'ArrowLeft':
           if (isGroup(entity) && isExpanded) {
             toggleExpanded(false);
-            e.preventDefault();
+            evt.preventDefault();
           } else {
-            focusParent(e);
+            focusParent(evt);
           }
           return;
 
@@ -93,10 +93,10 @@ function EntityItem(props: Props) {
             return;
           }
           if (isExpanded) {
-            focusNext(e);
+            focusNext(evt, true);
           } else {
             toggleExpanded(true);
-            e.preventDefault();
+            evt.preventDefault();
           }
       }
     },

--- a/packages/app/src/explorer/utils.ts
+++ b/packages/app/src/explorer/utils.ts
@@ -1,4 +1,9 @@
-import { assertStr, isGroup } from '@h5web/shared/guards';
+import {
+  assertDefined,
+  assertNonNull,
+  assertStr,
+  isGroup,
+} from '@h5web/shared/guards';
 import { type ChildEntity } from '@h5web/shared/hdf5-models';
 import { type KeyboardEvent } from 'react';
 
@@ -30,18 +35,19 @@ export function needsNxBadge(
   return false;
 }
 
-function getExplorerButtonList(): HTMLButtonElement[] {
-  const explorer = document.querySelector(`#${EXPLORER_ID}`);
-  return [...(explorer?.querySelectorAll('button') || [])];
+function getButtonList(
+  parent = document.querySelector(`#${EXPLORER_ID}`),
+): HTMLButtonElement[] {
+  assertNonNull(parent);
+  return [...parent.querySelectorAll('button')];
 }
 
-export function focusParent(e: KeyboardEvent<HTMLButtonElement>): void {
-  const activeElement = e.currentTarget;
+export function focusParent(evt: KeyboardEvent<HTMLButtonElement>): void {
+  const activeElement = evt.currentTarget;
   const { path } = activeElement.dataset;
-  if (!path) {
-    return;
-  }
-  const buttonList = getExplorerButtonList();
+  assertDefined(path);
+
+  const buttonList = getButtonList();
   const parentPath = path.slice(0, path.lastIndexOf('/')) || '/';
 
   const parentButton = buttonList.find(
@@ -49,42 +55,46 @@ export function focusParent(e: KeyboardEvent<HTMLButtonElement>): void {
   );
   if (parentButton) {
     parentButton.focus();
-    e.preventDefault();
+    evt.preventDefault();
   }
 }
 
-export function focusNext(e: KeyboardEvent<HTMLButtonElement>): void {
-  const activeElement = e.currentTarget;
-  const buttonList = getExplorerButtonList();
+export function focusNext(
+  evt: KeyboardEvent<HTMLButtonElement>,
+  childOnly = false,
+): void {
+  const activeElement = evt.currentTarget;
+  const parent = childOnly ? activeElement.parentElement : undefined;
+  const buttonList = getButtonList(parent);
   const activeIndex = buttonList.indexOf(activeElement);
 
   if (activeIndex !== -1 && activeIndex < buttonList.length - 1) {
     buttonList[activeIndex + 1].focus();
-    e.preventDefault();
+    evt.preventDefault();
   }
 }
 
-export function focusPrevious(e: KeyboardEvent<HTMLButtonElement>): void {
-  const activeElement = e.currentTarget;
-  const buttonList = getExplorerButtonList();
+export function focusPrevious(evt: KeyboardEvent<HTMLButtonElement>): void {
+  const activeElement = evt.currentTarget;
+  const buttonList = getButtonList();
   const activeIndex = buttonList.indexOf(activeElement);
 
   if (activeIndex > 0) {
     buttonList[activeIndex - 1].focus();
-    e.preventDefault();
+    evt.preventDefault();
   }
 }
 
-export function focusFirst(e: KeyboardEvent<HTMLButtonElement>): void {
-  const buttonList = getExplorerButtonList();
+export function focusFirst(evt: KeyboardEvent<HTMLButtonElement>): void {
+  const buttonList = getButtonList();
 
   buttonList[0]?.focus();
-  e.preventDefault();
+  evt.preventDefault();
 }
 
-export function focusLast(e: KeyboardEvent<HTMLButtonElement>): void {
-  const buttonList = getExplorerButtonList();
+export function focusLast(evt: KeyboardEvent<HTMLButtonElement>): void {
+  const buttonList = getButtonList();
 
   buttonList[buttonList.length - 1]?.focus();
-  e.preventDefault();
+  evt.preventDefault();
 }

--- a/packages/app/src/test-utils.tsx
+++ b/packages/app/src/test-utils.tsx
@@ -98,6 +98,10 @@ export async function waitForAllLoaders(): Promise<void> {
   });
 }
 
+export function getExplorerItem(name: string) {
+  return screen.getByRole('treeitem', { name });
+}
+
 function getVisSelector(): HTMLElement {
   return screen.getByRole('tablist', { name: 'Visualization' });
 }


### PR DESCRIPTION
The search wasn't tested at all, and in the explorer, we weren't testing the keyboard navigation.

Both the `search` and `explorer` folders now have 100% test coverage, which adds two percentage points overall. We're now on **62.66%**.

While testing the keyboard navigation in the explorer, I noticed a subtle bug: when pressing the **right arrow key** on an already expanded **empty group**, the focus would move to the sibling of the group instead of remaining on the group. Below is a screen recording of the bug where I press the right arrow key five times in a row:

[Screencast from 2025-12-22 16-08-08.webm](https://github.com/user-attachments/assets/5de8c424-4a02-4083-9b7c-e53be652f00c)

Now the focus remains on the group — here I press the right arrow key 10 times:

[Screencast from 2025-12-22 16-10-22.webm](https://github.com/user-attachments/assets/e51c9555-0a2b-416f-a553-beb5a77a7be5)


