### PR TITLE
Migrate tiled heatmap

### DIFF
--- a/apps/storybook/src/TiledHeatmapMesh/TiledHeatmapMesh.stories.tsx
+++ b/apps/storybook/src/TiledHeatmapMesh/TiledHeatmapMesh.stories.tsx
@@ -2,8 +2,10 @@ import {
   type AxisConfig,
   DefaultInteractions,
   type Domain,
+  ResetZoomButton,
   TiledHeatmapMesh,
   type TiledHeatmapMeshProps,
+  TiledHeatmapProvider,
   TiledTooltipMesh,
   VisCanvas,
 } from '@h5web/lib';
@@ -75,6 +77,7 @@ export const Default = {
         aspect="equal"
       >
         <DefaultInteractions />
+        <ResetZoomButton />
         <group
           scale={[
             abscissaConfig.flip ? -1 : 1,
@@ -82,7 +85,9 @@ export const Default = {
             1,
           ]}
         >
-          <TiledHeatmapMesh {...tiledHeatmapProps} />
+          <TiledHeatmapProvider>
+            <TiledHeatmapMesh {...tiledHeatmapProps} />
+          </TiledHeatmapProvider>
         </group>
         <TiledTooltipMesh renderTooltip={renderTooltip} />
       </VisCanvas>
@@ -171,14 +176,19 @@ export const WithTransforms = {
         aspect="equal"
       >
         <DefaultInteractions />
+        <ResetZoomButton />
         <LinearAxesGroup>
           <group position={[1, 1, 0]} rotation={[0, 0, Math.PI / 4]}>
-            <TiledHeatmapMesh api={api} size={size} {...tiledHeatmapProps} />
-            <TiledTooltipMesh size={size} renderTooltip={renderTooltip} />
+            <TiledHeatmapProvider>
+              <TiledHeatmapMesh api={api} size={size} {...tiledHeatmapProps} />
+              <TiledTooltipMesh size={size} renderTooltip={renderTooltip} />
+            </TiledHeatmapProvider>
           </group>
           <group position={[-1, 1, 0]} scale={[2, 2, 1]}>
-            <TiledHeatmapMesh api={api} size={size} {...tiledHeatmapProps} />
-            <TiledTooltipMesh size={size} renderTooltip={renderTooltip} />
+            <TiledHeatmapProvider>
+              <TiledHeatmapMesh api={api} size={size} {...tiledHeatmapProps} />
+              <TiledTooltipMesh size={size} renderTooltip={renderTooltip} />
+            </TiledHeatmapProvider>
           </group>
         </LinearAxesGroup>
       </VisCanvas>

--- a/apps/storybook/src/TiledHeatmapMesh/checkerboard-api.ts
+++ b/apps/storybook/src/TiledHeatmapMesh/checkerboard-api.ts
@@ -1,11 +1,7 @@
 import { getLayerSizes, type Size, TilesApi } from '@h5web/lib';
-import { createFetchStore } from '@h5web/shared/react-suspense-fetch';
 import greenlet from 'greenlet';
 import ndarray, { type NdArray } from 'ndarray';
 import { MathUtils, type Vector2 } from 'three';
-
-import { type TileParams } from './models';
-import { areTilesEqual } from './utils';
 
 const getCheckerboardArray = greenlet(
   async (length: number, value: number): Promise<Uint8Array> => {
@@ -14,38 +10,34 @@ const getCheckerboardArray = greenlet(
 );
 
 export class CheckerboardTilesApi extends TilesApi {
-  private readonly store;
-
   public constructor(size: Size, tileSize: Size) {
     super(tileSize, getLayerSizes(size, tileSize));
-
-    this.store = createFetchStore(async (tile: TileParams) => {
-      const { layer, offset } = tile;
-      const layerSize = this.layerSizes[layer];
-
-      // Clip slice to size of the level
-      const width = MathUtils.clamp(
-        layerSize.width - offset.x,
-        0,
-        this.tileSize.width,
-      );
-      const height = MathUtils.clamp(
-        layerSize.height - offset.y,
-        0,
-        this.tileSize.height,
-      );
-
-      const value = Math.abs(
-        (Math.floor(offset.x / this.tileSize.width) % 2) -
-          (Math.floor(offset.y / this.tileSize.height) % 2),
-      );
-
-      const arr = await getCheckerboardArray(width * height, value);
-      return ndarray(arr, [height, width]);
-    }, areTilesEqual);
   }
 
-  public get(layer: number, offset: Vector2): NdArray<Uint8Array> {
-    return this.store.get({ layer, offset });
+  public async get(
+    layer: number,
+    offset: Vector2,
+  ): Promise<NdArray<Uint8Array>> {
+    const layerSize = this.layerSizes[layer];
+
+    // Clip slice to size of the level
+    const width = MathUtils.clamp(
+      layerSize.width - offset.x,
+      0,
+      this.tileSize.width,
+    );
+    const height = MathUtils.clamp(
+      layerSize.height - offset.y,
+      0,
+      this.tileSize.height,
+    );
+
+    const value = Math.abs(
+      (Math.floor(offset.x / this.tileSize.width) % 2) -
+        (Math.floor(offset.y / this.tileSize.height) % 2),
+    );
+
+    const arr = await getCheckerboardArray(width * height, value);
+    return ndarray(arr, [height, width]);
   }
 }

--- a/apps/storybook/src/TiledHeatmapMesh/mandlebrot-api.ts
+++ b/apps/storybook/src/TiledHeatmapMesh/mandlebrot-api.ts
@@ -1,12 +1,8 @@
 import { getLayerSizes, type Size, TilesApi } from '@h5web/lib';
-import { createFetchStore } from '@h5web/shared/react-suspense-fetch';
 import { type Domain } from '@h5web/shared/vis-models';
 import greenlet from 'greenlet';
 import ndarray, { type NdArray } from 'ndarray';
 import { MathUtils, type Vector2 } from 'three';
-
-import { type TileParams } from './models';
-import { areTilesEqual } from './utils';
 
 // https://en.wikipedia.org/wiki/Mandelbrot_set
 const mandlebrot = greenlet(
@@ -56,7 +52,6 @@ const mandlebrot = greenlet(
 export class MandelbrotTilesApi extends TilesApi {
   public readonly xDomain: Domain;
   public readonly yDomain: Domain;
-  private readonly store;
 
   public constructor(
     size: Size,
@@ -67,40 +62,38 @@ export class MandelbrotTilesApi extends TilesApi {
     super(tileSize, getLayerSizes(size, tileSize));
     this.xDomain = xDomain;
     this.yDomain = yDomain;
-
-    this.store = createFetchStore(async (tile: TileParams) => {
-      const { layer, offset } = tile;
-      const layerSize = this.layerSizes[layer];
-
-      // Clip slice to size of the level
-      const width = MathUtils.clamp(
-        layerSize.width - offset.x,
-        0,
-        this.tileSize.width,
-      );
-      const height = MathUtils.clamp(
-        layerSize.height - offset.y,
-        0,
-        this.tileSize.height,
-      );
-
-      const xScale = (this.xDomain[1] - this.xDomain[0]) / layerSize.width;
-      const xRange: Domain = [
-        this.xDomain[0] + xScale * offset.x,
-        this.xDomain[0] + xScale * (offset.x + width),
-      ];
-      const yScale = (this.yDomain[1] - this.yDomain[0]) / layerSize.height;
-      const yRange: Domain = [
-        this.yDomain[0] + yScale * offset.y,
-        this.yDomain[0] + yScale * (offset.y + height),
-      ];
-
-      const arr = await mandlebrot(50, xRange, yRange, width, height);
-      return ndarray(arr, [height, width]);
-    }, areTilesEqual);
   }
 
-  public get(layer: number, offset: Vector2): NdArray<Float32Array> {
-    return this.store.get({ layer, offset });
+  public async get(
+    layer: number,
+    offset: Vector2,
+  ): Promise<NdArray<Float32Array>> {
+    const layerSize = this.layerSizes[layer];
+
+    // Clip slice to size of the level
+    const width = MathUtils.clamp(
+      layerSize.width - offset.x,
+      0,
+      this.tileSize.width,
+    );
+    const height = MathUtils.clamp(
+      layerSize.height - offset.y,
+      0,
+      this.tileSize.height,
+    );
+
+    const xScale = (this.xDomain[1] - this.xDomain[0]) / layerSize.width;
+    const xRange: Domain = [
+      this.xDomain[0] + xScale * offset.x,
+      this.xDomain[0] + xScale * (offset.x + width),
+    ];
+    const yScale = (this.yDomain[1] - this.yDomain[0]) / layerSize.height;
+    const yRange: Domain = [
+      this.yDomain[0] + yScale * offset.y,
+      this.yDomain[0] + yScale * (offset.y + height),
+    ];
+
+    const arr = await mandlebrot(50, xRange, yRange, width, height);
+    return ndarray(arr, [height, width]);
   }
 }

--- a/apps/storybook/src/TiledHeatmapMesh/models.ts
+++ b/apps/storybook/src/TiledHeatmapMesh/models.ts
@@ -1,6 +1,0 @@
-import { type Vector2 } from 'three';
-
-export interface TileParams {
-  layer: number;
-  offset: Vector2;
-}

--- a/apps/storybook/src/TiledHeatmapMesh/utils.tsx
+++ b/apps/storybook/src/TiledHeatmapMesh/utils.tsx
@@ -1,7 +1,5 @@
 import { formatTooltipVal } from '@h5web/shared/vis-utils';
 
-import { type TileParams } from './models';
-
 export function renderTooltip(x: number, y: number, v: number) {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
@@ -9,8 +7,4 @@ export function renderTooltip(x: number, y: number, v: number) {
       <strong>{formatTooltipVal(v)}</strong>
     </div>
   );
-}
-
-export function areTilesEqual(a: TileParams, b: TileParams) {
-  return a.layer === b.layer && a.offset.equals(b.offset);
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -57,6 +57,7 @@
   "dependencies": {
     "@floating-ui/react": "0.27.19",
     "@react-hookz/web": "25.1.1",
+    "@tanstack/react-query": "5.102.8",
     "@types/d3-array": "~3.2.2",
     "@types/d3-color": "~3.1.3",
     "@types/d3-format": "~3.0.4",

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -241,6 +241,7 @@ export { default as RgbVis } from './vis/rgb/RgbVis';
 export { default as VisMesh } from './vis/shared/VisMesh';
 export { default as ScatterPoints } from './vis/scatter/ScatterPoints';
 export { default as ScatterPointsGeometry } from './vis/scatter/scatterPointsGeometry';
+export { default as TiledHeatmapProvider } from './vis/tiles/TiledHeatmapProvider';
 export { default as TiledHeatmapMesh } from './vis/tiles/TiledHeatmapMesh';
 export { default as TiledTooltipMesh } from './vis/tiles/TiledTooltipMesh';
 export { getLayerSizes, TilesApi } from './vis/tiles/api';

--- a/packages/lib/src/vis/tiles/Tile.tsx
+++ b/packages/lib/src/vis/tiles/Tile.tsx
@@ -1,5 +1,6 @@
 import { useThrottledCallback } from '@react-hookz/web';
 import { type ThreeEvent } from '@react-three/fiber';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { memo } from 'react';
 import { type MagnificationTextureFilter, Vector2 } from 'three';
 
@@ -20,7 +21,11 @@ function Tile(props: Props) {
   const { api, layer, x, y, magFilter, onPointerMove, ...colorMapProps } =
     props;
 
-  const array = api.get(layer, new Vector2(x, y));
+  const { data: array } = useSuspenseQuery({
+    queryKey: ['tile', layer, x, y],
+    queryFn: async () => api.get(layer, new Vector2(x, y)),
+  });
+
   const [height, width] = array.shape;
 
   const handlePointerMove = useThrottledCallback(

--- a/packages/lib/src/vis/tiles/TiledHeatmapProvider.tsx
+++ b/packages/lib/src/vis/tiles/TiledHeatmapProvider.tsx
@@ -1,0 +1,27 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { type PropsWithChildren, useState } from 'react';
+
+function TiledHeatmapProvider(props: PropsWithChildren) {
+  const { children } = props;
+
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            networkMode: 'always', // always fire queries regardless of online/offline status
+            staleTime: 'static', // never ever refetch cached data
+            gcTime: 15 * 60 * 1000, // keep cached data with no active queries for 15 min
+            retry: false, // never retry fetching automatically on error
+            structuralSharing: false, // not relevant since data is never refetched
+          },
+        },
+      }),
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+export default TiledHeatmapProvider;

--- a/packages/lib/src/vis/tiles/api.ts
+++ b/packages/lib/src/vis/tiles/api.ts
@@ -54,5 +54,5 @@ export abstract class TilesApi {
     return this.layerSizes.length;
   }
 
-  public abstract get(layer: number, offset: Vector2): TileArray;
+  public abstract get(layer: number, offset: Vector2): Promise<TileArray>;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,7 +245,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)
+        version: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1))
       wait-on:
         specifier: 9.0.10
         version: 9.0.10(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
@@ -518,7 +518,7 @@ importers:
         version: 1.16.0(lightningcss@1.32.0)(postcss@8.5.16)(rollup@4.62.2)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1))
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)
+        version: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1))
       vitest-browser-react:
         specifier: 2.2.0
         version: 2.2.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@4.1.9)
@@ -585,7 +585,7 @@ importers:
         version: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)
+        version: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1))
 
   packages/lib:
     dependencies:
