### PR TITLE
Maintain camera zoom when applicable

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,5 +1,6 @@
-import '@h5web/lib'; // make sure lib styles come first in CSS bundle
+import '@h5web/lib'; // eslint-disable-line import/no-duplicates -- make sure lib styles come first in CSS bundle
 
+import { KeepZoomProvider } from '@h5web/lib'; // eslint-disable-line import/no-duplicates
 import { useToggle } from '@react-hookz/web';
 import { Suspense, useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
@@ -85,23 +86,25 @@ function App(props: Props) {
           />
           <VisConfigProvider>
             <DimMappingProvider>
-              <ErrorBoundary
-                resetKeys={[selectedPath, isInspecting]}
-                FallbackComponent={ErrorFallback}
-              >
-                <Suspense
-                  fallback={<EntityLoader isInspecting={isInspecting} />}
+              <KeepZoomProvider>
+                <ErrorBoundary
+                  resetKeys={[selectedPath, isInspecting]}
+                  FallbackComponent={ErrorFallback}
                 >
-                  {isInspecting ? (
-                    <MetadataViewer
-                      path={selectedPath}
-                      onSelectPath={onSelectPath}
-                    />
-                  ) : (
-                    <Visualizer path={selectedPath} />
-                  )}
-                </Suspense>
-              </ErrorBoundary>
+                  <Suspense
+                    fallback={<EntityLoader isInspecting={isInspecting} />}
+                  >
+                    {isInspecting ? (
+                      <MetadataViewer
+                        path={selectedPath}
+                        onSelectPath={onSelectPath}
+                      />
+                    ) : (
+                      <Visualizer path={selectedPath} />
+                    )}
+                  </Suspense>
+                </ErrorBoundary>
+              </KeepZoomProvider>
             </DimMappingProvider>
           </VisConfigProvider>
         </ReflexElement>

--- a/packages/app/src/vis-packs/core/complex/MappedComplexHeatmapVis.tsx
+++ b/packages/app/src/vis-packs/core/complex/MappedComplexHeatmapVis.tsx
@@ -1,6 +1,7 @@
 import {
   type DimensionMapping,
   HeatmapVis,
+  KeepZoom,
   useDomain,
   useSafeDomain,
   useSlicedDimsAndMapping,
@@ -115,7 +116,9 @@ function MappedComplexHeatmapVis(props: Props) {
               }
             : undefined
         }
-      />
+      >
+        <KeepZoom visKey="heatmap" />
+      </HeatmapVis>
     </>
   );
 }

--- a/packages/app/src/vis-packs/core/complex/MappedComplexLineVis.tsx
+++ b/packages/app/src/vis-packs/core/complex/MappedComplexLineVis.tsx
@@ -1,6 +1,7 @@
 import {
   ComplexVisType,
   type DimensionMapping,
+  KeepZoom,
   LineVis,
   useCombinedDomain,
   useDomains,
@@ -140,7 +141,9 @@ function MappedComplexLineVis(props: Props) {
         visible={valueVisible}
         interpolation={interpolation}
         testid={dimMapping.toString()}
-      />
+      >
+        <KeepZoom visKey="line" xOnly />
+      </LineVis>
     </>
   );
 }

--- a/packages/app/src/vis-packs/core/heatmap/MappedHeatmapVis.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/MappedHeatmapVis.tsx
@@ -3,6 +3,7 @@ import {
   getSliceSelection,
   HeatmapVis,
   type IgnoreValue,
+  KeepZoom,
   useDomain,
   useSafeDomain,
   useSlicedDimsAndMapping,
@@ -118,7 +119,9 @@ function MappedHeatmapVis(props: Props) {
         flipXAxis={flipXAxis}
         flipYAxis={flipYAxis}
         ignoreValue={ignoreValue}
-      />
+      >
+        <KeepZoom visKey="heatmap" />
+      </HeatmapVis>
     </>
   );
 }

--- a/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
+++ b/packages/app/src/vis-packs/core/line/MappedLineVis.tsx
@@ -2,6 +2,7 @@ import {
   type DimensionMapping,
   getSliceSelection,
   type IgnoreValue,
+  KeepZoom,
   LineVis,
   useCombinedDomain,
   useDomain,
@@ -191,7 +192,9 @@ function MappedLineVis(props: Props) {
         interpolation={interpolation}
         visible={valueVisible}
         testid={dimMapping.toString()}
-      />
+      >
+        <KeepZoom visKey="line" xOnly />
+      </LineVis>
     </>
   );
 }

