### PR TITLE
Add example project with `@h5web/lib`

### DIFF
--- a/.github/workflows/build-example.yml
+++ b/.github/workflows/build-example.yml
@@ -1,0 +1,22 @@
+name: Publish packages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  example:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🏷️
+        uses: actions/checkout@v6
+
+      - name: Install ⚙️
+        uses: ./.github/actions/install
+
+      - name: Build lib example 📦
+        run: pnpm --filter example-lib build

--- a/.gitignore
+++ b/.gitignore
@@ -2,13 +2,13 @@ node_modules/
 
 build/
 dist*/
+.sonda/
 
 /cypress/debug/
 /cypress/snapshots/**/__diff_output__
 /cypress/snapshots/**/__received_output__
 
 /coverage/
-/apps/demo/.sonda/
 /packages/app/src/__tests__/__screenshots__/
 /support/h5grove/__pycache__/
 

--- a/apps/example-lib/eslint.config.js
+++ b/apps/example-lib/eslint.config.js
@@ -1,0 +1,8 @@
+import { createConfig, detectOpts } from '@esrf/eslint-config';
+import { defineConfig, globalIgnores } from 'eslint/config';
+
+const opts = detectOpts(import.meta.dirname);
+
+const config = defineConfig([globalIgnores(['dist/']), ...createConfig(opts)]);
+
+export default config;

--- a/apps/example-lib/index.html
+++ b/apps/example-lib/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <title>H5Web</title>
+
+    <meta name="description" content="Web-based HDF5 file viewer." />
+    <link rel="icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" href="/favicon192.png" />
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/apps/example-lib/package.json
+++ b/apps/example-lib/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "example-lib",
+  "private": true,
+  "version": "0.0.1",
+  "description": "Example with H5Web lib",
+  "type": "module",
+  "scripts": {
+    "start": "vite",
+    "build": "vite build",
+    "serve": "vite preview",
+    "lint:eslint": "eslint --max-warnings=0",
+    "lint:tsc": "tsc"
+  },
+  "dependencies": {
+    "@h5web/lib": "workspace:*",
+    "modern-normalize": "3.0.1",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@esrf/eslint-config": "3.1.0",
+    "@types/node": "^24.13.2",
+    "@types/react": "^18.3.31",
+    "@types/react-dom": "^18.3.7",
+    "@vitejs/plugin-react": "6.0.3",
+    "eslint": "9.39.4",
+    "sonda": "0.13.1",
+    "typescript": "6.0.3",
+    "vite": "8.1.2",
+    "vite-css-modules": "1.16.0",
+    "vite-plugin-checker": "0.14.4",
+    "vite-plugin-eslint": "1.8.1"
+  }
+}

--- a/apps/example-lib/src/DemoLib.tsx
+++ b/apps/example-lib/src/DemoLib.tsx
@@ -1,0 +1,29 @@
+import { getDomain, HeatmapVis, LineVis, mockValues } from '@h5web/lib';
+
+const lineArray = mockValues.oneD();
+const lineDomain = getDomain(lineArray);
+
+const heatmapArray = mockValues.twoD();
+const heatmapDomain = getDomain(heatmapArray);
+
+function DemoLib() {
+  return (
+    <>
+      <h2>
+        <code>LineVis</code>
+      </h2>
+      <LineVis dataArray={lineArray} domain={lineDomain} showGrid />
+
+      <h2>
+        <code>HeatmapVis</code>
+      </h2>
+      <HeatmapVis
+        dataArray={heatmapArray}
+        domain={heatmapDomain}
+        aspect="auto"
+      />
+    </>
+  );
+}
+
+export default DemoLib;

--- a/apps/example-lib/src/index.tsx
+++ b/apps/example-lib/src/index.tsx
@@ -1,0 +1,16 @@
+import './styles.css'; // global styles
+
+import { assertNonNull } from '@h5web/lib';
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import DemoLib from './DemoLib';
+
+const rootElem = document.querySelector('#root');
+assertNonNull(rootElem);
+
+createRoot(rootElem).render(
+  <StrictMode>
+    <DemoLib />
+  </StrictMode>,
+);

--- a/apps/example-lib/src/styles.css
+++ b/apps/example-lib/src/styles.css
@@ -1,0 +1,23 @@
+@import 'modern-normalize/modern-normalize.css';
+/* In a real-world project, remember to import the lib's styles: */
+/* @import '@h5web/lib/styles.css'; */
+
+body {
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
+    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+}
+
+h2 {
+  margin-bottom: 0;
+  font-size: 1.125rem;
+  font-weight: normal;
+}
+
+#root {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  height: 100vh;
+  text-align: center;
+}

