### PR TITLE
Add peer dep bounds for react (app) and three (lib)

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -34,8 +34,8 @@
     "@types/react": "18.x",
     "@types/react-dom": "18.x",
     "axios": ">=1",
-    "react": ">=18",
-    "react-dom": ">=18",
+    "react": "18.x",
+    "react-dom": "18.x",
     "typescript": ">=4.5"
   },
   "peerDependenciesMeta": {

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -34,10 +34,10 @@
     "@react-three/fiber": "8.x",
     "@types/react": "18.x",
     "@types/react-dom": "18.x",
-    "@types/three": ">=0.138",
+    "@types/three": ">=0.138 <=0.182",
     "react": "18.x",
     "react-dom": "18.x",
-    "three": ">=0.138",
+    "three": ">=0.138 <=0.182",
     "typescript": ">=4.5"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Fix #2025 

`@react-three/fiber` is already set to `8.x`