### PR TITLE
Read datasets stored as the native HDF5 complex datatype

### DIFF
--- a/packages/h5wasm/src/worker-utils.test.ts
+++ b/packages/h5wasm/src/worker-utils.test.ts
@@ -1,0 +1,100 @@
+import { H5T_CLASS, H5T_ORDER } from '@h5web/shared/h5t';
+import { cplxType, floatType } from '@h5web/shared/hdf5-utils';
+import { type Metadata } from 'h5wasm';
+import { describe, expect, it } from 'vitest';
+
+import {
+  pairComplexComponents,
+  parseComplexValue,
+  parseDType,
+} from './worker-utils';
+
+/* h5wasm's `Metadata` is a wide interface; only the fields read by `parseDType`
+ * matter here, so build minimal objects and cast. */
+function meta(fields: Partial<Metadata>): Metadata {
+  return fields as unknown as Metadata;
+}
+
+function complexMeta(size: number, littleEndian = true): Metadata {
+  return meta({ type: H5T_CLASS.COMPLEX, size, littleEndian });
+}
+
+describe('parseDType', () => {
+  /* An `H5T_COMPLEX` carries no metadata describing its base float: both
+   * components are the same type, so each is half the itemsize. */
+  it('should derive the component type from half the itemsize', () => {
+    expect(parseDType(complexMeta(16))).toStrictEqual(
+      cplxType(floatType(64, H5T_ORDER.LE)),
+    );
+    expect(parseDType(complexMeta(8))).toStrictEqual(
+      cplxType(floatType(32, H5T_ORDER.LE)),
+    );
+  });
+
+  it('should carry the byte order over to the components', () => {
+    expect(parseDType(complexMeta(16, false))).toStrictEqual(
+      cplxType(floatType(64, H5T_ORDER.BE)),
+    );
+  });
+});
+
+describe('pairComplexComponents', () => {
+  it('should pair interleaved components', () => {
+    expect(pairComplexComponents([1, 2, 3, -4])).toStrictEqual([
+      [1, 2],
+      [3, -4],
+    ]);
+  });
+
+  it('should handle an empty array', () => {
+    expect(pairComplexComponents([])).toStrictEqual([]);
+  });
+
+  it('should reject an odd number of components', () => {
+    // Half a complex number cannot be salvaged, so the caller keeps the raw value
+    expect(pairComplexComponents([1, 2, 3])).toBeUndefined();
+  });
+
+  it('should preserve component precision from a typed array', () => {
+    // `Float32Array` rounds 0.1, and the pair must carry that same rounding
+    const components = new Float32Array([0.1, 0.2]);
+
+    expect(pairComplexComponents(components)).toStrictEqual([
+      [components[0], components[1]],
+    ]);
+  });
+
+  /* Property: pairing is a pure regrouping - it preserves order and total
+   * component count, and flattening the result recovers the input exactly. */
+  it('should be a lossless regrouping for any even length', () => {
+    for (let count = 0; count <= 8; count += 2) {
+      const components = Array.from({ length: count }, (_, i) => i * 1.5 - 3);
+      const pairs = pairComplexComponents(components);
+
+      expect(pairs).toHaveLength(count / 2);
+      expect(pairs?.flat()).toStrictEqual(components);
+    }
+  });
+});
+
+describe('parseComplexValue', () => {
+  it('should return one pair per element of an array dataset', () => {
+    expect(parseComplexValue([1, 2, 3, -4], false)).toStrictEqual([
+      [1, 2],
+      [3, -4],
+    ]);
+  });
+
+  it('should unwrap a scalar to a bare pair', () => {
+    // H5Web's value model for a scalar complex is `[real, imag]`, not `[[real, imag]]`
+    expect(parseComplexValue([1, 2], true)).toStrictEqual([1, 2]);
+  });
+
+  it('should pass a non-numeric value through untouched', () => {
+    // Leave anything unexpected to the caller's type guards rather than mangling it
+    const value = { not: 'components' };
+
+    expect(parseComplexValue(value, false)).toBe(value);
+    expect(parseComplexValue(['a', 'b'], false)).toStrictEqual(['a', 'b']);
+  });
+});