@@ -595,6 +595,9 @@ importers:
       '@react-hookz/web':
         specifier: 25.1.1
         version: 25.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/react-query':
+        specifier: 5.102.8
+        version: 5.102.8(react@18.3.1)
       '@types/d3-array':
         specifier: ~3.2.2
         version: 3.2.2
@@ -736,7 +739,7 @@ importers:
         version: 1.16.0(lightningcss@1.32.0)(postcss@8.5.16)(rollup@4.62.2)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1))
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)
+        version: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1))
 
   packages/shared:
     devDependencies:
@@ -784,7 +787,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)
+        version: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1))
       zustand:
         specifier: 5.0.14
         version: 5.0.14(@types/react@18.3.31)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
@@ -5245,6 +5248,7 @@ packages:
       '@vitest/ui': 4.1.9
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -6863,7 +6867,7 @@ snapshots:
       '@vitest/mocker': 4.1.9(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1))
       playwright: 1.61.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)
+      vitest: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -6879,7 +6883,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)
+      vitest: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -6899,7 +6903,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)
+      vitest: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1))
     optionalDependencies:
       '@vitest/browser': 4.1.9(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1))(vitest@4.1.9)
 
@@ -6911,7 +6915,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@9.39.4(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       typescript: 6.0.3
-      vitest: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)
+      vitest: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -6975,7 +6979,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)
+      vitest: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -10133,7 +10137,7 @@ snapshots:
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      vitest: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)
+      vitest: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1))
     optionalDependencies:
       '@types/react': 18.3.31
       '@types/react-dom': 18.3.7(@types/react@18.3.31)
