### PR TITLE
Remove suspense from tiled heatmap and NX badge

### DIFF
--- a/packages/app/src/explorer/EntityItem.tsx
+++ b/packages/app/src/explorer/EntityItem.tsx
@@ -131,11 +131,7 @@ function EntityItem(props: Props) {
         <Icon className={styles.icon} />
         <span className={styles.name}>{entity.name}</span>
 
-        {isGroup(entity) && (
-          <Suspense fallback={<span data-testid="LoadingNxBadge" />}>
-            <NxBadge group={entity} />
-          </Suspense>
-        )}
+        {isGroup(entity) && <NxBadge group={entity} />}
       </button>
 
       {isGroup(entity) && isExpanded && (

--- a/packages/app/src/explorer/NxBadge.tsx
+++ b/packages/app/src/explorer/NxBadge.tsx
@@ -1,5 +1,5 @@
 import { type Group } from '@h5web/shared/hdf5-models';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 
 import { useDataContext } from '../providers/DataProvider';
 import { resolvePathQuery } from '../visualizer/queries';
@@ -12,26 +12,16 @@ interface Props {
 function NxBadge(props: Props) {
   const { group } = props;
   const dataContext = useDataContext();
-  const { queryClient } = dataContext;
 
-  const { data: show } = useSuspenseQuery({
-    queryKey: [dataContext.filepath, 'nxBadge', group.path],
-    queryFn: async () => {
-      try {
-        const resolution = await queryClient.query(
-          resolvePathQuery(group.path, dataContext),
-        );
+  const { data: resolution, isPending } = useQuery(
+    resolvePathQuery(group.path, dataContext),
+  );
 
-        return !!resolution?.supportedVis.some((vis) =>
-          vis.name.startsWith('NX'),
-        );
-      } catch {
-        return false; // no badge if malformed NeXus metadata
-      }
-    },
-  });
+  if (isPending) {
+    return <span data-testid="LoadingNxBadge" />;
+  }
 
-  if (!show) {
+  if (!resolution?.supportedVis.some((vis) => vis.name.startsWith('NX'))) {
     return null;
   }
 

--- a/packages/lib/src/vis/tiles/Tile.tsx
+++ b/packages/lib/src/vis/tiles/Tile.tsx
@@ -1,6 +1,6 @@
 import { useThrottledCallback } from '@react-hookz/web';
 import { type ThreeEvent } from '@react-three/fiber';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { memo } from 'react';
 import { type MagnificationTextureFilter, Vector2 } from 'three';
 
@@ -21,20 +21,24 @@ function Tile(props: Props) {
   const { api, layer, x, y, magFilter, onPointerMove, ...colorMapProps } =
     props;
 
-  const { data: array } = useSuspenseQuery({
+  const { data: array } = useQuery({
     queryKey: ['tile', layer, x, y],
     queryFn: async () => api.get(layer, new Vector2(x, y)),
   });
 
-  const [height, width] = array.shape;
-
   const handlePointerMove = useThrottledCallback(
     (e: ThreeEvent<MouseEvent>) => {
-      onPointerMove?.(e, array);
+      onPointerMove!(e, array!); // eslint-disable-line @typescript-eslint/no-non-null-assertion
     },
-    [onPointerMove],
+    [array, onPointerMove],
     50,
   );
+
+  if (!array) {
+    return null;
+  }
+
+  const [height, width] = array.shape;
 
   return (
     <group

--- a/packages/lib/src/vis/tiles/TiledLayer.tsx
+++ b/packages/lib/src/vis/tiles/TiledLayer.tsx
@@ -1,5 +1,4 @@
 import { type ThreeEvent } from '@react-three/fiber';
-import { Suspense } from 'react';
 import { type Box3, LinearFilter, NearestFilter, Vector2 } from 'three';
 
 import { type Size } from '../models';
@@ -47,17 +46,16 @@ function TiledLayer(props: Props) {
       ]}
     >
       {tileOffsets.map((offset) => (
-        <Suspense key={`${offset.x},${offset.y}`} fallback={null}>
-          <Tile
-            api={api}
-            layer={layer}
-            x={offset.x}
-            y={offset.y}
-            {...colorMapProps}
-            magFilter={layer === baseLayerIndex ? NearestFilter : LinearFilter}
-            onPointerMove={onPointerMove}
-          />
-        </Suspense>
+        <Tile
+          key={`${offset.x},${offset.y}`}
+          api={api}
+          layer={layer}
+          x={offset.x}
+          y={offset.y}
+          {...colorMapProps}
+          magFilter={layer === baseLayerIndex ? NearestFilter : LinearFilter}
+          onPointerMove={onPointerMove}
+        />
       ))}
     </group>
   );


### PR DESCRIPTION
The two cases I've identified where `Suspense` is definitely worth removing. For `NxBadge`, it actually removes the "nxBadge" query altogether and makes the code simpler because the query no longer throws (errors become a state), so we no longer need to catch errors.