### PR TITLE
Fix sidebar disappearing on small screen

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -104,7 +104,7 @@ function App(props: Props) {
 
         <Separator className={styles.splitter} />
 
-        <Panel id={MAIN_AREA_ID} className={styles.mainArea} minSize={500}>
+        <Panel id={MAIN_AREA_ID} className={styles.mainArea}>
           <BreadcrumbsBar
             path={selectedPath}
             isSidebarOpen={isSidebarOpen}


### PR DESCRIPTION
Fix https://github.com/silx-kit/vscode-h5web/issues/77

On small screens, because of the minimum size on the main visualization panel, `react-resizable-panels` would collapse the sidebar and disallow showing it at all.

There's no real need for having that minimum size on the visualization panel. The content of the panel itself has a minimum size which triggers a horizontal scrollbar when needed.