@@ -10143,9 +10147,9 @@ snapshots:
       '@vitest/utils': 4.1.9
       chalk: 5.6.2
       vite: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)
-      vitest: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)
+      vitest: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1))
 
-  vitest@4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1):
+  vitest@4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)):
     dependencies:
       '@vitest/expect': 4.1.9
       '@vitest/mocker': 4.1.9(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1))
@@ -10173,18 +10177,7 @@ snapshots:
       '@vitest/coverage-v8': 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       '@vitest/ui': 4.1.9(vitest@4.1.9)
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
   wait-on@9.0.10(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:


### PR DESCRIPTION
The tiled visualization (`TiledHeatmapMesh`) expects an instance of `TilesApi`. This API has an abstract `get` method that is supposed to return the ndarray for a given tile synchronously — i.e. thanks to `react-suspense-fetch`.

This PR makes the `get` method async and invokes it via `useSuspenseQuery`. It also adds a `TiledHeatmapProvider` so consumers can easily render the required `QueryClientProvider` with the right query client configuration.

We have to add `@tanstack/react-query` to the lib, unfortunately, but since everything is self-contained, we don't have to make it a peer dep. :tada:

I've confirmed that, when the tiled heatmap is not used, `@tanstack/react-query` doesn't appear in the bundle. To test this, I brought the [lib demo](https://codesandbox.io/p/devbox/h5weblib-vite-xru04) from Codesandbox into the repo — I'll open a separate PR for this, though. I've been dragging my feet adding a second demo to the repo, but I think it's time.