### PR TITLE
Enhance HDF5 errors in `H5WasmApi#getEntity` method

### DIFF
--- a/packages/h5wasm/src/h5wasm-api.ts
+++ b/packages/h5wasm/src/h5wasm-api.ts
@@ -32,7 +32,11 @@ export class H5WasmApi extends DataProviderApi {
   }
 
   public override async getEntity(path: string): Promise<ProvidedEntity> {
-    return this.remote.getEntity(await this.fileId, path);
+    try {
+      return await this.remote.getEntity(await this.fileId, path);
+    } catch (error) {
+      throw getEnhancedError(error);
+    }
   }
 
   public override async getValue(params: ValuesStoreParams): Promise<unknown> {


### PR DESCRIPTION
This file has an invalid external link (as in not properly created) at `/1.1/measurement/pilatus4_4m_lima2`: https://myhdf5.hdfgroup.org/view?url=https%3A%2F%2Fwww.silx.org%2Fpub%2Fh5web%2Finvalid_external_link_syntax.h5

Selecting `/1.1/measurement` leads to an HDF5 library error being thrown in `H5WasmApi#getEntity` that doesn't get properly formatted, for instance in myHDF5:

<img width="1299" height="889" alt="image" src="https://github.com/user-attachments/assets/4fd0aec1-a299-4a74-b974-385119a12448" />

This PR calls `getEnhancedError` like in `H5WasmApi#getValue` to enhance the HDF5 error, which should improve its display in myHDF5 and VS Code, notably (after some additional changes in those projects), to something like this:

<img width="1755" height="789" alt="image" src="https://github.com/user-attachments/assets/b380255c-98fe-4fde-8b82-fbd8ed8a90f9" />
