### PR TITLE
Expose createArrayFromView and getAxisOffsets

### DIFF
--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -112,7 +112,7 @@ export type { VisCanvasContextValue } from './vis/shared/VisCanvasProvider';
 export type { InteractionsContextValue } from './interactions/InteractionsProvider';
 
 // Utilities
-export { toTypedNdArray } from '@h5web/shared/vis-utils';
+export { toTypedNdArray, createArrayFromView } from '@h5web/shared/vis-utils';
 
 export {
   getDomain,
@@ -120,6 +120,7 @@ export {
   getCombinedDomain,
   extendDomain,
   getAxisDomain,
+  getAxisOffsets,
   getValueToIndexScale,
   createBufferAttr,
   createIndex,


### PR DESCRIPTION
1. `@h5web/lib` does not handle views of `ndarray` so can end up using the wrong portion of the underlying 1D typed array and passing it to WebGL. Exposing `createArrayFromView` allows devs to handle this case.
2. The space left when displaying images, etc is a problem when a dev wants to pack in several plots close together in an UI. Exposing `getAxisOffsets` allows them to control the aspect ratio and match the length of the scale axes to the image.