--- a/packages/h5wasm/src/worker-utils.ts
+++ b/packages/h5wasm/src/worker-utils.ts
@@ -2,6 +2,7 @@ import {
   assertDefined,
   assertNonNull,
   isNumericType,
+  isTypedArray,
 } from '@h5web/shared/guards';
 import { H5T_CLASS, H5T_ORDER } from '@h5web/shared/h5t';
 import {
@@ -10,6 +11,7 @@ import {
   type DType,
   EntityKind,
   type Group,
+  type H5WebComplex,
   type ProvidedEntity,
   type VirtualSource,
 } from '@h5web/shared/hdf5-models';
@@ -18,6 +20,7 @@ import {
   bitfieldType,
   buildEntityPath,
   compoundOrCplxType,
+  cplxType,
   enumOrBoolType,
   floatType,
   getNameFromPath,
@@ -30,6 +33,7 @@ import {
   unknownType,
   vlenType,
 } from '@h5web/shared/hdf5-utils';
+import { type NumArray } from '@h5web/shared/vis-models';
 import { SCALAR_SELECTION_REGEXP } from '@h5web/shared/vis-utils';
 import {
   type Dataset as H5WasmDataset,
@@ -213,7 +217,7 @@ function parseAttributes(
 }
 
 /* eslint-disable @typescript-eslint/no-unsafe-enum-comparison */
-function parseDType(metadata: Metadata): DType {
+export function parseDType(metadata: Metadata): DType {
   const { type: h5tClass, size } = metadata;
 
   if (h5tClass === H5T_CLASS.INTEGER) {
@@ -289,6 +293,16 @@ function parseDType(metadata: Metadata): DType {
     return arrayType(parseDType(array_type), array_type.shape);
   }
 
+  if (h5tClass === H5T_CLASS.COMPLEX) {
+    const { littleEndian } = metadata;
+
+    /* Both components of an `H5T_COMPLEX` are the same float type, so each one
+     * is exactly half the itemsize and needs no metadata of its own. */
+    return cplxType(
+      floatType((size / 2) * 8, littleEndian ? H5T_ORDER.LE : H5T_ORDER.BE),
+    );
+  }
+
   return unknownType();
 }
 /* eslint-enable @typescript-eslint/no-unsafe-enum-comparison */
@@ -300,12 +314,63 @@ function parseVirtualSources(metadata: Metadata): VirtualSource[] | undefined {
   }));
 }
 
+/* h5wasm hands back a typed array for a dataset value but a plain array for an
+ * attribute's `json_value`, so both layouts have to be recognised. Only the
+ * plain array pays for the element check; a typed array is numeric by type. */
+function isComponentArray(value: unknown): value is NumArray {
+  return (
+    isTypedArray(value) ||
+    (Array.isArray(value) && value.every((val) => typeof val === 'number'))
+  );
+}
+
+/* h5wasm exposes an `H5T_COMPLEX` value as a flat typed array of interleaved
+ * components, which keeps them at storage precision and avoids allocating one
+ * object per element. H5Web's value model is one `[real, imag]` pair per
+ * element, so the components are paired up here. Exported for testing. */
+export function pairComplexComponents(
+  components: NumArray,
+): H5WebComplex[] | undefined {
+  if (components.length % 2 !== 0) {
+    return undefined; // not an interleaved component array after all
+  }
+
+  const pairs: H5WebComplex[] = [];
+  for (let i = 0; i < components.length; i += 2) {
+    pairs.push([components[i], components[i + 1]]);
+  }
+
+  return pairs;
+}
+
+/* `isScalar` covers both a scalar dataset and a scalar selection of an array
+ * one: H5Web expects a bare `[real, imag]` pair rather than an array of one. */
+export function parseComplexValue(value: unknown, isScalar: boolean): unknown {
+  if (!isComponentArray(value)) {
+    return value; // unexpected layout - leave it to the caller's type guards
+  }
+
+  const pairs = pairComplexComponents(value);
+  if (!pairs) {
+    return value;
+  }
+
+  return isScalar ? pairs[0] : pairs;
+}
+
 export function readSelectedValue(
   h5wDataset: H5WasmDataset,
   selection: string | undefined,
 ): unknown {
+  /* eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison --
+   * h5wasm types the class as a plain number */
+  const isComplex = h5wDataset.metadata.type === H5T_CLASS.COMPLEX;
+
   if (!selection) {
-    return h5wDataset.value;
+    const { value } = h5wDataset;
+    return isComplex
+      ? parseComplexValue(value, h5wDataset.shape?.length === 0)
+      : value;
   }
 
   const { shape } = h5wDataset;
@@ -321,10 +386,15 @@ export function readSelectedValue(
   });
 
   const slicedValue = h5wDataset.slice(ranges);
+  const isScalarSelection = SCALAR_SELECTION_REGEXP.test(selection);
+
+  if (isComplex) {
+    return parseComplexValue(slicedValue, isScalarSelection);
+  }
 
   /* h5wasm unwraps scalar slices inconsistently - e.g. it does so for opaque
    * datasets but not for compound, vlen, etc. */
-  if (SCALAR_SELECTION_REGEXP.test(selection) && Array.isArray(slicedValue)) {
+  if (isScalarSelection && Array.isArray(slicedValue)) {
     return slicedValue[0];
   }
 

--- a/packages/h5wasm/src/worker.ts
+++ b/packages/h5wasm/src/worker.ts
@@ -1,4 +1,5 @@
 import { isTypedArray } from '@h5web/shared/guards';
+import { H5T_CLASS } from '@h5web/shared/h5t';
 import { type ProvidedEntity } from '@h5web/shared/hdf5-models';
 import { expose, transfer } from 'comlink';
 import { Attribute, Dataset, File as H5WasmFile } from 'h5wasm';
@@ -7,6 +8,7 @@ import {
   getAvailableFileName,
   initH5Wasm,
   mountWorkerFS,
+  parseComplexValue,
   parseEntity,
   PLUGINS_FOLDER,
   readSelectedValue,
@@ -69,7 +71,16 @@ async function getAttrValue(
   path: string,
   attrName: string,
 ): Promise<unknown> {
-  return new Attribute(fileId, path, attrName).json_value;
+  const attr = new Attribute(fileId, path, attrName);
+  const value = attr.json_value;
+
+  /* eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison --
+   * h5wasm types the class as a plain number */
+  if (attr.metadata.type === H5T_CLASS.COMPLEX) {
+    return parseComplexValue(value, attr.shape?.length === 0);
+  }
+
+  return value;
 }
 
 async function getDescendantPaths(

--- a/packages/shared/src/h5t.ts
+++ b/packages/shared/src/h5t.ts
@@ -15,6 +15,7 @@ export enum H5T_CLASS {
   ENUM = 8,
   VLEN = 9,
   ARRAY = 10,
+  COMPLEX = 11, // HDF5 2.0
 }
 
 export enum H5T_ORDER {


### PR DESCRIPTION
HDF5 2.0 added `H5T_COMPLEX` (class 11), storing interleaved real and imaginary components of a base float. It is what h5py writes given a `COMPLEX_IEEE_*` type, and what HDF5 2.0 writers will produce in place of the legacy `{r, i}` compound H5Web already reads. `H5T_CLASS` stopped at `ARRAY = 10`, so such a dataset fell through `parseDType` to `unknownType()` and offered no visualisation at all.

Both components are the same float and each is half the itemsize, so the component type needs no metadata of its own. The values do need converting: h5wasm exposes the interleaved layout directly, whereas H5Web's model is one `[real, imag]` pair per element. Attributes need the same by a separate route, arriving through `Attribute.json_value` as a plain array.

The reader side is usnistgov/h5wasm#140. `packages/h5wasm/package.json` pins h5wasm 0.10.3, which predates it, so nothing exercises this in CI until that lands and the pin is bumped. Checked by hand against a local h5wasm build and a file written by h5py.