--- a/apps/example-lib/src/vite-env.d.ts
+++ b/apps/example-lib/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/example-lib/tsconfig.json
+++ b/apps/example-lib/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["*", "src"]
+}

--- a/apps/example-lib/vite.config.js
+++ b/apps/example-lib/vite.config.js
@@ -1,0 +1,18 @@
+import react from '@vitejs/plugin-react';
+import sonda from 'sonda/vite';
+import { defineConfig } from 'vite';
+import { patchCssModules } from 'vite-css-modules';
+import { checker } from 'vite-plugin-checker';
+import eslintPlugin from 'vite-plugin-eslint';
+
+export default defineConfig({
+  server: { open: true },
+  build: { sourcemap: true },
+  plugins: [
+    react(),
+    patchCssModules(),
+    { ...eslintPlugin(), apply: 'serve' }, // dev only to reduce build time
+    { ...checker({ typescript: true }), apply: 'serve' }, // dev only to reduce build time
+    sonda({ enabled: !process.env.CI }), // disable bundle analysis on build in CI
+  ],
+});

--- a/packages/lib/README.md
+++ b/packages/lib/README.md
@@ -72,12 +72,12 @@ function MyApp() {
 export default MyApp;
 ```
 
-### Examples
+### Example
 
-The following code sandboxes demonstrate how to set up and use `@h5web/lib` with
-various front-end development stacks:
-
-- [Vite](https://codesandbox.io/p/sandbox/h5weblib-vite-xru04?file=%2Fsrc%2FApp.tsx)
+An example Vite project demonstrating the use of `@h5web/lib` is available under
+`/app/example-lib`. You can start it with `pnpm --filter example-lib start`. It
+is also available as a
+[codesandbox](https://codesandbox.io/p/sandbox/h5weblib-vite-xru04?file=%2Fsrc%2FApp.tsx).
 
 ### Browser support
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,6 +320,58 @@ importers:
         specifier: 1.8.1
         version: 1.8.1(eslint@9.39.4(supports-color@8.1.1))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1))
 
+  apps/example-lib:
+    dependencies:
+      '@h5web/lib':
+        specifier: workspace:*
+        version: link:../../packages/lib
+      modern-normalize:
+        specifier: 3.0.1
+        version: 3.0.1
+      react:
+        specifier: 18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: 18.3.1
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@esrf/eslint-config':
+        specifier: 3.1.0
+        version: 3.1.0(@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@9.39.4(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(@typescript-eslint/utils@8.66.0(eslint@9.39.4(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@9.39.4(supports-color@8.1.1))(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@3.9.4)(react@18.3.1))(supports-color@8.1.1)(typescript@6.0.3)(vitest@4.1.9)
+      '@types/node':
+        specifier: ^24.13.2
+        version: 24.13.2
+      '@types/react':
+        specifier: ^18.3.31
+        version: 18.3.31
+      '@types/react-dom':
+        specifier: ^18.3.7
+        version: 18.3.7(@types/react@18.3.31)
+      '@vitejs/plugin-react':
+        specifier: 6.0.3
+        version: 6.0.3(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1))
+      eslint:
+        specifier: 9.39.4
+        version: 9.39.4(supports-color@8.1.1)
+      sonda:
+        specifier: 0.13.1
+        version: 0.13.1
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vite:
+        specifier: 8.1.2
+        version: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)
+      vite-css-modules:
+        specifier: 1.16.0
+        version: 1.16.0(lightningcss@1.32.0)(postcss@8.5.16)(rollup@4.62.2)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1))
+      vite-plugin-checker:
+        specifier: 0.14.4
+        version: 0.14.4(eslint@9.39.4(supports-color@8.1.1))(optionator@0.9.4)(typescript@6.0.3)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1))
+      vite-plugin-eslint:
+        specifier: 1.8.1
+        version: 1.8.1(eslint@9.39.4(supports-color@8.1.1))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1))
+
   apps/storybook:
     dependencies:
       '@h5web/lib':


### PR DESCRIPTION
Bringing the [`h5weblib-vite` codesandbox](https://codesandbox.io/p/devbox/h5weblib-vite-xru04) into the repo so we can more easily test installing and using `@h5web/lib` in a consumer project. I'm adding Sonda, the bundle analyzer, so we can check that unused parts of the lib are correctly tree-shaken.

<img width="870" height="752" alt="image" src="https://github.com/user-attachments/assets/b72eba09-2746-4b6a-9946-9093cb238ae1" />