--- a/packages/app/src/vis-packs/core/rgb/MappedRgbVis.tsx
+++ b/packages/app/src/vis-packs/core/rgb/MappedRgbVis.tsx
@@ -1,5 +1,6 @@
 import {
   type DimensionMapping,
+  KeepZoom,
   RgbVis,
   useSlicedDimsAndMapping,
 } from '@h5web/lib';
@@ -73,7 +74,9 @@ function MappedRgbVis(props: Props) {
         }}
         flipXAxis={flipXAxis}
         flipYAxis={flipYAxis}
-      />
+      >
+        <KeepZoom visKey="rgb" />
+      </RgbVis>
     </>
   );
 }

--- a/packages/app/src/vis-packs/core/scatter/MappedScatterVis.tsx
+++ b/packages/app/src/vis-packs/core/scatter/MappedScatterVis.tsx
@@ -1,4 +1,10 @@
-import { ScatterVis, useDomain, useSafeDomain, useVisDomain } from '@h5web/lib';
+import {
+  KeepZoom,
+  ScatterVis,
+  useDomain,
+  useSafeDomain,
+  useVisDomain,
+} from '@h5web/lib';
 import { assertDefined } from '@h5web/shared/guards';
 import { type ArrayValue, type NumericType } from '@h5web/shared/hdf5-models';
 import { type AxisMapping } from '@h5web/shared/nexus-models';
@@ -64,7 +70,9 @@ function MappedScatterVis(props: Props) {
         scaleType={scaleType}
         showGrid={showGrid}
         title={title}
-      />
+      >
+        <KeepZoom visKey="scatter" />
+      </ScatterVis>
     </>
   );
 }

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -83,6 +83,8 @@ export { default as AxialSelectToZoom } from './interactions/AxialSelectToZoom';
 export { default as SelectionTool } from './interactions/SelectionTool';
 export { default as AxialSelectionTool } from './interactions/AxialSelectionTool';
 export { default as PreventDefaultContextMenu } from './interactions/PreventDefaultContextMenu';
+export { default as KeepZoom } from './interactions/KeepZoom';
+export { KeepZoomProvider } from './interactions/keep-zoom-store';
 export type { PanProps } from './interactions/Pan';
 export type { ZoomProps } from './interactions/Zoom';
 export type { XAxisZoomProps } from './interactions/XAxisZoom';

--- a/packages/lib/src/interactions/KeepZoom.tsx
+++ b/packages/lib/src/interactions/KeepZoom.tsx
@@ -1,0 +1,62 @@
+import { useDebouncedCallback, useSyncedRef } from '@react-hookz/web';
+import { useFrame, useThree } from '@react-three/fiber';
+import { useLayoutEffect } from 'react';
+import { useStore } from 'zustand';
+
+import { useVisCanvasContext } from '../vis/shared/VisCanvasProvider';
+import { useMoveCameraTo } from './hooks';
+import { useKeepZoomStore } from './keep-zoom-store';
+
+interface Props {
+  visKey: string;
+  xOnly?: boolean;
+}
+
+function KeepZoom(props: Props) {
+  const { visKey, xOnly = false } = props;
+
+  const store = useKeepZoomStore();
+  const setState = useStore(store, (state) => state.setState);
+  const setStateDebounced = useDebouncedCallback(setState, [setState], 100);
+  const unset = useStore(store, (state) => state.unset);
+
+  const camera = useThree((state) => state.camera);
+  const moveCameraToRef = useSyncedRef(useMoveCameraTo());
+
+  const { abscissaConfig, ordinateConfig } = useVisCanvasContext();
+  const visContextKeyRef = useSyncedRef(
+    // When `xOnly` is true, only include abscissa domain in key
+    `${abscissaConfig.visDomain.toString()}${xOnly ? '' : `_${ordinateConfig.visDomain.toString()}`}`,
+  );
+
+  /* Restore camera position and scale on mount if current key matches persisted key from store.
+   * Synced refs are to ensure that the effect runs only on mount and not when the axis domains change. */
+  useLayoutEffect(() => {
+    const state = store.getState().states.get(visKey); // non-reactive state to avoid render loop
+
+    if (state && state.visContextKey === visContextKeyRef.current) {
+      camera.scale.copy(state.scale);
+      moveCameraToRef.current(state.position);
+    }
+  }, [visKey, visContextKeyRef, moveCameraToRef, camera, store]);
+
+  // Save camera position and scale on change
+  useFrame(() => {
+    // With `XOnly`, don't save if user has zoomed on `y` (and unset any previously saved state)
+    if (xOnly && camera.scale.y < 1) {
+      unset(visKey);
+      return;
+    }
+
+    setStateDebounced(
+      visKey,
+      visContextKeyRef.current,
+      camera.position,
+      camera.scale,
+    );
+  });
+
+  return null;
+}
+
+export default KeepZoom;

