### PR TITLE
Add bundle analyser plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist*/
 /cypress/snapshots/**/__received_output__
 
 /coverage/
+/apps/demo/.sonda/
 /packages/app/src/__tests__/__screenshots__/
 /support/h5grove/__pycache__/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,6 +216,10 @@ another React component:
 - `pnpm serve:storybook` - serve the built Storybook at http://localhost:6006
 - `pnpm packages` - build packages (cf. details below)
 
+> Locally, `pnpm build` also generates a bundle analysis report with a tool
+> called [Sonda](https://sonda.dev/). The report opens automatically at the end
+> of the build and is stored under `apps/demo/.sonda`.
+
 ### Package builds
 
 The build process of `@h5web/lib` works as follows:
@@ -263,8 +267,6 @@ other packages can inline them in their own `dist/index.d.ts`.
   projects
 - `pnpm lint:root:tsc` - type-check files at the root of the monorepo
 - `pnpm lint:cypress:tsc` - type-check the `cypress` folder
-- `pnpm --filter @h5web/<lib|app> analyze` - analyze a package's bundle (run
-  only after building the package)
 - `pnpm --filter storybook exec storybook doctor` - diagnose problems with
   Storybook installation
 

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -9,8 +9,7 @@
     "build": "vite build",
     "serve": "vite preview --port 5173",
     "lint:eslint": "eslint --max-warnings=0",
-    "lint:tsc": "tsc",
-    "analyze": "pnpm dlx source-map-explorer dist/assets/*.js --no-border-checks"
+    "lint:tsc": "tsc"
   },
   "dependencies": {
     "@h5web/app": "workspace:*",
@@ -30,6 +29,7 @@
     "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react": "6.0.1",
     "eslint": "9.39.2",
+    "sonda": "0.11.1",
     "typescript": "5.9.3",
     "vite": "8.0.7",
     "vite-css-modules": "1.15.0",

--- a/apps/demo/vite.config.js
+++ b/apps/demo/vite.config.js
@@ -1,4 +1,5 @@
 import react from '@vitejs/plugin-react';
+import sonda from 'sonda/vite';
 import { defineConfig } from 'vite';
 import { patchCssModules } from 'vite-css-modules';
 import { checker } from 'vite-plugin-checker';
@@ -12,6 +13,7 @@ export default defineConfig({
     patchCssModules(),
     { ...eslintPlugin(), apply: 'serve' }, // dev only to reduce build time
     { ...checker({ typescript: true }), apply: 'serve' }, // dev only to reduce build time
+    sonda({ enabled: !process.env.CI }), // disable bundle analysis on build in CI
   ],
 
   // Import HDF5 compression plugins as static assets

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -28,7 +28,6 @@
     "build:dts": "tsc --build tsconfig.build.json && rollup -c",
     "lint:eslint": "eslint --max-warnings=0",
     "lint:tsc": "tsc",
-    "analyze": "pnpm dlx source-map-explorer dist/index.js --no-border-checks",
     "sync-version": "dot-json ../../package.json version | xargs dot-json package.json version"
   },
   "peerDependencies": {

--- a/packages/h5wasm/package.json
+++ b/packages/h5wasm/package.json
@@ -26,7 +26,6 @@
     "build:dts": "tsc --build tsconfig.build.json && rollup -c",
     "lint:eslint": "eslint --max-warnings=0",
     "lint:tsc": "tsc",
-    "analyze": "pnpm dlx source-map-explorer dist/index.js --no-border-checks",
     "sync-version": "dot-json ../../package.json version | xargs dot-json package.json version"
   },
   "peerDependencies": {

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -28,7 +28,6 @@
     "build:dts": "tsc --build tsconfig.build.json && rollup -c",
     "lint:eslint": "eslint --max-warnings=0",
     "lint:tsc": "tsc",
-    "analyze": "pnpm dlx source-map-explorer dist/index.js --no-border-checks",
     "sync-version": "dot-json ../../package.json version | xargs dot-json package.json version"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       eslint:
         specifier: 9.39.2
         version: 9.39.2
+      sonda:
+        specifier: 0.11.1
+        version: 0.11.1
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -3002,6 +3005,10 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-in-ssh@1.0.0:
+    resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
+    engines: {node: '>=20'}
+
   is-inside-container@1.0.0:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
     engines: {node: '>=14.16'}
@@ -3601,6 +3608,10 @@ packages:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
 
+  open@11.0.0:
+    resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
+    engines: {node: '>=20'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -3750,6 +3761,10 @@ packages:
   postcss@8.5.9:
     resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
     engines: {node: ^10 || ^12 || >=14}
+
+  powershell-utils@0.1.0:
+    resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
+    engines: {node: '>=20'}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -4091,6 +4106,11 @@ packages:
   slice-ansi@4.0.0:
     resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
     engines: {node: '>=10'}
+
+  sonda@0.11.1:
+    resolution: {integrity: sha512-WruAwwzdjQ4U2c4dst8EMzFKf0s8EOWrr9ZOUrkjeQdxCjsFFo0/Em49NiLm5Op1yOXGT0VFDMcM4k5kl3wrCA==}
+    engines: {node: '>=20.19 || >=22.12'}
+    hasBin: true
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -4652,6 +4672,10 @@ packages:
   wsl-utils@0.1.0:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
+
+  wsl-utils@0.3.1:
+    resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
+    engines: {node: '>=20'}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -7348,6 +7372,8 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-in-ssh@1.0.0: {}
+
   is-inside-container@1.0.0:
     dependencies:
       is-docker: 3.0.0
@@ -8088,6 +8114,15 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
+  open@11.0.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-in-ssh: 1.0.0
+      is-inside-container: 1.0.0
+      powershell-utils: 0.1.0
+      wsl-utils: 0.3.1
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -8209,6 +8244,8 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  powershell-utils@0.1.0: {}
 
   prelude-ls@1.2.1: {}
 
@@ -8654,6 +8691,11 @@ snapshots:
       ansi-styles: 4.3.0
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
+
+  sonda@0.11.1:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      open: 11.0.0
 
   source-map-js@1.2.1: {}
 
@@ -9231,6 +9273,11 @@ snapshots:
   wsl-utils@0.1.0:
     dependencies:
       is-wsl: 3.1.1
+
+  wsl-utils@0.3.1:
+    dependencies:
+      is-wsl: 3.1.1
+      powershell-utils: 0.1.0
 
   yallist@3.1.1: {}
 


### PR DESCRIPTION
https://sonda.dev/

More up to date and accurate than `source-map-explorer`. I'm only setting it up for the `demo` — it's less relevant for the packages as all the dependencies are kept external.