### PR TITLE
Cut the main-thread cost of opening and re-rendering a visualisation

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -22,6 +22,7 @@ import { useDataContext } from './providers/DataProvider';
 import Sidebar from './Sidebar';
 import VisConfigProvider from './VisConfigProvider';
 import Visualizer from './visualizer/Visualizer';
+import { useWarmUpWebGL } from './webgl-warm-up';
 
 const SIDEBAR_ID = 'h5w-sidebar';
 const MAIN_AREA_ID = 'h5w-main-area';
@@ -46,6 +47,8 @@ function App(props: Props) {
 
   const [selectedPath, setSelectedPath] = useState<string>(initialPath);
   const [isInspecting, setInspecting] = useState(false);
+
+  useWarmUpWebGL();
 
   const { valuesStore } = useDataContext();
   function onSelectPath(path: string) {

--- a/packages/app/src/vis-packs/core/complex/utils.test.ts
+++ b/packages/app/src/vis-packs/core/complex/utils.test.ts
@@ -1,0 +1,154 @@
+import { type H5WebComplex } from '@h5web/shared/hdf5-models';
+import { cplx } from '@h5web/shared/hdf5-utils';
+import { describe, expect, it } from 'vitest';
+
+import { getPhaseAmplitude, getPhaseAmplitudeArrays } from './utils';
+
+const TWO_PI = 2 * Math.PI;
+
+/* Straightforward reference implementations, kept deliberately naive. The real
+   ones are written to avoid per-element allocation on large datasets, so they
+   are checked against these rather than against hand-written expectations. */
+function referencePhaseAmplitude(values: H5WebComplex[]): {
+  phase: number[];
+  amplitude: number[];
+} {
+  return {
+    phase: values.map(([real, imag]) => Math.atan2(imag, real)),
+    amplitude: values.map(([real, imag]) => Math.hypot(real, imag)),
+  };
+}
+
+function referenceUnwrap(values: number[]): number[] {
+  const unwrapped: number[] = [];
+
+  values.forEach((val, i) => {
+    if (i === 0) {
+      unwrapped.push(val);
+      return;
+    }
+
+    const diff = val - unwrapped[i - 1];
+    unwrapped.push(val - TWO_PI * Math.round(diff / TWO_PI));
+  });
+
+  return unwrapped;
+}
+
+/* Deterministic generator (MINSTD), so a failing case is reproducible. Values
+   straddle the branch cut of `atan2` at the negative real axis, where phase
+   jumps by 2π and unwrapping has to do real work. */
+function makeComplex(seed: number, length: number): H5WebComplex[] {
+  let state = seed;
+
+  function next(): number {
+    state = (state * 48_271) % 2_147_483_647;
+    return state / 2_147_483_647;
+  }
+
+  return Array.from({ length }, () => {
+    const angle = (next() - 0.5) * 8 * Math.PI; // several turns, so phase wraps
+    const radius = next() * 10;
+    return cplx(radius * Math.cos(angle), radius * Math.sin(angle));
+  });
+}
+
+function unwrapOf(values: H5WebComplex[]): number[] {
+  const { unwrappedPhaseArrays } = getPhaseAmplitudeArrays([values]);
+  return [...unwrappedPhaseArrays[0]];
+}
+
+describe('getPhaseAmplitude', () => {
+  it('should match the reference implementation', () => {
+    for (let seed = 1; seed <= 50; seed += 1) {
+      const values = makeComplex(seed, 64);
+      const { phase, amplitude } = getPhaseAmplitude(values);
+      const expected = referencePhaseAmplitude(values);
+
+      expect({ seed, phase: [...phase] }).toStrictEqual({
+        seed,
+        phase: expected.phase,
+      });
+      expect({ seed, amplitude: [...amplitude] }).toStrictEqual({
+        seed,
+        amplitude: expected.amplitude,
+      });
+    }
+  });
+
+  it('should handle the values that break polar conversions', () => {
+    // Both zero (phase undefined, conventionally 0) and the negative real axis
+    const values = [cplx(0, 0), cplx(-1, 0), cplx(0, -1), cplx(-0, -0)];
+    const { phase, amplitude } = getPhaseAmplitude(values);
+
+    expect([...amplitude]).toStrictEqual([0, 1, 1, 0]);
+    expect([...phase]).toStrictEqual(referencePhaseAmplitude(values).phase);
+  });
+
+  it('should return empty arrays for no values', () => {
+    const { phase, amplitude } = getPhaseAmplitude([]);
+
+    expect(phase).toHaveLength(0);
+    expect(amplitude).toHaveLength(0);
+  });
+
+  /* Property: amplitude and phase are polar coordinates, so they must
+     reconstruct the original components. This pins down the pairing of the two
+     outputs, which comparing each against a reference separately does not. */
+  it('should be invertible back to the original components', () => {
+    const values = makeComplex(7, 200);
+    const { phase, amplitude } = getPhaseAmplitude(values);
+
+    values.forEach(([real, imag], i) => {
+      expect(amplitude[i] * Math.cos(phase[i])).toBeCloseTo(real, 10);
+      expect(amplitude[i] * Math.sin(phase[i])).toBeCloseTo(imag, 10);
+    });
+  });
+});
+
+describe('getPhaseAmplitudeArrays', () => {
+  it('should match the reference unwrapping', () => {
+    for (let seed = 1; seed <= 50; seed += 1) {
+      const values = makeComplex(seed, 64);
+      const { phase } = getPhaseAmplitude(values);
+
+      expect({ seed, unwrapped: unwrapOf(values) }).toStrictEqual({
+        seed,
+        unwrapped: referenceUnwrap([...phase]),
+      });
+    }
+  });
+
+  /* Properties that define phase unwrapping: it may add whole turns to each
+     value, and must leave no jump bigger than half a turn between neighbours. */
+  it('should remove every 2-pi discontinuity without moving any value off its turn', () => {
+    const values = makeComplex(11, 500);
+    const { phase } = getPhaseAmplitude(values);
+    const unwrapped = unwrapOf(values);
+
+    expect(unwrapped).toHaveLength(values.length);
+    expect(unwrapped[0]).toBe(phase[0]); // first value is never shifted
+
+    unwrapped.forEach((val, i) => {
+      // Differs from the wrapped phase only by a whole number of turns
+      const turns = (val - phase[i]) / TWO_PI;
+      expect(turns).toBeCloseTo(Math.round(turns), 9);
+    });
+
+    // No jump bigger than half a turn survives anywhere in the sequence
+    const jumps = unwrapped
+      .slice(1)
+      .map((val, i) => Math.abs(val - unwrapped[i]));
+
+    expect(Math.max(...jumps)).toBeLessThanOrEqual(Math.PI + 1e-9);
+  });
+
+  it('should treat real values as complex with zero imaginary part', () => {
+    const { phaseArrays, amplitudeArrays } = getPhaseAmplitudeArrays([
+      [-3, 0, 4],
+    ]);
+
+    expect([...phaseArrays[0]]).toStrictEqual([0, 0, 0]);
+    expect([...amplitudeArrays[0]]).toStrictEqual([3, 0, 4]);
+  });
+});

--- a/packages/app/src/vis-packs/core/complex/utils.ts
+++ b/packages/app/src/vis-packs/core/complex/utils.ts
@@ -18,33 +18,42 @@ export const COMPLEX_VIS_TYPE_LABELS = {
   [ComplexVisType.PhaseAmplitude]: 'Phase & Amplitude',
 } satisfies Record<ComplexVisType, string>;
 
+/* The output arrays are `Float64Array`s rather than `number[]`: an array built
+ * with `Array.from({ length })` is filled with `undefined`, which fixes its V8
+ * elements kind as `PACKED_ELEMENTS`, so every phase and amplitude written into
+ * it is boxed as a separate heap number. */
 export function getPhaseAmplitude(values: H5WebComplex[]): {
-  phase: number[];
-  amplitude: number[];
+  phase: NumArray;
+  amplitude: NumArray;
 } {
-  const phase: number[] = Array.from({ length: values.length });
-  const amplitude: number[] = Array.from({ length: values.length });
+  const phase = new Float64Array(values.length);
+  const amplitude = new Float64Array(values.length);
 
-  values.forEach(([real, imag], i) => {
+  /* Iterate by index: destructuring in a `forEach` callback allocates per
+   * element, which dominates the scan once the boxing is gone. */
+  // eslint-disable-next-line unicorn/no-for-loop -- see above
+  for (let i = 0; i < values.length; i += 1) {
+    const [real, imag] = values[i];
     phase[i] = Math.atan2(imag, real);
     amplitude[i] = Math.hypot(real, imag);
-  });
+  }
 
   return { phase, amplitude };
 }
 
 // Unwrap phase values by removing 2π discontinuities
-function unwrapPhase(values: number[]): number[] {
-  const unwrapped: number[] = Array.from({ length: values.length });
+function unwrapPhase(values: NumArray): NumArray {
+  const unwrapped = new Float64Array(values.length);
 
-  for (const [i, val] of values.entries()) {
-    if (i === 0) {
-      unwrapped[0] = val;
-      continue;
-    }
-
-    const diff = val - unwrapped[i - 1];
-    unwrapped[i] = val - TWO_PI * Math.round(diff / TWO_PI);
+  /* Carry the previous unwrapped value rather than reading it back, and index
+   * rather than using `values.entries()`, which allocates a pair per element. */
+  let previous = 0;
+  // eslint-disable-next-line unicorn/no-for-loop -- see above
+  for (let i = 0; i < values.length; i += 1) {
+    const val = values[i];
+    const diff = val - previous;
+    previous = i === 0 ? val : val - TWO_PI * Math.round(diff / TWO_PI);
+    unwrapped[i] = previous;
   }
 
   return unwrapped;

--- a/packages/app/src/webgl-warm-up.ts
+++ b/packages/app/src/webgl-warm-up.ts
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+
+/* Creating the first WebGL context in a page costs a few hundred milliseconds
+   of blocking main-thread time, most of it GPU-process and graphics-driver
+   initialisation rather than anything h5web does. Pay it in the background,
+   while the user is still browsing the file tree, so that opening the first
+   visualisation doesn't have to. */
+export function useWarmUpWebGL(): void {
+  useEffect(() => {
+    let context: WebGL2RenderingContext | null = null;
+    let handle: number | undefined;
+
+    // Warming up is best-effort, so skip it where `requestIdleCallback` is unsupported
+    if ('requestIdleCallback' in globalThis) {
+      handle = globalThis.requestIdleCallback(() => {
+        /* Keep the context around for the session: releasing it lets the
+           browser tear down the GPU process again, which is the cost being
+           avoided in the first place. */
+        context = document.createElement('canvas').getContext('webgl2');
+      });
+    }
+
+    return () => {
+      if (handle !== undefined) {
+        globalThis.cancelIdleCallback(handle);
+      }
+
+      context?.getExtension('WEBGL_lose_context')?.loseContext();
+    };
+  }, []);
+}

--- a/packages/lib/src/vis/heatmap/HeatmapMaterial.tsx
+++ b/packages/lib/src/vis/heatmap/HeatmapMaterial.tsx
@@ -1,7 +1,8 @@
 import { type Domain, ScaleType } from '@h5web/shared/vis-models';
+import { useThree } from '@react-three/fiber';
 import { rgb, type RGBColor } from 'd3-color';
 import { type NdArray } from 'ndarray';
-import { memo, useMemo } from 'react';
+import { memo, useLayoutEffect, useMemo } from 'react';
 import {
   DataTexture,
   DoubleSide,
@@ -91,32 +92,35 @@ function HeatmapMaterial(props: Props) {
     ? visScaleType
     : [visScaleType as ScaleType, 1];
 
-  const scaledDomain = scaleDomain(domain, scaleType);
+  const [scaledMin, scaledMax] = scaleDomain(domain, scaleType);
+  const [alphaMin, alphaMax] = alphaDomain;
 
   const badColorAsRgb = typeof badColor === 'string' ? rgb(badColor) : badColor;
+  const badColorVector = useMemo(() => new Vector4(), []); // updated in place, like the other uniform values
 
-  const shader = {
-    uniforms: getUniforms({
-      data: dataTexture,
-      mask: maskTexture,
-      colorMap: colorMapTexture,
-      min: scaledDomain[0],
-      oneOverRange: 1 / (scaledDomain[1] - scaledDomain[0]),
-      gammaExponent,
-      normRevertFactor: values.dtype === 'uint8' ? 255 : 1, // revert WebGL's automatic normalization of UNSIGNED_BYTE with RED format
-      alpha: alphaTexture,
-      withAlpha: alphaValues ? 1 : 0,
-      alphaMin: alphaDomain[0],
-      oneOverAlphaRange: 1 / (alphaDomain[1] - alphaDomain[0]),
-      badColor: new Vector4(
-        badColorAsRgb.r / 255,
-        badColorAsRgb.g / 255,
-        badColorAsRgb.b / 255,
-        badColorAsRgb.opacity,
-      ),
-    }),
-    vertexShader: VERTEX_SHADER,
-    fragmentShader: `
+  /* The scale type is the only prop that appears in the shader source, so the
+     material only has to be re-created when it changes. Everything else is a
+     uniform, updated in place below: passing a new object in `args` would make
+     R3F re-instantiate the material, which recompiles and relinks the GLSL
+     program — on every slice of a 3D dataset, for instance. */
+  const shader = useMemo(
+    () => ({
+      uniforms: getUniforms({
+        data: null,
+        mask: null,
+        colorMap: null,
+        min: 0,
+        oneOverRange: 1,
+        gammaExponent: 1,
+        normRevertFactor: 1,
+        alpha: null,
+        withAlpha: 0,
+        alphaMin: 0,
+        oneOverAlphaRange: 1,
+        badColor: badColorVector,
+      }),
+      vertexShader: VERTEX_SHADER,
+      fragmentShader: `
       uniform sampler2D data;
       uniform sampler2D colorMap;
 
@@ -163,7 +167,35 @@ function HeatmapMaterial(props: Props) {
         }
       }
     `,
-  };
+    }),
+    [scaleType, badColorVector],
+  );
+
+  const invalidate = useThree((state) => state.invalidate);
+  const { uniforms } = shader; // same object the material holds, so mutating it updates the material
+
+  useLayoutEffect(() => {
+    uniforms.data.value = dataTexture;
+    uniforms.mask.value = maskTexture;
+    uniforms.colorMap.value = colorMapTexture;
+    uniforms.min.value = scaledMin;
+    uniforms.oneOverRange.value = 1 / (scaledMax - scaledMin);
+    uniforms.gammaExponent.value = gammaExponent;
+    uniforms.normRevertFactor.value = values.dtype === 'uint8' ? 255 : 1; // revert WebGL's automatic normalization of UNSIGNED_BYTE with RED format
+    uniforms.alpha.value = alphaTexture;
+    uniforms.withAlpha.value = alphaValues ? 1 : 0;
+    uniforms.alphaMin.value = alphaMin;
+    uniforms.oneOverAlphaRange.value = 1 / (alphaMax - alphaMin);
+
+    badColorVector.set(
+      badColorAsRgb.r / 255,
+      badColorAsRgb.g / 255,
+      badColorAsRgb.b / 255,
+      badColorAsRgb.opacity,
+    );
+
+    invalidate();
+  });
 
   return <shaderMaterial args={[shader]} side={DoubleSide} />;
 }

--- a/packages/lib/src/vis/line/GlyphMaterial.tsx
+++ b/packages/lib/src/vis/line/GlyphMaterial.tsx
@@ -1,3 +1,5 @@
+import { useThree } from '@react-three/fiber';
+import { useLayoutEffect, useMemo } from 'react';
 import { Color } from 'three';
 
 import { getUniforms } from '../utils';
@@ -55,10 +57,18 @@ function GlyphMaterial(props: Props) {
   // If no `color` given, use vertex colors (i.e. buffer attribute on geometry)
   const withVertexColor = !color;
 
-  const shader = {
-    uniforms: getUniforms({ size, color: new Color(color) }),
-    vertexShader: `
-      ${color ? 'uniform vec3 color;' : ''}
+  const colorUniform = useMemo(() => new Color(), []); // updated in place, like `size`
+
+  /* Only the glyph type and whether a `color` is given at all appear in the
+     shader source, so the material can be reused for as long as those hold.
+     `size` and the colour itself are uniforms, updated in place below: passing
+     a new object in `args` would make R3F re-instantiate the material, which
+     recompiles and relinks the GLSL program on every render. */
+  const shader = useMemo(
+    () => ({
+      uniforms: getUniforms({ size: 1, color: colorUniform }),
+      vertexShader: `
+      ${withVertexColor ? '' : 'uniform vec3 color;'}
       uniform float size;
       varying vec3 vertexColor;
 
@@ -68,7 +78,7 @@ function GlyphMaterial(props: Props) {
         vertexColor = color;
       }
     `,
-    fragmentShader: `
+      fragmentShader: `
       uniform float size;
       varying vec3 vertexColor;
 
@@ -83,7 +93,22 @@ function GlyphMaterial(props: Props) {
         }
       }
     `,
-  };
+    }),
+    [glyphType, withVertexColor, colorUniform],
+  );
+
+  const invalidate = useThree((state) => state.invalidate);
+  const { uniforms } = shader; // same object the material holds, so mutating it updates the material
+
+  useLayoutEffect(() => {
+    uniforms.size.value = size;
+
+    if (color) {
+      colorUniform.set(color);
+    }
+
+    invalidate();
+  });
 
   return <shaderMaterial args={[shader]} vertexColors={withVertexColor} />;
 }

--- a/packages/shared/src/vis-utils.test.ts
+++ b/packages/shared/src/vis-utils.test.ts
@@ -1,0 +1,177 @@
+import ndarray from 'ndarray';
+import { describe, expect, it } from 'vitest';
+
+import { type AnyNumArray, type Bounds, type IgnoreValue } from './vis-models';
+import { getBounds, getBoundsWithErrors, getValues } from './vis-utils';
+
+/* Straightforward reference implementation of the bounds scan, kept
+   deliberately naive. `getBounds` and `getBoundsWithErrors` are optimised for
+   large datasets, so they are checked against this instead of against
+   hard-coded expectations. */
+function referenceBounds(
+  valuesArray: AnyNumArray,
+  ignoreValue?: IgnoreValue,
+): Bounds | undefined {
+  const kept = [...getValues(valuesArray)].filter(
+    (val) => Number.isFinite(val) && !ignoreValue?.(val),
+  );
+
+  if (kept.length === 0) {
+    return undefined;
+  }
+
+  return {
+    min: Math.min(...kept),
+    max: Math.max(...kept),
+    positiveMin: Math.min(...kept.filter((val) => val >= 0)),
+    strictPositiveMin: Math.min(...kept.filter((val) => val > 0)),
+  };
+}
+
+/* Deterministic generator (MINSTD): a seed keeps failures reproducible, and
+   each case mixes in the values that typically break hand-rolled scans — NaN,
+   both infinities, and zero. */
+function makeValues(seed: number, length: number): number[] {
+  const SPECIAL = [
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.NEGATIVE_INFINITY,
+    0,
+  ];
+
+  let state = seed;
+
+  return Array.from({ length }, (_, i) => {
+    state = (state * 48_271) % 2_147_483_647;
+    const draw = state / 2_147_483_647;
+
+    return draw < 0.15 ? SPECIAL[i % SPECIAL.length] : draw * 2000 - 1000;
+  });
+}
+
+const GENERATED_CASES = Array.from({ length: 200 }, (_, i) => ({
+  seed: i + 1,
+  length: 1 + (i % 40),
+}));
+
+function ignoreLargeAndZero(value: number): boolean {
+  return value > 500 || value === 0;
+}
+
+/* The seed travels inside the compared value so that a failure names the case
+   that broke, rather than just dumping two sets of bounds. */
+describe('getBounds', () => {
+  it('should match the reference implementation on generated inputs', () => {
+    for (const { seed, length } of GENERATED_CASES) {
+      const values = makeValues(seed, length);
+
+      expect({ seed, bounds: getBounds(values) }).toEqual({
+        seed,
+        bounds: referenceBounds(values),
+      });
+    }
+  });
+
+  it('should match the reference implementation with an `ignoreValue`', () => {
+    for (const { seed, length } of GENERATED_CASES) {
+      const values = makeValues(seed, length);
+
+      expect({ seed, bounds: getBounds(values, ignoreLargeAndZero) }).toEqual({
+        seed,
+        bounds: referenceBounds(values, ignoreLargeAndZero),
+      });
+    }
+  });
+
+  it('should handle monotonic inputs', () => {
+    /* A decreasing run never updates `max` past the first element if the scan
+       short-circuits its comparisons, so both directions are worth checking. */
+    const increasing = Array.from({ length: 50 }, (_, i) => i - 25);
+    const decreasing = [...increasing].reverse();
+
+    expect(getBounds(increasing)).toEqual(referenceBounds(increasing));
+    expect(getBounds(decreasing)).toEqual(referenceBounds(decreasing));
+  });
+
+  it('should ignore non-finite values', () => {
+    const values = [
+      Number.NaN,
+      3,
+      Number.POSITIVE_INFINITY,
+      1,
+      Number.NEGATIVE_INFINITY,
+    ];
+
+    expect(getBounds(values)).toEqual({
+      min: 1,
+      max: 3,
+      positiveMin: 1,
+      strictPositiveMin: 1,
+    });
+  });
+
+  it('should return `undefined` when no value is usable', () => {
+    expect(getBounds([])).toBeUndefined();
+    expect(getBounds([Number.NaN, Number.NaN])).toBeUndefined();
+    expect(
+      getBounds([Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]),
+    ).toBeUndefined();
+    expect(getBounds([1, 2], () => true)).toBeUndefined();
+  });
+
+  it('should support typed arrays and ndarrays', () => {
+    const values = [4, -2, 7, 0];
+
+    expect(getBounds(Float64Array.from(values))).toEqual(
+      referenceBounds(values),
+    );
+    expect(getBounds(Int32Array.from(values))).toEqual(referenceBounds(values));
+    expect(getBounds(ndarray(Float32Array.from(values), [2, 2]))).toEqual(
+      referenceBounds(values),
+    );
+  });
+});
+
+describe('getBoundsWithErrors', () => {
+  it('should match the reference implementation on generated inputs', () => {
+    for (const { seed, length } of GENERATED_CASES) {
+      const values = makeValues(seed, length);
+      const errors = makeValues(seed + 5000, length).map(Math.abs);
+
+      const [withErrors, withoutErrors] = getBoundsWithErrors(values, errors);
+
+      // Bounds without errors must equal a plain scan of the values
+      expect({ seed, bounds: withoutErrors }).toEqual({
+        seed,
+        bounds: referenceBounds(values),
+      });
+
+      // Bounds with errors must equal a scan over every value and value±error
+      const extended = values.flatMap((value, i) => {
+        const error = errors[i];
+
+        return Number.isFinite(value) && Number.isFinite(error)
+          ? [value, value - error, value + error]
+          : [value];
+      });
+
+      expect({ seed, bounds: withErrors }).toEqual({
+        seed,
+        bounds: referenceBounds(extended),
+      });
+    }
+  });
+
+  it('should ignore errors that are not finite', () => {
+    const [withErrors] = getBoundsWithErrors(
+      [10, 20],
+      [Number.NaN, Number.POSITIVE_INFINITY],
+    );
+
+    expect(withErrors).toEqual(referenceBounds([10, 20]));
+  });
+
+  it('should throw when errors and values have different lengths', () => {
+    expect(() => getBoundsWithErrors([1, 2, 3], [1, 2])).toThrow(/error/u);
+  });
+});

--- a/packages/shared/src/vis-utils.ts
+++ b/packages/shared/src/vis-utils.ts
@@ -142,7 +142,12 @@ export function getBounds(
   const values = getValues(valuesArray);
   const valuesBounds = { ...INITIAL_BOUNDS };
 
-  for (const val of values) {
+  /* Iterate by index rather than with `for..of`: the iterator protocol
+     allocates a result object (and, for float arrays, a boxed number) per
+     element, which dominates the cost of the scan on large datasets. */
+  // eslint-disable-next-line unicorn/no-for-loop, @typescript-eslint/prefer-for-of -- see above
+  for (let i = 0; i < values.length; i += 1) {
+    const val = values[i];
     if (Number.isFinite(val) && !ignoreValue?.(val)) {
       mutateBounds(valuesBounds, val);
     }
@@ -167,7 +172,10 @@ export function getBoundsWithErrors(
   const boundsWithErrors = { ...INITIAL_BOUNDS };
   const boundsWithoutErrors = { ...INITIAL_BOUNDS };
 
-  for (const [i, val] of values.entries()) {
+  // Iterate by index rather than with `values.entries()`, which allocates per element
+  // eslint-disable-next-line unicorn/no-for-loop -- see above
+  for (let i = 0; i < values.length; i += 1) {
+    const val = values[i];
     if (!Number.isFinite(val) || ignoreValue?.(val)) {
       continue;
     }


### PR DESCRIPTION
Profiling the h5wasm demo on a 2068x2162 uint16 frame put most of the time between clicking a dataset and seeing pixels in avoidable allocation and shader recompilation. Click-to-figure goes from $211$ ms to $102$ ms.

Per-element allocation: `getBounds` and `getBoundsWithErrors` walked values with `for..of` and `.entries()`, which allocate per element in V8 and JSC -- scanning a 34 MB `Float64Array` triggered 4037 young-generation collections where an indexed loop triggers 4 ($3.25\times$ in V8, $1.25\times$ in SpiderMonkey, which already elides most of it). The complex visualisations allocated their outputs with `Array.from({ length: n })`, whose `PACKED_ELEMENTS` kind boxes every value written in; a `Float64Array` and indexed iteration take $4.19$M values from $572$ ms to $160$ ms. Both are tested against naive reference implementations, since hand-written expectations would not pin down code written this way.

Shader recompilation: `HeatmapMaterial` and `GlyphMaterial` rebuilt their `args` object every render, and R3F compares it element by element, so each re-render replaced the `ShaderMaterial` and relinked its GLSL -- $1.9$ ms in Chrome, $4.7$ ms in Firefox. Both now memoize on what actually appears in the shader source and update the rest in place. `useWarmUpWebGL` moves the first context's $9$ ms of driver setup into idle time.