### PR TITLE
Plot datasets against their HDF5 dimension scales

### DIFF
--- a/packages/app/src/__tests__/DimensionScales.browser.test.ts
+++ b/packages/app/src/__tests__/DimensionScales.browser.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from 'vitest';
+
+import { getAxis, getDimMappingBtn, renderApp } from '../test-utils';
+
+test('plot 1D dataset against its attached dimension scale', async () => {
+  await renderApp('/dimension_scales/oneD');
+
+  const abscissa = getAxis('abscissa');
+
+  // Label combines the dimension label and the scale's `units` attribute
+  expect(abscissa.getByText('position (nm)')).toBeVisible();
+
+  // Abscissa spans the scale's values (-20 to 20) rather than the indices (0 to 40)
+  expect(abscissa.getByText('−20', { exact: true })).toBeVisible();
+  expect(abscissa.getByText('20', { exact: true })).toBeVisible();
+});
+
+test('fall back to the scale name when the dimension has no label', async () => {
+  await renderApp('/dimension_scales/oneD_named_scale');
+
+  // `abscissa` is the scale's own name; the scale dataset is called `X`
+  expect(getAxis('abscissa').getByText('abscissa (nm)')).toBeVisible();
+});
+
+test('name the dimension even when no scale is attached', async () => {
+  await renderApp('/dimension_scales/oneD_label_only');
+
+  // The label is shown as a hint on the axis mapper button...
+  expect(getDimMappingBtn('x', 0)).toHaveAttribute('title', 'position');
+
+  // ...but with no scale to plot against, the abscissa stays the index axis
+  const abscissa = getAxis('abscissa');
+  expect(abscissa.getByText('40', { exact: true })).toBeVisible(); // last index
+  expect(abscissa.getByText('−20', { exact: true })).not.toBeInTheDocument();
+});
+
+test('skip an unusable scale for a usable one on the same dimension', async () => {
+  await renderApp('/dimension_scales/oneD_multi_scale');
+
+  /* `Y` is attached first but is the wrong length, so `X` is used. Falling back
+   * to indices here would discard a scale the file does provide. */
+  const abscissa = getAxis('abscissa');
+  expect(abscissa.getByText('−20', { exact: true })).toBeVisible(); // an `X` value
+  expect(abscissa.getByText('40', { exact: true })).not.toBeInTheDocument(); // last index
+});
+
+test('plot 2D dataset against the scale attached to its last dimension', async () => {
+  await renderApp('/dimension_scales/twoD');
+
+  const abscissa = getAxis('abscissa');
+  expect(abscissa.getByText('column (nm)')).toBeVisible();
+  expect(abscissa.getByText('−20', { exact: true })).toBeVisible(); // an `X` value
+
+  // The first dimension has neither scale nor label, so it stays unnamed
+  expect(getDimMappingBtn('y', 0)).not.toHaveAttribute('title');
+});
+
+test('plot complex dataset against its attached dimension scale', async () => {
+  await renderApp('/dimension_scales/oneD_complex');
+
+  // Scales reach every core visualization with axes, not just line and heatmap
+  const abscissa = getAxis('abscissa');
+  expect(abscissa.getByText('time (ms)')).toBeVisible();
+  expect(abscissa.getByText('100', { exact: true })).toBeVisible(); // last `T` value
+});

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -81,6 +81,7 @@ export type {
   Attribute,
   Filter,
   VirtualSource,
+  DimensionScales,
 
   // Definition
   DatasetDef,

--- a/packages/app/src/providers/DataProvider.tsx
+++ b/packages/app/src/providers/DataProvider.tsx
@@ -84,6 +84,7 @@ export interface DataContextValue {
   // Undocumented
   getExportURL?: DataProviderApi['getExportURL'];
   getSearchablePaths?: DataProviderApi['getSearchablePaths'];
+  getDimensionScales?: DataProviderApi['getDimensionScales'];
 }
 
 const DataContext = createContext({} as DataContextValue);
@@ -132,6 +133,7 @@ function DataProvider(props: PropsWithChildren<Props>) {
       progressStore,
       getExportURL: api.getExportURL?.bind(api),
       getSearchablePaths: api.getSearchablePaths?.bind(api),
+      getDimensionScales: api.getDimensionScales?.bind(api),
     };
   }, [api, queryClient, progressStore]);
 

