### PR TITLE
Improve feedback when copying path and test breadcrumbs bar

### DIFF
--- a/packages/app/src/__tests__/BreadcrumbsBar.test.tsx
+++ b/packages/app/src/__tests__/BreadcrumbsBar.test.tsx
@@ -1,0 +1,82 @@
+import { screen } from '@testing-library/react';
+import { expect, test, vi } from 'vitest';
+
+import { getExplorerItem, renderApp } from '../test-utils';
+
+test('toggle sidebar', async () => {
+  const { user } = await renderApp();
+
+  // Open by default
+  const toggleBtn = screen.getByRole('button', { name: 'Toggle sidebar' });
+  expect(toggleBtn).toBePressed();
+  expect(getExplorerItem('source.h5')).toBeVisible();
+
+  // Hide
+  await user.click(toggleBtn);
+  expect(toggleBtn).not.toBePressed();
+  expect(screen.queryByRole('treeitem', { name: 'source.h5' })).toBeNull();
+
+  // Show
+  await user.click(toggleBtn);
+  expect(toggleBtn).toBePressed();
+  expect(getExplorerItem('source.h5')).toBeVisible();
+});
+
+test('switch between "display" and "inspect" modes', async () => {
+  const { user } = await renderApp();
+
+  // Switch to "inspect" mode
+  await user.click(screen.getByRole('tab', { name: 'Inspect' }));
+  expect(screen.getByRole('row', { name: /^Path/ })).toBeVisible();
+
+  // Switch back to "display" mode
+  await user.click(screen.getByRole('tab', { name: 'Display' }));
+  expect(screen.queryByRole('row', { name: /^Path/ })).not.toBeInTheDocument();
+});
+
+test('navigate with breadcrumbs', async () => {
+  const { user, selectExplorerNode } = await renderApp();
+  expect(screen.getByRole('heading', { name: 'source.h5' })).toBeVisible();
+
+  // Select group
+  await selectExplorerNode('entities');
+  expect(screen.getByRole('heading', { name: 'entities' })).toBeVisible(); // no root crumb when sidebar is open
+
+  // Select child
+  await selectExplorerNode('empty_dataset');
+  expect(
+    screen.getByRole('heading', { name: 'entities / empty_dataset' }),
+  ).toBeVisible();
+
+  // Hide sidebar to show root crumb
+  const toggleBtn = screen.getByRole('button', { name: 'Toggle sidebar' });
+  await user.click(toggleBtn);
+  expect(
+    screen.getByRole('heading', {
+      name: 'source.h5 / entities / empty_dataset',
+    }),
+  ).toBeVisible();
+
+  // Select parent crumb
+  await user.click(screen.getByRole('button', { name: 'entities' }));
+  expect(
+    screen.getByRole('heading', { name: 'source.h5 / entities' }),
+  ).toBeVisible();
+
+  // Select root crumb
+  await user.click(screen.getByRole('button', { name: 'source.h5' }));
+  expect(screen.getByRole('heading', { name: 'source.h5' })).toBeVisible();
+});
+
+test('copy path to clipboard', async () => {
+  const { user } = await renderApp({ initialPath: '/entities/empty_dataset' });
+
+  const lastCrumb = screen.getByRole('button', {
+    name: 'empty_dataset (copy path)',
+  });
+  expect(lastCrumb).toBeVisible();
+
+  const mock = vi.spyOn(navigator.clipboard, 'writeText');
+  await user.click(lastCrumb);
+  expect(mock).toHaveBeenCalledWith('/entities/empty_dataset');
+});

--- a/packages/app/src/__tests__/MetadataViewer.test.tsx
+++ b/packages/app/src/__tests__/MetadataViewer.test.tsx
@@ -3,18 +3,6 @@ import { expect, test } from 'vitest';
 
 import { renderApp } from '../test-utils';
 
