### PR TITLE
Increase test coverage of metadata viewer

### DIFF
--- a/packages/app/src/__tests__/MetadataViewer.test.tsx
+++ b/packages/app/src/__tests__/MetadataViewer.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react';
 import { expect, test } from 'vitest';
 
-import { renderApp } from '../test-utils';
+import { mockConsoleMethod, renderApp } from '../test-utils';
 
 test('inspect group', async () => {
   const { user } = await renderApp('/entities');
@@ -12,19 +12,19 @@ test('inspect group', async () => {
   const pathRow = screen.getByRole('row', { name: /^Path/ });
 
   expect(column).toBeVisible();
-  expect(nameRow).toHaveTextContent(/entities/);
-  expect(pathRow).toHaveTextContent(/\/entities/);
+  expect(nameRow).toHaveTextContent(/entities$/);
+  expect(pathRow).toHaveTextContent(/\/entities$/);
 });
 
-test('inspect scalar dataset', async () => {
-  const { user } = await renderApp('/entities/scalar_num');
+test('inspect scalar datasets', async () => {
+  const { user, selectExplorerNode } = await renderApp('/entities/scalar_num');
   await user.click(screen.getByRole('tab', { name: 'Inspect' }));
 
   const column = screen.getByRole('columnheader', { name: /dataset/ });
   const nameRow = screen.getByRole('row', { name: /^Name/ });
   const pathRow = screen.getByRole('row', { name: /^Path/ });
-  const shapeRow = screen.getByRole('row', { name: /^Shape/ });
   const typeRow = screen.getByRole('row', { name: /^Type/ });
+  const shapeRow = screen.getByRole('row', { name: /^Shape/ });
   const attrRow = screen.getByRole('row', { name: /^attr/ });
 
   expect(column).toBeVisible();
@@ -33,6 +33,20 @@ test('inspect scalar dataset', async () => {
   expect(typeRow).toHaveTextContent(/Float, 64-bit, little-endian$/);
   expect(shapeRow).toHaveTextContent(/Scalar$/);
   expect(attrRow).toHaveTextContent(/0$/);
+
+  await selectExplorerNode('scalar_bigint');
+  expect(typeRow).toHaveTextContent(
+    /Integer \(signed\), 64-bit, little-endian$/,
+  );
+  expect(attrRow).toHaveTextContent(/"9007199254740992n"$/);
+
+  await selectExplorerNode('scalar_str');
+  expect(typeRow).toHaveTextContent(/ASCII string, variable length$/);
+  expect(attrRow).toHaveTextContent(/"foo"$/);
+
+  await selectExplorerNode('scalar_cplx');
+  expect(typeRow).toHaveTextContent(/Complex$/);
+  expect(attrRow).toHaveTextContent(/1 \+ 5 i$/);
 });
 
 test('inspect array dataset', async () => {
@@ -40,7 +54,13 @@ test('inspect array dataset', async () => {
   await user.click(screen.getByRole('tab', { name: 'Inspect' }));
 
   const shapeRow = screen.getByRole('row', { name: /^Shape/ });
-  expect(shapeRow).toHaveTextContent(/9 x 20 x 41 = 7380/);
+  expect(shapeRow).toHaveTextContent(/9 x 20 x 41 = 7380$/);
+
+  const chunkRow = screen.getByRole('row', { name: /^Chunk shape/ });
+  expect(chunkRow).toHaveTextContent(/1 x 20 x 41 = 820$/);
+
+  const filterRow = screen.getByRole('row', { name: /^12345/ });
+  expect(filterRow).toHaveTextContent(/Some filter$/);
 });
 
 test('inspect empty dataset', async () => {
@@ -49,48 +69,48 @@ test('inspect empty dataset', async () => {
 
   const shapeRow = screen.getByRole('row', { name: /^Shape/ });
   const typeRow = screen.getByRole('row', { name: /^Type/ });
-  expect(shapeRow).toHaveTextContent(/None/);
-  expect(typeRow).toHaveTextContent(/Unknown/);
+  expect(shapeRow).toHaveTextContent(/None$/);
+  expect(typeRow).toHaveTextContent(/Unknown$/);
 });
 
 test('inspect datatype', async () => {
   const { user } = await renderApp('/entities/datatype');
   await user.click(screen.getByRole('tab', { name: 'Inspect' }));
 
-  const column = screen.getByRole('columnheader', { name: /datatype/ });
+  const column = screen.getByRole('columnheader', { name: 'datatype' });
   const nameRow = screen.getByRole('row', { name: /^Name/ });
   const pathRow = screen.getByRole('row', { name: /^Path/ });
   const typeRow = screen.getByRole('row', { name: /^Type/ });
 
   expect(column).toBeVisible();
-  expect(nameRow).toHaveTextContent(/datatype/);
-  expect(pathRow).toHaveTextContent(/\/entities\/datatype/);
-  expect(typeRow).toHaveTextContent(/Compound/);
+  expect(nameRow).toHaveTextContent(/datatype$/);
+  expect(pathRow).toHaveTextContent(/\/entities\/datatype$/);
+  expect(typeRow).toHaveTextContent(/Compound$/);
 });
 
 test('inspect unresolved soft link', async () => {
   const { user } = await renderApp('/entities/unresolved_soft_link');
   await user.click(screen.getByRole('tab', { name: 'Inspect' }));
 
-  const column = screen.getByRole('columnheader', { name: /Entity/ });
+  const column = screen.getByRole('columnheader', { name: 'Entity' });
   const nameRow = screen.getByRole('row', { name: /^Name/ });
   const pathRow = screen.getByRole('row', { name: /^Path/ });
   const linkRow = screen.getByRole('row', { name: /^Soft link/ });
 
   expect(column).toBeVisible();
-  expect(nameRow).toHaveTextContent(/unresolved_soft_link/);
-  expect(pathRow).toHaveTextContent(/\/entities\/unresolved_soft_link/);
-  expect(linkRow).toHaveTextContent(/\/foo/);
+  expect(nameRow).toHaveTextContent(/unresolved_soft_link$/);
+  expect(pathRow).toHaveTextContent(/\/entities\/unresolved_soft_link$/);
+  expect(linkRow).toHaveTextContent(/\/foo$/);
 });
 
 test('inspect unresolved external link', async () => {
   const { user } = await renderApp('/entities/unresolved_external_link');
   await user.click(screen.getByRole('tab', { name: 'Inspect' }));
 
-  const column = screen.getByRole('columnheader', { name: /Entity/ });
+  const column = screen.getByRole('columnheader', { name: 'Entity' });
   const linkRow = screen.getByRole('row', { name: /^External link/ });
   expect(column).toBeVisible();
-  expect(linkRow).toHaveTextContent(/my_file.h5:entry_000\/dataset/);
+  expect(linkRow).toHaveTextContent(/my_file.h5:entry_000\/dataset$/);
 });
 
 test('follow path attributes', async () => {
@@ -117,4 +137,13 @@ test('follow path attributes', async () => {
   const nxData = screen.getByRole('treeitem', { name: /nx_data/ });
   expect(nxData).toHaveAttribute('aria-selected', 'true');
   expect(nxData).toHaveAttribute('aria-expanded', 'true');
+});
+
+test("show error when attribute values can't be fetched", async () => {
+  const errorSpy = mockConsoleMethod('error');
+  const { user } = await renderApp('/resilience/error_value');
+
+  await user.click(screen.getByRole('tab', { name: 'Inspect' }));
+  expect(screen.getByText('some error')).toBeVisible();
+  errorSpy.mockRestore();
 });

--- a/packages/app/src/providers/mock/mock-api.ts
+++ b/packages/app/src/providers/mock/mock-api.ts
@@ -85,6 +85,10 @@ export class MockApi extends DataProviderApi {
   public override async getAttrValues(
     entity: Entity,
   ): Promise<AttributeValues> {
+    if (entity.name === 'error_value') {
+      throw new Error('some error');
+    }
+
     return Object.fromEntries(
       entity.attributes.map((attr) => {
         assertMockAttribute(attr);

--- a/packages/app/src/providers/mock/mock-file.ts
+++ b/packages/app/src/providers/mock/mock-file.ts
@@ -154,7 +154,10 @@ export function makeMockFile(): GroupWithChildren {
         array('twoD_enum', {
           type: enumType(intType(false, 8), ENUM_MAPPING),
         }),
-        array('threeD'),
+        array('threeD', {
+          chunks: [1, 20, 41],
+          filters: [{ id: 12_345, name: 'Some filter' }],
+        }),
         array('threeD_bool'),
         array('threeD_cplx'),
         withImageAttr(array('threeD_rgb')),
@@ -431,7 +434,7 @@ export function makeMockFile(): GroupWithChildren {
         }),
       ]),
       group('resilience', [
-        scalar('error_value', 0),
+        scalar('error_value', 0, { attributes: [scalarAttr('attr', 1)] }),
         scalar('slow_value', 42),
         array('slow_slicing', { valueId: 'threeD' }),
         group('slow_metadata'),

--- a/packages/app/src/setupTests.ts
+++ b/packages/app/src/setupTests.ts
@@ -7,6 +7,10 @@ import { useState } from 'react';
 import { afterEach, vi } from 'vitest';
 import failOnConsole from 'vitest-fail-on-console';
 
+import { enableBigIntSerialization } from './utils';
+
+enableBigIntSerialization();
+
 globalThis.ResizeObserver = class ResizeObserver {
   public observe() {}
   public unobserve() {}

--- a/packages/shared/src/mock-utils.ts
+++ b/packages/shared/src/mock-utils.ts
@@ -101,6 +101,8 @@ export function withImageAttr<T extends Entity>(entity: T): T {
 
 type EntityOpts = Partial<Pick<Entity, 'attributes' | 'link'>>;
 type GroupOpts = EntityOpts & { isRoot?: boolean; children?: ChildEntity[] };
+type DatasetOpts = EntityOpts &
+  Pick<Dataset, 'chunks' | 'filters' | 'virtualSources'>;
 
 export function group(
   name: string,
@@ -128,9 +130,9 @@ export function dataset<S extends Shape, T extends DType>(
   type: T,
   shape: S,
   value?: unknown,
-  opts: EntityOpts = {},
+  opts: DatasetOpts = {},
 ): MockDataset<S, T> {
-  const { attributes = [], link } = opts;
+  const { attributes = [], link, chunks, filters, virtualSources } = opts;
 
   return {
     name,
@@ -141,23 +143,26 @@ export function dataset<S extends Shape, T extends DType>(
     type,
     value,
     link,
+    chunks,
+    filters,
+    virtualSources,
   };
 }
 
 export function scalar(
   name: string,
   value: unknown,
-  opts: EntityOpts & { type?: DType } = {},
+  opts: DatasetOpts & { type?: DType } = {},
 ): MockDataset<ScalarShape> {
-  const { type, ...entityOpts } = opts;
-  return dataset(name, type || guessType(value), [], value, entityOpts);
+  const { type, ...datasetOpts } = opts;
+  return dataset(name, type || guessType(value), [], value, datasetOpts);
 }
 
 export function array(
   name: string,
-  opts: EntityOpts & { type?: DType; valueId?: MockValueId } = {},
+  opts: DatasetOpts & { type?: DType; valueId?: MockValueId } = {},
 ): MockDataset<ArrayShape> {
-  const { type, valueId = name, ...entityOpts } = opts;
+  const { type, valueId = name, ...datasetOpts } = opts;
   const arr = mockValues[valueId as MockValueId]();
 
   return dataset(
@@ -165,7 +170,7 @@ export function array(
     type || guessType(arr.data[0]),
     arr.shape,
     arr.data,
-    entityOpts,
+    datasetOpts,
   );
 }
 


### PR DESCRIPTION
Test metadata viewer with other dtypes, with chunks and filters, and with an error thrown by the provider's `getAttrValues()` method. This increases test coverage by 1 percentage point to 63%. I'm not trying to cover every logical branch — just the most common ones.