### PR TITLE
Upgrade h5wasm to fix error with some compression filters

### DIFF
--- a/packages/h5wasm/package.json
+++ b/packages/h5wasm/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "comlink": "4.4.2",
-    "h5wasm": "0.8.10",
+    "h5wasm": "0.8.11",
     "nanoid": "5.1.6"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
         version: 5.1.1(axios@1.13.2)(react@18.3.1)
       h5wasm-plugins:
         specifier: 0.2.1
-        version: 0.2.1(h5wasm@0.8.10)
+        version: 0.2.1(h5wasm@0.8.11)
       normalize.css:
         specifier: 8.0.1
         version: 8.0.1
@@ -333,8 +333,8 @@ importers:
         specifier: 4.4.2
         version: 4.4.2
       h5wasm:
-        specifier: 0.8.10
-        version: 0.8.10
+        specifier: 0.8.11
+        version: 0.8.11
       nanoid:
         specifier: 5.1.6
         version: 5.1.6
@@ -2801,8 +2801,8 @@ packages:
       h5wasm:
         optional: true
 
-  h5wasm@0.8.10:
-    resolution: {integrity: sha512-NBgMgrT3Jtwkg1N9BFo84wKybMSH56NrzwP2tlDeHBSSgCuyTEEfy1iVs+asfDPFBetcJX7NqUX9XeJi1yLgYw==}
+  h5wasm@0.8.11:
+    resolution: {integrity: sha512-oZ/sZA155VVQl6d37Gay6RnjwGTrS63Lm8wZzhrbRdJr0nAswr9KCmu8qSUMlQn1TSOIK1kEBnpmH2XztwFq6w==}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -7095,11 +7095,11 @@ snapshots:
 
   greenlet@1.1.0: {}
 
-  h5wasm-plugins@0.2.1(h5wasm@0.8.10):
+  h5wasm-plugins@0.2.1(h5wasm@0.8.11):
     optionalDependencies:
-      h5wasm: 0.8.10
+      h5wasm: 0.8.11
 
-  h5wasm@0.8.10: {}
+  h5wasm@0.8.11: {}
 
   has-bigints@1.1.0: {}
 


### PR DESCRIPTION
- [Example file](https://h5web.panosc.eu/h5wasm?url=https%3A%2F%2Fwww.silx.org%2Fpub%2Fh5web%2F20250829_113923_frame-altimeter.h5) — select `/height_min_1` dataset => "indirect call to null"
- The same file also causes memory corruption issues in development.
- Bug fix https://github.com/usnistgov/h5wasm/pull/117
- Release: https://github.com/usnistgov/h5wasm/releases/tag/v0.8.11
