### PR TITLE
Remove react-measure

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -64,7 +64,6 @@
     "@types/d3-scale": "~4.0.9",
     "@types/d3-scale-chromatic": "~3.1.0",
     "@types/ndarray": "~1.0.14",
-    "@types/react-measure": "~2.0.12",
     "@types/react-slider": "~1.3.6",
     "@visx/axis": "3.12.0",
     "@visx/drag": "3.12.0",
@@ -82,7 +81,6 @@
     "react-icons": "5.4.0",
     "react-is": "^18.3.1",
     "react-keyed-flatten-children": "5.1.1",
-    "react-measure": "2.5.2",
     "react-slider": "2.0.6",
     "react-window": "2.2.3",
     "zustand": "5.0.12"

--- a/packages/lib/src/toolbar/MeasuredControl.tsx
+++ b/packages/lib/src/toolbar/MeasuredControl.tsx
@@ -1,5 +1,5 @@
-import { type ReactElement } from 'react';
-import Measure from 'react-measure';
+import { useMeasure, useSyncedRef } from '@react-hookz/web';
+import { type ReactElement, useLayoutEffect } from 'react';
 
 import styles from './MeasuredControl.module.css';
 
@@ -12,27 +12,26 @@ interface Props {
 function MeasuredControl(props: Props) {
   const { children: child, knownWidth, onMeasure } = props;
 
+  const [size, ref] = useMeasure<HTMLDivElement>();
+
+  const knownWidthRef = useSyncedRef(knownWidth);
+  const onMeasureRef = useSyncedRef(onMeasure);
+
+  useLayoutEffect(() => {
+    if (size && size.width > (knownWidthRef.current || 0)) {
+      onMeasureRef.current(size.width);
+    }
+  }, [size, knownWidthRef, onMeasureRef]);
+
   return (
-    <Measure
-      onResize={({ entry }: { entry?: DOMRect }) => {
-        if (entry && entry.width > (knownWidth || 0)) {
-          onMeasure(entry.width);
-        }
-      }}
+    <div
+      className={styles.controlWrapper}
+      data-measured={knownWidth !== undefined} // hide control until measured for the first time
     >
-      {(
-        { measureRef }, // eslint-disable-line @typescript-eslint/unbound-method
-      ) => (
-        <div
-          className={styles.controlWrapper}
-          data-measured={knownWidth !== undefined} // hide control until measured for the first time
-        >
-          <div ref={measureRef} className={styles.control}>
-            {child}
-          </div>
-        </div>
-      )}
-    </Measure>
+      <div ref={ref} className={styles.control}>
+        {child}
+      </div>
+    </div>
   );
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -411,9 +411,6 @@ importers:
       '@types/ndarray':
         specifier: ~1.0.14
         version: 1.0.14
-      '@types/react-measure':
-        specifier: ~2.0.12
-        version: 2.0.12
       '@types/react-slider':
         specifier: ~1.3.6
         version: 1.3.6
@@ -465,9 +462,6 @@ importers:
       react-keyed-flatten-children:
         specifier: 5.1.1
         version: 5.1.1(react-is@18.3.1)(react@18.3.1)
-      react-measure:
-        specifier: 2.5.2
-        version: 2.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-slider:
         specifier: 2.0.6
         version: 2.0.6(react@18.3.1)
@@ -1551,9 +1545,6 @@ packages:
     resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
     peerDependencies:
       '@types/react': ^18.0.0
-
-  '@types/react-measure@2.0.12':
-    resolution: {integrity: sha512-Y6V11CH6bU7RhqrIdENPwEUZlPXhfXNGylMNnGwq5TAEs2wDoBA3kSVVM/EQ8u72sz5r9ja+7W8M8PIVcS841Q==}
 
   '@types/react-reconciler@0.26.7':
     resolution: {integrity: sha512-mBDYl8x+oyPX/VBb3E638N0B7xG+SPk/EAMcVPeexqus/5aTpTphQi0curhhshOqRrc9t6OPoJfEUkbymse/lQ==}
@@ -2768,9 +2759,6 @@ packages:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
 
-  get-node-dimensions@1.2.1:
-    resolution: {integrity: sha512-2MSPMu7S1iOTL+BOa6K1S62hB2zUAYNF/lV0gSVlOaacd087lc6nR1H1r0e3B1CerTo+RceOmi1iJW+vp21xcQ==}
-
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
@@ -3854,12 +3842,6 @@ packages:
       react: '>=18.0.0'
       react-is: '>=18.0.0'
 
-  react-measure@2.5.2:
-    resolution: {integrity: sha512-M+rpbTLWJ3FD6FXvYV6YEGvQ5tMayQ3fGrZhRPHrE9bVlBYfDCLuDcgNttYfk8IqfOI03jz6cbpqMRTUclQnaA==}
-    peerDependencies:
-      react: '>0.13.0'
-      react-dom: '>0.13.0'
-
   react-reconciler@0.27.0:
     resolution: {integrity: sha512-HmMDKciQjYmBRGuuhIaKA1ba/7a+UsM5FzOZsMO2JYHt9Jh8reCb7j1eDC95NOyUlKM9KRyvdx0flBuDvYSBoA==}
     engines: {node: '>=0.10.0'}
@@ -3953,9 +3935,6 @@ packages:
 
   request-progress@3.0.0:
     resolution: {integrity: sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==}
-
-  resize-observer-polyfill@1.5.1:
-    resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -5600,10 +5579,6 @@ snapshots:
     dependencies:
       '@types/react': 18.3.28
 
-  '@types/react-measure@2.0.12':
-    dependencies:
-      '@types/react': 18.3.28
-
   '@types/react-reconciler@0.26.7':
     dependencies:
       '@types/react': 18.3.28
@@ -7164,8 +7139,6 @@ snapshots:
       hasown: 2.0.2
       math-intrinsics: 1.1.0
 
-  get-node-dimensions@1.2.1: {}
-
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
@@ -8337,15 +8310,6 @@ snapshots:
       react: 18.3.1
       react-is: 18.3.1
 
-  react-measure@2.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@babel/runtime': 7.28.4
-      get-node-dimensions: 1.2.1
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      resize-observer-polyfill: 1.5.1
-
   react-reconciler@0.27.0(react@18.3.1):
     dependencies:
       loose-envify: 1.4.0
@@ -8468,8 +8432,6 @@ snapshots:
   request-progress@3.0.0:
     dependencies:
       throttleit: 1.0.1
-
-  resize-observer-polyfill@1.5.1: {}
 
   resolve-from@4.0.0: {}
 


### PR DESCRIPTION
It was used only in `MeasuredControl` to measure toolbar controls. I replace it with the `useMeasure` hook from `@react-hookz/web`, which is already used in a few places. This removes 10kB from the bundle and one very old library from the project (last updated [6 years ago](https://github.com/souporserious/react-measure)).