### PR TITLE
Migrate values store to React Query

### DIFF
--- a/apps/demo/.env
+++ b/apps/demo/.env
@@ -18,3 +18,6 @@ VITE_HSDS_FALLBACK_FILEPATH="water_224.h5"
 
 # Feedback email
 VITE_FEEDBACK_EMAIL="h5web@esrf.fr"
+
+# Tanstack Query dev tools ('true' to enable)
+VITE_QUERY_DEVTOOLS=

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@h5web/app": "workspace:*",
     "@h5web/h5wasm": "workspace:*",
+    "@tanstack/react-query-devtools": "5.102.8",
     "h5wasm-plugins": "0.3.0",
     "modern-normalize": "3.0.1",
     "react": "18.3.1",

--- a/apps/demo/src/H5GroveApp.tsx
+++ b/apps/demo/src/H5GroveApp.tsx
@@ -1,10 +1,12 @@
 import { App, assertEnvVar, H5GroveProvider } from '@h5web/app';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { useSearchParams } from 'wouter';
 
 import { getFeedbackURL } from './utils';
 
 const URL = import.meta.env.VITE_H5GROVE_URL;
 const FILEPATH = import.meta.env.VITE_H5GROVE_FALLBACK_FILEPATH;
+const DEVTOOLS = import.meta.env.VITE_QUERY_DEVTOOLS === 'true';
 
 function H5GroveApp() {
   assertEnvVar(URL, 'VITE_H5GROVE_URL');
@@ -19,6 +21,7 @@ function H5GroveApp() {
         sidebarOpen={!searchParams.has('wide')}
         getFeedbackURL={getFeedbackURL}
       />
+      {DEVTOOLS && <ReactQueryDevtools />}
     </H5GroveProvider>
   );
 }

--- a/apps/demo/src/HsdsApp.tsx
+++ b/apps/demo/src/HsdsApp.tsx
@@ -5,6 +5,7 @@ import {
   createBasicFetcher,
   HsdsProvider,
 } from '@h5web/app';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { useMemo } from 'react';
 import { useSearchParams } from 'wouter';
 
@@ -15,6 +16,7 @@ const USERNAME = import.meta.env.VITE_HSDS_USERNAME;
 const PASSWORD = import.meta.env.VITE_HSDS_PASSWORD;
 const SUBDOMAIN = import.meta.env.VITE_HSDS_SUBDOMAIN;
 const FILEPATH = import.meta.env.VITE_HSDS_FALLBACK_FILEPATH;
+const DEVTOOLS = import.meta.env.VITE_QUERY_DEVTOOLS === 'true';
 
 function HsdsApp() {
   assertEnvVar(URL, 'VITE_HSDS_URL');
@@ -38,6 +40,7 @@ function HsdsApp() {
         sidebarOpen={!searchParams.has('wide')}
         getFeedbackURL={getFeedbackURL}
       />
+      {DEVTOOLS && <ReactQueryDevtools />}
     </HsdsProvider>
   );
 }

--- a/apps/demo/src/MockApp.tsx
+++ b/apps/demo/src/MockApp.tsx
@@ -1,7 +1,10 @@
 import { App, MockProvider } from '@h5web/app';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { useSearchParams } from 'wouter';
 
 import { getFeedbackURL } from './utils';
+
+const DEVTOOLS = import.meta.env.VITE_QUERY_DEVTOOLS === 'true';
 
 function MockApp() {
   const [searchParams] = useSearchParams();
@@ -12,6 +15,7 @@ function MockApp() {
         sidebarOpen={!searchParams.has('wide')}
         getFeedbackURL={getFeedbackURL}
       />
+      {DEVTOOLS && <ReactQueryDevtools />}
     </MockProvider>
   );
 }

--- a/apps/demo/src/h5wasm/H5WasmApp.tsx
+++ b/apps/demo/src/h5wasm/H5WasmApp.tsx
@@ -1,5 +1,6 @@
 import { App } from '@h5web/app';
 import { H5WasmBufferProvider, H5WasmLocalFileProvider } from '@h5web/h5wasm';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { useState } from 'react';
 import { useSearchParams } from 'wouter';
 