--- a/packages/lib/src/interactions/keep-zoom-store.tsx
+++ b/packages/lib/src/interactions/keep-zoom-store.tsx
@@ -1,0 +1,64 @@
+import { type NoProps } from '@h5web/shared/vis-models';
+import {
+  createContext,
+  type PropsWithChildren,
+  useContext,
+  useState,
+} from 'react';
+import { type Vector3 } from 'three';
+import { createStore, type StoreApi } from 'zustand';
+
+interface KeepZoomState {
+  states: Map<
+    string,
+    { visContextKey: string | undefined; position: Vector3; scale: Vector3 }
+  >;
+  setState: (
+    visKey: string,
+    visContextKey: string,
+    position: Vector3,
+    scale: Vector3,
+  ) => void;
+  unset: (visKey: string) => void;
+}
+
+function createKeepZoomStore() {
+  return createStore<KeepZoomState>()(
+    (set, get): KeepZoomState => ({
+      states: new Map(),
+
+      setState: (visKey, visContextKey, position, scale) => {
+        const states = new Map(get().states);
+        states.set(visKey, {
+          visContextKey,
+          position: position.clone(),
+          scale: scale.clone(),
+        });
+
+        set({ states });
+      },
+
+      unset: (visKey) => {
+        const states = new Map(get().states);
+        states.delete(visKey);
+        set({ states });
+      },
+    }),
+  );
+}
+
+const StoreContext = createContext({} as StoreApi<KeepZoomState>);
+
+export function KeepZoomProvider(props: PropsWithChildren<NoProps>) {
+  const { children } = props;
+
+  const [store] = useState(createKeepZoomStore);
+
+  return (
+    <StoreContext.Provider value={store}>{children}</StoreContext.Provider>
+  );
+}
+
+export function useKeepZoomStore() {
+  return useContext(StoreContext);
+}

--- a/packages/lib/src/vis/shared/RatioEnforcer.tsx
+++ b/packages/lib/src/vis/shared/RatioEnforcer.tsx
@@ -1,5 +1,5 @@
 import { useThree } from '@react-three/fiber';
-import { useEffect } from 'react';
+import { useLayoutEffect } from 'react';
 
 import { useMoveCameraTo } from '../../interactions/hooks';
 import { useVisCanvasContext } from './VisCanvasProvider';
@@ -9,8 +9,8 @@ function RatioEnforcer() {
   const camera = useThree((state) => state.camera);
   const moveCameraTo = useMoveCameraTo();
 
-  useEffect(() => {
-    if (!visRatio || camera.scale.x === camera.scale.y) {
+  useLayoutEffect(() => {
+    if (visRatio === undefined || camera.scale.x === camera.scale.y) {
       return;
     }
 

--- a/packages/lib/src/vis/tiles/store.ts
+++ b/packages/lib/src/vis/tiles/store.ts
@@ -7,8 +7,5 @@ interface TooltipStore {
 
 export const useTooltipStore = create<TooltipStore>((set) => ({
   val: undefined,
-  setTooltipValue: (x: number, y: number, v: number) =>
-    set(() => ({
-      val: { x, y, v },
-    })),
+  setTooltipValue: (x, y, v) => set(() => ({ val: { x, y, v } })),
 }));


### PR DESCRIPTION
Fix #1572 

Contrary to what I initially suggested in the issue above, I went with a solution that's fully transparent for users. There's no "pin" button; everything is automatic. The solution relies on the axis domains to decide whether to restore the camera scale and position:

- The position and scale of the R3F camera are saved in a zustand store every time the user zooms or pans (with some debouncing), along with a `visContextKey` string computed from the axis domain(s).
- When switching dataset, if the current key and the key saved in the store match, the camera position and scale are restored.

The store can keep the camera states of multiple visualizations at once (cf. `visKey` prop of `KeepZoom`).

[Screencast from 2026-01-14 10-25-19.webm](https://github.com/user-attachments/assets/511297ca-7d12-4907-9dd5-78d8734446d2)

For the Line visualization, the zoom gets saved as long the user zooms only on the `x` axis (cf `xOnly` prop):

[Screencast from 2026-01-14 13-32-56.webm](https://github.com/user-attachments/assets/286fd313-fdcc-4d46-ae1a-f9c880fabc9a)