--- a/packages/app/src/providers/api.ts
+++ b/packages/app/src/providers/api.ts
@@ -2,6 +2,7 @@ import {
   type ArrayShape,
   type AttributeValues,
   type Dataset,
+  type DimensionScales,
   type Entity,
   type ProvidedEntity,
   type ScalarShape,
@@ -44,4 +45,12 @@ export abstract class DataProviderApi {
   ): ExportURL | undefined;
 
   public getSearchablePaths?(path: string): Promise<string[]>; // optional, so can't be abstract
+
+  /**
+   * Resolve the `DIMENSION_LIST` attribute of a dataset into the scale datasets
+   * attached to each of its dimensions. Providers that can't dereference
+   * `DIMENSION_LIST` should leave this method undefined, in which case datasets
+   * are plotted against their indices as before.
+   */
+  public getDimensionScales?(dataset: Dataset): Promise<DimensionScales>; // optional, so can't be abstract
 }

--- a/packages/app/src/providers/mock/mock-api.ts
+++ b/packages/app/src/providers/mock/mock-api.ts
@@ -7,6 +7,7 @@ import {
   type ArrayShape,
   type AttributeValues,
   type Dataset,
+  type DimensionScales,
   type Entity,
   type GroupWithChildren,
   type ProvidedEntity,
@@ -127,5 +128,12 @@ export class MockApi extends DataProviderApi {
 
   public override async getSearchablePaths(path: string): Promise<string[]> {
     return getChildrenPaths(this.mockFile, path);
+  }
+
+  public override async getDimensionScales(
+    dataset: Dataset,
+  ): Promise<DimensionScales> {
+    assertMockDataset(dataset);
+    return dataset.dimScales || [];
   }
 }

--- a/packages/app/src/providers/mock/mock-file.ts
+++ b/packages/app/src/providers/mock/mock-file.ts
@@ -28,6 +28,7 @@ import {
   scalar,
   scalarAttr,
   unresolved,
+  withDimScales,
   withImageAttr,
   withNxAttr,
 } from '@h5web/shared/mock-utils';
@@ -495,6 +496,43 @@ export function makeMockFile(): GroupWithChildren {
         array('_FillValue (negative)', {
           valueId: 'twoD',
           attributes: [scalar('_FillValue', -9)],
+        }),
+      ]),
+      group('dimension_scales', [
+        array('X', { attributes: [scalarAttr('units', 'nm')] }),
+        array('Y'), // too short to scale a `oneD` or `twoD` dimension
+        withDimScales(array('oneD', { valueId: 'oneD' }), {
+          labels: ['position'],
+          scales: [[{ path: '/dimension_scales/X' }]],
+        }),
+        withDimScales(array('oneD_named_scale', { valueId: 'oneD' }), {
+          // No dimension label, so the name given to `make_scale` is used
+          scales: [[{ path: '/dimension_scales/X', name: 'abscissa' }]],
+        }),
+        withDimScales(array('oneD_label_only', { valueId: 'oneD' }), {
+          labels: ['position'],
+        }),
+        withDimScales(array('oneD_multi_scale', { valueId: 'oneD' }), {
+          labels: ['position'],
+          // `Y` is attached first but is the wrong length, so `X` is used
+          scales: [
+            [{ path: '/dimension_scales/Y' }, { path: '/dimension_scales/X' }],
+          ],
+        }),
+        withDimScales(array('twoD', { valueId: 'twoD' }), {
+          labels: [undefined, 'column'],
+          scales: [[], [{ path: '/dimension_scales/X' }]],
+        }),
+        dataset(
+          'T',
+          arrayShape([10]),
+          floatType(),
+          [10, 20, 30, 40, 50, 60, 70, 80, 90, 100],
+          { attributes: [scalarAttr('units', 'ms')] },
+        ),
+        withDimScales(array('oneD_complex'), {
+          labels: ['time'],
+          scales: [[{ path: '/dimension_scales/T' }]],
         }),
       ]),
       group('resilience', [

--- a/packages/app/src/test-utils.tsx
+++ b/packages/app/src/test-utils.tsx
@@ -141,6 +141,15 @@ export function getDimMappingBtn(axis: 'x' | 'y', dim: number): Locator {
     .getByRole('radio', { name: `D${dim}` });
 }
 
+/* Scope queries to one axis, since the same text may appear elsewhere: the
+ * tooltip echoes the axis label, and `@visx/text` measures strings in a
+ * `<text>` element it appends to `document.body`. */
+export function getAxis(type: 'abscissa' | 'ordinate'): Locator {
+  const axis = document.querySelector(`svg[data-type="${type}"]`);
+  assertNonNull(axis, `Expected ${type} axis`);
+  return page.elementLocator(axis);
+}
+
 /**
  * Mock a console method.
  * Mocks are automatically cleared and restored after every test but you

--- a/packages/app/src/vis-packs/core/complex/ComplexHeatmapVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/complex/ComplexHeatmapVisContainer.tsx
@@ -9,6 +9,7 @@ import {
 import { useDimMappingState } from '../../../dim-mapping-store';
 import { useValuesInCache } from '../../../hooks';
 import visualizerStyles from '../../../visualizer/Visualizer.module.css';
+import { useDimScales } from '../../dimscales/hooks';
 import { type VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
 import { useHeatmapConfig } from '../heatmap/config';
@@ -31,11 +32,16 @@ function ComplexHeatmapVisContainer(props: VisContainerProps) {
   const config = useHeatmapConfig();
   const selection = getSliceSelection(dimMapping);
 
+  const dimScales = useDimScales(entity);
+  const axisLabels = dimScales.map((scale) => scale?.label);
+  const axisValues = dimScales.map((scale) => scale?.value);
+
   return (
     <>
       <DimensionMapper
         className={visualizerStyles.dimMapper}
         dims={dims}
+        dimHints={axisLabels}
         dimMapping={dimMapping}
         canSliceFast={useValuesInCache(entity)}
         onChange={setDimMapping}
@@ -49,6 +55,8 @@ function ComplexHeatmapVisContainer(props: VisContainerProps) {
               value={value}
               dims={dims}
               dimMapping={dimMapping}
+              axisLabels={axisLabels}
+              axisValues={axisValues}
               title={entity.name}
               toolbarContainer={toolbarContainer}
               config={config}

--- a/packages/app/src/vis-packs/core/complex/ComplexLineVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/complex/ComplexLineVisContainer.tsx
@@ -8,6 +8,7 @@ import {
 import { useDimMappingState } from '../../../dim-mapping-store';
 import { useValuesInCache } from '../../../hooks';
 import visualizerStyles from '../../../visualizer/Visualizer.module.css';
+import { useDimScales } from '../../dimscales/hooks';
 import { type VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
 import { useLineConfig } from '../line/config';
@@ -29,11 +30,16 @@ function ComplexLineVisContainer(props: VisContainerProps) {
   const config = useLineConfig();
   const selection = getSliceSelection(dimMapping);
 
+  const dimScales = useDimScales(entity);
+  const axisLabels = dimScales.map((scale) => scale?.label);
+  const axisValues = dimScales.map((scale) => scale?.value);
+
   return (
     <>
       <DimensionMapper
         className={visualizerStyles.dimMapper}
         dims={dims}
+        dimHints={axisLabels}
         dimMapping={dimMapping}
         canSliceFast={useValuesInCache(entity)}
         onChange={setDimMapping}
@@ -47,6 +53,8 @@ function ComplexLineVisContainer(props: VisContainerProps) {
               value={value}
               dims={dims}
               dimMapping={dimMapping}
+              axisLabels={axisLabels}
+              axisValues={axisValues}
               title={entity.name}
               toolbarContainer={toolbarContainer}
               config={config}

--- a/packages/app/src/vis-packs/core/heatmap/HeatmapVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/heatmap/HeatmapVisContainer.tsx
@@ -9,6 +9,7 @@ import {
 import { useDimMappingState } from '../../../dim-mapping-store';
 import { useValuesInCache } from '../../../hooks';
 import visualizerStyles from '../../../visualizer/Visualizer.module.css';
+import { useDimScales } from '../../dimscales/hooks';
 import { type VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
 import ValueFetcher from '../ValueFetcher';
@@ -31,11 +32,16 @@ function HeatmapVisContainer(props: VisContainerProps) {
   const config = useHeatmapConfig();
   const selection = getSliceSelection(dimMapping);
 
+  const dimScales = useDimScales(entity);
+  const axisLabels = dimScales.map((scale) => scale?.label);
+  const axisValues = dimScales.map((scale) => scale?.value);
+
   return (
     <>
       <DimensionMapper
         className={visualizerStyles.dimMapper}
         dims={dims}
+        dimHints={axisLabels}
         dimMapping={dimMapping}
         canSliceFast={useValuesInCache(entity)}
         onChange={setDimMapping}
@@ -49,6 +55,8 @@ function HeatmapVisContainer(props: VisContainerProps) {
               dataset={entity}
               value={value}
               dimMapping={dimMapping}
+              axisLabels={axisLabels}
+              axisValues={axisValues}
               title={entity.name}
               toolbarContainer={toolbarContainer}
               config={config}

--- a/packages/app/src/vis-packs/core/line/LineVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/line/LineVisContainer.tsx
@@ -8,6 +8,7 @@ import {
 import { useDimMappingState } from '../../../dim-mapping-store';
 import { useValuesInCache } from '../../../hooks';
 import visualizerStyles from '../../../visualizer/Visualizer.module.css';
+import { useDimScales } from '../../dimscales/hooks';
 import { type VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
 import ValueFetcher from '../ValueFetcher';
@@ -29,11 +30,16 @@ function LineVisContainer(props: VisContainerProps) {
   const config = useLineConfig();
   const selection = getSliceSelection(dimMapping);
 
+  const dimScales = useDimScales(entity);
+  const axisLabels = dimScales.map((scale) => scale?.label);
+  const axisValues = dimScales.map((scale) => scale?.value);
+
   return (
     <>
       <DimensionMapper
         className={visualizerStyles.dimMapper}
         dims={dims}
+        dimHints={axisLabels}
         dimMapping={dimMapping}
         canSliceFast={useValuesInCache(entity)}
         onChange={setDimMapping}
@@ -47,6 +53,8 @@ function LineVisContainer(props: VisContainerProps) {
               dataset={entity}
               value={value}
               dimMapping={dimMapping}
+              axisLabels={axisLabels}
+              axisValues={axisValues}
               title={entity.name}
               toolbarContainer={toolbarContainer}
               config={config}

--- a/packages/app/src/vis-packs/core/rgb/RgbVisContainer.tsx
+++ b/packages/app/src/vis-packs/core/rgb/RgbVisContainer.tsx
@@ -10,6 +10,7 @@ import { useDimMappingState } from '../../../dim-mapping-store';
 import { useAttrValue, useValuesInCache } from '../../../hooks';
 import { findScalarStrAttr } from '../../../utils';
 import visualizerStyles from '../../../visualizer/Visualizer.module.css';
+import { useDimScales } from '../../dimscales/hooks';
 import { type VisContainerProps } from '../../models';
 import VisBoundary from '../../VisBoundary';
 import ValueFetcher from '../ValueFetcher';
@@ -39,11 +40,16 @@ function RgbVisContainer(props: VisContainerProps) {
   const config = useRgbConfig();
   const selection = getSliceSelection(dimMapping);
 
+  const dimScales = useDimScales(entity);
+  const axisLabels = dimScales.map((scale) => scale?.label);
+  const axisValues = dimScales.map((scale) => scale?.value);
+
   return (
     <>
       <DimensionMapper
         className={visualizerStyles.dimMapper}
         dims={dims}
+        dimHints={axisLabels}
         dimMapping={dimMapping}
         canSliceFast={useValuesInCache(entity)}
         onChange={setDimMapping}
@@ -57,6 +63,8 @@ function RgbVisContainer(props: VisContainerProps) {
               dataset={entity}
               value={value}
               dimMapping={dimMapping}
+              axisLabels={axisLabels}
+              axisValues={axisValues}
               title={entity.name}
               toolbarContainer={toolbarContainer}
               config={config}

--- a/packages/app/src/vis-packs/dimscales/hooks.ts
+++ b/packages/app/src/vis-packs/dimscales/hooks.ts
@@ -1,0 +1,21 @@
+import { type ArrayShape, type Dataset } from '@h5web/shared/hdf5-models';
+import { type AxisMapping } from '@h5web/shared/nexus-models';
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import { useDataContext } from '../../providers/DataProvider';
+import { type DimScale, getDimScales } from './utils';
+
+/* Resolve the HDF5 dimension scales attached to a dataset's dimensions into an
+ * axis label and, where a usable scale is attached, the values to plot against.
+ * NeXus metadata takes precedence, so this is used by the core vis pack only.
+ * See https://support.hdfgroup.org/documentation/hdf5/latest/_h5_d_s__u_g.html */
+export function useDimScales(
+  dataset: Dataset<ArrayShape>,
+): AxisMapping<DimScale> {
+  const dataContext = useDataContext();
+
+  return useSuspenseQuery({
+    queryKey: [dataContext.filepath, 'dimScales', dataset.path],
+    queryFn: async () => getDimScales(dataset, dataContext),
+  }).data;
+}

--- a/packages/app/src/vis-packs/dimscales/utils.test.ts
+++ b/packages/app/src/vis-packs/dimscales/utils.test.ts
@@ -1,0 +1,36 @@
+import { arrayShape, floatType, strType } from '@h5web/shared/hdf5-utils';
+import { dataset, group } from '@h5web/shared/mock-utils';
+import { describe, expect, it } from 'vitest';
+
+import { isUsableScale } from './utils';
+
+function scaleOfShape(dims: number[]) {
+  return dataset('scale', arrayShape(dims), floatType());
+}
+
+describe('isUsableScale', () => {
+  it('should accept a 1D numeric dataset matching the dimension', () => {
+    expect(isUsableScale(scaleOfShape([10]), 10)).toBe(true);
+  });
+
+  it('should reject an entity that could not be resolved', () => {
+    expect(isUsableScale(undefined, 10)).toBe(false);
+  });
+
+  it('should reject an entity that is not a dataset', () => {
+    expect(isUsableScale(group('scale'), 10)).toBe(false);
+  });
+
+  it('should reject a non-numeric scale', () => {
+    // A string scale is legal HDF5 but cannot be plotted as an axis
+    expect(isUsableScale(dataset('s', arrayShape([10]), strType()), 10)).toBe(
+      false,
+    );
+  });
+
+  it('should reject a scale that would misalign the data', () => {
+    expect(isUsableScale(scaleOfShape([9]), 10)).toBe(false);
+    expect(isUsableScale(scaleOfShape([11]), 10)).toBe(false);
+    expect(isUsableScale(scaleOfShape([10, 2]), 10)).toBe(false);
+  });
+});

--- a/packages/app/src/vis-packs/dimscales/utils.ts
+++ b/packages/app/src/vis-packs/dimscales/utils.ts
@@ -1,0 +1,147 @@
+import {
+  assertValue,
+  hasArrayShape,
+  hasNumericType,
+  hasStringType,
+  isDataset,
+  isDefined,
+} from '@h5web/shared/guards';
+import {
+  type ArrayShape,
+  type ArrayValue,
+  type Dataset,
+  type DimensionScales,
+  type Entity,
+  type NumericType,
+} from '@h5web/shared/hdf5-models';
+import { type AxisMapping } from '@h5web/shared/nexus-models';
+
+import { type DataContextValue } from '../../providers/DataProvider';
+import {
+  findAttribute,
+  findScalarStrAttr,
+  getAttributeValue,
+} from '../../utils';
+
+export interface DimScale {
+  label?: string;
+  value?: ArrayValue<NumericType>; // undefined if the dimension is labelled but has no usable scale
+}
+
+interface UsableScale {
+  dataset: Dataset<ArrayShape, NumericType>;
+  name?: string; // name given to `make_scale`, if any
+}
+
+export async function getDimScales(
+  dataset: Dataset<ArrayShape>,
+  dataContext: DataContextValue,
+): Promise<AxisMapping<DimScale>> {
+  const { queryClient, queries } = dataContext;
+  const { dims } = dataset.shape;
+
+  const labels = await getDimLabels(dataset, dataContext);
+  const scales = await getAttachedScales(dataset, dataContext);
+
+  return Promise.all(
+    dims.map(async (dimSize, index) => {
+      const label = labels[index];
+      const scale = await findUsableScale(
+        scales[index] || [],
+        dimSize,
+        dataContext,
+      );
+
+      if (!scale) {
+        // A label names the dimension even when no scale is attached
+        return label ? { label } : undefined;
+      }
+
+      const unit = await getAttributeValue(
+        scale.dataset,
+        findScalarStrAttr(scale.dataset, 'units'),
+        dataContext,
+      );
+
+      // The dimension label wins over the scale's own name, as for NeXus `long_name`
+      const base = label || scale.name || scale.dataset.name;
+      const value = await queryClient.query(queries.value(scale.dataset));
+      assertValue(value, scale.dataset);
+
+      return { label: unit ? `${base} (${unit})` : base, value };
+    }),
+  );
+}
+
+export function isUsableScale(
+  entity: Entity | undefined,
+  dimSize: number,
+): entity is Dataset<ArrayShape, NumericType> {
+  return (
+    !!entity &&
+    isDataset(entity) &&
+    hasArrayShape(entity) &&
+    hasNumericType(entity) &&
+    entity.shape.dims.length === 1 &&
+    entity.shape.dims[0] === dimSize
+  );
+}
+
+async function getAttachedScales(
+  dataset: Dataset<ArrayShape>,
+  dataContext: DataContextValue,
+): Promise<DimensionScales> {
+  try {
+    return (await dataContext.getDimensionScales?.(dataset)) || [];
+  } catch {
+    /* Plotting against indices is the documented fallback, so a provider that
+     * can't dereference `DIMENSION_LIST` leaves the dataset viewable as before. */
+    return [];
+  }
+}
+
+/* HDF5 allows several scales per dimension, but H5Web can plot only one, so the
+ * first usable scale wins: a dimension carrying N+1 bin boundaries next to N
+ * bin centres still gets an axis. The spec allows a scale of "any rank and
+ * shape" and leaves it "up to the application to interpret or resolve the
+ * difference", so an unusable scale falls back to the index axis rather than
+ * erroring. */
+async function findUsableScale(
+  scales: DimensionScales[number],
+  dimSize: number,
+  dataContext: DataContextValue,
+): Promise<UsableScale | undefined> {
+  const { queryClient, queries } = dataContext;
+
+  const candidates = await Promise.all(
+    scales.map<Promise<UsableScale | undefined>>(async ({ path, name }) => {
+      try {
+        const entity = await queryClient.query(queries.entity(path));
+        return isUsableScale(entity, dimSize)
+          ? { dataset: entity, name }
+          : undefined;
+      } catch {
+        return undefined; // reference to an unlinked object, say
+      }
+    }),
+  );
+
+  return candidates.find(isDefined);
+}
+
+/* `DIMENSION_LABELS` is a plain attribute, so a dimension can be named even when
+ * no scale is attached. HDF5 writes an empty string for unlabelled dimensions,
+ * and may write fewer labels than the dataset has dimensions. */
+async function getDimLabels(
+  dataset: Dataset<ArrayShape>,
+  dataContext: DataContextValue,
+): Promise<AxisMapping<string>> {
+  const attr = findAttribute(dataset, 'DIMENSION_LABELS');
+
+  const labels =
+    attr && hasArrayShape(attr) && hasStringType(attr)
+      ? await getAttributeValue(dataset, attr, dataContext)
+      : [];
+
+  return dataset.shape.dims.map((_, index) => labels[index] || undefined);
+}

--- a/packages/h5wasm/src/h5wasm-api.ts
+++ b/packages/h5wasm/src/h5wasm-api.ts
@@ -4,6 +4,7 @@ import {
   type ArrayShape,
   type AttributeValues,
   type Dataset,
+  type DimensionScales,
   type Entity,
   type ProvidedEntity,
   type ScalarShape,
@@ -97,6 +98,18 @@ export class H5WasmApi extends DataProviderApi {
   public override async getSearchablePaths(root: string): Promise<string[]> {
     const fileId = await this.fileId;
     return this.remote.getDescendantPaths(fileId, root);
+  }
+
+  public override async getDimensionScales(
+    dataset: Dataset,
+  ): Promise<DimensionScales> {
+    const fileId = await this.fileId;
+
+    try {
+      return await this.remote.getDimensionScales(fileId, dataset.path);
+    } catch (error) {
+      throw getEnhancedError(error);
+    }
   }
 
   public async cleanUp(): Promise<number> {

--- a/packages/h5wasm/src/worker.ts
+++ b/packages/h5wasm/src/worker.ts
@@ -1,5 +1,8 @@
 import { isTypedArray } from '@h5web/shared/guards';
-import { type ProvidedEntity } from '@h5web/shared/hdf5-models';
+import {
+  type DimensionScales,
+  type ProvidedEntity,
+} from '@h5web/shared/hdf5-models';
 import { expose, transfer } from 'comlink';
 import { Attribute, Dataset, File as H5WasmFile } from 'h5wasm';
 
@@ -72,6 +75,29 @@ async function getAttrValue(
   return new Attribute(fileId, path, attrName).json_value;
 }
 
+/* h5wasm dereferences the object references in `DIMENSION_LIST` for us; the raw
+ * attribute value is not usable directly. Dimension names come from
+ * `DIMENSION_LABELS`, a plain attribute the app reads itself. */
+async function getDimensionScales(
+  fileId: bigint,
+  path: string,
+): Promise<DimensionScales> {
+  const dataset = new Dataset(fileId, path);
+
+  return (dataset.shape || []).map((_, index) => {
+    try {
+      return dataset.get_attached_scales(index).map((scalePath) => ({
+        path: scalePath,
+        // h5wasm returns an empty name for a scale created without one
+        name: new Dataset(fileId, scalePath).get_scale_name() || undefined,
+      }));
+    } catch {
+      // Reference to an unlinked object, say; the app falls back to the index axis
+      return [];
+    }
+  });
+}
+
 async function getDescendantPaths(
   fileId: bigint,
   rootPath: string,
@@ -103,6 +129,7 @@ const api = {
   getEntity,
   getValue,
   getAttrValue,
+  getDimensionScales,
   getDescendantPaths,
   isPluginLoaded,
   loadPlugin,

--- a/packages/shared/src/hdf5-models.ts
+++ b/packages/shared/src/hdf5-models.ts
@@ -87,6 +87,13 @@ export interface VirtualSource {
   path: string;
 }
 
+/* Scale datasets attached to each of a dataset's dimensions, as recorded in its
+ * `DIMENSION_LIST` attribute. `path` is one of possibly several valid paths to
+ * the scale, since an object reference doesn't identify a single path; `name`
+ * is the name passed to `make_scale`, if any.
+ * https://support.hdfgroup.org/documentation/hdf5/latest/_h5_d_s__u_g.html */
+export type DimensionScales = { path: string; name?: string }[][];
+
 /* --------------------- */
 /* ---- DEFINITIONS ---- */
 

--- a/packages/shared/src/mock-models.ts
+++ b/packages/shared/src/mock-models.ts
@@ -1,6 +1,7 @@
 import {
   type Attribute,
   type Dataset,
+  type DimensionScales,
   type DType,
   type Shape,
 } from './hdf5-models';
@@ -11,6 +12,7 @@ export interface MockDataset<
   T extends DType = DType,
 > extends Dataset<S, T> {
   value: unknown;
+  dimScales?: DimensionScales; // stands in for `DIMENSION_LIST`, whose object references a mock entity can't represent
 }
 
 export interface MockAttribute<

--- a/packages/shared/src/mock-utils.ts
+++ b/packages/shared/src/mock-utils.ts
@@ -5,6 +5,7 @@ import {
   type ChildEntity,
   type Dataset,
   type Datatype,
+  type DimensionScales,
   type DType,
   type Entity,
   EntityKind,
@@ -305,6 +306,34 @@ export function withNxAttr<T extends MockDataset<ArrayShape>>(
     ...(longName ? [scalarAttr('long_name', longName)] : []),
     ...(units ? [scalarAttr('units', units)] : []),
   ]);
+}
+
+/* ---------------------------- */
+/* ----- DIMENSION SCALES ----- */
+
+/* Attach HDF5 dimension scales to a mock dataset, as `make_scale` and
+ * `attach_scale` would: `labels` becomes a real `DIMENSION_LABELS` attribute,
+ * while `scales` stands in for the `DIMENSION_LIST` object references and is
+ * served by `MockApi#getDimensionScales`. */
+export function withDimScales<T extends MockDataset<ArrayShape>>(
+  dat: T,
+  dimScales: {
+    labels?: (string | undefined)[];
+    scales?: DimensionScales;
+  },
+): T {
+  const { labels, scales } = dimScales;
+
+  const withLabels = labels
+    ? withAttr(dat, [
+        arrayAttr(
+          'DIMENSION_LABELS',
+          dat.shape.dims.map((_, index) => labels[index] || ''),
+        ),
+      ])
+    : dat;
+
+  return { ...withLabels, dimScales: scales };
 }
 
 /* ------------------------ */


### PR DESCRIPTION
H5Web derives plot axes from NeXus metadata only, so a file that labels its
axes the native HDF5 way -- `make_scale` plus `attach_scale` -- is plotted
against the sample index. A non-uniform abscissa can't be recovered from
indices, so such plots are wrong in shape, not merely unlabelled; today the
only workaround is to duplicate the data into hand-written `NXdata` groups.

Scales are resolved behind a new optional `getDimensionScales` on
`DataProviderApi`, implemented here for h5wasm, which can lean on libhdf5 to
dereference `DIMENSION_LIST`. Providers that leave it undefined keep plotting
against indices, as does any dimension whose scale is missing, non-numeric or
the wrong length -- the spec leaves that mismatch to the application.

Towards silx-kit#1313.