### PR TITLE
Optimize phase/amplitude computations on large datasets

### DIFF
--- a/packages/app/eslint.config.js
+++ b/packages/app/eslint.config.js
@@ -6,6 +6,17 @@ const opts = detectOpts(import.meta.dirname);
 const config = defineConfig([
   globalIgnores(['dist/', 'dist-css/', 'dist-ts/']),
   ...createConfig(opts),
+  {
+    files: ['src/**/*.test.ts'],
+    rules: {
+      'vitest/expect-expect': [
+        'warn',
+        {
+          assertFunctionNames: ['expect*'],
+        },
+      ],
+    },
+  },
 ]);
 
 export default config;

--- a/packages/app/src/vis-packs/core/complex/utils.test.ts
+++ b/packages/app/src/vis-packs/core/complex/utils.test.ts
@@ -1,0 +1,60 @@
+import { mockValues } from '@h5web/lib';
+import { describe, expect, it } from 'vitest';
+
+import { getPhaseAmplitude, unwrapPhase } from './utils';
+
+const VALUES = mockValues.oneD_complex().data;
+
+function expectCloseTo(sourceArray: Float64Array, expectedArray: number[]) {
+  sourceArray.forEach((val, i) => {
+    expect(val, `index=${i}`).toBeCloseTo(expectedArray[i], 1);
+  });
+}
+
+describe('getPhaseAmplitude', () => {
+  it('should compute phase and amplitude of complex numbers', () => {
+    const { phase, amplitude } = getPhaseAmplitude(VALUES);
+
+    expectCloseTo(amplitude, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expectCloseTo(phase, [
+      Math.PI,
+      0,
+      Math.PI,
+      0,
+      Math.PI,
+      0,
+      Math.PI,
+      0,
+      Math.PI,
+      0,
+    ]);
+  });
+});
+
+describe('unwrapPhase', () => {
+  it('should unwrap phase values by removing 2π discontinuities', () => {
+    const { phase } = getPhaseAmplitude(VALUES);
+    const unwrapped = unwrapPhase(phase);
+
+    expectCloseTo(unwrapped, [
+      Math.PI,
+      2 * Math.PI,
+      3 * Math.PI,
+      4 * Math.PI,
+      5 * Math.PI,
+      6 * Math.PI,
+      7 * Math.PI,
+      8 * Math.PI,
+      9 * Math.PI,
+      10 * Math.PI,
+    ]);
+  });
+
+  it('should handle arrays with 0 or 1 values', () => {
+    const unwrapped1 = unwrapPhase(new Float64Array([]));
+    expect(unwrapped1).toStrictEqual(new Float64Array([]));
+
+    const unwrapped2 = unwrapPhase(new Float64Array([2 * Math.PI]));
+    expect(unwrapped2).toStrictEqual(new Float64Array([2 * Math.PI]));
+  });
+});

--- a/packages/app/src/vis-packs/core/complex/utils.ts
+++ b/packages/app/src/vis-packs/core/complex/utils.ts
@@ -19,32 +19,39 @@ export const COMPLEX_VIS_TYPE_LABELS = {
 } satisfies Record<ComplexVisType, string>;
 
 export function getPhaseAmplitude(values: H5WebComplex[]): {
-  phase: number[];
-  amplitude: number[];
+  phase: Float64Array;
+  amplitude: Float64Array;
 } {
-  const phase: number[] = Array.from({ length: values.length });
-  const amplitude: number[] = Array.from({ length: values.length });
+  const phase = new Float64Array(values.length);
+  const amplitude = new Float64Array(values.length);
 
-  values.forEach(([real, imag], i) => {
+  // eslint-disable-next-line unicorn/no-for-loop -- classic loop is more efficient
+  for (let i = 0; i < values.length; i += 1) {
+    const [real, imag] = values[i];
     phase[i] = Math.atan2(imag, real);
     amplitude[i] = Math.hypot(real, imag);
-  });
+  }
 
   return { phase, amplitude };
 }
 
 // Unwrap phase values by removing 2π discontinuities
-function unwrapPhase(values: number[]): number[] {
-  const unwrapped: number[] = Array.from({ length: values.length });
+export function unwrapPhase(values: Float64Array): Float64Array {
+  const unwrapped = new Float64Array(values.length);
 
-  for (const [i, val] of values.entries()) {
-    if (i === 0) {
-      unwrapped[0] = val;
-      continue;
-    }
+  if (values.length === 0) {
+    return unwrapped;
+  }
 
-    const diff = val - unwrapped[i - 1];
-    unwrapped[i] = val - TWO_PI * Math.round(diff / TWO_PI);
+  let previous = values[0]; // eslint-disable-line @typescript-eslint/prefer-destructuring
+  unwrapped[0] = previous;
+
+  for (let i = 1; i < values.length; i += 1) {
+    const val = values[i];
+    const diff = val - previous;
+
+    previous = val - TWO_PI * Math.round(diff / TWO_PI);
+    unwrapped[i] = previous;
   }
 
   return unwrapped;


### PR DESCRIPTION
Extracted from #2037 — thanks @NAThompson!

I've simplified the unit tests significantly and used our mock complex 1D array.