### PR TITLE
Use `PropsWithChildren` consistently

### DIFF
--- a/apps/storybook/src/Annotation.stories.tsx
+++ b/apps/storybook/src/Annotation.stories.tsx
@@ -151,9 +151,11 @@ export const FollowPointer = {
   },
 } satisfies Story;
 
-function PointerTracker(props: {
+interface PointerTrackerProps {
   children: (x: number, y: number) => ReactNode;
-}) {
+}
+
+function PointerTracker(props: PointerTrackerProps) {
   const { children } = props;
   const [coords, setCoords] = useRafState<[number, number]>();
 

--- a/apps/storybook/src/TiledHeatmapMesh/LinearAxesGroup.tsx
+++ b/apps/storybook/src/TiledHeatmapMesh/LinearAxesGroup.tsx
@@ -1,9 +1,8 @@
 import { useVisCanvasContext } from '@h5web/lib';
+import { type NoProps } from '@h5web/shared/vis-models';
 import { type PropsWithChildren } from 'react';
 
-interface Props {}
-
-function LinearAxesGroup(props: PropsWithChildren<Props>) {
+function LinearAxesGroup(props: PropsWithChildren<NoProps>) {
   const { children } = props;
   const { abscissaConfig, ordinateConfig, visSize } = useVisCanvasContext();
   const { width, height } = visSize;

--- a/apps/storybook/src/TooltipMesh.stories.tsx
+++ b/apps/storybook/src/TooltipMesh.stories.tsx
@@ -20,7 +20,13 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-function TooltipContent(props: { x: number; y: number; text?: string }) {
+interface TooltipContentProps {
+  x: number;
+  y: number;
+  text?: string;
+}
+
+function TooltipContent(props: TooltipContentProps) {
   const { x, y, text } = props;
   return (
     <>

--- a/packages/app/src/VisConfigProvider.tsx
+++ b/packages/app/src/VisConfigProvider.tsx
@@ -1,5 +1,6 @@
 import { isDefined } from '@h5web/shared/guards';
-import { type ReactNode } from 'react';
+import { type NoProps } from '@h5web/shared/vis-models';
+import { type PropsWithChildren } from 'react';
 
 import { CORE_VIS } from './vis-packs/core/visualizations';
 import { type VisDef } from './vis-packs/models';
@@ -15,11 +16,7 @@ const nexusProviders = Object.values<VisDef>(NX_DATA_VIS)
 
 const allConfigProviders = new Set([...coreProviders, ...nexusProviders]);
 
-interface Props {
-  children: ReactNode;
-}
-
-function VisConfigProvider(props: Props) {
+function VisConfigProvider(props: PropsWithChildren<NoProps>) {
   const { children } = props;
 
   return [...allConfigProviders].reduce(

--- a/packages/app/src/dim-mapping-store.tsx
+++ b/packages/app/src/dim-mapping-store.tsx
@@ -1,5 +1,6 @@
 import { type DimensionMapping, initDimMapping } from '@h5web/lib';
 import { type ArrayShape } from '@h5web/shared/hdf5-models';
+import { type NoProps } from '@h5web/shared/vis-models';
 import {
   createContext,
   type PropsWithChildren,
@@ -31,8 +32,7 @@ function createDimMappingStore() {
 
 const StoreContext = createContext({} as StoreApi<DimMappingState>);
 
-interface Props {}
-export function DimMappingProvider(props: PropsWithChildren<Props>) {
+export function DimMappingProvider(props: PropsWithChildren<NoProps>) {
   const { children } = props;
 
   const [store] = useState(createDimMappingStore);

--- a/packages/app/src/vis-packs/VisBoundary.tsx
+++ b/packages/app/src/vis-packs/VisBoundary.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, Suspense } from 'react';
+import { type PropsWithChildren, Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
 import ErrorFallback from '../ErrorFallback';
@@ -9,10 +9,9 @@ import ValueLoader from './ValueLoader';
 interface Props {
   resetKey?: unknown;
   isSlice?: boolean;
-  children: ReactNode;
 }
 
-function VisBoundary(props: Props) {
+function VisBoundary(props: PropsWithChildren<Props>) {
   const { resetKey, isSlice, children } = props;
   const { valuesStore } = useDataContext();
 

--- a/packages/app/src/vis-packs/core/heatmap/config.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/config.tsx
@@ -3,14 +3,19 @@ import { isDefined } from '@h5web/shared/guards';
 import {
   type ColorScaleType,
   ComplexVisType,
+  type NoProps,
   ScaleType,
 } from '@h5web/shared/vis-models';
 import { useMap } from '@react-hookz/web';
-import { createContext, useContext, useState } from 'react';
+import {
+  createContext,
+  type PropsWithChildren,
+  useContext,
+  useState,
+} from 'react';
 import { createStore, type StoreApi, useStore } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-import { type ConfigProviderProps } from '../../models';
 import { type ColorMap } from './models';
 
 export interface HeatmapConfig {
@@ -88,7 +93,7 @@ function createHeatmapConfigStore() {
 
 const StoreContext = createContext({} as StoreApi<HeatmapConfig>);
 
-export function HeatmapConfigProvider(props: ConfigProviderProps) {
+export function HeatmapConfigProvider(props: PropsWithChildren<NoProps>) {
   const { children } = props;
 
   const [store] = useState(createHeatmapConfigStore);

--- a/packages/app/src/vis-packs/core/line/config.tsx
+++ b/packages/app/src/vis-packs/core/line/config.tsx
@@ -4,14 +4,18 @@ import {
   type AxisScaleType,
   type ComplexLineVisType,
   ComplexVisType,
+  type NoProps,
   ScaleType,
 } from '@h5web/shared/vis-models';
 import { useMap } from '@react-hookz/web';
-import { createContext, useContext, useState } from 'react';
+import {
+  createContext,
+  type PropsWithChildren,
+  useContext,
+  useState,
+} from 'react';
 import { createStore, type StoreApi, useStore } from 'zustand';
 import { persist } from 'zustand/middleware';
-
-import { type ConfigProviderProps } from '../../models';
 
 export interface LineConfig {
   customDomain: CustomDomain;
@@ -75,7 +79,7 @@ function createLineConfigStore() {
 
 const StoreContext = createContext({} as StoreApi<LineConfig>);
 
-export function LineConfigProvider(props: ConfigProviderProps) {
+export function LineConfigProvider(props: PropsWithChildren<NoProps>) {
   const { children } = props;
 
   const [store] = useState(createLineConfigStore);

--- a/packages/app/src/vis-packs/core/matrix/config.tsx
+++ b/packages/app/src/vis-packs/core/matrix/config.tsx
@@ -1,9 +1,13 @@
 import { Notation } from '@h5web/lib';
-import { createContext, useContext, useState } from 'react';
+import { type NoProps } from '@h5web/shared/vis-models';
+import {
+  createContext,
+  type PropsWithChildren,
+  useContext,
+  useState,
+} from 'react';
 import { createStore, type StoreApi, useStore } from 'zustand';
 import { persist } from 'zustand/middleware';
-
-import { type ConfigProviderProps } from '../../models';
 
 export interface MatrixVisConfig {
   customCellWidth: number | undefined;
@@ -33,7 +37,7 @@ function createMatrixConfigStore() {
 
 const StoreContext = createContext({} as StoreApi<MatrixVisConfig>);
 
-export function MatrixConfigProvider(props: ConfigProviderProps) {
+export function MatrixConfigProvider(props: PropsWithChildren<NoProps>) {
   const { children } = props;
 
   const [store] = useState(createMatrixConfigStore);

--- a/packages/app/src/vis-packs/core/raw/config.tsx
+++ b/packages/app/src/vis-packs/core/raw/config.tsx
@@ -1,8 +1,12 @@
-import { createContext, useContext, useState } from 'react';
+import { type NoProps } from '@h5web/shared/vis-models';
+import {
+  createContext,
+  type PropsWithChildren,
+  useContext,
+  useState,
+} from 'react';
 import { createStore, type StoreApi, useStore } from 'zustand';
 import { persist } from 'zustand/middleware';
-
-import { type ConfigProviderProps } from '../../models';
 
 export interface RawConfig {
   fitImage: boolean;
@@ -26,7 +30,7 @@ function createRawConfigStore() {
 
 const StoreContext = createContext({} as StoreApi<RawConfig>);
 
-export function RawConfigProvider(props: ConfigProviderProps) {
+export function RawConfigProvider(props: PropsWithChildren<NoProps>) {
   const { children } = props;
 
   const [store] = useState(createRawConfigStore);

--- a/packages/app/src/vis-packs/core/rgb/config.tsx
+++ b/packages/app/src/vis-packs/core/rgb/config.tsx
@@ -1,9 +1,13 @@
 import { ImageType } from '@h5web/lib';
-import { createContext, useContext, useState } from 'react';
+import { type NoProps } from '@h5web/shared/vis-models';
+import {
+  createContext,
+  type PropsWithChildren,
+  useContext,
+  useState,
+} from 'react';
 import { createStore, type StoreApi, useStore } from 'zustand';
 import { persist } from 'zustand/middleware';
-
-import { type ConfigProviderProps } from '../../models';
 
 export interface RgbVisConfig {
   showGrid: boolean;
@@ -54,7 +58,7 @@ function createRgbConfigStore() {
 
 const StoreContext = createContext({} as StoreApi<RgbVisConfig>);
 
-export function RgbConfigProvider(props: ConfigProviderProps) {
+export function RgbConfigProvider(props: PropsWithChildren<NoProps>) {
   const { children } = props;
 
   const [store] = useState(createRgbConfigStore);

--- a/packages/app/src/vis-packs/core/scatter/config.tsx
+++ b/packages/app/src/vis-packs/core/scatter/config.tsx
@@ -3,14 +3,19 @@ import { isDefined } from '@h5web/shared/guards';
 import {
   type AxisScaleType,
   type ColorScaleType,
+  type NoProps,
   ScaleType,
 } from '@h5web/shared/vis-models';
 import { useMap } from '@react-hookz/web';
-import { createContext, useContext, useState } from 'react';
+import {
+  createContext,
+  type PropsWithChildren,
+  useContext,
+  useState,
+} from 'react';
 import { createStore, type StoreApi, useStore } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-import { type ConfigProviderProps } from '../../models';
 import { type ColorMap } from '../heatmap/models';
 
 export interface ScatterConfig {
@@ -70,7 +75,7 @@ function createScatterConfigStore() {
 
 const StoreContext = createContext({} as StoreApi<ScatterConfig>);
 
-export function ScatterConfigProvider(props: ConfigProviderProps) {
+export function ScatterConfigProvider(props: PropsWithChildren<NoProps>) {
   const { children } = props;
 
   const [store] = useState(createScatterConfigStore);

--- a/packages/app/src/vis-packs/core/surface/config.tsx
+++ b/packages/app/src/vis-packs/core/surface/config.tsx
@@ -1,12 +1,20 @@
 import { type CustomDomain } from '@h5web/lib';
 import { isDefined } from '@h5web/shared/guards';
-import { type ColorScaleType, ScaleType } from '@h5web/shared/vis-models';
+import {
+  type ColorScaleType,
+  type NoProps,
+  ScaleType,
+} from '@h5web/shared/vis-models';
 import { useMap } from '@react-hookz/web';
-import { createContext, useContext, useState } from 'react';
+import {
+  createContext,
+  type PropsWithChildren,
+  useContext,
+  useState,
+} from 'react';
 import { createStore, type StoreApi, useStore } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-import { type ConfigProviderProps } from '../../models';
 import { type ColorMap } from '../heatmap/models';
 
 export interface SurfaceConfig {
@@ -50,7 +58,7 @@ function createSurfaceConfigStore() {
 
 const StoreContext = createContext({} as StoreApi<SurfaceConfig>);
 
-export function SurfaceConfigProvider(props: ConfigProviderProps) {
+export function SurfaceConfigProvider(props: PropsWithChildren<NoProps>) {
   const { children } = props;
 
   const [store] = useState(createSurfaceConfigStore);

--- a/packages/app/src/vis-packs/models.ts
+++ b/packages/app/src/vis-packs/models.ts
@@ -1,5 +1,6 @@
 import { type ProvidedEntity } from '@h5web/shared/hdf5-models';
-import { type ElementType, type ReactNode } from 'react';
+import { type NoProps } from '@h5web/shared/vis-models';
+import { type ElementType, type PropsWithChildren } from 'react';
 import { type IconType } from 'react-icons';
 
 export interface VisContainerProps {
@@ -7,13 +8,9 @@ export interface VisContainerProps {
   toolbarContainer: HTMLDivElement | undefined;
 }
 
-export interface ConfigProviderProps {
-  children: ReactNode;
-}
-
 export interface VisDef {
   name: string;
   Icon: IconType;
   Container: ElementType<VisContainerProps>;
-  ConfigProvider?: ElementType<ConfigProviderProps>;
+  ConfigProvider?: ElementType<PropsWithChildren<NoProps>>;
 }

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -99,7 +99,6 @@ export { default as SvgElement } from './interactions/svg/SvgElement';
 export { default as SvgLine } from './interactions/svg/SvgLine';
 export { default as SvgRect } from './interactions/svg/SvgRect';
 export { default as SvgCircle } from './interactions/svg/SvgCircle';
-export type { SvgElementProps } from './interactions/svg/SvgElement';
 export type { SvgLineProps } from './interactions/svg/SvgLine';
 export type { SvgRectProps } from './interactions/svg/SvgRect';
 export type { SvgCircleProps } from './interactions/svg/SvgCircle';

--- a/packages/lib/src/interactions/InteractionsProvider.tsx
+++ b/packages/lib/src/interactions/InteractionsProvider.tsx
@@ -1,7 +1,8 @@
+import { type NoProps } from '@h5web/shared/vis-models';
 import { castArray } from '@h5web/shared/vis-utils';
 import {
   createContext,
-  type ReactNode,
+  type PropsWithChildren,
   useCallback,
   useContext,
   useState,
@@ -26,7 +27,7 @@ export function useInteractionsContext() {
   return useContext(InteractionsContext);
 }
 
-function InteractionsProvider(props: { children: ReactNode }) {
+function InteractionsProvider(props: PropsWithChildren<NoProps>) {
   const { children } = props;
 
   const [interactionMap] = useState(new Map<string, Interaction>());

--- a/packages/lib/src/interactions/svg/SvgElement.tsx
+++ b/packages/lib/src/interactions/svg/SvgElement.tsx
@@ -1,12 +1,11 @@
+import { type NoProps } from '@h5web/shared/vis-models';
 import { type PropsWithChildren } from 'react';
 import { createPortal } from 'react-dom';
 
 import Html from '../../vis/shared/Html';
 import { useVisCanvasContext } from '../../vis/shared/VisCanvasProvider';
 
-interface Props {}
-
-function SvgElement(props: PropsWithChildren<Props>) {
+function SvgElement(props: PropsWithChildren<NoProps>) {
   const { children } = props;
   const { svgOverlay } = useVisCanvasContext();
 
@@ -17,5 +16,4 @@ function SvgElement(props: PropsWithChildren<Props>) {
   return <Html>{createPortal(children, svgOverlay)}</Html>;
 }
 
-export type { Props as SvgElementProps };
 export default SvgElement;

--- a/packages/lib/src/toolbar/OverflowMenu.tsx
+++ b/packages/lib/src/toolbar/OverflowMenu.tsx
@@ -6,6 +6,7 @@ import {
   useFloating,
   useInteractions,
 } from '@floating-ui/react';
+import { type NoProps } from '@h5web/shared/vis-models';
 import { useToggle } from '@react-hookz/web';
 import {
   cloneElement,
@@ -21,9 +22,7 @@ import { POPOVER_CLEARANCE, useFloatingDismiss } from './controls/hooks';
 import styles from './OverflowMenu.module.css';
 import Separator from './Separator';
 
-interface Props {}
-
-function OverflowMenu(props: PropsWithChildren<Props>) {
+function OverflowMenu(props: PropsWithChildren<NoProps>) {
   const { children } = props;
   const validChildren = flattenChildren(children).filter(isValidElement);
 

--- a/packages/lib/src/toolbar/floating/FloatingControl.tsx
+++ b/packages/lib/src/toolbar/floating/FloatingControl.tsx
@@ -1,12 +1,11 @@
+import { type NoProps } from '@h5web/shared/vis-models';
 import { type PropsWithChildren } from 'react';
 import { createPortal } from 'react-dom';
 
 import Html from '../../vis/shared/Html';
 import { useVisCanvasContext } from '../../vis/shared/VisCanvasProvider';
 
-interface Props {}
-
-function FloatingControl(props: PropsWithChildren<Props>) {
+function FloatingControl(props: PropsWithChildren<NoProps>) {
   const { children } = props;
   const { floatingToolbar } = useVisCanvasContext();
 

--- a/packages/lib/src/vis/heatmap/HeatmapVis.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapVis.tsx
@@ -7,7 +7,7 @@ import {
 } from '@h5web/shared/vis-models';
 import { formatTooltipVal, getDims } from '@h5web/shared/vis-utils';
 import { type NdArray } from 'ndarray';
-import { type ReactElement, type ReactNode } from 'react';
+import { type PropsWithChildren, type ReactElement } from 'react';
 import {
   type MagnificationTextureFilter,
   type MinificationTextureFilter,
@@ -51,12 +51,11 @@ interface Props extends ClassStyleAttrs {
   flipXAxis?: boolean;
   flipYAxis?: boolean;
   renderTooltip?: (data: TooltipData) => ReactElement;
-  children?: ReactNode;
   interactions?: DefaultInteractionsConfig;
   ignoreValue?: IgnoreValue;
 }
 
-function HeatmapVis(props: Props) {
+function HeatmapVis(props: PropsWithChildren<Props>) {
   const {
     dataArray,
     domain = DEFAULT_DOMAIN,

--- a/packages/lib/src/vis/line/LineVis.tsx
+++ b/packages/lib/src/vis/line/LineVis.tsx
@@ -8,7 +8,7 @@ import {
 } from '@h5web/shared/vis-models';
 import { formatTooltipErr, formatTooltipVal } from '@h5web/shared/vis-utils';
 import { type NdArray } from 'ndarray';
-import { type ReactElement, type ReactNode, useMemo } from 'react';
+import { type PropsWithChildren, type ReactElement, useMemo } from 'react';
 
 import DefaultInteractions, {
   type DefaultInteractionsConfig,
@@ -43,7 +43,6 @@ interface Props extends ClassStyleAttrs {
   showErrors?: boolean;
   auxiliaries?: AuxiliaryParams[];
   renderTooltip?: (data: TooltipData) => ReactElement;
-  children?: ReactNode;
   interactions?: DefaultInteractionsConfig;
   testid?: string;
   ignoreValue?: IgnoreValue;
@@ -51,7 +50,7 @@ interface Props extends ClassStyleAttrs {
   visible?: boolean;
 }
 
-function LineVis(props: Props) {
+function LineVis(props: PropsWithChildren<Props>) {
   const {
     dataArray,
     domain,

--- a/packages/lib/src/vis/rgb/RgbVis.tsx
+++ b/packages/lib/src/vis/rgb/RgbVis.tsx
@@ -2,7 +2,7 @@ import { assertDefined } from '@h5web/shared/guards';
 import { type NumArray } from '@h5web/shared/vis-models';
 import { getDims } from '@h5web/shared/vis-utils';
 import { type NdArray } from 'ndarray';
-import { type ReactNode, useMemo } from 'react';
+import { type PropsWithChildren, useMemo } from 'react';
 
 import DefaultInteractions, {
   type DefaultInteractionsConfig,
@@ -27,11 +27,10 @@ interface Props extends ClassStyleAttrs {
   ordinateParams?: AxisParams;
   flipXAxis?: boolean;
   flipYAxis?: boolean;
-  children?: ReactNode;
   interactions?: DefaultInteractionsConfig;
 }
 
-function RgbVis(props: Props) {
+function RgbVis(props: PropsWithChildren<Props>) {
   const {
     dataArray,
     aspect = 'equal',

--- a/packages/lib/src/vis/scatter/ScatterVis.tsx
+++ b/packages/lib/src/vis/scatter/ScatterVis.tsx
@@ -9,7 +9,7 @@ import { formatTooltipVal } from '@h5web/shared/vis-utils';
 import { type ThreeEvent } from '@react-three/fiber';
 import { useTooltip } from '@visx/tooltip';
 import { type NdArray } from 'ndarray';
-import { type ReactNode } from 'react';
+import { type PropsWithChildren } from 'react';
 
 import DefaultInteractions, {
   type DefaultInteractionsConfig,
@@ -36,12 +36,11 @@ interface Props extends ClassStyleAttrs {
   showGrid?: boolean;
   title?: string;
   size?: number;
-  children?: ReactNode;
   interactions?: DefaultInteractionsConfig;
   onPointClick?: (index: number, evt: ThreeEvent<MouseEvent>) => void;
 }
 
-function ScatterVis(props: Props) {
+function ScatterVis(props: PropsWithChildren<Props>) {
   const {
     abscissaParams,
     ordinateParams,

--- a/packages/shared/src/vis-models.ts
+++ b/packages/shared/src/vis-models.ts
@@ -7,6 +7,8 @@ import {
 
 import { type DType, type ScalarValue } from './hdf5-models';
 
+export interface NoProps {}
+
 export type NumArray = TypedArray | number[];
 export type AnyNumArray = NdArray<NumArray> | NumArray;
 


### PR DESCRIPTION
We still had a few `children?: ReactNode` lying around. I'm also adding an empty `NoProps` interface in the shared package as, if you recall, `PropsWithChildren` alone or `PropsWithChildren<{}>` actually allows any props to be passed instead of _only_ the `children` prop.