### PR TITLE
Fix passing custom classname to `Separator`

### DIFF
--- a/packages/app/src/breadcrumbs/BreadcrumbsBar.module.css
+++ b/packages/app/src/breadcrumbs/BreadcrumbsBar.module.css
@@ -8,13 +8,19 @@
   font-size: 0.875rem;
 }
 
+.sep {
+  margin-left: 0.375rem;
+  margin-right: 0.375rem;
+}
+
 .breadCrumbs {
   flex: 1;
   display: flex;
   align-items: center;
   overflow: hidden;
   min-width: 0;
-  margin: 0 0.5rem 0 0;
+  margin: 0;
+  padding: 0 0.5rem;
   font-size: inherit;
   font-weight: inherit;
   line-height: 1.3; /* fix cropping of glyphs */

--- a/packages/app/src/breadcrumbs/BreadcrumbsBar.tsx
+++ b/packages/app/src/breadcrumbs/BreadcrumbsBar.tsx
@@ -49,7 +49,7 @@ function BreadcrumbsBar(props: Props) {
         onToggle={onToggleSidebar}
       />
 
-      <Separator style={{ marginLeft: '0.375rem', marginRight: '0.875rem' }} />
+      <Separator className={styles.sep} />
 
       <Breadcrumbs
         path={path}

--- a/packages/lib/src/toolbar/Separator.tsx
+++ b/packages/lib/src/toolbar/Separator.tsx
@@ -3,7 +3,8 @@ import { type HTMLAttributes } from 'react';
 import styles from './Toolbar.module.css';
 
 function Separator(props: HTMLAttributes<HTMLSpanElement>) {
-  return <span className={styles.sep} {...props} />;
+  const { className, ...otherProps } = props;
+  return <span className={`${styles.sep} ${className}`} {...otherProps} />;
 }
 
 export default Separator;


### PR DESCRIPTION
The custom classname was overriding the default classname.

I also replace some margin with padding in the breadcrumbs bar to avoid hiding a focus outline.