@@ -7,6 +8,8 @@ import { getFeedbackURL } from '../utils';
 import DropZone from './DropZone';
 import { type RemoteFile } from './models';
 import { getPlugin } from './plugin-utils';
+
+const DEVTOOLS = import.meta.env.VITE_QUERY_DEVTOOLS === 'true';
 
 function H5WasmApp() {
   const [searchParams] = useSearchParams();
@@ -23,10 +26,12 @@ function H5WasmApp() {
       {h5File instanceof File ? (
         <H5WasmLocalFileProvider file={h5File} getPlugin={getPlugin}>
           <App sidebarOpen={!isWide} getFeedbackURL={getFeedbackURL} />
+          {DEVTOOLS && <ReactQueryDevtools />}
         </H5WasmLocalFileProvider>
       ) : (
         <H5WasmBufferProvider {...h5File} getPlugin={getPlugin}>
           <App sidebarOpen={!isWide} getFeedbackURL={getFeedbackURL} />
+          {DEVTOOLS && <ReactQueryDevtools />}
         </H5WasmBufferProvider>
       )}
     </DropZone>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -56,6 +56,7 @@
     "@h5web/lib": "workspace:*",
     "@react-hookz/web": "25.1.1",
     "@react-three/fiber": "8.18.0",
+    "@tanstack/react-query": "5.102.8",
     "@types/d3-format": "~3.0.4",
     "@types/ndarray": "1.0.14",
     "d3-format": "3.1.2",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -47,10 +47,13 @@ function App(props: Props) {
   const [selectedPath, setSelectedPath] = useState<string>(initialPath);
   const [isInspecting, setInspecting] = useState(false);
 
-  const { valuesStore } = useDataContext();
+  const { filepath, queryClient } = useDataContext();
   function onSelectPath(path: string) {
     setSelectedPath(path);
-    valuesStore.abortAll('entity changed', true);
+    void queryClient.cancelQueries(
+      { queryKey: [filepath, 'value'] },
+      { silent: true },
+    );
   }
 
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({

--- a/packages/app/src/ErrorFallback.tsx
+++ b/packages/app/src/ErrorFallback.tsx
@@ -1,4 +1,5 @@
 import { AbortError } from '@h5web/shared/react-suspense-fetch';
+import { CancelledError } from '@tanstack/react-query';
 import { type FallbackProps } from 'react-error-boundary';
 
 import styles from './App.module.css';
@@ -11,7 +12,7 @@ interface Props extends FallbackProps {
 function ErrorFallback(props: Props) {
   const { className = '', error, resetErrorBoundary } = props;
 
-  if (error instanceof AbortError) {
+  if (error instanceof AbortError || error instanceof CancelledError) {
     return (
       <p className={`${styles.error} ${className}`}>
         Request cancelled

--- a/packages/app/src/hooks.ts
+++ b/packages/app/src/hooks.ts
@@ -4,6 +4,7 @@ import {
   assertShape,
   assertType,
   assertValue,
+  isDefined,
 } from '@h5web/shared/guards';
 import {
   type ArrayShape,
@@ -14,6 +15,7 @@ import {
   type ScalarShape,
   type Value,
 } from '@h5web/shared/hdf5-models';
+import { useSuspenseQueries } from '@tanstack/react-query';
 
 import { useDataContext } from './providers/DataProvider';
 import { type ValuesStoreParams } from './providers/models';
@@ -65,17 +67,18 @@ export function useValue<D extends Dataset<ArrayShape | ScalarShape>>(
   dataset: D | undefined,
   selection?: string,
 ): Value<D> | undefined {
-  const { valuesStore } = useDataContext();
+  const { queries } = useDataContext();
+
+  const [result] = useSuspenseQueries({
+    queries: [...(dataset ? [queries.value(dataset, selection)] : [])],
+  });
 
   if (!dataset) {
     return undefined;
   }
 
-  // If `selection` is undefined, the entire dataset will be fetched
-  const value = valuesStore.get({ dataset, selection });
-
-  assertValue(value, dataset);
-  return value;
+  assertValue(result.data, dataset);
+  return result.data;
 }
 
 type ValueFromParams<
@@ -85,35 +88,42 @@ type ValueFromParams<
 export function useValues<
   R extends Record<string, ValuesStoreParams['dataset'] | ValuesStoreParams>,
 >(datasets: R): { [K in keyof R]: ValueFromParams<R[K]> } {
-  const { valuesStore } = useDataContext();
+  const { queries } = useDataContext();
 
-  const storeParams = Object.entries(datasets).map(
-    ([key, datasetOrStoreParams]) =>
-      [
-        key,
-        'dataset' in datasetOrStoreParams
-          ? datasetOrStoreParams // already store params => keep as is
-          : { dataset: datasetOrStoreParams, selection: undefined }, // dataset => prepare store params
-      ] as const,
-  );
+  const keys = Object.keys(datasets);
+  const storeParams = Object.values(datasets).map((datasetOrStoreParams) => {
+    return 'dataset' in datasetOrStoreParams
+      ? datasetOrStoreParams // already store params => keep as is
+      : { dataset: datasetOrStoreParams }; // dataset => prepare store params
+  });
 
-  storeParams.forEach(([, params]) => {
-    valuesStore.prefetch(params);
+  const results = useSuspenseQueries({
+    queries: storeParams.map(({ dataset, selection }) => {
+      return queries.value(dataset, selection);
+    }),
   });
 
   return Object.fromEntries(
-    storeParams.map(([key, params]) => [key, valuesStore.get(params)]),
+    results.map(({ data }, i) => {
+      assertValue(data, storeParams[i].dataset);
+      return [keys[i], data];
+    }),
   ) as { [K in keyof R]: ValueFromParams<R[K]> };
 }
 
 export function useValuesInCache(
   ...datasets: (Dataset<ScalarShape | ArrayShape> | undefined)[]
 ): (dimMapping: DimensionMapping) => boolean {
-  const { valuesStore } = useDataContext();
+  const { queries, queryClient } = useDataContext();
+
+  const definedDatasets = datasets.filter(isDefined);
+
   return (nextMapping) => {
     const selection = getSliceSelection(nextMapping);
-    return datasets.every(
-      (dataset) => !dataset || valuesStore.has({ dataset, selection }),
-    );
+
+    return definedDatasets.every((dataset) => {
+      const { queryKey } = queries.value(dataset, selection);
+      return queryClient.getQueryData(queryKey) !== undefined;
+    });
   };
 }

--- a/packages/app/src/providers/DataProvider.tsx
+++ b/packages/app/src/providers/DataProvider.tsx
@@ -1,25 +1,62 @@
 import { isGroup } from '@h5web/shared/guards';
+import {
+  type ArrayShape,
+  type Dataset,
+  type ScalarShape,
+} from '@h5web/shared/hdf5-models';
 import { getNameFromPath } from '@h5web/shared/hdf5-utils';
 import { createFetchStore } from '@h5web/shared/react-suspense-fetch';
+import {
+  hashKey,
+  QueryClient,
+  QueryClientProvider,
+  queryOptions,
+} from '@tanstack/react-query';
 import {
   createContext,
   type PropsWithChildren,
   useContext,
   useMemo,
+  useState,
 } from 'react';
 
 import { type DataProviderApi } from './api';
+import { type AttrValuesStore, type EntitiesStore } from './models';
 import {
-  type AttrValuesStore,
-  type EntitiesStore,
-  type ValuesStore,
-} from './models';
+  createProgressStore,
+  type ProgressStore,
+  trackProgress,
+} from './progress-store';
+
+function getQueryOptionsFactories(
+  api: DataProviderApi,
+  scope: string,
+  progressStore: ProgressStore,
+) {
+  return {
+    value: (dataset: Dataset<ScalarShape | ArrayShape>, selection?: string) => {
+      const queryKey = [scope, 'value', dataset.path, selection] as const;
+      const queryHash = hashKey(queryKey);
+
+      return queryOptions({
+        queryKey,
+        queryFn: async ({ signal }) => {
+          return trackProgress(progressStore, queryHash, async (onProgress) => {
+            return api.getValue({ dataset, selection }, signal, onProgress);
+          });
+        },
+      });
+    },
+  };
+}
 
 export interface DataContextValue {
   filepath: string;
   filename: string;
+  queries: ReturnType<typeof getQueryOptionsFactories>;
+  queryClient: QueryClient;
+  progressStore: ProgressStore;
   entitiesStore: EntitiesStore;
-  valuesStore: ValuesStore;
   attrValuesStore: AttrValuesStore;
 
   // Undocumented
@@ -39,6 +76,23 @@ interface Props {
 
 function DataProvider(props: PropsWithChildren<Props>) {
   const { api, children } = props;
+
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            networkMode: 'always', // always fire queries regardless of online/offline status
+            staleTime: 'static', // never ever refetch cached data
+            gcTime: 15 * 60 * 1000, // keep cached data with no active queries for 15 min
+            retry: false, // never retry fetching automatically on error
+            structuralSharing: false, // not relevant since data is never refetched
+          },
+        },
+      }),
+  );
+
+  const [progressStore] = useState(createProgressStore);
 
   const entitiesStore = useMemo(() => {
     const store = createFetchStore(async (path: string) => {
@@ -60,12 +114,6 @@ function DataProvider(props: PropsWithChildren<Props>) {
     return store;
   }, [api]);
 
-  const valuesStore = useMemo(() => {
-    return createFetchStore(api.getValue.bind(api), (a, b) => {
-      return a.dataset.path === b.dataset.path && a.selection === b.selection;
-    });
-  }, [api]);
-
   const attrValuesStore = useMemo(() => {
     return createFetchStore(
       api.getAttrValues.bind(api),
@@ -73,20 +121,26 @@ function DataProvider(props: PropsWithChildren<Props>) {
     );
   }, [api]);
 
+  const value = useMemo(() => {
+    const { filepath } = api;
+
+    return {
+      filepath,
+      filename: getNameFromPath(filepath),
+      queries: getQueryOptionsFactories(api, filepath, progressStore),
+      queryClient,
+      progressStore,
+      entitiesStore,
+      attrValuesStore,
+      getExportURL: api.getExportURL?.bind(api),
+      getSearchablePaths: api.getSearchablePaths?.bind(api),
+    };
+  }, [api, entitiesStore, attrValuesStore, queryClient, progressStore]);
+
   return (
-    <DataContext.Provider
-      value={{
-        filepath: api.filepath,
-        filename: getNameFromPath(api.filepath),
-        entitiesStore,
-        valuesStore,
-        attrValuesStore,
-        getExportURL: api.getExportURL?.bind(api),
-        getSearchablePaths: api.getSearchablePaths?.bind(api),
-      }}
-    >
-      {children}
-    </DataContext.Provider>
+    <QueryClientProvider client={queryClient}>
+      <DataContext.Provider value={value}>{children}</DataContext.Provider>
+    </QueryClientProvider>
   );
 }
 

--- a/packages/app/src/providers/models.ts
+++ b/packages/app/src/providers/models.ts
@@ -17,7 +17,7 @@ export type AttrValuesStore = FetchStore<Entity, AttributeValues>;
 
 export interface ValuesStoreParams {
   dataset: Dataset<ScalarShape | ArrayShape>;
-  selection?: string | undefined;
+  selection?: string | undefined; // if omitted or `undefined`, provider should return the full dataset
 }
 
 export type Fetcher = (

--- a/packages/app/src/providers/progress-store.ts
+++ b/packages/app/src/providers/progress-store.ts
@@ -1,0 +1,46 @@
+import { createStore, type StoreApi } from 'zustand';
+
+interface ProgressState {
+  ongoing: Map<string, number | undefined>;
+  setProgress: (queryHash: string, value: number | undefined) => void;
+  clearProgress: (queryHash: string) => void;
+}
+
+export type ProgressStore = StoreApi<ProgressState>;
+
+export function createProgressStore(): ProgressStore {
+  return createStore<ProgressState>((set): ProgressState => ({
+    ongoing: new Map(),
+    setProgress: (queryHash, value) => {
+      set(({ ongoing }) => {
+        const next = new Map(ongoing);
+        next.set(queryHash, value);
+        return { ongoing: next };
+      });
+    },
+    clearProgress: (queryHash) =>
+      set(({ ongoing }) => {
+        const next = new Map(ongoing);
+        next.delete(queryHash);
+        return { ongoing: next };
+      }),
+  }));
+}
+
+export type OnProgress = (value: number) => void;
+
+export async function trackProgress<TResult>(
+  progressStore: ProgressStore,
+  queryHash: string,
+  fn: (onProgress: OnProgress) => Promise<TResult>,
+): Promise<TResult> {
+  progressStore.getState().setProgress(queryHash, undefined);
+
+  try {
+    return await fn((value) => {
+      progressStore.getState().setProgress(queryHash, value);
+    });
+  } finally {
+    progressStore.getState().clearProgress(queryHash);
+  }
+}

--- a/packages/app/src/vis-packs/ValueLoader.tsx
+++ b/packages/app/src/vis-packs/ValueLoader.tsx
@@ -12,14 +12,14 @@ interface Props {
 
 function ValueLoader(props: Props) {
   const { isSlice = false } = props;
-  const { valuesStore } = useDataContext();
+  const { filepath, queryClient, progressStore } = useDataContext();
 
   // Wait a bit before showing loader to avoid flash
   const [isReady, toggleReady] = useToggle();
   useTimeoutEffect(toggleReady, 100);
 
   // Track progress
-  const ongoing = useStore(valuesStore.progressStore, (state) => state.ongoing);
+  const ongoing = useStore(progressStore, (state) => state.ongoing);
 
   return (
     <div className={styles.loader} data-testid="LoadingDatasetValue">
@@ -40,11 +40,7 @@ function ValueLoader(props: Props) {
             {[...ongoing.entries()]
               .slice(0, MAX_PROGRESS_BARS)
               .map(([key, val]) => (
-                <progress
-                  className={styles.progress}
-                  key={`${key.dataset.path}_${key.selection || ''}`}
-                  value={val}
-                />
+                <progress key={key} className={styles.progress} value={val} />
               ))}
           </div>
           <p>{isSlice ? 'Loading current slice' : 'Loading data'}...</p>
@@ -52,7 +48,12 @@ function ValueLoader(props: Props) {
             <button
               className={styles.cancelBtn}
               type="button"
-              onClick={() => valuesStore.abortAll('cancelled by user')}
+              onClick={() => {
+                void queryClient.cancelQueries(
+                  { queryKey: [filepath, 'value'] },
+                  { revert: false },
+                );
+              }}
             >
               Cancel?
             </button>

--- a/packages/app/src/vis-packs/VisBoundary.tsx
+++ b/packages/app/src/vis-packs/VisBoundary.tsx
@@ -13,15 +13,19 @@ interface Props {
 
 function VisBoundary(props: PropsWithChildren<Props>) {
   const { resetKey, isSlice, children } = props;
-  const { valuesStore } = useDataContext();
+  const { queryClient } = useDataContext();
 
   return (
     <ErrorBoundary
+      resetKeys={[resetKey]}
       fallbackRender={(args) => (
         <ErrorFallback className={visualizerStyles.vis} {...args} />
       )}
-      resetKeys={[resetKey]}
-      onError={() => valuesStore.evictErrors()}
+      onError={() => {
+        queryClient.removeQueries({
+          predicate: (query) => query.state.status === 'error',
+        });
+      }}
     >
       <Suspense fallback={<ValueLoader isSlice={isSlice} />}>
         {children}

--- a/packages/app/src/vis-packs/core/scalar/ScalarFetcher.tsx
+++ b/packages/app/src/vis-packs/core/scalar/ScalarFetcher.tsx
@@ -6,6 +6,7 @@ import {
   type ScalarShape,
   type ScalarValue,
 } from '@h5web/shared/hdf5-models';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { type ReactNode } from 'react';
 
 import { useDataContext } from '../../../providers/DataProvider';
@@ -23,16 +24,16 @@ function ScalarFetcher<D extends Dataset<ScalarShape | ArrayShape>>(
   props: Props<D>,
 ) {
   const { dataset, selection, render } = props;
-  const { valuesStore } = useDataContext();
+  const { queries } = useDataContext();
 
   if (selection && !isScalarSelection(selection)) {
     throw new Error('Expected scalar selection');
   }
 
-  const value = valuesStore.get({ dataset, selection });
-  assertScalarValue(value, dataset.type);
+  const { data } = useSuspenseQuery(queries.value(dataset, selection));
+  assertScalarValue(data, dataset.type);
 
-  return render(value);
+  return render(data);
 }
 
 export default ScalarFetcher;

--- a/packages/app/src/vis-packs/nexus/NxValuesFetcher.tsx
+++ b/packages/app/src/vis-packs/nexus/NxValuesFetcher.tsx
@@ -2,10 +2,11 @@ import {
   type ComplexType,
   type NumericLikeType,
 } from '@h5web/shared/hdf5-models';
+import { getAssertedValue } from '@h5web/shared/hdf5-utils';
 import { type ReactNode } from 'react';
 
-import { useValue } from '../../hooks';
-import { useNxValues, usePrefetchNxValues } from './hooks';
+import { useValues } from '../../hooks';
+import { type ValuesStoreParams } from '../../providers/models';
 import { type NxData, type NxValues } from './models';
 
 interface Props<T extends NumericLikeType | ComplexType> {
@@ -20,27 +21,47 @@ function NxValuesFetcher<T extends NumericLikeType | ComplexType>(
   const { nxData, selection, render } = props;
   const { signalDef, axisDefs, auxDefs, titleDataset } = nxData;
 
-  const axisDatasets = axisDefs.map((def) => def?.dataset);
-  const auxDatasets = auxDefs.map((def) => def.dataset);
-  const auxErrorDatasets = auxDefs.map((def) => def.errorDataset);
+  // 1. Prepare record of defined `{ dataset, selection }` objects for `useValues`
+  const datasets: Record<string, ValuesStoreParams> = {
+    signal: { dataset: signalDef.dataset, selection },
+    ...(titleDataset && { title: { dataset: titleDataset } }),
+    ...(signalDef.errorDataset && {
+      errors: { dataset: signalDef.errorDataset, selection },
+    }),
+  };
 
-  usePrefetchNxValues([titleDataset, ...axisDatasets]);
-  usePrefetchNxValues(
-    [
-      signalDef.dataset,
-      signalDef.errorDataset,
-      ...auxDatasets,
-      ...auxErrorDatasets,
-    ],
-    selection,
+  // Compute keys from indices so `undefined` gaps can be restored after `useValues`
+  auxDefs.forEach((def, i) => {
+    datasets[`auxValues-${i}`] = { dataset: def.dataset, selection };
+    if (def.errorDataset) {
+      datasets[`auxErrors-${i}`] = { dataset: def.errorDataset, selection };
+    }
+  });
+
+  axisDefs.forEach((def, i) => {
+    if (def) {
+      datasets[`axisValues-${i}`] = { dataset: def.dataset };
+    }
+  });
+
+  // 2. Fetch the values
+  const values = useValues(datasets);
+
+  // 3. Assert the values again (because the `datasets` record is loosely typed)
+  const signal = getAssertedValue(values.signal, signalDef.dataset);
+  const title = getAssertedValue(values.title, titleDataset) || signalDef.label;
+  const errors = getAssertedValue(values.errors, signalDef.errorDataset);
+
+  // Map over the original definitions arrays to preserve `undefined` gaps
+  const auxValues = auxDefs.map((def, i) =>
+    getAssertedValue(values[`auxValues-${i}`], def.dataset),
   );
-
-  const title = useValue(titleDataset) || signalDef.label;
-  const signal = useValue(signalDef.dataset, selection);
-  const errors = useValue(signalDef.errorDataset, selection);
-  const auxValues = useNxValues(auxDatasets, selection);
-  const auxErrors = useNxValues(auxErrorDatasets, selection);
-  const axisValues = useNxValues(axisDatasets);
+  const auxErrors = auxDefs.map((def, i) =>
+    getAssertedValue(values[`auxErrors-${i}`], def.errorDataset),
+  );
+  const axisValues = axisDefs.map((def, i) =>
+    getAssertedValue(values[`axisValues-${i}`], def?.dataset),
+  );
 
   return render({ title, signal, errors, auxValues, auxErrors, axisValues });
 }

--- a/packages/app/src/vis-packs/nexus/hooks.ts
+++ b/packages/app/src/vis-packs/nexus/hooks.ts
@@ -1,14 +1,9 @@
 import { type DimensionMapping } from '@h5web/lib';
 import { createMemo } from '@h5web/shared/createMemo';
-import { assertValue, isDefined } from '@h5web/shared/guards';
 import {
-  type ArrayShape,
   type ComplexType,
-  type Dataset,
   type GroupWithChildren,
   type NumericLikeType,
-  type ScalarShape,
-  type Value,
 } from '@h5web/shared/hdf5-models';
 
 import { useValuesInCache } from '../../hooks';
@@ -60,43 +55,6 @@ export function useNxData(group: GroupWithChildren): NxData {
     ),
     silxStyle: getSilxStyle(group, attrValuesStore),
   };
-}
-
-export function usePrefetchNxValues(
-  datasets: (Dataset<ScalarShape | ArrayShape> | undefined)[],
-  selection?: string,
-): void {
-  const { valuesStore } = useDataContext();
-  datasets.filter(isDefined).forEach((dataset) => {
-    valuesStore.prefetch({ dataset, selection });
-  });
-}
-
-export function useNxValues<D extends Dataset<ArrayShape | ScalarShape>>(
-  datasets: D[],
-  selection?: string,
-): Value<D>[];
-
-export function useNxValues<D extends Dataset<ArrayShape | ScalarShape>>(
-  datasets: (D | undefined)[],
-  selection?: string,
-): (Value<D> | undefined)[];
-
-export function useNxValues<D extends Dataset<ArrayShape | ScalarShape>>(
-  datasets: (D | undefined)[],
-  selection?: string,
-): (Value<D> | undefined)[] {
-  const { valuesStore } = useDataContext();
-
-  return datasets.map((dataset) => {
-    if (!dataset) {
-      return undefined;
-    }
-
-    const value = valuesStore.get({ dataset, selection });
-    assertValue(value, dataset);
-    return value;
-  });
 }
 
 export function useNxHeatmapDataToFetch<

--- a/packages/app/src/visualizer/VisManager.tsx
+++ b/packages/app/src/visualizer/VisManager.tsx
@@ -29,10 +29,13 @@ function VisManager(props: Props) {
 
   const [visBarElem, setVisBarElem] = useState<HTMLDivElement>();
 
-  const { valuesStore } = useDataContext();
+  const { filepath, queryClient } = useDataContext();
   function onVisChange(index: number) {
     setActiveVis(index);
-    valuesStore.abortAll('visualization changed', true);
+    void queryClient.cancelQueries(
+      { queryKey: [filepath, 'value'] },
+      { silent: true },
+    );
   }
 
   return (

--- a/packages/shared/src/hdf5-utils.ts
+++ b/packages/shared/src/hdf5-utils.ts
@@ -1,4 +1,4 @@
-import { isNumericType } from './guards';
+import { assertValue, isNumericType } from './guards';
 import {
   H5T_CSET,
   H5T_ORDER,
@@ -22,6 +22,8 @@ import {
   type FloatType,
   type GroupWithChildren,
   type H5WebComplex,
+  type HasShape,
+  type HasType,
   type IntegerType,
   type NullShape,
   type NumericType,
@@ -33,6 +35,7 @@ import {
   type StringType,
   type TimeType,
   type UnknownType,
+  type Value,
   type VLenType,
 } from './hdf5-models';
 
@@ -235,4 +238,23 @@ export function unknownType(): UnknownType {
 
 export function cplx(real: number, imag: number): H5WebComplex {
   return [real, imag];
+}
+
+export function getAssertedValue<
+  O extends HasShape<ArrayShape | ScalarShape> & HasType,
+>(value: unknown, obj: O): Value<O>;
+
+export function getAssertedValue<
+  O extends HasShape<ArrayShape | ScalarShape> & HasType,
+>(value: unknown, obj: O | undefined): Value<O> | undefined;
+
+export function getAssertedValue<
+  O extends HasShape<ArrayShape | ScalarShape> & HasType,
+>(value: unknown, obj: O | undefined): Value<O> | undefined {
+  if (obj) {
+    assertValue(value, obj);
+    return value;
+  }
+
+  return undefined;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,9 @@ importers:
       '@h5web/h5wasm':
         specifier: workspace:*
         version: link:../../packages/h5wasm
+      '@tanstack/react-query-devtools':
+        specifier: 5.102.8
+        version: 5.102.8(@tanstack/react-query@5.102.8(react@18.3.1))(react@18.3.1)
       h5wasm-plugins:
         specifier: 0.3.0
         version: 0.3.0(h5wasm@0.10.3)
@@ -419,6 +422,9 @@ importers:
       '@react-three/fiber':
         specifier: 8.18.0
         version: 8.18.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.185.1)
+      '@tanstack/react-query':
+        specifier: 5.102.8
+        version: 5.102.8(react@18.3.1)
       '@types/d3-format':
         specifier: ~3.0.4
         version: 3.0.4
@@ -1877,6 +1883,23 @@ packages:
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
 
+  '@tanstack/query-core@5.102.8':
+    resolution: {integrity: sha512-ZNjkJ33CqvPNec/6lZBnHqLc3EVGPZ9ySLhYahU9TcuRFdmwXewuj0c4hwSWcGHqEUwcSrKeZ+oGcvPBqXcQcg==}
+
+  '@tanstack/query-devtools@5.102.8':
+    resolution: {integrity: sha512-ZgeMKuF5d/zOE+tgWm3cSbD6Zcbr6IugVsnbHzUcSismqLZDSUPBKM6ILUxExgwe6rPAOox2x5bA5T+PSOQG0Q==}
+
+  '@tanstack/react-query-devtools@5.102.8':
+    resolution: {integrity: sha512-QKb7A44BZOU7nxsGA4gFN1fofjYovar5O0T83Ff4Y+2eRq09RGFrAzzutVdF/6/emfSaMDohp6e759BjB3fxEw==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.102.8
+      react: ^18 || ^19
+
+  '@tanstack/react-query@5.102.8':
+    resolution: {integrity: sha512-TYBea4OuXWD7MhaSHq069TWbFe7rcwWN6kzT7JF0OKi1K6c1gTv2IzD6A6ExJsCMozdkqBWeuIUZmu4KQg0O5A==}
+    peerDependencies:
+      react: ^18 || ^19
+
   '@testing-library/cypress@10.1.3':
     resolution: {integrity: sha512-rVCH92TmU8idROHqCdTSp/bosIIUezihSwFfR/J2GZD0EAwyzRuYNseh54eziKJWjJ64BCXPT3X3jLO7v4yenQ==}
     engines: {node: '>=12', npm: '>=6'}
@@ -3229,6 +3252,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -6279,6 +6303,21 @@ snapshots:
       estraverse: 5.3.0
       picomatch: 4.0.5
 
+  '@tanstack/query-core@5.102.8': {}
+
+  '@tanstack/query-devtools@5.102.8': {}
+
+  '@tanstack/react-query-devtools@5.102.8(@tanstack/react-query@5.102.8(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-devtools': 5.102.8
+      '@tanstack/react-query': 5.102.8(react@18.3.1)
+      react: 18.3.1
+
+  '@tanstack/react-query@5.102.8(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 5.102.8
+      react: 18.3.1
+
   '@testing-library/cypress@10.1.3(cypress@15.18.0)':
     dependencies:
       '@babel/runtime': 7.29.7
@@ -7950,9 +7989,9 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fdir@6.5.0(picomatch@4.0.4):
+  fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   fflate@0.8.3: {}
 
@@ -8579,8 +8618,8 @@ snapshots:
 
   magicast@0.5.3:
     dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
@@ -9810,8 +9849,8 @@ snapshots:
 
   tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinyrainbow@2.0.0: {}
 
@@ -10120,7 +10159,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.3
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.2.4


### PR DESCRIPTION
This PR starts the migration to [Tanstack Query](https://tanstack.com/query/latest) (also referred to as "React Query").

The goal is to replace our suspense store implementation, which is not fully compatible with React 19. Our current solution also had a lot of limitations in terms of caching, cancelling, etc. React Query already improves on some of these aspects (I'll point out how inline) and opens the door to further improvements.

I start with migrating the values store. It's good to see that our architecture allows migrating this store independently from the others (entities and attributes). The migration was mostly straightforward, as it's still the same suspense-based architecture. Most calls to our `react-suspense-fetch` store are replaced one to one — the main exception is with `useNxValues`, which I'll discuss inline.

The main challenges were that `useSuspenseQuery(ies)` cannot be called conditionally (unlike `valuesStore.get()`), and that suspense-enabled queries cannot be disabled/skipped (it's not possible to pass an `undefined` query, and the `enabled` flag is not allowed unlike with `useQuery(ies)`).

All the tests remain unchanged and still pass, so there's really no noticeable change in behaviour for end users, which is also a big relief.