-test('switch between "display" and "inspect" modes', async () => {
-  const { user } = await renderApp();
-
-  // Switch to "inspect" mode
-  await user.click(screen.getByRole('tab', { name: 'Inspect' }));
-  expect(screen.getByRole('row', { name: /^Path/ })).toBeVisible();
-
-  // Switch back to "display" mode
-  await user.click(screen.getByRole('tab', { name: 'Display' }));
-  expect(screen.queryByRole('row', { name: /^Path/ })).not.toBeInTheDocument();
-});
-
 test('inspect group', async () => {
   const { user } = await renderApp('/entities');
   await user.click(screen.getByRole('tab', { name: 'Inspect' }));

--- a/packages/app/src/breadcrumbs/Breadcrumbs.tsx
+++ b/packages/app/src/breadcrumbs/Breadcrumbs.tsx
@@ -27,7 +27,7 @@ function Breadcrumbs(props: Props) {
     );
   }
 
-  // Remove leading /
+  // Remove leading slash
   const crumbs = path.slice(1).split('/');
 
   return (
@@ -43,7 +43,11 @@ function Breadcrumbs(props: Props) {
           />
         );
       })}
-      <CopyableCrumb name={crumbs[crumbs.length - 1]} path={path} />
+      <CopyableCrumb
+        key={path} // reset path copied state
+        name={crumbs[crumbs.length - 1]}
+        path={path}
+      />
     </h1>
   );
 }

--- a/packages/app/src/breadcrumbs/BreadcrumbsBar.module.css
+++ b/packages/app/src/breadcrumbs/BreadcrumbsBar.module.css
@@ -58,7 +58,6 @@
 
 .copyIcon {
   position: absolute;
-  display: none;
   font-size: 0.9rem;
   top: calc(50% - 0.125rem);
   right: 0.875rem;
@@ -66,6 +65,6 @@
   transform: translate(100%, -50%);
 }
 
-.crumbButton:hover > .copyIcon {
-  display: flex;
+.crumbButton:not(:hover, :focus-visible, [data-copied]) > .copyIcon {
+  display: none;
 }

--- a/packages/app/src/breadcrumbs/CopyableCrumb.tsx
+++ b/packages/app/src/breadcrumbs/CopyableCrumb.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useTimeoutEffect, useToggle } from '@react-hookz/web';
 import { FiCheck, FiClipboard } from 'react-icons/fi';
 
 import styles from './BreadcrumbsBar.module.css';
@@ -11,20 +11,23 @@ interface Props {
 function CopyableCrumb(props: Props) {
   const { name, path } = props;
 
-  const [isPathCopied, setPathCopied] = useState(false);
+  const [isPathCopied, togglePathCopied] = useToggle();
   const CopyIcon = isPathCopied ? FiCheck : FiClipboard;
+
+  useTimeoutEffect(togglePathCopied, isPathCopied ? 3000 : undefined);
 
   return (
     <button
       className={styles.crumbButton}
       type="button"
       title="Copy path to clipboard"
+      aria-label={`${name} (copy path)`}
+      data-current
+      data-copied={isPathCopied || undefined}
       onClick={() => {
         void navigator.clipboard.writeText(path);
-        setPathCopied(true);
+        togglePathCopied(true);
       }}
-      onPointerLeave={() => setPathCopied(false)}
-      data-current
     >
       <span className={styles.crumb}>{name}</span>
       <CopyIcon className={styles.copyIcon} />


### PR DESCRIPTION
- Show confirmation icon for 3s after copying path regardless of pointer (and focus) — previously it was shown until the pointer left the crumb
- Add aria label to last crumb to convey that path can be copied
- Show copy icon when last crumb is focused with the keyboard

[Screencast from 2025-12-23 10-43-24.webm](https://github.com/user-attachments/assets/33293e1d-19f5-4717-9855-4bf08038d9cc)

As mentioned, I also test the breadcrumbs bar a little (but I leave out the fullscreen and feedback buttons, which aren't easy to test in JSDOM, at least for now).